### PR TITLE
runtime: disclose LMCache lifecycle plan contract

### DIFF
--- a/scripts/sparkring_exl3_lmcache_launcher.py
+++ b/scripts/sparkring_exl3_lmcache_launcher.py
@@ -383,6 +383,24 @@ def lifecycle_sequence(
         for name, timeout in raw
     ]
 
+
+def rank_completeness(phases: dict[str, list[exl3.RemoteAction]], site) -> dict:
+    """Describe whether every lifecycle phase targets every configured rank."""
+    required = sorted(rank.id for rank in site.ranks)
+    phase_rank_ids = {
+        name: sorted(action.rank for action in actions)
+        for name, actions in phases.items()
+    }
+    return {
+        "required_ranks": len(required),
+        "rank_ids": required,
+        "phase_rank_ids": phase_rank_ids,
+        "all_phases_have_all_ranks": all(
+            rank_ids == required for rank_ids in phase_rank_ids.values()
+        ),
+    }
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
     parser.add_argument("--site", required=True)
@@ -411,6 +429,7 @@ def main(argv: list[str] | None = None) -> int:
     except (OSError, KeyError, json.JSONDecodeError, SiteConfigError, exl3.ProfileError) as exc:
         parser.error(str(exc))
 
+    seq = lifecycle_sequence(args.command, profile)
     plan = {
         "schema": "sparkring-public-exl3-lmcache-plan/v1",
         "profile_id": PROFILE_ID,
@@ -418,6 +437,43 @@ def main(argv: list[str] | None = None) -> int:
         "mutates_remote": args.command
         in ("start", "restart-engines", "restart-stack", "rollback"),
         "phases": {name: render(actions) for name, actions in phases.items()},
+        "lifecycle": seq,
+        "rank_completeness": rank_completeness(phases, site),
+        "ownership_guards": {
+            "profile_label": "org.sparkring.exl3-profile",
+            "component_label": "org.sparkring.component",
+            "managed_label": "org.sparkring.managed",
+            "rollback_exit_73": (
+                "foreign container with same name but different profile "
+                "label is not removed (exit 73)"
+            ),
+            "rollback_exit_74": (
+                "component label mismatch on targeted removal (exit 74)"
+            ),
+        },
+        "readiness_scope": {
+            "checks": [
+                "container State.Running = true",
+                "RestartCount = 0",
+                "State.OOMKilled = false",
+                "no CUDA out of memory|OutOfMemoryError|OOMKilled in logs",
+                "rank 0: /health and /v1/models return HTTP success",
+                "nonzero ranks: container running (headless, no API)",
+                "LMCache server: /healthcheck and /status endpoints responding",
+            ],
+            "does_not_verify": [
+                "model output correctness or determinism",
+                "fabric qualification or transport probe",
+                "performance or throughput",
+                "LMCache cache hit ratio or persistence",
+                "graph capture completeness",
+            ],
+            "engine_timeout_seconds": profile.startup_timeout_seconds + 60,
+        },
+        "plan_disclaimer": (
+            "A successful plan is not acceptance; it describes what the "
+            "launcher would do, not what the deployment achieves"
+        ),
     }
     if args.command == "plan" or not args.execute:
         print(json.dumps(plan, indent=2))
@@ -430,10 +486,8 @@ def main(argv: list[str] | None = None) -> int:
     ) and args.confirmation != CONFIRMATION:
         parser.error(f"execute requires --confirmation {CONFIRMATION}")
 
-    # Consume the same lifecycle oracle exported to the bundle bridge for
-    # every executable command, including read-only status/verification and
-    # rollback itself.
-    seq = lifecycle_sequence(args.command, profile)
+    # Reuse the lifecycle sequence already computed for the plan document
+    # so the bundle bridge and execution path share one oracle call.
     results = {}
     any_failed = False
     for step in seq:

--- a/scripts/test_sparkring_exl3_lmcache_launcher.py
+++ b/scripts/test_sparkring_exl3_lmcache_launcher.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 import subprocess
+from types import SimpleNamespace
 
 import pytest
 
@@ -122,6 +123,92 @@ def test_plan_is_dry_run_and_records_every_phase(tmp_path, capsys):
         "verify_rollback",
     }
     assert all(len(actions) == 4 for actions in document["phases"].values())
