### PR TITLE
runtime: add rank-scoped structured services

### DIFF
--- a/docs/GENERIC_RUNTIME.md
+++ b/docs/GENERIC_RUNTIME.md
@@ -402,6 +402,7 @@ A bundle is a JSON file with schema `sparkring-runtime-bundle/v1`:
       "service_id": "cache",
       "role": "cache",
       "depends_on": [],
+      "ranks": [0, 1],
       "source": {
         "kind": "structured-container",
         "path": "cache-sidecar.json"
@@ -427,6 +428,12 @@ Key constraints:
 - Exactly one `serving` role; zero or more `cache`/`sidecar` roles.
 - Maximum 16 services. Service ids are lowercase, unique, and match
   `^[a-z][a-z0-9-]{0,62}$`.
+- Optional `ranks` is a non-empty, duplicate-free list of non-negative site
+  rank ids. It is accepted only for `structured-container` cache/sidecar
+  services; omitting it targets every site rank. Unknown ids fail closed when
+  a site-aware plan or execution is built. Runtime-profile serving and
+  canonical bridge services always target the complete site because their
+  TP/DCP and lifecycle contracts are whole-stack.
 - `depends_on` is a list of service ids; cycles, self-edges, unknown
   services, and duplicate entries are rejected. `depends_on` is stored as
   a `frozenset` — equivalent permutations produce byte-identical plans.
@@ -450,8 +457,11 @@ Key constraints:
 ### Structured containers
 
 A `structured-container` source runs a declared argv directly — no vLLM
-`serve` subcommand, no TP/DCP flags, no entrypoint override. The container
-definition file has schema `sparkring-structured-container/v1`:
+`serve` subcommand and no TP/DCP flags. `argv[0]` is emitted as Docker's
+explicit `--entrypoint`; only `argv[1:]` follows the image as arguments. This
+prevents an image's inherited ENTRYPOINT from intercepting the declared
+executable. The container definition file has schema
+`sparkring-structured-container/v1`:
 
 ```json
 {
@@ -475,6 +485,13 @@ Mount paths containing `..` are rejected. The
 `privileged` flag should be `false` unless a demonstrated need is
 documented. See `scripts/config/example-cache-sidecar.json` for a template
 example.
+
+Rank scoping belongs to the bundle service, not this container document. It
+applies consistently to plan, start, readiness, status, stop, invocation-local
+rollback, and verify-rollback. Container-name collision checks compare only
+ranks on which two services actually overlap. A service using readiness
+`rank_scope: rank0` must include rank 0 in its `ranks`; otherwise site-aware
+validation fails instead of silently producing no readiness action.
 
 ### Graph ordering
 
@@ -522,6 +539,19 @@ whole-stack rather than invocation-ledgered, and canonical labels do not
 carry the bundle/service/source-profile ownership tuple. Use the canonical
 launcher for execution. A successful offline bridge plan is not new live
 validation or acceptance.
+
+This boundary follows from the published ownership schemas. A static generic
+runtime profile cannot truthfully reproduce the canonical EXL3 action set:
+the receipt-gated image entrypoint requires runtime-owned `SPARKRING_*`
+identity variables, while the LMCache connector argument contains server URLs
+derived from the resolved site at action-build time. The canonical launcher
+also owns its exact allocator, privilege, entrypoint, and rollback contract.
+Allowing a profile to inject those runtime-owned values would weaken the
+generic schema's safety boundary. Therefore the bridge remains useful for
+deterministic plan inspection and parity, but only the canonical EXL3+LMCache
+launcher is executable. Rank-scoped structured containers and direct-entrypoint
+execution are generic offline-validated capabilities; they do not constitute
+live EXL3 composition validation.
 
 ### Offline conformance commands
 

--- a/scripts/sparkring_bundle.py
+++ b/scripts/sparkring_bundle.py
@@ -23,7 +23,8 @@ Safety:
 * The EXL3+LMCache bridge is plan-only (``execution_supported: false``).
 * Source paths are confined to the resolved bundle directory.
 * Shell entrypoints (sh/bash/pwsh/cmd) are rejected for structured
-  containers.
+  containers; ``argv[0]`` is emitted as Docker ``--entrypoint`` so
+  the image's inherited ENTRYPOINT cannot override it.
 """
 
 from __future__ import annotations
@@ -121,7 +122,9 @@ class StructuredContainer:
     """A bounded structured container definition for cache/sidecar roles.
 
     Unlike ``runtime-profile`` (which appends vLLM ``serve`` flags),
-    a structured container runs the declared ``argv`` directly.
+    a structured container runs ``argv[0]`` as the direct executable via
+    Docker's ``--entrypoint`` flag, passing ``argv[1:]`` as arguments.
+    The image's inherited ENTRYPOINT is never used.
     """
     image: str
     image_id: str
@@ -146,6 +149,10 @@ class BundleService:
     profile: runtime.RuntimeProfile | None  # None for structured/bridge
     structured: StructuredContainer | None  # None for runtime-profile/bridge
     readiness: ReadinessProbe | None = None
+    # Optional per-rank constraint: None = all site ranks (backward
+    # compatible); a frozenset limits start/stop/status/readiness/
+    # verify-rollback to the listed rank IDs only.
+    ranks: frozenset[int] | None = None
     document: dict[str, Any] = field(default_factory=dict)
 
 
@@ -549,7 +556,7 @@ def parse_bundle(
             raise BundleError(f"{where}.services[{index}]: must be an object")
 
         svc_required = {"service_id", "role", "source"}
-        svc_optional = {"depends_on", "readiness"}
+        svc_optional = {"depends_on", "readiness", "ranks"}
         svc_unknown = sorted(set(svc_doc) - svc_required - svc_optional)
         if svc_unknown:
             raise BundleError(
@@ -605,6 +612,34 @@ def parse_bundle(
                 seen_deps.add(dep)
             depends_on = frozenset(raw_deps)
 
+        # Optional per-rank constraint: None = all site ranks.
+        # Permitted only for structured-container cache/sidecar services.
+        svc_ranks: frozenset[int] | None = None
+        if "ranks" in svc_doc:
+            raw_ranks = svc_doc["ranks"]
+            if not isinstance(raw_ranks, list):
+                raise BundleError(
+                    f"{where}.services[{index}].ranks: must be a list"
+                )
+            if not raw_ranks:
+                raise BundleError(
+                    f"{where}.services[{index}].ranks: must be non-empty"
+                )
+            seen_ranks: set[int] = set()
+            for r in raw_ranks:
+                if not isinstance(r, int) or isinstance(r, bool) or r < 0:
+                    raise BundleError(
+                        f"{where}.services[{index}].ranks: "
+                        f"invalid rank id {r!r}"
+                    )
+                if r in seen_ranks:
+                    raise BundleError(
+                        f"{where}.services[{index}].ranks: "
+                        f"duplicate rank id {r}"
+                    )
+                seen_ranks.add(r)
+            svc_ranks = frozenset(raw_ranks)
+
         readiness = _validate_readiness(
             svc_doc.get("readiness"),
             f"{where}.services[{index}].readiness",
@@ -641,6 +676,19 @@ def parse_bundle(
             src_path, effective_dir,
             f"{where}.services[{index}].source.path",
         )
+
+        # Rank scoping is only safe for structured-container cache/sidecar
+        # services.  runtime-profile serving must always target all site
+        # ranks because its generated --nnodes, TP, and DCP contract
+        # still describes the whole site.  Canonical bridge services are
+        # plan-only and delegate to the canonical launcher which has no
+        # rank-scope concept.
+        if svc_ranks is not None and src_kind != SOURCE_STRUCTURED_CONTAINER:
+            raise BundleError(
+                f"{where}.services[{index}]: 'ranks' is only permitted "
+                f"for structured-container cache/sidecar services; "
+                f"source kind {src_kind!r} must target all site ranks"
+            )
 
         profile: runtime.RuntimeProfile | None = None
         structured: StructuredContainer | None = None
@@ -697,6 +745,7 @@ def parse_bundle(
             service_id=svc_id, role=role, depends_on=depends_on,
             source_kind=src_kind, source_path=src_path,
             profile=profile, structured=structured, readiness=readiness,
+            ranks=svc_ranks,
             document=svc_doc,
         ))
 
@@ -812,6 +861,49 @@ def reverse_order(
 
 
 # ---------------------------------------------------------------------------
+# Per-rank expansion constraint
+# ---------------------------------------------------------------------------
+
+
+def _service_ranks(svc: BundleService, site: Any) -> frozenset[int]:
+    """Return the effective rank set for a service.
+
+    If the service declares ``ranks``, only those rank IDs that exist
+    in the site are returned.  Otherwise all site rank IDs are returned
+    (backward-compatible default).
+    """
+    site_ranks = {r.id for r in site.ranks}
+    if svc.ranks is None:
+        return frozenset(site_ranks)
+    return frozenset(svc.ranks) & site_ranks
+
+
+def validate_service_ranks(
+    bundle: RuntimeBundle, site: Any,
+) -> None:
+    """Fail-closed validation that all declared rank IDs exist in the site."""
+    site_ranks = {r.id for r in site.ranks}
+    for svc in bundle.services:
+        if svc.ranks is None:
+            continue
+        unknown = sorted(svc.ranks - site_ranks)
+        if unknown:
+            raise BundleError(
+                f"service {svc.service_id!r}: rank(s) {unknown} not "
+                f"found in site (available: {sorted(site_ranks)})"
+            )
+        if (
+            svc.readiness is not None
+            and svc.readiness.rank_scope == READINESS_RANK_SCOPE_RANK0
+            and 0 not in svc.ranks
+        ):
+            raise BundleError(
+                f"service {svc.service_id!r}: readiness rank_scope "
+                "'rank0' requires rank 0 in the service's ranks"
+            )
+
+
+# ---------------------------------------------------------------------------
 # Container name collision detection
 # ---------------------------------------------------------------------------
 
@@ -822,8 +914,8 @@ def check_container_name_collisions(
     """Reject per-rank container name collisions across services."""
     names: dict[str, str] = {}
     for svc in bundle.services:
-        for rank in site.ranks:
-            name = _container_name(svc, rank.id)
+        for rank_id in sorted(_service_ranks(svc, site)):
+            name = _container_name(svc, rank_id)
             if name in names and names[name] != svc.service_id:
                 raise BundleError(
                     f"container name collision: {name!r} used by "
@@ -914,7 +1006,10 @@ def _readiness_actions(
         else svc.structured.image_id if svc.structured else ""
     )
 
+    effective_ranks = _service_ranks(svc, site)
     for rank in sorted(site.ranks, key=lambda r: r.id):
+        if rank.id not in effective_ranks:
+            continue
         if probe.rank_scope == READINESS_RANK_SCOPE_RANK0 and rank.id != 0:
             continue
         name = _container_name(svc, rank.id)
@@ -990,7 +1085,11 @@ def _native_start_actions(
         actions = runtime.start_actions(
             site, svc.profile, ownership=_ownership_for(bundle, svc),
         )
-        return sorted(actions, key=lambda a: a.rank)
+        effective = _service_ranks(svc, site)
+        return sorted(
+            (a for a in actions if a.rank in effective),
+            key=lambda a: a.rank,
+        )
     if svc.structured is not None:
         return _structured_start_actions(
             site, svc, bundle,
@@ -1009,7 +1108,10 @@ def _structured_start_actions(
     sc = svc.structured
     ownership = _ownership_for(bundle, svc)
     actions: list[runtime.RemoteAction] = []
+    effective_ranks = _service_ranks(svc, site)
     for rank in sorted(site.ranks, key=lambda r: r.id):
+        if rank.id not in effective_ranks:
+            continue
         name = f"{sc.container_name}-r{rank.id}"
         command: list[str] = [
             "docker", "run", "--detach", "--name", name,
@@ -1029,8 +1131,9 @@ def _structured_start_actions(
             command.extend(("--volume", f"{host_path}:{container_path}:{mode}"))
         for env_key in sorted(sc.environment):
             command.extend(("--env", f"{env_key}={sc.environment[env_key]}"))
+        command.extend(["--entrypoint", sc.argv[0]])
         command.append(sc.image_id)
-        command.extend(sc.argv)
+        command.extend(sc.argv[1:])
 
         # Image verify guard (fail-closed on identity drift)
         guard = (
@@ -1063,7 +1166,10 @@ def _native_stop_actions(
         svc.profile.profile_id if svc.profile
         else svc.structured.image_id if svc.structured else ""
     )
+    effective_ranks = _service_ranks(svc, site)
     for rank in sorted(site.ranks, key=lambda r: r.id):
+        if rank.id not in effective_ranks:
+            continue
         name = _container_name(svc, rank.id)
         script = (
             # Daemon probe
@@ -1097,7 +1203,10 @@ def _native_status_actions(
         svc.profile.profile_id if svc.profile
         else svc.structured.image_id if svc.structured else ""
     )
+    effective_ranks = _service_ranks(svc, site)
     for rank in sorted(site.ranks, key=lambda r: r.id):
+        if rank.id not in effective_ranks:
+            continue
         name = _container_name(svc, rank.id)
         script = (
             f"{engine} info >/dev/null 2>&1 || exit {EXIT_DAEMON_ERROR}; "
@@ -1131,7 +1240,10 @@ def _native_verify_rollback_actions(
         svc.profile.profile_id if svc.profile
         else svc.structured.image_id if svc.structured else ""
     )
+    effective_ranks = _service_ranks(svc, site)
     for rank in sorted(site.ranks, key=lambda r: r.id):
+        if rank.id not in effective_ranks:
+            continue
         name = _container_name(svc, rank.id)
         script = (
             # Daemon probe
@@ -1241,6 +1353,7 @@ def bundle_plan(
 
     ordered = topological_order(bundle.services)
     reversed_ = reverse_order(bundle.services)
+    validate_service_ranks(bundle, site)
     check_container_name_collisions(bundle, site)
 
     # Item 13: complete plan phases
@@ -1372,6 +1485,10 @@ def bundle_plan(
                         else None
                     ),
                 },
+                "ranks": (
+                    sorted(svc.ranks) if svc.ranks is not None
+                    else sorted({r.id for r in site.ranks})
+                ),
             }
             for svc in ordered
         ],
@@ -1545,6 +1662,8 @@ def _service_projection(svc: BundleService) -> dict[str, Any]:
             "timeout_seconds": svc.readiness.timeout_seconds,
             "interval_seconds": svc.readiness.interval_seconds,
         }
+    if svc.ranks is not None:
+        proj["ranks"] = sorted(svc.ranks)
     return proj
 
 
@@ -1698,6 +1817,10 @@ def bundle_explain(bundle: RuntimeBundle, site: Any = None) -> dict[str, Any]:
                     }
                     if svc.readiness else None
                 ),
+                "ranks": (
+                    sorted(svc.ranks) if svc.ranks is not None
+                    else None
+                ),
             }
             for svc in ordered
         ],
@@ -1762,6 +1885,7 @@ def execute_native_start(
 
     ordered = topological_order(bundle.services)
     reversed_ = reverse_order(bundle.services)
+    validate_service_ranks(bundle, site)
     check_container_name_collisions(bundle, site)
 
     ledger: set[tuple[str, int]] = set()
@@ -1932,6 +2056,7 @@ def execute_native_status(
 ) -> dict[str, Any]:
     """Execute native status checks.  Item 7: aggregate, nonzero on failure."""
     ordered = topological_order(bundle.services)
+    validate_service_ranks(bundle, site)
     results: dict[str, Any] = {"phases": []}
     any_failed = False
     for svc in ordered:
@@ -1964,6 +2089,7 @@ def execute_native_verify_rollback(
     a nonzero observation as proven absent.
     """
     reversed_ = reverse_order(bundle.services)
+    validate_service_ranks(bundle, site)
     results: dict[str, Any] = {"phases": []}
     any_present = False
     any_unknown = False

--- a/scripts/sparkring_bundle_launcher.py
+++ b/scripts/sparkring_bundle_launcher.py
@@ -138,6 +138,7 @@ def _lifecycle_plan(args: Any, parser: Any) -> int:
     try:
         bundle = _load_bundle(Path(args.bundle))
         site = load_site(args.site)
+        bundle_mod.validate_service_ranks(bundle, site)
     except (OSError, KeyError, json.JSONDecodeError,
             SiteConfigError, bundle_mod.BundleError,
             runtime.ProfileError) as exc:
@@ -152,6 +153,7 @@ def _lifecycle_status(args: Any, parser: Any) -> int:
     try:
         bundle = _load_bundle(Path(args.bundle))
         site = load_site(args.site)
+        bundle_mod.validate_service_ranks(bundle, site)
     except (OSError, KeyError, json.JSONDecodeError,
             SiteConfigError, bundle_mod.BundleError,
             runtime.ProfileError) as exc:
@@ -178,6 +180,7 @@ def _lifecycle_verify_rollback(args: Any, parser: Any) -> int:
     try:
         bundle = _load_bundle(Path(args.bundle))
         site = load_site(args.site)
+        bundle_mod.validate_service_ranks(bundle, site)
     except (OSError, KeyError, json.JSONDecodeError,
             SiteConfigError, bundle_mod.BundleError,
             runtime.ProfileError) as exc:
@@ -209,6 +212,10 @@ def _lifecycle_mutation(args: Any, parser: Any, command: str) -> int:
     try:
         bundle = _load_bundle(Path(args.bundle))
         site = load_site(args.site)
+        # Action builders intentionally intersect with the effective rank
+        # scope. Validate membership first so no mutating command can silently
+        # omit an unknown configured rank.
+        bundle_mod.validate_service_ranks(bundle, site)
     except (OSError, KeyError, json.JSONDecodeError,
             SiteConfigError, bundle_mod.BundleError,
             runtime.ProfileError) as exc:
@@ -227,7 +234,6 @@ def _lifecycle_mutation(args: Any, parser: Any, command: str) -> int:
 
     _reject_bridge_execution(parser, bundle)
     _check_confirmation(parser, bundle, args)
-
     if command == "start":
         result = bundle_mod.execute_native_start(
             bundle, site, confirmation=args.confirmation or None,

--- a/scripts/test_sparkring_bundle.py
+++ b/scripts/test_sparkring_bundle.py
@@ -2242,3 +2242,737 @@ def test_structured_container_rejects_wrong_schema(tmp_path):
     with pytest.raises(bundle_mod.BundleError) as exc:
         bundle_mod.load_bundle(path)
     assert "schema" in str(exc.value).lower()
+
+
+# ---------------------------------------------------------------------------
+# Rank-scope feature: per-service rank constraint for structured containers
+# ---------------------------------------------------------------------------
+
+
+def _scoped_bundle(tmp_path, ranks=None, **kw):
+    """Create a bundle with a scoped cache sidecar + all-rank serving engine."""
+    sc_path = _write_structured(tmp_path, "cache", _structured_doc())
+    profile = _write_profile(tmp_path, "engine", _generic_doc())
+    cache_svc = _structured_service(
+        "cache", "cache", sc_path,
+        readiness={"kind": "container-running"},
+    )
+    if ranks is not None:
+        cache_svc["ranks"] = ranks
+    engine_svc = _native_service("engine", "serving", profile, depends_on=["cache"])
+    doc = _bundle_doc([cache_svc, engine_svc], **kw)
+    return _write_bundle(tmp_path, doc)
+
+
+def test_ranks_accepted_for_structured_container(tmp_path):
+    """A structured-container cache service with valid ranks must parse."""
+    path = _scoped_bundle(tmp_path, ranks=[0, 1])
+    bundle = bundle_mod.load_bundle(path)
+    cache_svc = [s for s in bundle.services if s.service_id == "cache"][0]
+    assert cache_svc.ranks == frozenset({0, 1})
+    engine_svc = [s for s in bundle.services if s.service_id == "engine"][0]
+    assert engine_svc.ranks is None  # serving always all-ranks
+
+
+def test_ranks_none_default_all_ranks(tmp_path):
+    """No ranks field means all site ranks (backward compatible)."""
+    path = _scoped_bundle(tmp_path)
+    bundle = bundle_mod.load_bundle(path)
+    cache_svc = [s for s in bundle.services if s.service_id == "cache"][0]
+    assert cache_svc.ranks is None
+
+
+@pytest.mark.parametrize("bad_ranks,expected_fragment", [
+    ([], "non-empty"),
+    ([0, 0], "duplicate"),
+    ([-1], "invalid"),
+    ([0, -3], "invalid"),
+    (["0"], "invalid"),
+    ([0, 1, "2"], "invalid"),
+    ([True], "invalid"),
+])
+def test_ranks_invalid_values_rejected(tmp_path, bad_ranks, expected_fragment):
+    """Invalid rank lists must be rejected during structural validation."""
+    path = _scoped_bundle(tmp_path, ranks=bad_ranks)
+    with pytest.raises(bundle_mod.BundleError) as exc:
+        bundle_mod.load_bundle(path)
+    assert expected_fragment in str(exc.value).lower()
+
+
+def test_ranks_rejected_for_runtime_profile(tmp_path):
+    """ranks field must be rejected for runtime-profile serving services."""
+    profile = _write_profile(tmp_path, "engine", _generic_doc())
+    engine_svc = _native_service("engine", "serving", profile, ranks=[0])
+    doc = _bundle_doc([engine_svc])
+    path = _write_bundle(tmp_path, doc)
+    with pytest.raises(bundle_mod.BundleError) as exc:
+        bundle_mod.load_bundle(path)
+    assert "ranks" in str(exc.value).lower()
+    assert "runtime-profile" in str(exc.value).lower() or "structured" in str(exc.value).lower()
+
+
+def test_ranks_rejected_for_structured_serving(tmp_path):
+    """A structured container cannot bypass all-rank serving semantics."""
+    structured = _write_structured(tmp_path, "engine", _structured_doc())
+    engine_svc = _structured_service(
+        "engine", "serving", structured, ranks=[0],
+    )
+    path = _write_bundle(tmp_path, _bundle_doc([engine_svc]))
+    with pytest.raises(bundle_mod.BundleError) as exc:
+        bundle_mod.load_bundle(path)
+    assert "serving" in str(exc.value).lower()
+    assert "structured-container" in str(exc.value).lower()
+
+
+def test_ranks_rejected_for_canonical_bridge(tmp_path):
+    """ranks field must be rejected for canonical-exl3-lmcache-cs512 services."""
+    profile = _write_profile(tmp_path, "bridge", _generic_doc())
+    cache_svc = _bridge_service("cache", "cache", profile, ranks=[0])
+    engine_svc = _bridge_service("engine", "serving", profile, depends_on=["cache"])
+    doc = _bundle_doc([cache_svc, engine_svc], confirmation=None)
+    path = _write_bundle(tmp_path, doc)
+    with pytest.raises(bundle_mod.BundleError) as exc:
+        bundle_mod.load_bundle(path)
+    assert "ranks" in str(exc.value).lower()
+
+
+def test_ranks_unknown_id_rejected_at_plan(tmp_path):
+    """Ranks referencing non-existent site IDs must fail at plan time."""
+    path = _scoped_bundle(tmp_path, ranks=[0, 99])
+    bundle = bundle_mod.load_bundle(path)  # structural validation passes
+    site = load_site(SITE)
+    with pytest.raises(bundle_mod.BundleError) as exc:
+        bundle_mod.bundle_plan(bundle, site)
+    assert "99" in str(exc.value)
+    assert "not found" in str(exc.value).lower()
+
+
+def test_ranks_filters_start_actions(tmp_path):
+    """Scoped cache service start actions must only target scoped ranks."""
+    path = _scoped_bundle(tmp_path, ranks=[0])
+    bundle = bundle_mod.load_bundle(path)
+    site = load_site(SITE)
+    plan = bundle_mod.bundle_plan(bundle, site)
+    # Find the cache start phase
+    cache_start = [
+        p for p in plan["phases"]
+        if p["phase"] == "start" and p["service_id"] == "cache"
+    ][0]
+    start_ranks = {a["rank"] for a in cache_start["actions"]}
+    assert start_ranks == {0}
+    # Engine should still target all 4 ranks
+    engine_start = [
+        p for p in plan["phases"]
+        if p["phase"] == "start" and p["service_id"] == "engine"
+    ][0]
+    engine_ranks = {a["rank"] for a in engine_start["actions"]}
+    assert engine_ranks == {0, 1, 2, 3}
+
+
+def test_ranks_filters_stop_and_verify_rollback(tmp_path):
+    """Scoped service stop/verify-rollback must only target scoped ranks."""
+    path = _scoped_bundle(tmp_path, ranks=[1])
+    bundle = bundle_mod.load_bundle(path)
+    site = load_site(SITE)
+    plan = bundle_mod.bundle_plan(bundle, site)
+    for phase_name in ("stop", "rollback", "verify_rollback"):
+        phase = [
+            p for p in plan["phases"]
+            if p["phase"] == phase_name and p["service_id"] == "cache"
+        ][0]
+        phase_ranks = {a["rank"] for a in phase["actions"]}
+        assert phase_ranks == {1}, f"{phase_name} ranks: {phase_ranks}"
+
+
+def test_ranks_filters_readiness(tmp_path):
+    """Scoped service readiness must only target scoped ranks."""
+    path = _scoped_bundle(tmp_path, ranks=[2])
+    bundle = bundle_mod.load_bundle(path)
+    site = load_site(SITE)
+    plan = bundle_mod.bundle_plan(bundle, site)
+    ready = [
+        p for p in plan["phases"]
+        if p["phase"] == "readiness" and p["service_id"] == "cache"
+    ]
+    assert len(ready) == 1
+    ready_ranks = {a["rank"] for a in ready[0]["actions"]}
+    assert ready_ranks == {2}
+
+
+def test_ranks_exposed_in_plan(tmp_path):
+    """Plan must expose expected ranks per service."""
+    path = _scoped_bundle(tmp_path, ranks=[0, 1])
+    bundle = bundle_mod.load_bundle(path)
+    site = load_site(SITE)
+    plan = bundle_mod.bundle_plan(bundle, site)
+    cache_entry = [s for s in plan["services"] if s["service_id"] == "cache"][0]
+    assert cache_entry["ranks"] == [0, 1]
+    engine_entry = [s for s in plan["services"] if s["service_id"] == "engine"][0]
+    assert engine_entry["ranks"] == [0, 1, 2, 3]
+
+
+def test_ranks_exposed_in_explain(tmp_path):
+    """Explain must expose ranks for scoped services."""
+    path = _scoped_bundle(tmp_path, ranks=[0])
+    bundle = bundle_mod.load_bundle(path)
+    explain = bundle_mod.bundle_explain(bundle)
+    cache_entry = [s for s in explain["services"] if s["service_id"] == "cache"][0]
+    assert cache_entry["ranks"] == [0]
+    engine_entry = [s for s in explain["services"] if s["service_id"] == "engine"][0]
+    assert engine_entry["ranks"] is None
+
+
+def test_ranks_collision_only_on_overlapping_ranks(tmp_path):
+    """Collision check should only check ranks where both services run."""
+    # Cache on ranks 0,1 with same container_name prefix as another service
+    # on ranks 2,3 — no collision because ranks don't overlap.
+    sc1 = _write_structured(tmp_path, "c1", _structured_doc(container_name="sparkring-shared"))
+    sc2 = _write_structured(tmp_path, "c2", _structured_doc(container_name="sparkring-shared"))
+    profile = _write_profile(tmp_path, "engine", _generic_doc())
+    doc = _bundle_doc([
+        _structured_service("cache-a", "cache", sc1, ranks=[0, 1],
+                            readiness={"kind": "container-running"}),
+        _structured_service("cache-b", "cache", sc2, ranks=[2, 3],
+                            readiness={"kind": "container-running"}),
+        _native_service("engine", "serving", profile, depends_on=["cache-a", "cache-b"]),
+    ])
+    path = _write_bundle(tmp_path, doc)
+    bundle = bundle_mod.load_bundle(path)
+    site = load_site(SITE)
+    # Should not raise — same name on non-overlapping ranks
+    bundle_mod.check_container_name_collisions(bundle, site)
+
+
+def test_ranks_collision_detected_on_overlapping_ranks(tmp_path):
+    """Collision check must detect same name on overlapping ranks."""
+    sc1 = _write_structured(tmp_path, "c1", _structured_doc(container_name="sparkring-shared"))
+    sc2 = _write_structured(tmp_path, "c2", _structured_doc(container_name="sparkring-shared"))
+    profile = _write_profile(tmp_path, "engine", _generic_doc())
+    doc = _bundle_doc([
+        _structured_service("cache-a", "cache", sc1, ranks=[0, 1],
+                            readiness={"kind": "container-running"}),
+        _structured_service("cache-b", "cache", sc2, ranks=[1, 2],
+                            readiness={"kind": "container-running"}),
+        _native_service("engine", "serving", profile, depends_on=["cache-a", "cache-b"]),
+    ])
+    path = _write_bundle(tmp_path, doc)
+    bundle = bundle_mod.load_bundle(path)
+    site = load_site(SITE)
+    with pytest.raises(bundle_mod.BundleError) as exc:
+        bundle_mod.check_container_name_collisions(bundle, site)
+    assert "collision" in str(exc.value).lower()
+
+
+def test_ranks_deterministic_ordering_byte_identical(tmp_path):
+    """Equivalent rank orderings must produce byte-identical plans."""
+    sc_path = _write_structured(tmp_path, "cache", _structured_doc())
+    profile = _write_profile(tmp_path, "engine", _generic_doc())
+    doc_a = _bundle_doc([
+        _structured_service("cache", "cache", sc_path, ranks=[2, 0, 1],
+                            readiness={"kind": "container-running"}),
+        _native_service("engine", "serving", profile, depends_on=["cache"]),
+    ])
+    doc_b = _bundle_doc([
+        _structured_service("cache", "cache", sc_path, ranks=[0, 1, 2],
+                            readiness={"kind": "container-running"}),
+        _native_service("engine", "serving", profile, depends_on=["cache"]),
+    ])
+    path_a = _write_bundle(tmp_path, doc_a, "a.json")
+    path_b = _write_bundle(tmp_path, doc_b, "b.json")
+    site = load_site(SITE)
+    plan_a = bundle_mod.bundle_plan(bundle_mod.load_bundle(path_a), site)
+    plan_b = bundle_mod.bundle_plan(bundle_mod.load_bundle(path_b), site)
+    assert plan_a == plan_b
+    assert plan_a["plan_identity"] == plan_b["plan_identity"]
+
+
+def test_ranks_projection_includes_ranks(tmp_path):
+    """Service projection for diff must include ranks for scoped services."""
+    path = _scoped_bundle(tmp_path, ranks=[0, 2])
+    bundle = bundle_mod.load_bundle(path)
+    proj = bundle_mod.bundle_projection(bundle)
+    cache_proj = proj["services"]["cache"]
+    assert cache_proj["ranks"] == [0, 2]
+
+
+def test_ranks_diff_detects_different_scopes(tmp_path):
+    """Diff must detect different rank scopes."""
+    sc_path = _write_structured(tmp_path, "cache", _structured_doc())
+    profile = _write_profile(tmp_path, "engine", _generic_doc())
+    doc_a = _bundle_doc([
+        _structured_service("cache", "cache", sc_path, ranks=[0],
+                            readiness={"kind": "container-running"}),
+        _native_service("engine", "serving", profile, depends_on=["cache"]),
+    ])
+    doc_b = _bundle_doc([
+        _structured_service("cache", "cache", sc_path, ranks=[1],
+                            readiness={"kind": "container-running"}),
+        _native_service("engine", "serving", profile, depends_on=["cache"]),
+    ])
+    path_a = _write_bundle(tmp_path, doc_a, "a.json")
+    path_b = _write_bundle(tmp_path, doc_b, "b.json")
+    diffs = bundle_mod.recursive_diff(
+        bundle_mod.bundle_projection(bundle_mod.load_bundle(path_a)),
+        bundle_mod.bundle_projection(bundle_mod.load_bundle(path_b)),
+    )
+    assert any("ranks" in d.get("field", "") for d in diffs)
+
+
+def test_ranks_execute_start_filters_actions(tmp_path, monkeypatch):
+    """execute_native_start must only start on scoped ranks."""
+    path = _scoped_bundle(tmp_path, ranks=[0])
+    bundle = bundle_mod.load_bundle(path)
+    site = load_site(SITE)
+    _poison_remote(monkeypatch)
+    # Poison execute to capture which ranks are attempted
+    captured_ranks: dict[str, list[int]] = {}
+    orig_execute = runtime.execute
+
+    def fake_execute(actions, timeout):
+        if actions:
+            command = actions[0].shell_command
+            key = "cache" if "sparkring-cache" in command else "engine"
+            captured_ranks.setdefault(key, []).extend(
+                sorted(a.rank for a in actions)
+            )
+        return {a.rank: {"exit_code": 0,
+                         "stdout": "a" * 12, "stderr": ""}
+                for a in actions}
+
+    monkeypatch.setattr(runtime, "execute", fake_execute)
+    try:
+        bundle_mod.execute_native_start(
+            bundle, site, confirmation="START-test",
+        )
+    finally:
+        monkeypatch.setattr(runtime, "execute", orig_execute)
+    assert sorted(set(captured_ranks["cache"])) == [0]
+    assert sorted(set(captured_ranks["engine"])) == [0, 1, 2, 3]
+
+
+def test_ranks_execute_status_filters_actions(tmp_path, monkeypatch):
+    """execute_native_status must only check scoped ranks for scoped service."""
+    path = _scoped_bundle(tmp_path, ranks=[1])
+    bundle = bundle_mod.load_bundle(path)
+    site = load_site(SITE)
+    _poison_remote(monkeypatch)
+    captured_ranks: dict[str, list[int]] = {}
+    orig_execute = runtime.execute
+
+    def fake_execute(actions, timeout):
+        ranks = sorted(a.rank for a in actions)
+        # Tag by service by looking at the command
+        key = "cache" if any("sparkring-cache" in a.shell_command for a in actions) else "engine"
+        captured_ranks.setdefault(key, []).extend(ranks)
+        return {a.rank: {"exit_code": 0, "stdout": "", "stderr": ""}
+                for a in actions}
+
+    monkeypatch.setattr(runtime, "execute", fake_execute)
+    try:
+        bundle_mod.execute_native_status(bundle, site)
+    finally:
+        monkeypatch.setattr(runtime, "execute", orig_execute)
+    assert captured_ranks.get("cache") == [1]
+    assert sorted(set(captured_ranks.get("engine", []))) == [0, 1, 2, 3]
+
+
+def test_ranks_execute_verify_rollback_filters(tmp_path, monkeypatch):
+    """execute_native_verify_rollback must only check scoped ranks."""
+    path = _scoped_bundle(tmp_path, ranks=[1])
+    bundle = bundle_mod.load_bundle(path)
+    site = load_site(SITE)
+    _poison_remote(monkeypatch)
+    captured_ranks: dict[str, list[int]] = {}
+    orig_execute = runtime.execute
+
+    def fake_execute(actions, timeout):
+        ranks = sorted(a.rank for a in actions)
+        key = "cache" if any("sparkring-cache" in a.shell_command for a in actions) else "engine"
+        captured_ranks.setdefault(key, []).extend(ranks)
+        return {a.rank: {"exit_code": 0, "stdout": "", "stderr": ""}
+                for a in actions}
+
+    monkeypatch.setattr(runtime, "execute", fake_execute)
+    try:
+        bundle_mod.execute_native_verify_rollback(bundle, site)
+    finally:
+        monkeypatch.setattr(runtime, "execute", orig_execute)
+    assert captured_ranks.get("cache") == [1]
+    assert sorted(set(captured_ranks.get("engine", []))) == [0, 1, 2, 3]
+
+
+def test_ranks_unknown_id_rejected_at_execute_start(tmp_path, monkeypatch):
+    """execute_native_start must reject unknown rank IDs."""
+    path = _scoped_bundle(tmp_path, ranks=[0, 99])
+    bundle = bundle_mod.load_bundle(path)
+    site = load_site(SITE)
+    _poison_remote(monkeypatch)
+    with pytest.raises(bundle_mod.BundleError) as exc:
+        bundle_mod.execute_native_start(
+            bundle, site, confirmation="START-test",
+        )
+    assert "99" in str(exc.value)
+
+
+def test_ranks_unknown_id_rejected_at_execute_status(tmp_path, monkeypatch):
+    """execute_native_status must reject unknown rank IDs."""
+    path = _scoped_bundle(tmp_path, ranks=[0, 99])
+    bundle = bundle_mod.load_bundle(path)
+    site = load_site(SITE)
+    _poison_remote(monkeypatch)
+    with pytest.raises(bundle_mod.BundleError) as exc:
+        bundle_mod.execute_native_status(bundle, site)
+    assert "99" in str(exc.value)
+
+
+def test_ranks_unknown_id_rejected_at_execute_verify_rollback(tmp_path, monkeypatch):
+    """execute_native_verify_rollback must reject unknown rank IDs."""
+    path = _scoped_bundle(tmp_path, ranks=[0, 99])
+    bundle = bundle_mod.load_bundle(path)
+    site = load_site(SITE)
+    _poison_remote(monkeypatch)
+    with pytest.raises(bundle_mod.BundleError) as exc:
+        bundle_mod.execute_native_verify_rollback(bundle, site)
+    assert "99" in str(exc.value)
+
+
+@pytest.mark.parametrize(
+    "command,extra_args",
+    [
+        ("start", ["--execute", "--confirmation", "START-test"]),
+        ("stop", ["--execute", "--confirmation", "START-test"]),
+        ("rollback", ["--execute", "--confirmation", "START-test"]),
+        ("status", ["--execute"]),
+        ("verify-rollback", ["--execute"]),
+    ],
+)
+def test_ranks_unknown_id_rejected_by_executed_cli(
+    tmp_path, monkeypatch, command, extra_args,
+):
+    """Every executed lifecycle command rejects unknown ranks pre-SSH."""
+    import sparkring_bundle_launcher as launcher
+
+    path = _scoped_bundle(tmp_path, ranks=[0, 99])
+    remote_calls = []
+
+    def fail_if_called(*args, **kwargs):
+        remote_calls.append((args, kwargs))
+        raise AssertionError("remote executor reached")
+
+    monkeypatch.setattr(runtime, "execute", fail_if_called)
+    with pytest.raises(SystemExit) as exc:
+        launcher.main([
+            "--bundle", str(path), "--site", str(SITE), command,
+            *extra_args,
+        ])
+    assert exc.value.code == 2
+    assert remote_calls == []
+
+
+def test_scoped_rank0_readiness_requires_rank0_at_plan(tmp_path):
+    """A rank0 probe cannot silently disappear from a non-rank0 scope."""
+    path = _scoped_bundle(tmp_path, ranks=[2])
+    document = json.loads(path.read_text(encoding="utf-8"))
+    document["services"][0]["readiness"] = {
+        "kind": "container-running",
+        "rank_scope": "rank0",
+    }
+    path = _write_bundle(tmp_path, document)
+    bundle = bundle_mod.load_bundle(path)
+    with pytest.raises(bundle_mod.BundleError) as exc:
+        bundle_mod.bundle_plan(bundle, load_site(SITE))
+    assert "rank_scope 'rank0' requires rank 0" in str(exc.value)
+
+
+def test_scoped_rank0_readiness_rejected_before_execute(tmp_path, monkeypatch):
+    """Invalid scoped readiness fails before any remote start action."""
+    path = _scoped_bundle(tmp_path, ranks=[2])
+    document = json.loads(path.read_text(encoding="utf-8"))
+    document["services"][0]["readiness"] = {
+        "kind": "container-running",
+        "rank_scope": "rank0",
+    }
+    path = _write_bundle(tmp_path, document)
+    bundle = bundle_mod.load_bundle(path)
+    _poison_remote(monkeypatch)
+    with pytest.raises(bundle_mod.BundleError) as exc:
+        bundle_mod.execute_native_start(
+            bundle, load_site(SITE), confirmation="START-test",
+        )
+    assert "rank_scope 'rank0' requires rank 0" in str(exc.value)
+
+
+def test_ranks_rollback_only_removes_ledgered_scoped_ranks(tmp_path, monkeypatch):
+    """Invocation-local rollback must only remove started scoped ranks."""
+    path = _scoped_bundle(tmp_path, ranks=[0, 1])
+    bundle = bundle_mod.load_bundle(path)
+    site = load_site(SITE)
+    _poison_remote(monkeypatch)
+    rollback_ranks: list[int] = []
+    orig_execute = runtime.execute
+
+    def fake_execute(actions, timeout):
+        ranks = sorted(a.rank for a in actions)
+        rollback_ranks.extend(ranks)
+        return {a.rank: {"exit_code": 0, "stdout": "", "stderr": ""}
+                for a in actions}
+
+    monkeypatch.setattr(runtime, "execute", fake_execute)
+    try:
+        # Simulate a start where cache succeeds on rank 0 only, then
+        # engine fails — rollback should remove cache from rank 0 only.
+        call_count = [0]
+
+        def fake_execute_staged(actions, timeout):
+            call_count[0] += 1
+            ranks = sorted(a.rank for a in actions)
+            if call_count[0] == 1:
+                # Cache start: succeed on rank 0, fail on rank 1
+                return {a.rank: {"exit_code": 0 if a.rank == 0 else 1,
+                                 "stdout": "a" * 12 if a.rank == 0 else "",
+                                 "stderr": "" if a.rank == 0 else "fail"}
+                        for a in actions}
+            # Subsequent calls (engine start, rollback) — track rollback
+            if "rm --force" in " ".join(a.shell_command for a in actions):
+                rollback_ranks.extend(ranks)
+            return {a.rank: {"exit_code": 0, "stdout": "a" * 12,
+                             "stderr": ""}
+                    for a in actions}
+
+        monkeypatch.setattr(runtime, "execute", fake_execute_staged)
+        result = bundle_mod.execute_native_start(
+            bundle, site, confirmation="START-test",
+        )
+    finally:
+        monkeypatch.setattr(runtime, "execute", orig_execute)
+    # Rollback should have been attempted
+    assert result.get("rollback") is not None
+    # Cache rollback should only target rank 0 (the only one that started)
+    assert rollback_ranks == [0]
+
+
+# ---------------------------------------------------------------------------
+# Structured-container direct-entrypoint contract
+# ---------------------------------------------------------------------------
+
+def test_structured_start_emits_entrypoint_flag(tmp_path):
+    """docker run must include --entrypoint <argv[0]> before the image."""
+    sc_path = _write_structured(tmp_path, "cache", _structured_doc())
+    profile = _write_profile(tmp_path, "engine", _generic_doc())
+    doc = _bundle_doc([
+        _structured_service("cache", "cache", sc_path),
+        _native_service("engine", "serving", profile, depends_on=["cache"]),
+    ])
+    path = _write_bundle(tmp_path, doc)
+    bundle = bundle_mod.load_bundle(path)
+    site = load_site(_site(tmp_path))
+    actions = bundle_mod._native_start_actions(site, bundle.services[0], bundle)
+    cmd = actions[0].shell_command
+    assert "--entrypoint /opt/bin/cache-server" in cmd
+    # argv[0] must NOT appear after the image (it's the entrypoint, not a CMD arg)
+    # Find image_id position; everything after it is CMD args = argv[1:]
+    image_id = "sha256:" + "b" * 64
+    # image_id appears in both the guard and docker run; use last occurrence
+    idx = cmd.rindex(image_id)
+    after_image = cmd[idx + len(image_id):]
+    assert "/opt/bin/cache-server" not in after_image
+    # argv[1:] must appear after the image
+    assert "--port" in after_image
+    assert "6556" in after_image
+
+
+def test_structured_start_entrypoint_overrides_image_entrypoint(tmp_path):
+    """An inherited image ENTRYPOINT cannot override the declared executable.
+
+    Docker's --entrypoint flag always takes precedence over the image's
+    built-in ENTRYPOINT.  Verify the command shape puts argv[0] as
+    --entrypoint so no image entrypoint can intercept it.
+    """
+    sc_path = _write_structured(tmp_path, "cache", _structured_doc(
+        argv=["/opt/venv/bin/lmcache", "server",
+              "--port", "6556", "--kv-Role", "LMCacheWorker"],
+    ))
+    profile = _write_profile(tmp_path, "engine", _generic_doc())
+    doc = _bundle_doc([
+        _structured_service("cache", "cache", sc_path),
+        _native_service("engine", "serving", profile, depends_on=["cache"]),
+    ])
+    path = _write_bundle(tmp_path, doc)
+    bundle = bundle_mod.load_bundle(path)
+    site = load_site(_site(tmp_path))
+    actions = bundle_mod._native_start_actions(site, bundle.services[0], bundle)
+    cmd = actions[0].shell_command
+    assert "--entrypoint /opt/venv/bin/lmcache" in cmd
+    image_id = "sha256:" + "b" * 64
+    idx = cmd.rindex(image_id)
+    after_image = cmd[idx + len(image_id):]
+    # Only argv[1:] should follow the image
+    assert "server" in after_image
+    assert "--port" in after_image
+    assert "6556" in after_image
+    assert "--kv-Role" in after_image
+    assert "LMCacheWorker" in after_image
+    # argv[0] must not be duplicated after the image
+    assert "/opt/venv/bin/lmcache" not in after_image
+
+
+def test_structured_start_zero_argument_executable(tmp_path):
+    """A zero-argument executable (argv has only argv[0]) must work."""
+    sc_path = _write_structured(tmp_path, "cache", _structured_doc(
+        argv=["/opt/bin/standalone-cache"],
+    ))
+    profile = _write_profile(tmp_path, "engine", _generic_doc())
+    doc = _bundle_doc([
+        _structured_service("cache", "cache", sc_path),
+        _native_service("engine", "serving", profile, depends_on=["cache"]),
+    ])
+    path = _write_bundle(tmp_path, doc)
+    bundle = bundle_mod.load_bundle(path)
+    site = load_site(_site(tmp_path))
+    actions = bundle_mod._native_start_actions(site, bundle.services[0], bundle)
+    cmd = actions[0].shell_command
+    assert "--entrypoint /opt/bin/standalone-cache" in cmd
+    image_id = "sha256:" + "b" * 64
+    # The docker run command itself ends at the image with no trailing args
+    # Nothing should follow the image when argv has only one element
+    # (the guard "test ... && exec ..." is before the docker run)
+    # The docker run command itself ends at the image with no trailing args
+    docker_part = cmd[cmd.index("docker run"):]
+    # Split on image_id — everything after image in the docker command
+    docker_after = docker_part[docker_part.index(image_id) + len(image_id):]
+    # Should be empty or just the closing quote of exec
+    assert "--port" not in docker_after
+    assert "6556" not in docker_after
+
+
+def test_structured_start_arguments_are_exact_tokens(tmp_path):
+    """Arguments must remain exact tokens — no shell interpolation."""
+    sc_path = _write_structured(tmp_path, "cache", _structured_doc(
+        argv=["/opt/bin/cache-server", "--port", "6556",
+              "--extra", "value with spaces", "--flag"],
+    ))
+    profile = _write_profile(tmp_path, "engine", _generic_doc())
+    doc = _bundle_doc([
+        _structured_service("cache", "cache", sc_path),
+        _native_service("engine", "serving", profile, depends_on=["cache"]),
+    ])
+    path = _write_bundle(tmp_path, doc)
+    bundle = bundle_mod.load_bundle(path)
+    site = load_site(_site(tmp_path))
+    actions = bundle_mod._native_start_actions(site, bundle.services[0], bundle)
+    cmd = actions[0].shell_command
+    # shlex.join preserves tokens with spaces via quoting
+    assert "--entrypoint /opt/bin/cache-server" in cmd
+    # The value-with-spaces must be quoted, not split
+    assert "value with spaces" in cmd  # shlex.join quotes it but content present
+    image_id = "sha256:" + "b" * 64
+    # The digest occurs in both the identity guard and docker run.  Inspect
+    # arguments after the final occurrence, which is the actual image token.
+    idx = cmd.rindex(image_id)
+    after_image = cmd[idx + len(image_id):]
+    assert "--port" in after_image
+    assert "6556" in after_image
+    assert "--extra" in after_image
+    assert "--flag" in after_image
+
+
+def test_structured_shell_entrypoint_still_rejected(tmp_path):
+    """Shell entrypoints must remain rejected under the entrypoint contract."""
+    for shell in ["/bin/sh", "/bin/bash", "sh", "bash", "/usr/bin/zsh",
+                  "pwsh", "powershell", "cmd", "/bin/ash", "/bin/dash"]:
+        sc_path = _write_structured(tmp_path, f"cache-{shell.replace('/', '_')}",
+                                    _structured_doc(argv=[shell, "-c", "true"]))
+        doc = _bundle_doc([_structured_service("cache", "cache", sc_path)])
+        path = _write_bundle(tmp_path, doc)
+        with pytest.raises(bundle_mod.BundleError) as exc:
+            bundle_mod.load_bundle(path)
+        assert "shell entrypoint" in str(exc.value).lower()
+
+
+def test_structured_start_plan_stable_with_entrypoint(tmp_path):
+    """Plan output must be deterministic and stable with the --entrypoint fix."""
+    sc_path = _write_structured(tmp_path, "cache", _structured_doc())
+    profile = _write_profile(tmp_path, "engine", _generic_doc())
+    doc = _bundle_doc([
+        _structured_service("cache", "cache", sc_path),
+        _native_service("engine", "serving", profile, depends_on=["cache"]),
+    ])
+    path = _write_bundle(tmp_path, doc)
+    site = _site(tmp_path)
+    rc1, out1, _ = _run_cli(path, site, "plan")
+    assert rc1 == 0
+    rc2, out2, _ = _run_cli(path, site, "plan")
+    assert rc2 == 0
+    assert out1 == out2, "plan output must be byte-identical across runs"
+    # Plan must show --entrypoint in the action command
+    assert "--entrypoint" in out1
+    assert "/opt/bin/cache-server" in out1
+
+
+# ---------------------------------------------------------------------------
+# Structured-container naming and rank representability
+# ---------------------------------------------------------------------------
+
+def test_structured_no_doubled_rank_suffix(tmp_path):
+    """container_name base must not end in -rN; builder appends -r{rank}."""
+    sc_path = _write_structured(tmp_path, "cache", _structured_doc(
+        container_name="sparkring-bundle-lmcache-cs512",
+    ))
+    profile = _write_profile(tmp_path, "engine", _generic_doc())
+    doc = _bundle_doc([
+        _structured_service("cache", "cache", sc_path, ranks=[1]),
+        _native_service("engine", "serving", profile, depends_on=["cache"]),
+    ])
+    path = _write_bundle(tmp_path, doc)
+    bundle = bundle_mod.load_bundle(path)
+    site = load_site(_site(tmp_path))
+    actions = bundle_mod._native_start_actions(site, bundle.services[0], bundle)
+    cmd = actions[0].shell_command
+    # The effective name must be base-r1, NOT base-r1-r1
+    assert "sparkring-bundle-lmcache-cs512-r1" in cmd
+    assert "sparkring-bundle-lmcache-cs512-r1-r1" not in cmd
+
+
+def test_disjoint_ranks_same_container_name_no_collision(tmp_path):
+    """Same unsuffixed container_name with disjoint rank scopes must not collide."""
+    # All four cache services share the same container_name base but target
+    # different ranks, so the effective names (base-r0, base-r1, ...) are unique.
+    services = []
+    for rank in range(4):
+        sc_path = _write_structured(tmp_path, f"cache-r{rank}", _structured_doc(
+            container_name="sparkring-bundle-lmcache-cs512",
+        ))
+        services.append(_structured_service(
+            f"lmcache-r{rank}", "cache", sc_path, ranks=[rank],
+        ))
+    profile = _write_profile(tmp_path, "engine", _generic_doc())
+    services.append(_native_service(
+        "engine", "serving", profile,
+        depends_on=[f"lmcache-r{r}" for r in range(4)],
+    ))
+    doc = _bundle_doc(services)
+    path = _write_bundle(tmp_path, doc)
+    # Must load without collision error
+    bundle_mod.load_bundle(path)
+    # Plan must succeed and produce 4 cache + 4 engine = 8 start actions
+    rc, out, err = _run_cli(path, _site(tmp_path), "plan")
+    assert rc == 0, err
+    plan = json.loads(out)
+    # Collect all start-phase actions across all phases entries
+    all_actions = []
+    for phase in plan["phases"]:
+        if phase["phase"] == "start":
+            all_actions.extend(phase["actions"])
+    cache_names = set()
+    for a in all_actions:
+        for token in a["remote_command"].split():
+            if "sparkring-bundle-lmcache-cs512-r" in token:
+                cache_names.add(token)
+    # Each rank produces a unique effective name
+    assert len(cache_names) == 4
+    assert cache_names == {
+        "sparkring-bundle-lmcache-cs512-r0",
+        "sparkring-bundle-lmcache-cs512-r1",
+        "sparkring-bundle-lmcache-cs512-r2",
+        "sparkring-bundle-lmcache-cs512-r3",
+    }


### PR DESCRIPTION
## Resulting behavior

- permits structured cache and sidecar services to target an explicit, non-empty set of site ranks
- rejects unknown, duplicate, negative, or incompatible rank scopes before plan or execution
- applies rank scope consistently to start, readiness, status, stop, rollback verification, collision checks, and plan/diff projections
- runs structured-container argv[0] through Docker's explicit --entrypoint so an inherited image entrypoint cannot intercept the declared executable
- preserves all-rank runtime-profile serving and canonical bridge contracts

## Safety and compatibility

Omitting ranks remains backward-compatible and targets all site ranks. Runtime-profile serving and canonical bridge services reject rank scoping. This PR performs no remote operations and changes no serving configuration.

## Validation

- focused bundle tests: 178 passed, 1 skipped
- full offline repository suite: 2,445 passed, 14 skipped
- repo-wide Ruff E/F/W: passed
- Python compilation and diff checks: passed