+
+def test_plan_discloses_lifecycle_sequence(tmp_path, capsys):
+    site_path, profile_path = generated(tmp_path)
+    lmcache.main(
+        ["--site", str(site_path), "--profile", str(profile_path), "plan"]
+    )
+    document = json.loads(capsys.readouterr().out)
+    seq = document["lifecycle"]
+    assert isinstance(seq, list)
+    assert all("phase" in step and "timeout" in step for step in seq)
+    assert all("on_failure" in step for step in seq)
+
+
+def test_plan_discloses_rank_completeness(tmp_path, capsys):
+    site_path, profile_path = generated(tmp_path)
+    lmcache.main(
+        ["--site", str(site_path), "--profile", str(profile_path), "plan"]
+    )
+    document = json.loads(capsys.readouterr().out)
+    rc = document["rank_completeness"]
+    assert rc["required_ranks"] == 4
+    assert rc["rank_ids"] == [0, 1, 2, 3]
+    assert all(
+        rank_ids == [0, 1, 2, 3]
+        for rank_ids in rc["phase_rank_ids"].values()
+    )
+    assert rc["all_phases_have_all_ranks"] is True
+
+
+def test_rank_completeness_requires_exact_rank_identity():
+    site = SimpleNamespace(
+        ranks=[SimpleNamespace(id=0), SimpleNamespace(id=1)]
+    )
+    complete = {
+        "ready": [SimpleNamespace(rank=0), SimpleNamespace(rank=1)]
+    }
+    duplicate = {
+        "ready": [SimpleNamespace(rank=0), SimpleNamespace(rank=0)]
+    }
+    missing = {"ready": [SimpleNamespace(rank=0)]}
+
+    assert lmcache.rank_completeness(
+        complete, site
+    )["all_phases_have_all_ranks"] is True
+    assert lmcache.rank_completeness(
+        duplicate, site
+    )["all_phases_have_all_ranks"] is False
+    assert lmcache.rank_completeness(
+        missing, site
+    )["all_phases_have_all_ranks"] is False
+
+
+def test_plan_discloses_ownership_guards(tmp_path, capsys):
+    site_path, profile_path = generated(tmp_path)
+    lmcache.main(
+        ["--site", str(site_path), "--profile", str(profile_path), "plan"]
+    )
+    document = json.loads(capsys.readouterr().out)
+    guards = document["ownership_guards"]
+    assert "org.sparkring.exl3-profile" in guards["profile_label"]
+    assert "exit 73" in guards["rollback_exit_73"]
+    assert "exit 74" in guards["rollback_exit_74"]
+
+
+def test_plan_discloses_readiness_scope_truthfully(tmp_path, capsys):
+    site_path, profile_path = generated(tmp_path)
+    lmcache.main(
+        ["--site", str(site_path), "--profile", str(profile_path), "plan"]
+    )
+    document = json.loads(capsys.readouterr().out)
+    scope = document["readiness_scope"]
+    assert "checks" in scope
+    assert "does_not_verify" in scope
+    assert any("determinism" in item for item in scope["does_not_verify"])
+    assert any("fabric" in item for item in scope["does_not_verify"])
+    assert "engine_timeout_seconds" in scope
+    assert any("HTTP success" in item for item in scope["checks"])
+
+
+def test_plan_has_disclaimer(tmp_path, capsys):
+    site_path, profile_path = generated(tmp_path)
+    lmcache.main(
+        ["--site", str(site_path), "--profile", str(profile_path), "plan"]
+    )
+    document = json.loads(capsys.readouterr().out)
+    assert "not acceptance" in document["plan_disclaimer"]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Resulting behavior

The EXL3+LMCache dry-run plan now exposes:

- the exact ordered lifecycle and per-phase failure policy
- the required site ranks and exact rank IDs scheduled by every phase
- ownership-label and rollback exit-code guards
- readiness checks, explicit exclusions, and engine timeout
- a clear statement that a successful plan is not deployment acceptance

Planning and execution reuse the same lifecycle sequence, avoiding drift between the receipt and executed order.

## Corrections made during extraction

- rank completeness compares exact rank identities, so duplicate or missing actions cannot pass by list length
- the /v1/models probe is described as HTTP-success only; it does not claim model-list semantic validation

## Validation

- focused launcher tests: 24 passed
- full offline repository suite: 2,451 passed, 14 skipped
- repo-wide Ruff E/F/W: passed
- Python compilation and diff checks: passed

No remote actions or serving changes were performed.