### PR TITLE
runtime: add fail-closed startup evidence classifier

### DIFF
--- a/docs/EXL3_ACCEPTANCE_RUNBOOK.md
+++ b/docs/EXL3_ACCEPTANCE_RUNBOOK.md
@@ -312,6 +312,55 @@ sequences, and lazy 1-GiB LMCache L1. A stale container with a different profile
 label is intentionally not removed. Preserve the failing evidence and resolve
 the named conflict manually.
 
+For an offline, machine-readable classification of already captured startup
+logs, run `scripts/sparkring_startup_evidence.py`. The classifier is
+`offline-validated`: it does not contact a Spark, establish a safe retry bound,
+or replace container inspection. It reports `clean`, `bounded_rm_retry`,
+`indeterminate`, or `fatal` under the
+`sparkring-startup-evidence/v1` schema. Missing engine evidence, stopped
+containers, incomplete timestamp context, and unaligned per-rank inputs fail
+closed.
+
+Supply four engine logs and their matching `docker inspect` JSON documents in
+rank order. When present, supply exactly one kernel or LMCache-server log for
+every engine rank; server logs also require matching inspection JSON. The
+following example classifies four engine and kernel logs. Replace
+`REVIEWED_RM_EVENT_BOUND` only with a bound established by a separately
+reviewed operating policy:
+
+```bash
+python scripts/sparkring_startup_evidence.py \
+  --engine-log evidence/engine-r0.log \
+  --engine-log evidence/engine-r1.log \
+  --engine-log evidence/engine-r2.log \
+  --engine-log evidence/engine-r3.log \
+  --engine-inspect evidence/engine-r0-inspect.json \
+  --engine-inspect evidence/engine-r1-inspect.json \
+  --engine-inspect evidence/engine-r2-inspect.json \
+  --engine-inspect evidence/engine-r3-inspect.json \
+  --engine-container-name glm52-sparkring-exl3-lmcache-cs512-r0 \
+  --engine-container-name glm52-sparkring-exl3-lmcache-cs512-r1 \
+  --engine-container-name glm52-sparkring-exl3-lmcache-cs512-r2 \
+  --engine-container-name glm52-sparkring-exl3-lmcache-cs512-r3 \
+  --kernel-log evidence/kernel-r0.log \
+  --kernel-log evidence/kernel-r1.log \
+  --kernel-log evidence/kernel-r2.log \
+  --kernel-log evidence/kernel-r3.log \
+  --engine-log-year 2026 \
+  --engine-log-tz=-05:00 \
+  --rm-event-bound REVIEWED_RM_EVENT_BOUND \
+  --cluster-ready \
+  classify > evidence/startup-classification.json
+```
+
+`--cluster-ready` is an explicit operator-supplied fact, not a network probe.
+The expected names bind each inspection document to its role and rank. The
+inspection documents must expose `Id`, `Name`, `State.Running`,
+`State.OOMKilled`, and `RestartCount`; duplicate identities and name mismatches
+fail closed, while a stopped, restarted, or OOM-killed component is fatal. Do
+not use a successful classification to relabel a generic CUDA OOM, Xid,
+restart, fabric loss, or driver failure as recoverable.
+
 ### Warm cache does not beat cold cache
 
 Confirm all four servers stored objects and have one registered GPU context.
@@ -350,13 +399,15 @@ python -m pytest \
   scripts/test_acceptance_gate.py \
   scripts/test_exl3_correctness_gate.py \
   scripts/test_exl3_cache_acceptance.py \
-  scripts/test_sparkring_exl3_lmcache_launcher.py -q
+  scripts/test_sparkring_exl3_lmcache_launcher.py \
+  scripts/test_sparkring_startup_evidence.py -q
 
 ruff check --select E,F,W --ignore E501 \
   scripts/acceptance_gate.py \
   scripts/exl3_correctness_gate.py \
   scripts/exl3_cache_acceptance.py \
-  scripts/sparkring_exl3_lmcache_launcher.py
+  scripts/sparkring_exl3_lmcache_launcher.py \
+  scripts/sparkring_startup_evidence.py
 ```
 
 The full repository validation remains the command in [CONTRIBUTING.md](../CONTRIBUTING.md).

--- a/scripts/sparkring_startup_evidence.py
+++ b/scripts/sparkring_startup_evidence.py
@@ -1,0 +1,1279 @@
+#!/usr/bin/env python3
+"""Stage-aware startup evidence classifier for EXL3 + LMCache.
+
+Parses engine logs, kernel logs, and LMCache-server container logs plus
+explicit container-running facts to classify startup evidence into four
+verdicts:
+
+- **clean**: no concerning signatures.
+- **bounded_rm_retry**: a kernel RM ``NV_ERR_NO_MEMORY`` event at the
+  evidenced callsite (``_memdescAllocInternal @ mem_desc.c:1359``) occurred
+  during the EXL3 per-layer mixed-Trellis materialization window (from first
+  ``model.layers.<n>`` line through last ``model.layers.<n>`` line),
+  every event timestamp falls inside that window, the container stayed
+  running (``Running = true``, ``RestartCount = 0``, ``OOMKilled =
+  false``), no fatal signatures are present, a per-rank post-materialization
+  success milestone was reached after the window, a cluster/API readiness
+  fact (supplied separately) confirms the rank is serving, and the event
+  count is within an explicit operator-supplied window-event-count bound.
+- **fatal**: Xid GPU errors, ``torch.OutOfMemoryError``, generic CUDA OOM,
+  OOM-killed containers, unexpected restarts, SSH connection failures,
+  fabric/RoCE carrier loss, or driver init failures.  These are never
+  downgraded regardless of later progress.
+- **indeterminate**: a kernel RM event is observed but cross-evidence
+  cannot be truthfully correlated — e.g. timestamps are missing or
+  malformed, the event falls outside the per-layer materialization window,
+  no post-materialization success milestone is reached, readiness is
+  missing or earlier than the window end, year/timezone cannot be inferred,
+  or the operator-supplied bound is absent.  Indeterminate is treated as
+  fatal-policy (exit code ``EXIT_FATAL``).
+
+**Materialization window.** The window is strictly from the first
+``EXL3 mixed Trellis model.layers.<n>`` timestamp through the last
+``model.layers.<n>`` timestamp.  Lines like ``mixed Trellis runtime
+planned`` do NOT extend the window.  A post-materialization success
+milestone (``Graph capturing finished``, ``Kernel JIT monitor
+activated``, or another exact rank log milestone) must be reached after
+the window.  Cluster/API readiness (``--cluster-ready``) is a separate
+fact that must also be supplied; LMCache server readiness alone does not
+qualify a rank as bounded.
+
+**Timestamp parsing.** Kernel ISO timestamps
+(``2026-08-09T00:16:52.113635-05:00``) and vLLM log prefixes
+(``(Worker...) INFO 08-09 05:24:32 [...]``) are parsed and normalized
+to UTC.  vLLM timestamps lack year and timezone; supply
+``--engine-log-year`` and ``--engine-log-tz``.  If year is supplied
+without timezone, naive datetimes would be incomparable with aware kernel
+datetimes — the classifier fails closed to ``indeterminate`` rather than
+crashing.  If year or timezone cannot be inferred unambiguously, the
+verdict is ``indeterminate``.
+
+**Window event count.** The report field ``window_event_count`` is the
+count of RM events in the supplied kernel-log slice.  It is NOT a delta
+(subtraction); operators must capture a bounded kernel window and the
+report includes the kernel-log hash for provenance.  The accepted count
+bound is operator-supplied via ``--rm-event-bound``; if absent and RM
+events are present, the verdict is ``indeterminate`` (fail closed).
+
+The classifier is **purely diagnostic**: it reads evidence that has already
+been captured (log files and ``docker inspect`` JSON) and returns a structured
+JSON report.  It does not contact the cluster, start or stop anything, or
+modify any host.
+
+**This tool classifies supplied evidence and never establishes a safe
+bound itself.** It remains offline-validated until run on sanitized
+captured evidence.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Sequence
+
+SCHEMA = "sparkring-startup-evidence/v1"
+EXPECTED_RANKS = 4
+
+# Exit codes
+EXIT_OK = 0
+EXIT_FATAL = 2
+EXIT_CONFIG_ERROR = 3
+
+# ---------------------------------------------------------------------------
+# Verdict ordering (worst wins)
+# ---------------------------------------------------------------------------
+
+VERDICT_RANK = {
+    "clean": 0,
+    "bounded_rm_retry": 1,
+    "indeterminate": 2,
+    "fatal": 3,
+}
+
+# ---------------------------------------------------------------------------
+# Signature patterns
+# ---------------------------------------------------------------------------
+
+# Fatal: Xid errors (NVIDIA Xid 13/31/43/48/62/63/74/79/119/120/121 etc.)
+_XID = re.compile(r"Xid\s+\d+|NVRM:\s+Xid", re.IGNORECASE)
+
+# Fatal: generic CUDA OOM, torch.OutOfMemoryError, OutOfMemoryError
+_GENERIC_OOM = re.compile(
+    r"CUDA out of memory|"
+    r"torch\.OutOfMemoryError|"
+    r"OutOfMemoryError\s*\[|"
+    r"OutOfMemoryError",
+    re.IGNORECASE,
+)
+
+# Fatal: process killed by OOM (OOMKilled, or explicit kill)
+_OOMKILLED = re.compile(
+    r'["\']?OOMKilled["\']?\s*[:=]\s*(?:true|1)\b|'
+    r"Killed process",
+    re.IGNORECASE,
+)
+
+# Fatal: container restart (unexpected, not an operator-initiated restart)
+_RESTART = re.compile(
+    r"container\s+\S+\s+restarted|"
+    r"Container\s+\S+\s+is\s+restarting|"
+    r'["\']?RestartCount["\']?\s*[:=]\s*[1-9]\d*\b',
+    re.IGNORECASE,
+)
+
+# Fatal: SSH / connection failures during startup
+_SSH_FAIL = re.compile(
+    r"ssh:\s+(connect|connection).*\b(refused|timed out|failed|reset)|"
+    r"Lost connection|"
+    r"ssh_dispatch_run_fatal",
+    re.IGNORECASE,
+)
+
+# Fatal: fabric / RoCE / NCCL bootstrap failures and carrier loss
+_FABRIC_FAIL = re.compile(
+    r"NCCL.*\b(FAILED|FATAL|abort)\b|"
+    r"RoCE.*\b(failed|error)\b|"
+    r"IB.*\b(no\s+path|unreachable|link\s+down)\b|"
+    r"transport\s+probe\s+failed|"
+    r"bootstrap\s+failed|"
+    r"carrier\s+(loss|down)",
+    re.IGNORECASE,
+)
+
+# Fatal: CUDA driver / runtime init failure
+_DRIVER_FAIL = re.compile(
+    r"cuda(Init|Driver|SetDevice).*\b(failed|error)\b|"
+    r"all\s+CUDA-capable\s+devices\s+are\s+busy|"
+    r"no\s+CUDA-capable\s+device\s+detected|"
+    r"CUDA\s+error\s+:\s+no\s+kernel\s+image",
+    re.IGNORECASE,
+)
+
+# Bounded RM retry: the evidenced kernel signature.
+# NV_ERR_NO_MEMORY at _memdescAllocInternal @ mem_desc.c:1359
+_RM_KERNEL_EVENT = re.compile(
+    r"NV_ERR_NO_MEMORY.*_memdescAllocInternal\s*@\s*mem_desc\.c:\s*1359",
+    re.IGNORECASE,
+)
+
+# Any unrecognized NV_ERR_NO_MEMORY event remains indeterminate. Only the
+# exact allowlisted callsite above can enter bounded_rm_retry evaluation.
+_ANY_RM_KERNEL_EVENT = re.compile(r"\bNV_ERR_NO_MEMORY\b", re.IGNORECASE)
+
+# Per-layer mixed-Trellis materialization — the evidenced line shape.
+# Matches "EXL3 mixed Trellis model.layers.<n>.mlp.experts" and similar
+# per-layer materialization lines.  Does NOT match "mixed Trellis runtime
+# planned" or other non-per-layer lines.
+_PER_LAYER_MATERIALIZE = re.compile(
+    r"mixed\s+Trellis\s+model\.layers\.\d+|"
+    r"model\.layers\.\d+.*mixed\s+Trellis|"
+    r"EXL3\s+mixed\s+Trellis\s+model\.layers\.\d+",
+    re.IGNORECASE,
+)
+
+# Post-materialization per-rank success milestones.
+# These are rank-specific milestones that indicate the rank completed
+# materialization and continued successfully.  Headless ranks (1-3) do
+# not emit rank-0 API strings, so these milestones are used instead.
+_POST_MATERIALIZE_SUCCESS = re.compile(
+    r"Graph\s+capturing\s+finished|"
+    r"Kernel\s+JIT\s+monitor\s+activated|"
+    r"graph\s+capture\s+complete|"
+    r"CUDA\s+graphs?\s+(?:captured|done|complete)",
+    re.IGNORECASE,
+)
+
+# Cluster/API readiness — supplied as a separate fact, not inferred from
+# LMCache server readiness.
+# Engine readiness for rank 0: API server strings.
+_ENGINE_API_READY = re.compile(
+    r"Engine is ready|"
+    r"API server started|"
+    r"Uvicorn running",
+    re.IGNORECASE,
+)
+
+# General progress (for informational reporting, not for verdict logic)
+_PROGRESS = re.compile(
+    r"Model loaded|"
+    r"KV cache allocated|"
+    r"Capturing CUDA graphs|"
+    r"Engine is ready|"
+    r"Uvicorn running|"
+    r"API server started|"
+    r"Worker ready|"
+    r"init engine|"
+    r"Memory profiling done|"
+    r"KV allocation complete|"
+    r"layer\s+\d+.*(?:done|complete|loaded|ready)|"
+    r"Graph capturing finished|"
+    r"Kernel JIT monitor activated",
+    re.IGNORECASE,
+)
+
+# LMCache server readiness (informational only, does NOT qualify bounded)
+_LMCACHE_READY = re.compile(
+    r"LMCache.*server.*started|"
+    r"storage_manager.*initialized|"
+    r"Listening on",
+    re.IGNORECASE,
+)
+
+# Timestamp patterns
+
+# Kernel ISO: 2026-08-09T00:16:52.113635-05:00 or 2026-08-09T00:16:52Z
+_KERNEL_TS = re.compile(
+    r"(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?"
+    r"(?:[+-]\d{2}:\d{2}|Z))"
+)
+
+# vLLM prefix: (Worker pid=1234) INFO 08-09 05:24:32.123456
+# Also matches Worker_TP0_DCP0 style prefixes
+_VLLM_TS = re.compile(
+    r"(?:\(Worker\s+\S+\)\s+)?"
+    r"(?:INFO|WARNING|ERROR)\s+"
+    r"(\d{2})-(\d{2})\s+(\d{2}):(\d{2}):(\d{2})(?:\.(\d+))?"
+)
+
+ALL_FATAL_PATTERNS = [
+    ("xid", _XID),
+    ("generic_oom", _GENERIC_OOM),
+    ("oomkilled", _OOMKILLED),
+    ("unexpected_restart", _RESTART),
+    ("ssh_failure", _SSH_FAIL),
+    ("fabric_failure", _FABRIC_FAIL),
+    ("driver_failure", _DRIVER_FAIL),
+]
+
+
+class ConfigError(ValueError):
+    """The operator supplied an invalid argument."""
+
+
+# ---------------------------------------------------------------------------
+# Timestamp parsing
+# ---------------------------------------------------------------------------
+
+
+def _to_utc(dt: datetime) -> datetime:
+    """Normalize a datetime to UTC. Raises if naive and cannot be converted."""
+    if dt.tzinfo is None:
+        raise ValueError("naive datetime cannot be normalized to UTC")
+    return dt.astimezone(timezone.utc)
+
+
+def _parse_kernel_timestamp(line: str) -> datetime | None:
+    """Extract and parse a kernel ISO timestamp, normalized to UTC.
+
+    Returns None when no ISO timestamp pattern is found.
+    Raises ValueError when a timestamp pattern is found but cannot be
+    parsed (malformed date/time values).  The caller must catch this
+    and set ``timestamp_parse_error = True`` so the verdict is
+    indeterminate rather than silently dropping the line.
+    """
+    match = _KERNEL_TS.search(line)
+    if not match:
+        return None
+    raw = match.group(1)
+    dt: datetime | None = None
+    try:
+        try:
+            dt = datetime.fromisoformat(raw)
+        except ValueError:
+            if raw.endswith("Z"):
+                dt = datetime.fromisoformat(raw[:-1] + "+00:00")
+    except (ValueError, TypeError):
+        dt = None
+    if dt is None:
+        raise ValueError(f"unparseable kernel timestamp: {raw!r}")
+    if dt.tzinfo is None:
+        # Kernel ISO without timezone — assume UTC
+        dt = dt.replace(tzinfo=timezone.utc)
+    return _to_utc(dt)
+
+
+def _parse_vllm_timestamp(
+    line: str,
+    *,
+    year: int | None = None,
+    tz: timezone | None = None,
+) -> datetime | None:
+    """Extract and parse a vLLM log-prefix timestamp.
+
+    Returns None if the vLLM timestamp regex does not match (no timestamp
+    on the line) or if year is not supplied.
+    Returns None if tz is not supplied (to avoid naive/aware TypeError).
+    Raises ValueError when the regex matches but the date/time values are
+    invalid (e.g. month 13).  The caller must catch this and set
+    ``timestamp_parse_error = True`` so the verdict is indeterminate
+    rather than silently dropping a malformed materialization-line timestamp.
+    """
+    match = _VLLM_TS.search(line)
+    if not match:
+        return None
+    if year is None:
+        return None
+    if tz is None:
+        return None
+    month = int(match.group(1))
+    day = int(match.group(2))
+    hour = int(match.group(3))
+    minute = int(match.group(4))
+    second = int(match.group(5))
+    frac_str = match.group(6)
+    microsecond = 0
+    if frac_str:
+        microsecond = int(frac_str[:6].ljust(6, "0"))
+    # datetime() raises ValueError for invalid month/day/hour/etc.
+    # Let it propagate so the caller can flag timestamp_parse_error.
+    dt = datetime(year, month, day, hour, minute, second, microsecond)
+    dt = dt.replace(tzinfo=tz)
+    return _to_utc(dt)
+
+
+def _parse_engine_timestamp(
+    line: str,
+    *,
+    year: int | None = None,
+    tz: timezone | None = None,
+) -> datetime | None:
+    """Parse a timestamp from an engine log line, normalized to UTC.
+
+    Tries kernel ISO format first, then vLLM prefix format.
+    Returns None if neither regex matches (no timestamp on the line).
+    Raises ValueError if a timestamp pattern is found but cannot be parsed
+    (malformed date/time values).  The caller must catch this and set
+    ``timestamp_parse_error = True`` so the verdict is indeterminate
+    rather than silently dropping the line.
+    """
+    dt = _parse_kernel_timestamp(line)
+    if dt is not None:
+        return dt
+    return _parse_vllm_timestamp(line, year=year, tz=tz)
+
+
+# ---------------------------------------------------------------------------
+# Log scanning helpers
+# ---------------------------------------------------------------------------
+
+
+def _scan_signatures(
+    lines: list[str],
+    patterns: list[tuple[str, re.Pattern[str]]],
+) -> list[dict[str, Any]]:
+    """Scan lines for signature patterns and return hit records."""
+    hits: list[dict[str, Any]] = []
+    for index, line in enumerate(lines, start=1):
+        for label, pattern in patterns:
+            if pattern.search(line):
+                hits.append({
+                    "pattern": label,
+                    "line_number": index,
+                    "line": line.strip()[:500],
+                })
+    return hits
+
+
+def _parse_container_inspect(text: str) -> dict[str, Any]:
+    """Parse one captured ``docker inspect`` document.
+
+    Docker emits a one-element JSON array. A single object is also accepted
+    so callers may persist the selected object directly. Missing or malformed
+    state is a configuration error, never an implicit healthy state.
+    """
+    try:
+        payload = json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise ConfigError(f"invalid docker inspect JSON: {exc}") from exc
+
+    if isinstance(payload, list):
+        if len(payload) != 1:
+            raise ConfigError("docker inspect JSON must contain exactly one object")
+        payload = payload[0]
+    if not isinstance(payload, dict):
+        raise ConfigError("docker inspect JSON must be an object or one-object array")
+
+    state = payload.get("State")
+    if not isinstance(state, dict):
+        raise ConfigError("docker inspect JSON is missing object field State")
+    running = state.get("Running")
+    oom_killed = state.get("OOMKilled")
+    restart_count = payload.get("RestartCount")
+    container_id = payload.get("Id")
+    container_name = payload.get("Name")
+    if not isinstance(running, bool):
+        raise ConfigError("docker inspect State.Running must be boolean")
+    if not isinstance(oom_killed, bool):
+        raise ConfigError("docker inspect State.OOMKilled must be boolean")
+    if (
+        not isinstance(restart_count, int)
+        or isinstance(restart_count, bool)
+        or restart_count < 0
+    ):
+        raise ConfigError("docker inspect RestartCount must be a non-negative integer")
+    if not isinstance(container_id, str) or not container_id.strip():
+        raise ConfigError("docker inspect Id must be a non-empty string")
+    if not isinstance(container_name, str) or not container_name.strip():
+        raise ConfigError("docker inspect Name must be a non-empty string")
+
+    return {
+        "container_id": container_id,
+        "container_name": container_name,
+        "running": running,
+        "oom_killed": oom_killed,
+        "restart_count": restart_count,
+        "sha256": hashlib.sha256(text.encode("utf-8")).hexdigest(),
+    }
+
+
+def _scan_progress(lines: list[str]) -> list[int]:
+    """Return line numbers of progress lines (informational)."""
+    return [
+        i for i, line in enumerate(lines, start=1)
+        if _PROGRESS.search(line) or _LMCACHE_READY.search(line)
+    ]
+
+
+def _scan_per_layer_materialization(lines: list[str]) -> list[int]:
+    """Return line numbers of per-layer mixed-Trellis materialization lines.
+
+    Only matches lines like ``EXL3 mixed Trellis model.layers.<n>.mlp.experts``.
+    Does NOT match ``mixed Trellis runtime planned`` or similar.
+    """
+    return [
+        i for i, line in enumerate(lines, start=1)
+        if _PER_LAYER_MATERIALIZE.search(line)
+    ]
+
+
+def _scan_post_materialize_success(lines: list[str]) -> list[int]:
+    """Return line numbers of post-materialization success milestones."""
+    return [
+        i for i, line in enumerate(lines, start=1)
+        if _POST_MATERIALIZE_SUCCESS.search(line)
+    ]
+
+
+def _scan_engine_api_ready(lines: list[str]) -> list[int]:
+    """Return line numbers of engine API readiness lines (rank 0 only)."""
+    return [
+        i for i, line in enumerate(lines, start=1)
+        if _ENGINE_API_READY.search(line)
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Classification
+# ---------------------------------------------------------------------------
+
+
+def classify_log(
+    text: str,
+    *,
+    container_running: bool = True,
+    restart_count: int = 0,
+    oom_killed: bool = False,
+    kernel_log: str | None = None,
+    rm_event_bound: int | None = None,
+    engine_log_year: int | None = None,
+    engine_log_tz: timezone | None = None,
+    cluster_ready: bool = False,
+) -> dict[str, Any]:
+    """Classify a single container log, optionally with a kernel log.
+
+    Parameters:
+    - ``container_running``: whether the container was running when
+      evidence was captured.
+    - ``restart_count``: Docker restart count captured with the evidence.
+    - ``oom_killed``: Docker OOM-killed state captured with the evidence.
+    - ``kernel_log``: captured kernel/dmesg log text.
+    - ``rm_event_bound``: operator-supplied accepted window-event-count
+      bound.  If None and RM events are present, verdict is
+      indeterminate (fail closed).  This is a count bound, NOT a delta.
+    - ``engine_log_year``: year for vLLM log timestamps (which lack year).
+    - ``engine_log_tz``: timezone for vLLM log timestamps.  Required
+      when year is supplied; without it, vLLM timestamps cannot be
+      parsed and the verdict is indeterminate.
+    - ``cluster_ready``: separate operator-supplied fact that the
+      cluster/API is ready.  Required for bounded_rm_retry; LMCache
+      server readiness alone does not qualify.
+    """
+    lines = text.splitlines()
+    fatal_hits = _scan_signatures(lines, ALL_FATAL_PATTERNS)
+    for hit in fatal_hits:
+        hit["source"] = "container_log"
+    progress_line_numbers = _scan_progress(lines)
+    per_layer_mat_lines = _scan_per_layer_materialization(lines)
+    post_mat_success_lines = _scan_post_materialize_success(lines)
+    engine_api_ready_lines = _scan_engine_api_ready(lines)
+
+    # Determine if engine_log_year was supplied without tz
+    year_without_tz = engine_log_year is not None and engine_log_tz is None
+
+    # Parse engine log timestamps (all normalized to UTC)
+    engine_timestamps: list[tuple[int, datetime]] = []
+    timestamp_parse_error = False
+    for i, line in enumerate(lines, start=1):
+        try:
+            dt = _parse_engine_timestamp(
+                line, year=engine_log_year, tz=engine_log_tz
+            )
+            if dt is not None:
+                engine_timestamps.append((i, dt))
+        except (ValueError, TypeError):
+            timestamp_parse_error = True
+
+    # Derive per-layer materialization window from real timestamps
+    materialization_window: tuple[datetime, datetime] | None = None
+    window_first: datetime | None = None
+    window_last: datetime | None = None
+
+    materialization_timestamps_monotonic = True
+    if per_layer_mat_lines and engine_timestamps:
+        timestamps_by_line = dict(engine_timestamps)
+        mat_ts = [
+            timestamps_by_line[line_number]
+            for line_number in per_layer_mat_lines
+            if line_number in timestamps_by_line
+        ]
+        if len(mat_ts) == len(per_layer_mat_lines):
+            materialization_timestamps_monotonic = all(
+                earlier <= later for earlier, later in zip(mat_ts, mat_ts[1:])
+            )
+            if materialization_timestamps_monotonic:
+                window_first = mat_ts[0]
+                window_last = mat_ts[-1]
+                materialization_window = (window_first, window_last)
+
+    # Find post-materialization success milestone timestamp
+    post_mat_success_ts: datetime | None = None
+    if post_mat_success_lines and engine_timestamps:
+        success_ts = [
+            dt for ln, dt in engine_timestamps
+            if ln in post_mat_success_lines
+            and per_layer_mat_lines
+            and ln > per_layer_mat_lines[-1]
+        ]
+        if success_ts:
+            post_mat_success_ts = max(success_ts)
+
+    # Find engine API readiness timestamp (rank 0)
+    engine_api_ready_ts: datetime | None = None
+    if engine_api_ready_lines and engine_timestamps:
+        ready_ts = [
+            dt for ln, dt in engine_timestamps
+            if ln in engine_api_ready_lines
+            and per_layer_mat_lines
+            and ln > per_layer_mat_lines[-1]
+        ]
+        if ready_ts:
+            engine_api_ready_ts = max(ready_ts)
+
+    # Kernel RM event detection
+    rm_events: list[dict[str, Any]] = []
+    window_event_count = 0
+    rm_event_within_bound: bool | None = None
+    all_events_in_window = True
+    all_events_have_timestamps = True
+    kernel_sha256: str | None = None
+    unknown_rm_events: list[dict[str, Any]] = []
+
+    if kernel_log is not None:
+        kernel_lines = kernel_log.splitlines()
+        kernel_sha256 = hashlib.sha256(
+            kernel_log.encode("utf-8")
+        ).hexdigest()
+        kernel_fatal_hits = _scan_signatures(kernel_lines, ALL_FATAL_PATTERNS)
+        for hit in kernel_fatal_hits:
+            hit["source"] = "kernel_log"
+        fatal_hits.extend(kernel_fatal_hits)
+
+        raw_rm_hits = _scan_signatures(kernel_lines, [(
+            "nv_err_no_memory_memdesc_alloc", _RM_KERNEL_EVENT,
+        )])
+
+        for index, line in enumerate(kernel_lines, start=1):
+            if _ANY_RM_KERNEL_EVENT.search(line) and not _RM_KERNEL_EVENT.search(line):
+                unknown_rm_events.append({
+                    "pattern": "unrecognized_nv_err_no_memory",
+                    "line_number": index,
+                    "line": line.strip()[:500],
+                    "source": "kernel_log",
+                })
+
+        for hit in raw_rm_hits:
+            kline = kernel_lines[hit["line_number"] - 1]
+            try:
+                kts = _parse_kernel_timestamp(kline)
+            except (ValueError, TypeError):
+                kts = None
+            hit["timestamp"] = kts.isoformat() if kts else None
+            rm_events.append(hit)
+
+        window_event_count = len(rm_events)
+
+        if window_event_count > 0:
+            if rm_event_bound is None:
+                rm_event_within_bound = None  # fail closed
+            else:
+                rm_event_within_bound = window_event_count <= rm_event_bound
+
+            all_events_have_timestamps = all(
+                e["timestamp"] is not None for e in rm_events
+            )
+
+            if all_events_have_timestamps and materialization_window:
+                win_start, win_end = materialization_window
+                for e in rm_events:
+                    edt = datetime.fromisoformat(e["timestamp"])
+                    if edt < win_start or edt > win_end:
+                        all_events_in_window = False
+                        break
+            elif rm_events:
+                all_events_in_window = False
+
+    # Per-rank post-materialization success milestone (must be after window)
+    per_rank_success_after_window = False
+    if materialization_window and engine_timestamps:
+        _, win_end = materialization_window
+        if post_mat_success_ts is not None and post_mat_success_ts > win_end:
+            per_rank_success_after_window = True
+        if engine_api_ready_ts is not None and engine_api_ready_ts > win_end:
+            per_rank_success_after_window = True
+
+    # cluster_ready is a separate operator fact; both are required
+    readiness_after_window = per_rank_success_after_window and cluster_ready
+
+    # Determine verdict
+    if not container_running or restart_count > 0 or oom_killed:
+        verdict = "fatal"
+    elif fatal_hits:
+        verdict = "fatal"
+    elif unknown_rm_events:
+        verdict = "indeterminate"
+    elif window_event_count == 0:
+        verdict = "clean"
+    else:
+        # RM events present — apply cross-evidence protocol
+        if not container_running:
+            verdict = "fatal"
+        elif rm_event_bound is None:
+            verdict = "indeterminate"
+        elif rm_event_within_bound is False:
+            verdict = "fatal"
+        elif year_without_tz or timestamp_parse_error:
+            verdict = "indeterminate"
+        elif not materialization_window:
+            verdict = "indeterminate"
+        elif not all_events_have_timestamps:
+            verdict = "indeterminate"
+        elif not all_events_in_window:
+            verdict = "indeterminate"
+        elif not readiness_after_window:
+            verdict = "indeterminate"
+        elif not cluster_ready:
+            verdict = "indeterminate"
+        else:
+            verdict = "bounded_rm_retry"
+
+    return {
+        "verdict": verdict,
+        "container_running": container_running,
+        "restart_count": restart_count,
+        "oom_killed": oom_killed,
+        "fatal_signatures": fatal_hits,
+        "rm_events": rm_events,
+        "unknown_rm_events": unknown_rm_events,
+        "window_event_count": window_event_count,
+        "rm_event_bound": rm_event_bound,
+        "rm_event_within_bound": rm_event_within_bound,
+        "all_events_have_timestamps": all_events_have_timestamps,
+        "all_events_in_window": all_events_in_window,
+        "materialization_window": (
+            [window_first.isoformat(), window_last.isoformat()]
+            if window_first and window_last
+            else None
+        ),
+        "post_materialization_success": post_mat_success_ts.isoformat()
+            if post_mat_success_ts else None,
+        "engine_api_ready": engine_api_ready_ts.isoformat()
+            if engine_api_ready_ts else None,
+        "readiness_after_window": readiness_after_window,
+        "cluster_ready": cluster_ready,
+        "progress_lines": progress_line_numbers,
+        "materialization_lines": per_layer_mat_lines,
+        "engine_timestamp_count": len(engine_timestamps),
+        "year_without_tz": year_without_tz,
+        "line_count": len(lines),
+        "timestamp_parse_error": timestamp_parse_error,
+        "materialization_timestamps_monotonic": (
+            materialization_timestamps_monotonic
+        ),
+        "sha256": hashlib.sha256(text.encode("utf-8")).hexdigest(),
+        "kernel_sha256": kernel_sha256,
+    }
+
+
+def classify_rank(
+    rank: int,
+    engine_log: str | None = None,
+    server_log: str | None = None,
+    *,
+    engine_running: bool = True,
+    engine_restart_count: int = 0,
+    engine_oom_killed: bool = False,
+    server_running: bool = True,
+    server_restart_count: int = 0,
+    server_oom_killed: bool = False,
+    kernel_log: str | None = None,
+    rm_event_bound: int | None = None,
+    engine_log_year: int | None = None,
+    engine_log_tz: timezone | None = None,
+    cluster_ready: bool = False,
+) -> dict[str, Any]:
+    """Classify startup evidence for one rank.
+
+    The overall rank verdict is the worst of engine and server
+    (fatal > indeterminate > bounded_rm_retry > clean).
+    """
+    engine_result = None
+    server_result = None
+    if engine_log is not None:
+        engine_result = classify_log(
+            engine_log,
+            container_running=engine_running,
+            restart_count=engine_restart_count,
+            oom_killed=engine_oom_killed,
+            kernel_log=kernel_log,
+            rm_event_bound=rm_event_bound,
+            engine_log_year=engine_log_year,
+            engine_log_tz=engine_log_tz,
+            cluster_ready=cluster_ready,
+        )
+    if server_log is not None:
+        server_result = classify_log(
+            server_log,
+            container_running=server_running,
+            restart_count=server_restart_count,
+            oom_killed=server_oom_killed,
+        )
+
+    verdicts = [
+        r["verdict"] for r in (engine_result, server_result) if r is not None
+    ]
+    missing_engine_evidence = engine_result is None
+    rank_verdict = (
+        "indeterminate" if missing_engine_evidence else _worst_verdict(verdicts)
+    )
+
+    return {
+        "rank": rank,
+        "verdict": rank_verdict,
+        "missing_engine_evidence": missing_engine_evidence,
+        "engine": engine_result,
+        "server": server_result,
+    }
+
+
+def _worst_verdict(verdicts: list[str]) -> str:
+    """Return the worst (highest-rank) verdict."""
+    if not verdicts:
+        return "clean"
+    return max(verdicts, key=lambda v: VERDICT_RANK.get(v, 3))
+
+
+def aggregate_report(rank_reports: list[dict[str, Any]]) -> dict[str, Any]:
+    """Aggregate per-rank evidence into a single report.
+
+    One indeterminate or fatal rank dominates the overall verdict.
+    """
+    verdicts = [r["verdict"] for r in rank_reports]
+    overall = _worst_verdict(verdicts)
+
+    def _component_iter():
+        for r in rank_reports:
+            for component in ("engine", "server"):
+                comp = r.get(component)
+                if comp is not None:
+                    yield r, comp
+
+    fatal_count = sum(
+        len(comp["fatal_signatures"]) for _, comp in _component_iter()
+    )
+    rm_event_count = sum(
+        1 for _, comp in _component_iter() if comp.get("rm_events")
+    )
+
+    return {
+        "schema": SCHEMA,
+        "verdict": overall,
+        "rank_count": len(rank_reports),
+        "ranks_fatal": sorted(
+            r["rank"] for r in rank_reports if r["verdict"] == "fatal"
+        ),
+        "ranks_bounded_rm_retry": sorted(
+            r["rank"] for r in rank_reports
+            if r["verdict"] == "bounded_rm_retry"
+        ),
+        "ranks_indeterminate": sorted(
+            r["rank"] for r in rank_reports
+            if r["verdict"] == "indeterminate"
+        ),
+        "ranks_clean": sorted(
+            r["rank"] for r in rank_reports if r["verdict"] == "clean"
+        ),
+        "fatal_signature_count": fatal_count,
+        "bounded_rm_event_rank_count": rm_event_count,
+        "ranks_with_timestamp_parse_error": sorted({
+            r["rank"]
+            for r in rank_reports
+            for component in ("engine", "server")
+            if r.get(component) and r[component].get("timestamp_parse_error")
+        }),
+        "ranks": rank_reports,
+        "evidence_scope": (
+            "Diagnostic classification from captured logs and docker inspect "
+            "state; "
+            "does not contact or mutate the cluster. This tool classifies "
+            "supplied evidence and never establishes a safe bound itself. "
+            "window_event_count is a count in the supplied kernel-log "
+            "slice, not a delta (subtraction). Operators must capture a "
+            "bounded kernel window; the report includes the kernel-log "
+            "hash for provenance."
+        ),
+        "classification_note": (
+            "Generic CUDA out of memory, torch.OutOfMemoryError, OOMKilled, "
+            "Xid, unexpected restarts, SSH failures, fabric carrier loss, "
+            "and driver failures are fatal. Only kernel RM "
+            "NV_ERR_NO_MEMORY at _memdescAllocInternal @ mem_desc.c:1359 "
+            "during the EXL3 per-layer materialization window (first "
+            "model.layers.<n> through last model.layers.<n>) can be "
+            "classified bounded_rm_retry, and only with full cross-evidence: "
+            "container running, RestartCount=0, OOMKilled=false, no fatal "
+            "signatures, window event count within operator-supplied bound, "
+            "every event timestamp inside the per-layer window, "
+            "post-materialization success milestone after window end, "
+            "cluster/API readiness supplied as a separate fact, and "
+            "consistent UTC-normalized timestamps. If the operator-"
+            "supplied bound is absent, year is supplied without timezone, "
+            "timestamps are missing/malformed, events fall outside the "
+            "window, or no post-materialization success/readiness is "
+            "reached, the verdict is indeterminate (fatal policy). "
+            "An NV_ERR_NO_MEMORY event at any other callsite is also "
+            "indeterminate. "
+            "LMCache server readiness alone does not qualify a rank as "
+            "bounded. This is evidence-scoped to the identified EXL3 "
+            "materialization callsite and does not prove all RM errors "
+            "safe. Matched NVIDIA Xid and NV_ERR_NO_MEMORY events are never "
+            "globally ignored. This tool "
+            "classifies supplied evidence and never establishes a safe "
+            "bound itself. window_event_count is a count, not a delta. "
+            "It remains offline-validated until run on sanitized captured "
+            "evidence."
+        ),
+    }
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _parse_tz(arg: str) -> timezone:
+    """Parse a timezone argument like 'UTC' or '-05:00' or '+05:30'."""
+    if arg.upper() == "UTC":
+        return timezone.utc
+    match = re.match(r"^([+-])(\d{2}):(\d{2})$", arg)
+    if match:
+        sign = 1 if match.group(1) == "+" else -1
+        hours = int(match.group(2))
+        minutes = int(match.group(3))
+        if hours > 23 or minutes > 59:
+            raise ConfigError(f"invalid timezone: {arg}")
+        return timezone(sign * timedelta(hours=hours, minutes=minutes))
+    raise ConfigError(f"invalid timezone: {arg}")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--engine-log",
+        action="append",
+        dest="engine_logs",
+        default=[],
+        help=(
+            "path to a captured engine container log; repeat once per rank "
+            "(order = rank 0, 1, 2, 3)"
+        ),
+    )
+    parser.add_argument(
+        "--server-log",
+        action="append",
+        dest="server_logs",
+        default=[],
+        help=(
+            "path to a captured LMCache server container log; "
+            "repeat once per rank"
+        ),
+    )
+    parser.add_argument(
+        "--engine-inspect",
+        action="append",
+        dest="engine_inspects",
+        default=[],
+        help=(
+            "path to captured docker inspect JSON for an engine container; "
+            "repeat once per rank in --engine-log order"
+        ),
+    )
+    parser.add_argument(
+        "--engine-container-name",
+        action="append",
+        dest="engine_container_names",
+        default=[],
+        help=(
+            "expected engine container name; repeat once per rank in "
+            "--engine-log order"
+        ),
+    )
+    parser.add_argument(
+        "--server-inspect",
+        action="append",
+        dest="server_inspects",
+        default=[],
+        help=(
+            "path to captured docker inspect JSON for an LMCache server; "
+            "required once per rank when --server-log is supplied"
+        ),
+    )
+    parser.add_argument(
+        "--server-container-name",
+        action="append",
+        dest="server_container_names",
+        default=[],
+        help=(
+            "expected LMCache server container name; required once per rank "
+            "when --server-log is supplied"
+        ),
+    )
+    parser.add_argument(
+        "--kernel-log",
+        action="append",
+        dest="kernel_logs",
+        default=[],
+        help=(
+            "path to a captured kernel/dmesg log; repeat once per rank. "
+            "Only NV_ERR_NO_MEMORY at _memdescAllocInternal @ mem_desc.c:1359 "
+            "is matched for bounded_rm_retry classification."
+        ),
+    )
+    parser.add_argument(
+        "--rm-event-bound",
+        type=int,
+        default=None,
+        help=(
+            "operator-supplied accepted window-event-count bound. "
+            "Required for bounded_rm_retry verdict; if absent and RM "
+            "events are present, verdict is indeterminate (fail closed). "
+            "This is a count bound, NOT a delta. This tool never "
+            "establishes a safe bound itself."
+        ),
+    )
+    parser.add_argument(
+        "--engine-log-year",
+        type=int,
+        default=None,
+        help=(
+            "year for vLLM log timestamps (which lack year). "
+            "Required for vLLM timestamp parsing. Must be paired with "
+            "--engine-log-tz; without it, verdict is indeterminate."
+        ),
+    )
+    parser.add_argument(
+        "--engine-log-tz",
+        type=str,
+        default=None,
+        help=(
+            "timezone for vLLM log timestamps, e.g. 'UTC' or '-05:00'. "
+            "Required when --engine-log-year is supplied."
+        ),
+    )
+    parser.add_argument(
+        "--cluster-ready",
+        action="store_true",
+        default=False,
+        help=(
+            "operator-supplied fact that the cluster/API is ready. "
+            "Required for bounded_rm_retry; LMCache server readiness "
+            "alone does not qualify."
+        ),
+    )
+    parser.add_argument("command", choices=("classify",))
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    if len(args.engine_logs) != EXPECTED_RANKS:
+        parser.error(
+            f"expected exactly {EXPECTED_RANKS} --engine-log inputs, "
+            f"received {len(args.engine_logs)}"
+        )
+    if len(args.engine_inspects) != EXPECTED_RANKS:
+        parser.error(
+            f"expected exactly {EXPECTED_RANKS} --engine-inspect inputs, "
+            f"received {len(args.engine_inspects)}"
+        )
+    if len(args.engine_container_names) != EXPECTED_RANKS:
+        parser.error(
+            f"expected exactly {EXPECTED_RANKS} --engine-container-name "
+            f"inputs, received {len(args.engine_container_names)}"
+        )
+
+    rank_count = EXPECTED_RANKS
+    for option, paths in (
+        ("--server-log", args.server_logs),
+        ("--kernel-log", args.kernel_logs),
+    ):
+        if paths and len(paths) != rank_count:
+            parser.error(
+                f"{option} must be omitted or supplied exactly once for each "
+                f"of the {rank_count} engine ranks"
+            )
+
+    if args.server_logs and len(args.server_inspects) != rank_count:
+        parser.error(
+            f"--server-inspect must be supplied exactly once for each of the "
+            f"{rank_count} server logs"
+        )
+    if args.server_inspects and not args.server_logs:
+        parser.error("--server-inspect requires --server-log evidence")
+    if args.server_logs and len(args.server_container_names) != rank_count:
+        parser.error(
+            f"--server-container-name must be supplied exactly once for each "
+            f"of the {rank_count} server logs"
+        )
+    if args.server_container_names and not args.server_logs:
+        parser.error("--server-container-name requires --server-log evidence")
+
+    for option, paths in (
+        ("--engine-log", args.engine_logs),
+        ("--engine-inspect", args.engine_inspects),
+        ("--server-log", args.server_logs),
+        ("--server-inspect", args.server_inspects),
+        ("--kernel-log", args.kernel_logs),
+    ):
+        resolved = [str(Path(path).resolve()) for path in paths]
+        if len(resolved) != len(set(resolved)):
+            parser.error(f"{option} inputs must use distinct files per rank")
+    expected_engine_names = [name.lstrip("/") for name in args.engine_container_names]
+    expected_server_names = [name.lstrip("/") for name in args.server_container_names]
+    if any(not name for name in expected_engine_names + expected_server_names):
+        parser.error("expected container names must be non-empty")
+    if len(expected_engine_names) != len(set(expected_engine_names)):
+        parser.error("--engine-container-name values must be unique")
+    if len(expected_server_names) != len(set(expected_server_names)):
+        parser.error("--server-container-name values must be unique")
+    if set(expected_engine_names) & set(expected_server_names):
+        parser.error("engine and server container names must be disjoint")
+
+    if args.rm_event_bound is not None and args.rm_event_bound < 0:
+        parser.error("--rm-event-bound must be non-negative")
+
+    if args.engine_log_year is not None and not 1 <= args.engine_log_year <= 9999:
+        parser.error("--engine-log-year must be between 1 and 9999")
+
+    max_ranks = rank_count
+
+    engine_log_tz: timezone | None = None
+    if args.engine_log_tz is not None:
+        try:
+            engine_log_tz = _parse_tz(args.engine_log_tz)
+        except ConfigError as exc:
+            print(f"sparkring-startup-evidence: {exc}", file=sys.stderr)
+            return EXIT_CONFIG_ERROR
+
+    rank_reports: list[dict[str, Any]] = []
+    seen_container_ids: set[str] = set()
+    seen_container_names: set[str] = set()
+    for rank in range(max_ranks):
+        engine_log = None
+        server_log = None
+        kernel_log = None
+        path = Path(args.engine_logs[rank])
+        if not path.is_file():
+            print(
+                f"sparkring-startup-evidence: engine log not found: {path}",
+                file=sys.stderr,
+            )
+            return EXIT_CONFIG_ERROR
+        engine_log = path.read_text(encoding="utf-8", errors="replace")
+        if not engine_log.strip():
+            print(
+                f"sparkring-startup-evidence: engine log is empty: {path}",
+                file=sys.stderr,
+            )
+            return EXIT_CONFIG_ERROR
+
+        inspect_path = Path(args.engine_inspects[rank])
+        if not inspect_path.is_file():
+            print(
+                "sparkring-startup-evidence: engine inspect not found: "
+                f"{inspect_path}",
+                file=sys.stderr,
+            )
+            return EXIT_CONFIG_ERROR
+        try:
+            engine_state = _parse_container_inspect(
+                inspect_path.read_text(encoding="utf-8", errors="replace")
+            )
+        except ConfigError as exc:
+            print(
+                f"sparkring-startup-evidence: {inspect_path}: {exc}",
+                file=sys.stderr,
+            )
+            return EXIT_CONFIG_ERROR
+        engine_name = engine_state["container_name"].lstrip("/")
+        if engine_name != expected_engine_names[rank]:
+            print(
+                f"sparkring-startup-evidence: rank {rank} engine inspect name "
+                f"{engine_name!r} does not match expected "
+                f"{expected_engine_names[rank]!r}",
+                file=sys.stderr,
+            )
+            return EXIT_CONFIG_ERROR
+        if (
+            engine_state["container_id"] in seen_container_ids
+            or engine_name in seen_container_names
+        ):
+            print(
+                "sparkring-startup-evidence: container inspect identities "
+                "must be unique across all engine and server ranks",
+                file=sys.stderr,
+            )
+            return EXIT_CONFIG_ERROR
+        seen_container_ids.add(engine_state["container_id"])
+        seen_container_names.add(engine_name)
+
+        server_state: dict[str, Any] | None = None
+        if rank < len(args.server_logs):
+            path = Path(args.server_logs[rank])
+            if not path.is_file():
+                print(
+                    f"sparkring-startup-evidence: server log not found: "
+                    f"{path}",
+                    file=sys.stderr,
+                )
+                return EXIT_CONFIG_ERROR
+            server_log = path.read_text(encoding="utf-8", errors="replace")
+            if not server_log.strip():
+                print(
+                    f"sparkring-startup-evidence: server log is empty: {path}",
+                    file=sys.stderr,
+                )
+                return EXIT_CONFIG_ERROR
+            inspect_path = Path(args.server_inspects[rank])
+            if not inspect_path.is_file():
+                print(
+                    "sparkring-startup-evidence: server inspect not found: "
+                    f"{inspect_path}",
+                    file=sys.stderr,
+                )
+                return EXIT_CONFIG_ERROR
+            try:
+                server_state = _parse_container_inspect(
+                    inspect_path.read_text(encoding="utf-8", errors="replace")
+                )
+            except ConfigError as exc:
+                print(
+                    f"sparkring-startup-evidence: {inspect_path}: {exc}",
+                    file=sys.stderr,
+                )
+                return EXIT_CONFIG_ERROR
+            server_name = server_state["container_name"].lstrip("/")
+            if server_name != expected_server_names[rank]:
+                print(
+                    f"sparkring-startup-evidence: rank {rank} server inspect "
+                    f"name {server_name!r} does not match expected "
+                    f"{expected_server_names[rank]!r}",
+                    file=sys.stderr,
+                )
+                return EXIT_CONFIG_ERROR
+            if (
+                server_state["container_id"] in seen_container_ids
+                or server_name in seen_container_names
+            ):
+                print(
+                    "sparkring-startup-evidence: container inspect identities "
+                    "must be unique across all engine and server ranks",
+                    file=sys.stderr,
+                )
+                return EXIT_CONFIG_ERROR
+            seen_container_ids.add(server_state["container_id"])
+            seen_container_names.add(server_name)
+        if rank < len(args.kernel_logs):
+            path = Path(args.kernel_logs[rank])
+            if not path.is_file():
+                print(
+                    f"sparkring-startup-evidence: kernel log not found: "
+                    f"{path}",
+                    file=sys.stderr,
+                )
+                return EXIT_CONFIG_ERROR
+            kernel_log = path.read_text(encoding="utf-8", errors="replace")
+
+        rank_report = classify_rank(
+            rank,
+            engine_log=engine_log,
+            server_log=server_log,
+            engine_running=engine_state["running"],
+            engine_restart_count=engine_state["restart_count"],
+            engine_oom_killed=engine_state["oom_killed"],
+            server_running=(
+                server_state["running"] if server_state is not None else True
+            ),
+            server_restart_count=(
+                server_state["restart_count"] if server_state is not None else 0
+            ),
+            server_oom_killed=(
+                server_state["oom_killed"] if server_state is not None else False
+            ),
+            kernel_log=kernel_log,
+            rm_event_bound=args.rm_event_bound,
+            engine_log_year=args.engine_log_year,
+            engine_log_tz=engine_log_tz,
+            cluster_ready=args.cluster_ready,
+        )
+        rank_report["engine_inspect_sha256"] = engine_state["sha256"]
+        rank_report["engine_container_id"] = engine_state["container_id"]
+        rank_report["engine_container_name"] = engine_state["container_name"]
+        rank_report["server_inspect_sha256"] = (
+            server_state["sha256"] if server_state is not None else None
+        )
+        rank_report["server_container_id"] = (
+            server_state["container_id"] if server_state is not None else None
+        )
+        rank_report["server_container_name"] = (
+            server_state["container_name"] if server_state is not None else None
+        )
+        rank_reports.append(rank_report)
+
+    report = aggregate_report(rank_reports)
+    print(json.dumps(report, indent=2, sort_keys=True))
+    if report["verdict"] in ("fatal", "indeterminate"):
+        return EXIT_FATAL
+    return EXIT_OK
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_sparkring_startup_evidence.py
+++ b/scripts/test_sparkring_startup_evidence.py
@@ -1,0 +1,1472 @@
+"""Tests for the stage-aware startup evidence classifier (v1).
+
+Verdict model:
+- clean: no concerning signatures
+- bounded_rm_retry: kernel NV_ERR_NO_MEMORY at _memdescAllocInternal @
+  mem_desc.c:1359, every event timestamp inside the per-layer
+  materialization window, post-materialization success milestone after
+  window, cluster/API readiness supplied, event count within
+  operator-supplied bound, full cross-evidence
+- fatal: generic CUDA OOM, torch.OutOfMemoryError, OOMKilled, Xid,
+  restart, SSH loss, fabric loss, driver failure — never downgraded
+- indeterminate: RM event present but cross-evidence incomplete
+  (fatal policy)
+
+The classifier never establishes a safe bound itself. window_event_count
+is a count, not a delta. It remains offline-validated until run on
+sanitized captured evidence.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from datetime import timezone, timedelta
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "scripts"))
+
+import sparkring_startup_evidence as evidence  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Fixtures — real log shapes
+# ---------------------------------------------------------------------------
+
+CLEAN_ENGINE = """\
+(Worker pid=1234) INFO 08-09 05:20:00.000000 [engine] Starting vLLM engine...
+(Worker pid=1234) INFO 08-09 05:21:00.000000 [engine] Model loaded successfully
+(Worker pid=1234) INFO 08-09 05:22:00.000000 [engine] KV cache allocated: 562688 tokens
+(Worker pid=1234) INFO 08-09 05:23:00.000000 [engine] Engine is ready
+"""
+
+# Per-layer materialization lines — the evidenced shape
+ENGINE_PER_LAYER_MATERIALIZATION = """\
+(Worker pid=1234) INFO 08-09 05:20:00.000000 [engine] Starting vLLM engine...
+(Worker pid=1234) INFO 08-09 05:20:10.000000 [engine] EXL3 mixed Trellis model.layers.0.mlp.experts
+(Worker pid=1234) INFO 08-09 05:20:30.000000 [engine] EXL3 mixed Trellis model.layers.1.mlp.experts
+(Worker pid=1234) INFO 08-09 05:21:00.000000 [engine] Graph capturing finished
+(Worker pid=1234) INFO 08-09 05:22:00.000000 [engine] Engine is ready
+"""
+
+# ISO timestamp version
+ENGINE_PER_LAYER_ISO = """\
+2026-08-09T05:20:00.000000-05:00 [INFO] Starting vLLM engine...
+2026-08-09T05:20:10.000000-05:00 [INFO] EXL3 mixed Trellis model.layers.0.mlp.experts
+2026-08-09T05:20:30.000000-05:00 [INFO] EXL3 mixed Trellis model.layers.1.mlp.experts
+2026-08-09T05:21:00.000000-05:00 [INFO] Graph capturing finished
+2026-08-09T05:22:00.000000-05:00 [INFO] Engine is ready
+"""
+
+# Headless rank (1-3) — no API strings, has graph-finished milestone
+ENGINE_HEADLESS = """\
+(Worker_TP1_DCP1) INFO 08-09 05:20:00.000000 Starting vLLM engine...
+(Worker_TP1_DCP1) INFO 08-09 05:20:10.000000 EXL3 mixed Trellis model.layers.0.mlp.experts
+(Worker_TP1_DCP1) INFO 08-09 05:20:30.000000 EXL3 mixed Trellis model.layers.1.mlp.experts
+(Worker_TP1_DCP1) INFO 08-09 05:21:00.000000 Graph capturing finished
+"""
+
+# Headless rank with Kernel JIT monitor milestone
+ENGINE_HEADLESS_JIT = """\
+(Worker_TP2_DCP2) INFO 08-09 05:20:00.000000 Starting vLLM engine...
+(Worker_TP2_DCP2) INFO 08-09 05:20:10.000000 EXL3 mixed Trellis model.layers.0.mlp.experts
+(Worker_TP2_DCP2) INFO 08-09 05:20:30.000000 EXL3 mixed Trellis model.layers.1.mlp.experts
+(Worker_TP2_DCP2) INFO 08-09 05:21:00.000000 Kernel JIT monitor activated
+"""
+
+# Rank 0 with API readiness
+ENGINE_RANK0_API = """\
+(Worker pid=1234) INFO 08-09 05:20:00.000000 [engine] Starting vLLM engine...
+(Worker pid=1234) INFO 08-09 05:20:10.000000 [engine] EXL3 mixed Trellis model.layers.0.mlp.experts
+(Worker pid=1234) INFO 08-09 05:20:30.000000 [engine] EXL3 mixed Trellis model.layers.1.mlp.experts
+(Worker pid=1234) INFO 08-09 05:21:00.000000 [engine] Graph capturing finished
+(Worker pid=1234) INFO 08-09 05:22:00.000000 [engine] Engine is ready
+(Worker pid=1234) INFO 08-09 05:22:30.000000 [engine] API server started
+"""
+
+# "mixed Trellis runtime planned" — must NOT extend the window
+ENGINE_NON_PER_LAYER = """\
+2026-08-09T05:20:00.000000-05:00 [INFO] Starting vLLM engine...
+2026-08-09T05:20:10.000000-05:00 [INFO] EXL3 mixed Trellis model.layers.0.mlp.experts
+2026-08-09T05:20:30.000000-05:00 [INFO] EXL3 mixed Trellis model.layers.1.mlp.experts
+2026-08-09T05:25:00.000000-05:00 [INFO] mixed Trellis runtime planned
+2026-08-09T05:26:00.000000-05:00 [INFO] Graph capturing finished
+"""
+
+# Kernel RM event inside window
+KERNEL_RM_IN_WINDOW = """\
+2026-08-09T05:20:15.000000-05:00 NV_ERR_NO_MEMORY: _memdescAllocInternal @ mem_desc.c:1359
+"""
+
+# Kernel RM event between last layer and graph capture (after window end)
+KERNEL_RM_AFTER_WINDOW = """\
+2026-08-09T05:20:45.000000-05:00 NV_ERR_NO_MEMORY: _memdescAllocInternal @ mem_desc.c:1359
+"""
+
+# Kernel RM event before materialization starts
+KERNEL_RM_BEFORE_WINDOW = """\
+2026-08-09T05:15:00.000000-05:00 NV_ERR_NO_MEMORY: _memdescAllocInternal @ mem_desc.c:1359
+"""
+
+# Kernel RM event with no timestamp
+KERNEL_RM_NO_TS = """\
+NV_ERR_NO_MEMORY: _memdescAllocInternal @ mem_desc.c:1359
+"""
+
+# Kernel RM event with wrong callsite
+KERNEL_RM_WRONG_CALLSITE = """\
+2026-08-09T05:20:15.000000-05:00 NV_ERR_NO_MEMORY: _someOtherFunction @ other.c:42
+"""
+
+# Multiple events within bound
+KERNEL_RM_3_EVENTS = "\n".join(
+    f"2026-08-09T05:20:{15 + i * 5:02d}.000000-05:00 "
+    f"NV_ERR_NO_MEMORY: _memdescAllocInternal @ mem_desc.c:1359"
+    for i in range(3)
+) + "\n"
+
+# 36 events within a large bound
+KERNEL_RM_36_EVENTS = "\n".join(
+    f"2026-08-09T05:20:{15 + i:02d}.{i * 1000:06d}-05:00 "
+    f"NV_ERR_NO_MEMORY: _memdescAllocInternal @ mem_desc.c:1359"
+    for i in range(36)
+) + "\n"
+
+# UTC versions
+ENGINE_UTC = """\
+2026-08-09T10:20:00.000000Z [INFO] Starting vLLM engine...
+2026-08-09T10:20:10.000000Z [INFO] EXL3 mixed Trellis model.layers.0.mlp.experts
+2026-08-09T10:20:30.000000Z [INFO] EXL3 mixed Trellis model.layers.1.mlp.experts
+2026-08-09T10:21:00.000000Z [INFO] Graph capturing finished
+2026-08-09T10:22:00.000000Z [INFO] Engine is ready
+"""
+
+KERNEL_RM_UTC = """\
+2026-08-09T10:20:15.000000Z NV_ERR_NO_MEMORY: _memdescAllocInternal @ mem_desc.c:1359
+"""
+
+# Cross-midnight
+ENGINE_CROSS_MIDNIGHT = """\
+2026-08-09T23:58:00.000000-05:00 [INFO] Starting vLLM engine...
+2026-08-09T23:59:00.000000-05:00 [INFO] EXL3 mixed Trellis model.layers.0.mlp.experts
+2026-08-10T00:00:30.000000-05:00 [INFO] EXL3 mixed Trellis model.layers.1.mlp.experts
+2026-08-10T00:01:00.000000-05:00 [INFO] Graph capturing finished
+2026-08-10T00:02:00.000000-05:00 [INFO] Engine is ready
+"""
+
+KERNEL_RM_CROSS_MIDNIGHT = """\
+2026-08-09T23:59:30.000000-05:00 NV_ERR_NO_MEMORY: _memdescAllocInternal @ mem_desc.c:1359
+"""
+
+# TZ mismatch: kernel -05:00, engine UTC
+KERNEL_RM_TZ_MISMATCH = """\
+2026-08-09T05:20:15.000000-05:00 NV_ERR_NO_MEMORY: _memdescAllocInternal @ mem_desc.c:1359
+"""
+
+# Malformed timestamp
+KERNEL_RM_MALFORMED = """\
+2026-13-45T99:99:99.999999-99:99 NV_ERR_NO_MEMORY: _memdescAllocInternal @ mem_desc.c:1359
+"""
+
+# Unrelated earlier boot RM line (before engine even starts)
+KERNEL_RM_EARLY_BOOT = """\
+2026-08-09T05:00:00.000000-05:00 NV_ERR_NO_MEMORY: _memdescAllocInternal @ mem_desc.c:1359
+"""
+
+# Materialization with NO post-materialization success milestone
+ENGINE_NO_POST_MAT_SUCCESS = """\
+2026-08-09T05:20:00.000000-05:00 [INFO] Starting vLLM engine...
+2026-08-09T05:20:10.000000-05:00 [INFO] EXL3 mixed Trellis model.layers.0.mlp.experts
+2026-08-09T05:20:30.000000-05:00 [INFO] EXL3 mixed Trellis model.layers.1.mlp.experts
+"""
+
+# Readiness BEFORE last materialization line
+ENGINE_READINESS_BEFORE_LAST_LAYER = """\
+2026-08-09T05:20:00.000000-05:00 [INFO] Starting vLLM engine...
+2026-08-09T05:20:10.000000-05:00 [INFO] EXL3 mixed Trellis model.layers.0.mlp.experts
+2026-08-09T05:20:15.000000-05:00 [INFO] Graph capturing finished
+2026-08-09T05:20:30.000000-05:00 [INFO] EXL3 mixed Trellis model.layers.1.mlp.experts
+"""
+
+# Fatal fixtures
+GENERIC_CUDA_OOM = """\
+(Worker pid=1234) INFO 08-09 05:20:00.000000 [engine] Starting vLLM engine...
+(Worker pid=1234) ERROR 08-09 05:21:00.000000 [engine] CUDA out of memory. Tried to allocate 2.00 GiB.
+(Worker pid=1234) INFO 08-09 05:22:00.000000 [engine] Engine is ready
+"""
+
+XID_FATAL = """\
+[INFO] Starting vLLM engine...
+[NVRM] Xid 119 (GPU has fallen off the bus)
+"""
+
+OOMKILLED_FATAL = """\
+[INFO] Starting vLLM engine...
+Killed process (OOMKilled)
+"""
+
+SSH_FAILURE = """\
+ssh: connect to host 10.0.0.2 port 22: Connection refused
+"""
+
+FABRIC_FAILURE = """\
+[INFO] Starting NCCL bootstrap
+[ERROR] NCCL: bootstrap failed (RoCE link down)
+"""
+
+CARRIER_LOSS = """\
+[ERROR] carrier loss detected on ib0
+"""
+
+RESTART_FATAL = """\
+[INFO] Starting vLLM engine...
+Container engine-r0 is restarting (restart count: 1)
+"""
+
+DRIVER_FAILURE = """\
+[ERROR] cudaSetDevice failed: no CUDA-capable device detected
+"""
+
+BARE_OOM = """\
+[INFO] Starting vLLM engine...
+[ERROR] CUDA out of memory
+"""
+
+SERVER_CLEAN = """\
+[INFO] LMCache server started
+[INFO] storage_manager initialized
+[INFO] Listening on 0.0.0.0:6556
+"""
+
+SERVER_OOM = """\
+[INFO] LMCache server started
+OutOfMemoryError [ CUDA error ]
+"""
+
+
+# ---------------------------------------------------------------------------
+# Clean
+# ---------------------------------------------------------------------------
+
+
+def test_clean_log_classifies_clean():
+    result = evidence.classify_log(CLEAN_ENGINE, container_running=True)
+    assert result["verdict"] == "clean"
+
+
+def test_stopped_container_is_fatal_without_log_signature():
+    result = evidence.classify_log(CLEAN_ENGINE, container_running=False)
+    assert result["verdict"] == "fatal"
+    assert result["container_running"] is False
+    assert result["fatal_signatures"] == []
+    assert result["window_event_count"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Fatal — generic CUDA OOM is FATAL regardless of progress
+# ---------------------------------------------------------------------------
+
+
+def test_generic_cuda_oom_with_progress_is_fatal():
+    result = evidence.classify_log(GENERIC_CUDA_OOM, container_running=True)
+    assert result["verdict"] == "fatal"
+
+
+def test_bare_oom_is_fatal():
+    result = evidence.classify_log(BARE_OOM, container_running=True)
+    assert result["verdict"] == "fatal"
+
+
+def test_bare_oom_dead_container_fatal():
+    result = evidence.classify_log(BARE_OOM, container_running=False)
+    assert result["verdict"] == "fatal"
+
+
+def test_xid_fatal():
+    result = evidence.classify_log(XID_FATAL, container_running=True)
+    assert result["verdict"] == "fatal"
+
+
+def test_oomkilled_fatal():
+    result = evidence.classify_log(OOMKILLED_FATAL, container_running=True)
+    assert result["verdict"] == "fatal"
+
+
+def test_oomkilled_false_is_not_a_fatal_signature():
+    result = evidence.classify_log('State: {"OOMKilled": false}')
+    assert result["verdict"] == "clean"
+    assert result["fatal_signatures"] == []
+
+
+def test_ssh_failure_fatal():
+    result = evidence.classify_log(SSH_FAILURE, container_running=True)
+    assert result["verdict"] == "fatal"
+
+
+def test_fabric_failure_fatal():
+    result = evidence.classify_log(FABRIC_FAILURE, container_running=True)
+    assert result["verdict"] == "fatal"
+
+
+def test_carrier_loss_fatal():
+    result = evidence.classify_log(CARRIER_LOSS, container_running=True)
+    assert result["verdict"] == "fatal"
+
+
+def test_restart_fatal():
+    result = evidence.classify_log(RESTART_FATAL, container_running=True)
+    assert result["verdict"] == "fatal"
+
+
+def test_driver_failure_fatal():
+    result = evidence.classify_log(DRIVER_FAILURE, container_running=True)
+    assert result["verdict"] == "fatal"
+
+
+# ---------------------------------------------------------------------------
+# Bounded RM retry — full cross-evidence
+# ---------------------------------------------------------------------------
+
+
+def test_bounded_rm_retry_iso_with_cluster_ready():
+    """Full cross-evidence: per-layer window, event in window,
+    post-materialization success, cluster ready, bound supplied."""
+    result = evidence.classify_log(
+        ENGINE_PER_LAYER_ISO,
+        container_running=True,
+        kernel_log=KERNEL_RM_IN_WINDOW,
+        rm_event_bound=10,
+        cluster_ready=True,
+    )
+    assert result["verdict"] == "bounded_rm_retry"
+    assert result["window_event_count"] == 1
+    assert result["all_events_in_window"] is True
+    assert result["readiness_after_window"] is True
+    assert result["materialization_window"] is not None
+
+
+def test_bounded_rm_retry_utc():
+    result = evidence.classify_log(
+        ENGINE_UTC,
+        container_running=True,
+        kernel_log=KERNEL_RM_UTC,
+        rm_event_bound=10,
+        cluster_ready=True,
+    )
+    assert result["verdict"] == "bounded_rm_retry"
+
+
+def test_bounded_rm_retry_vllm_with_year_tz():
+    tz = timezone(-timedelta(hours=5))
+    result = evidence.classify_log(
+        ENGINE_PER_LAYER_MATERIALIZATION,
+        container_running=True,
+        kernel_log=KERNEL_RM_IN_WINDOW,
+        rm_event_bound=10,
+        engine_log_year=2026,
+        engine_log_tz=tz,
+        cluster_ready=True,
+    )
+    assert result["verdict"] == "bounded_rm_retry"
+
+
+def test_bounded_rm_retry_36_events():
+    result = evidence.classify_log(
+        ENGINE_PER_LAYER_ISO,
+        container_running=True,
+        kernel_log=KERNEL_RM_36_EVENTS,
+        rm_event_bound=50,
+        cluster_ready=True,
+    )
+    assert result["window_event_count"] == 36
+    assert result["rm_event_within_bound"] is True
+    assert result["verdict"] in ("bounded_rm_retry", "indeterminate")
+
+
+def test_wrong_rm_callsite_is_indeterminate():
+    result = evidence.classify_log(
+        ENGINE_PER_LAYER_ISO,
+        container_running=True,
+        kernel_log=KERNEL_RM_WRONG_CALLSITE,
+        rm_event_bound=10,
+        cluster_ready=True,
+    )
+    assert result["window_event_count"] == 0
+    assert result["verdict"] == "indeterminate"
+    assert len(result["unknown_rm_events"]) == 1
+
+
+def test_bounded_rm_retry_exact_bound():
+    result = evidence.classify_log(
+        ENGINE_PER_LAYER_ISO,
+        container_running=True,
+        kernel_log=KERNEL_RM_3_EVENTS,
+        rm_event_bound=3,
+        cluster_ready=True,
+    )
+    assert result["rm_event_within_bound"] is True
+
+
+# ---------------------------------------------------------------------------
+# cluster_ready required — LMCache readiness alone does not qualify
+# ---------------------------------------------------------------------------
+
+
+def test_bounded_rm_retry_requires_cluster_ready():
+    """Without --cluster-ready, bounded_rm_retry cannot be reached."""
+    result = evidence.classify_log(
+        ENGINE_PER_LAYER_ISO,
+        container_running=True,
+        kernel_log=KERNEL_RM_IN_WINDOW,
+        rm_event_bound=10,
+        cluster_ready=False,
+    )
+    assert result["verdict"] == "indeterminate"
+
+
+def test_lmcache_server_readiness_alone_does_not_qualify():
+    """LMCache server readiness must not classify a rank as bounded."""
+    result = evidence.classify_log(
+        SERVER_CLEAN,
+        container_running=True,
+        kernel_log=KERNEL_RM_IN_WINDOW,
+        rm_event_bound=10,
+        cluster_ready=False,
+    )
+    # Server log with LMCache ready but no cluster_ready fact
+    assert result["verdict"] != "bounded_rm_retry"
+
+
+# ---------------------------------------------------------------------------
+# Operator-supplied bound — fail closed when absent
+# ---------------------------------------------------------------------------
+
+
+def test_indeterminate_when_bound_missing():
+    result = evidence.classify_log(
+        ENGINE_PER_LAYER_ISO,
+        container_running=True,
+        kernel_log=KERNEL_RM_IN_WINDOW,
+        rm_event_bound=None,
+        cluster_ready=True,
+    )
+    assert result["verdict"] == "indeterminate"
+    assert result["rm_event_within_bound"] is None
+
+
+def test_over_bound_is_fatal():
+    result = evidence.classify_log(
+        ENGINE_PER_LAYER_ISO,
+        container_running=True,
+        kernel_log=KERNEL_RM_3_EVENTS,
+        rm_event_bound=2,
+        cluster_ready=True,
+    )
+    assert result["verdict"] == "fatal"
+    assert result["rm_event_within_bound"] is False
+
+
+# ---------------------------------------------------------------------------
+# Window — per-layer materialization only
+# ---------------------------------------------------------------------------
+
+
+def test_non_per_layer_line_does_not_extend_window():
+    """'mixed Trellis runtime planned' must NOT be a materialization line."""
+    result = evidence.classify_log(
+        ENGINE_NON_PER_LAYER,
+        container_running=True,
+        kernel_log=KERNEL_RM_IN_WINDOW,
+        rm_event_bound=10,
+        cluster_ready=True,
+    )
+    # The window must be from layers.0 through layers.1, not extended
+    # by "mixed Trellis runtime planned" at 05:25
+    window = result["materialization_window"]
+    assert window is not None
+    # Window end should be 05:20:30 (last model.layers line), not 05:25
+    # Window end should be before "mixed Trellis runtime planned"
+    # Both are ISO strings with tz; string comparison works for same tz
+    assert "10:20:30" in window[1]  # UTC normalized from 05:20:30-05:00
+
+
+def test_rm_after_window_is_indeterminate():
+    """RM event between last layer and graph capture (after window end)
+    must be indeterminate."""
+    result = evidence.classify_log(
+        ENGINE_PER_LAYER_ISO,
+        container_running=True,
+        kernel_log=KERNEL_RM_AFTER_WINDOW,
+        rm_event_bound=10,
+        cluster_ready=True,
+    )
+    assert result["verdict"] == "indeterminate"
+    assert result["all_events_in_window"] is False
+
+
+def test_rm_before_window_is_indeterminate():
+    result = evidence.classify_log(
+        ENGINE_PER_LAYER_ISO,
+        container_running=True,
+        kernel_log=KERNEL_RM_BEFORE_WINDOW,
+        rm_event_bound=10,
+        cluster_ready=True,
+    )
+    assert result["verdict"] == "indeterminate"
+    assert result["all_events_in_window"] is False
+
+
+def test_rm_early_boot_is_indeterminate():
+    """An unrelated RM event from earlier boot (before engine start)
+    must be indeterminate."""
+    result = evidence.classify_log(
+        ENGINE_PER_LAYER_ISO,
+        container_running=True,
+        kernel_log=KERNEL_RM_EARLY_BOOT,
+        rm_event_bound=10,
+        cluster_ready=True,
+    )
+    assert result["verdict"] == "indeterminate"
+    assert result["all_events_in_window"] is False
+
+
+# ---------------------------------------------------------------------------
+# Timestamp issues
+# ---------------------------------------------------------------------------
+
+
+def test_event_missing_timestamp_indeterminate():
+    result = evidence.classify_log(
+        ENGINE_PER_LAYER_ISO,
+        container_running=True,
+        kernel_log=KERNEL_RM_NO_TS,
+        rm_event_bound=10,
+        cluster_ready=True,
+    )
+    assert result["verdict"] == "indeterminate"
+
+
+def test_malformed_timestamp_indeterminate():
+    result = evidence.classify_log(
+        ENGINE_PER_LAYER_ISO,
+        container_running=True,
+        kernel_log=KERNEL_RM_MALFORMED,
+        rm_event_bound=10,
+        cluster_ready=True,
+    )
+    assert result["verdict"] == "indeterminate"
+    assert result["all_events_have_timestamps"] is False
+
+
+def test_year_without_tz_no_crash_indeterminate():
+    """Year supplied without timezone must not crash; must be indeterminate."""
+    result = evidence.classify_log(
+        ENGINE_PER_LAYER_MATERIALIZATION,
+        container_running=True,
+        kernel_log=KERNEL_RM_IN_WINDOW,
+        rm_event_bound=10,
+        engine_log_year=2026,
+        engine_log_tz=None,
+        cluster_ready=True,
+    )
+    assert result["verdict"] == "indeterminate"
+    assert result["year_without_tz"] is True
+
+# Engine log with a materialization line that has a malformed vLLM timestamp
+# (month 13, day 45). The regex matches but datetime() raises ValueError.
+# The classifier must catch it and set timestamp_parse_error=True, producing
+# indeterminate — not silently drop the timestamp and proceed.
+ENGINE_MALFORMED_VLLM_TS_MAT = """\
+(Worker pid=1234) INFO 13-45 05:20:15 EXL3 mixed Trellis model.layers.0.mlp.experts
+(Worker pid=1234) INFO 08-09 05:20:25 EXL3 mixed Trellis model.layers.1.mlp.experts
+(Worker pid=1234) INFO 08-09 05:20:35 Graph capturing finished
+"""
+
+
+def test_malformed_vllm_ts_on_mat_line_indeterminate():
+    """A malformed vLLM timestamp on a materialization line must set
+    timestamp_parse_error and produce indeterminate, not silently drop
+    the timestamp."""
+    from datetime import timezone, timedelta
+    result = evidence.classify_log(
+        ENGINE_MALFORMED_VLLM_TS_MAT,
+        container_running=True,
+        kernel_log=KERNEL_RM_IN_WINDOW,
+        rm_event_bound=10,
+        engine_log_year=2026,
+        engine_log_tz=timezone(-timedelta(hours=5)),
+        cluster_ready=True,
+    )
+    assert result["verdict"] == "indeterminate"
+    assert result["timestamp_parse_error"] is True
+
+
+def test_cross_midnight_window():
+    result = evidence.classify_log(
+        ENGINE_CROSS_MIDNIGHT,
+        container_running=True,
+        kernel_log=KERNEL_RM_CROSS_MIDNIGHT,
+        rm_event_bound=10,
+        cluster_ready=True,
+    )
+    assert result["verdict"] == "bounded_rm_retry"
+
+
+def test_tz_mismatch_normalizes():
+    """Kernel -05:00, engine UTC — both normalize to UTC for comparison."""
+    result = evidence.classify_log(
+        ENGINE_UTC,
+        container_running=True,
+        kernel_log=KERNEL_RM_TZ_MISMATCH,
+        rm_event_bound=10,
+        cluster_ready=True,
+    )
+    # Event at 05:20:15-05:00 = 10:20:15 UTC, inside UTC window
+    assert result["verdict"] == "bounded_rm_retry"
+
+
+# ---------------------------------------------------------------------------
+# Post-materialization success milestones
+# ---------------------------------------------------------------------------
+
+
+def test_no_post_materialization_success_indeterminate():
+    """RM event with per-layer materialization but no success milestone
+    after window → indeterminate."""
+    result = evidence.classify_log(
+        ENGINE_NO_POST_MAT_SUCCESS,
+        container_running=True,
+        kernel_log=KERNEL_RM_IN_WINDOW,
+        rm_event_bound=10,
+        cluster_ready=True,
+    )
+    assert result["verdict"] == "indeterminate"
+
+
+def test_readiness_before_last_layer_indeterminate():
+    """Readiness milestone before the last materialization line → not
+    after window → indeterminate."""
+    result = evidence.classify_log(
+        ENGINE_READINESS_BEFORE_LAST_LAYER,
+        container_running=True,
+        kernel_log=KERNEL_RM_IN_WINDOW,
+        rm_event_bound=10,
+        cluster_ready=True,
+    )
+    assert result["verdict"] == "indeterminate"
+
+
+# ---------------------------------------------------------------------------
+# Headless rank success milestones
+# ---------------------------------------------------------------------------
+
+
+def test_headless_graph_finished_success():
+    """Headless rank (1-3) with 'Graph capturing finished' milestone
+    and cluster_ready → bounded_rm_retry."""
+    tz = timezone(-timedelta(hours=5))
+    result = evidence.classify_log(
+        ENGINE_HEADLESS,
+        container_running=True,
+        kernel_log=KERNEL_RM_IN_WINDOW,
+        rm_event_bound=10,
+        engine_log_year=2026,
+        engine_log_tz=tz,
+        cluster_ready=True,
+    )
+    assert result["verdict"] == "bounded_rm_retry"
+    assert result["post_materialization_success"] is not None
+
+
+def test_headless_jit_monitor_success():
+    """Headless rank with 'Kernel JIT monitor activated' milestone."""
+    tz = timezone(-timedelta(hours=5))
+    result = evidence.classify_log(
+        ENGINE_HEADLESS_JIT,
+        container_running=True,
+        kernel_log=KERNEL_RM_IN_WINDOW,
+        rm_event_bound=10,
+        engine_log_year=2026,
+        engine_log_tz=tz,
+        cluster_ready=True,
+    )
+    assert result["verdict"] == "bounded_rm_retry"
+
+
+def test_rank0_api_readiness_success():
+    """Rank 0 with API server started → engine API readiness qualifies."""
+    tz = timezone(-timedelta(hours=5))
+    result = evidence.classify_log(
+        ENGINE_RANK0_API,
+        container_running=True,
+        kernel_log=KERNEL_RM_IN_WINDOW,
+        rm_event_bound=10,
+        engine_log_year=2026,
+        engine_log_tz=tz,
+        cluster_ready=True,
+    )
+    assert result["verdict"] == "bounded_rm_retry"
+    assert result["engine_api_ready"] is not None
+
+
+# ---------------------------------------------------------------------------
+# RM events with fatal conditions
+# ---------------------------------------------------------------------------
+
+
+def test_rm_event_in_dead_container_fatal():
+    result = evidence.classify_log(
+        ENGINE_PER_LAYER_ISO,
+        container_running=False,
+        kernel_log=KERNEL_RM_IN_WINDOW,
+        rm_event_bound=10,
+        cluster_ready=True,
+    )
+    assert result["verdict"] == "fatal"
+
+
+def test_rm_event_with_xid_fatal():
+    engine = ENGINE_PER_LAYER_ISO + "[NVRM] Xid 43\n"
+    result = evidence.classify_log(
+        engine, container_running=True,
+        kernel_log=KERNEL_RM_IN_WINDOW,
+        rm_event_bound=10, cluster_ready=True,
+    )
+    assert result["verdict"] == "fatal"
+
+
+def test_kernel_xid_is_fatal_even_when_engine_log_is_clean():
+    result = evidence.classify_log(
+        CLEAN_ENGINE,
+        kernel_log="2026-08-09T05:20:15-05:00 NVRM: Xid 79\n",
+    )
+    assert result["verdict"] == "fatal"
+    assert any(
+        hit["pattern"] == "xid" and hit["source"] == "kernel_log"
+        for hit in result["fatal_signatures"]
+    )
+
+
+def test_unrecognized_kernel_rm_event_is_indeterminate():
+    result = evidence.classify_log(
+        CLEAN_ENGINE,
+        kernel_log=(
+            "2026-08-09T05:20:15-05:00 NV_ERR_NO_MEMORY "
+            "at another_callsite.c:1\n"
+        ),
+    )
+    assert result["verdict"] == "indeterminate"
+    assert result["unknown_rm_events"][0]["source"] == "kernel_log"
+
+
+def test_restart_count_zero_does_not_match_later_numeric_field():
+    result = evidence.classify_log(
+        '{"RestartCount":0,"ExitCode":1,"OOMKilled":false}'
+    )
+    assert result["verdict"] == "clean"
+
+
+def test_torch_oom_is_counted_once():
+    result = evidence.classify_log("torch.OutOfMemoryError: allocation failed")
+    assert result["verdict"] == "fatal"
+    assert len(result["fatal_signatures"]) == 1
+
+
+def test_reordered_materialization_timestamps_are_indeterminate():
+    engine = """\
+2026-08-09T05:20:30-05:00 EXL3 mixed Trellis model.layers.0.mlp.experts
+2026-08-09T05:20:10-05:00 EXL3 mixed Trellis model.layers.1.mlp.experts
+2026-08-09T05:21:00-05:00 Graph capturing finished
+"""
+    result = evidence.classify_log(
+        engine,
+        kernel_log=KERNEL_RM_IN_WINDOW,
+        rm_event_bound=10,
+        cluster_ready=True,
+    )
+    assert result["verdict"] == "indeterminate"
+    assert result["materialization_timestamps_monotonic"] is False
+
+
+def test_success_line_before_materialization_window_does_not_qualify():
+    engine = """\
+2026-08-09T05:21:00-05:00 Graph capturing finished
+2026-08-09T05:20:10-05:00 EXL3 mixed Trellis model.layers.0.mlp.experts
+2026-08-09T05:20:30-05:00 EXL3 mixed Trellis model.layers.1.mlp.experts
+"""
+    result = evidence.classify_log(
+        engine,
+        kernel_log=KERNEL_RM_IN_WINDOW,
+        rm_event_bound=10,
+        cluster_ready=True,
+    )
+    assert result["verdict"] == "indeterminate"
+    assert result["post_materialization_success"] is None
+
+
+# ---------------------------------------------------------------------------
+# No invented patterns
+# ---------------------------------------------------------------------------
+
+
+def test_no_invented_recoverable_patterns():
+    assert not hasattr(evidence, "_RM_RETRY")
+    assert not hasattr(evidence, "_ALLOC_CONTINUE")
+    assert not hasattr(evidence, "RECOVERABLE_PATTERNS")
+    assert not hasattr(evidence, "RM_EVENT_BOUND")
+
+
+# ---------------------------------------------------------------------------
+# Timestamp parsing unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_parse_kernel_timestamp_iso():
+    dt = evidence._parse_kernel_timestamp(
+        "2026-08-09T05:21:00.113635-05:00 NV_ERR_NO_MEMORY"
+    )
+    assert dt is not None
+    assert dt.year == 2026
+    assert dt.tzinfo is not None
+
+
+def test_parse_kernel_timestamp_utc():
+    dt = evidence._parse_kernel_timestamp(
+        "2026-08-09T10:21:00.113635Z NV_ERR_NO_MEMORY"
+    )
+    assert dt is not None
+    assert dt.tzinfo == timezone.utc
+
+
+def test_parse_kernel_timestamp_none():
+    assert evidence._parse_kernel_timestamp("no ts") is None
+
+
+def test_parse_vllm_timestamp_with_year_tz():
+    tz = timezone(-timedelta(hours=5))
+    dt = evidence._parse_vllm_timestamp(
+        "(Worker pid=1234) INFO 08-09 05:24:32.123456 [engine]",
+        year=2026, tz=tz,
+    )
+    assert dt is not None
+    assert dt.year == 2026
+    assert dt.tzinfo == timezone.utc  # normalized to UTC
+
+
+def test_parse_vllm_timestamp_no_year_none():
+    assert evidence._parse_vllm_timestamp(
+        "INFO 08-09 05:24:32 [engine]", year=None,
+    ) is None
+
+
+def test_parse_vllm_timestamp_no_tz_none():
+    """Year supplied without tz → None (fail closed, no crash)."""
+    assert evidence._parse_vllm_timestamp(
+        "INFO 08-09 05:24:32 [engine]", year=2026, tz=None,
+    ) is None
+
+
+def test_parse_vllm_timestamp_worker_tp_prefix():
+    """Real Worker_TP0_DCP0 prefix must be parsed."""
+    tz = timezone(-timedelta(hours=5))
+    dt = evidence._parse_vllm_timestamp(
+        "(Worker_TP0_DCP0) INFO 08-09 05:24:32.123456 Starting",
+        year=2026, tz=tz,
+    )
+    assert dt is not None
+    assert dt.year == 2026
+
+
+def test_parse_vllm_malformed_raises():
+    """Malformed vLLM timestamps that match the regex but have invalid
+    date/time values must raise ValueError (caller catches and flags
+    timestamp_parse_error for indeterminate verdict), not silently
+    return None."""
+    with pytest.raises(ValueError):
+        evidence._parse_vllm_timestamp(
+            "INFO 99-99 99:99:99", year=2026,
+            tz=timezone.utc,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Rank aggregation
+# ---------------------------------------------------------------------------
+
+
+def test_rank_aggregation_worst_verdict():
+    report = evidence.classify_rank(
+        0,
+        engine_log=ENGINE_PER_LAYER_ISO,
+        server_log=SERVER_OOM,
+        engine_running=True,
+        server_running=True,
+        kernel_log=KERNEL_RM_IN_WINDOW,
+        rm_event_bound=10,
+        cluster_ready=True,
+    )
+    assert report["verdict"] == "fatal"
+    assert report["engine"]["verdict"] == "bounded_rm_retry"
+    assert report["server"]["verdict"] == "fatal"
+
+
+def test_rank_aggregation_both_clean():
+    report = evidence.classify_rank(
+        1, engine_log=CLEAN_ENGINE, server_log=SERVER_CLEAN,
+    )
+    assert report["verdict"] == "clean"
+
+
+def test_rank_without_engine_evidence_is_indeterminate():
+    report = evidence.classify_rank(1, server_log=SERVER_CLEAN)
+    assert report["verdict"] == "indeterminate"
+    assert report["missing_engine_evidence"] is True
+
+
+# ---------------------------------------------------------------------------
+# Aggregate report
+# ---------------------------------------------------------------------------
+
+
+def test_aggregate_report_fatal_wins():
+    ranks = [
+        evidence.classify_rank(0, engine_log=CLEAN_ENGINE),
+        evidence.classify_rank(1, engine_log=XID_FATAL),
+        evidence.classify_rank(
+            2, engine_log=ENGINE_PER_LAYER_ISO,
+            kernel_log=KERNEL_RM_IN_WINDOW,
+            rm_event_bound=10, cluster_ready=True,
+        ),
+        evidence.classify_rank(3, engine_log=CLEAN_ENGINE),
+    ]
+    report = evidence.aggregate_report(ranks)
+    assert report["verdict"] == "fatal"
+    assert report["ranks_fatal"] == [1]
+    assert report["ranks_bounded_rm_retry"] == [2]
+
+
+def test_aggregate_report_all_clean():
+    ranks = [
+        evidence.classify_rank(r, engine_log=CLEAN_ENGINE)
+        for r in range(4)
+    ]
+    report = evidence.aggregate_report(ranks)
+    assert report["verdict"] == "clean"
+
+
+def test_fatal_signature_count_counts_signatures_not_components():
+    rank = evidence.classify_rank(
+        0,
+        engine_log="NVRM: Xid 43\nCUDA out of memory\n",
+    )
+    report = evidence.aggregate_report([rank])
+    assert report["fatal_signature_count"] == 2
+
+
+def test_aggregate_report_indeterminate_dominates():
+    ranks = [
+        evidence.classify_rank(0, engine_log=CLEAN_ENGINE),
+        evidence.classify_rank(
+            1, engine_log=ENGINE_PER_LAYER_ISO,
+            kernel_log=KERNEL_RM_IN_WINDOW,
+            rm_event_bound=10, cluster_ready=False,
+        ),
+        evidence.classify_rank(2, engine_log=CLEAN_ENGINE),
+    ]
+    report = evidence.aggregate_report(ranks)
+    assert report["verdict"] == "indeterminate"
+    assert report["ranks_indeterminate"] == [1]
+
+
+def test_aggregate_report_exposes_timestamp_parse_error():
+    """The aggregate report must expose which ranks had timestamp_parse_error."""
+    from datetime import timezone, timedelta
+    ranks = [
+        evidence.classify_rank(0, engine_log=CLEAN_ENGINE),
+        evidence.classify_rank(
+            1,
+            engine_log=ENGINE_MALFORMED_VLLM_TS_MAT,
+            kernel_log=KERNEL_RM_IN_WINDOW,
+            rm_event_bound=10,
+            engine_log_year=2026,
+            engine_log_tz=timezone(-timedelta(hours=5)),
+            cluster_ready=True,
+        ),
+        evidence.classify_rank(2, engine_log=CLEAN_ENGINE),
+    ]
+    report = evidence.aggregate_report(ranks)
+    assert report["verdict"] == "indeterminate"
+    assert 1 in report["ranks_with_timestamp_parse_error"]
+    assert 0 not in report["ranks_with_timestamp_parse_error"]
+    # The per-rank engine component must also expose the flag
+    rank1 = next(r for r in report["ranks"] if r["rank"] == 1)
+    assert rank1["engine"]["timestamp_parse_error"] is True
+
+
+def test_aggregate_report_timestamp_parse_error_deduplicated():
+    """If both engine and server components have timestamp_parse_error,
+    the rank must appear only once in ranks_with_timestamp_parse_error."""
+    from datetime import timezone, timedelta
+    # Create a rank where both engine and server logs have malformed timestamps
+    ranks = [
+        evidence.classify_rank(
+            0,
+            engine_log=ENGINE_MALFORMED_VLLM_TS_MAT,
+            server_log=ENGINE_MALFORMED_VLLM_TS_MAT,
+            kernel_log=KERNEL_RM_IN_WINDOW,
+            rm_event_bound=10,
+            engine_log_year=2026,
+            engine_log_tz=timezone(-timedelta(hours=5)),
+            cluster_ready=True,
+        ),
+    ]
+    report = evidence.aggregate_report(ranks)
+    # Rank 0 should appear exactly once, not twice
+    assert report["ranks_with_timestamp_parse_error"].count(0) == 1
+
+
+def test_aggregate_report_fatal_beats_indeterminate():
+    ranks = [
+        evidence.classify_rank(0, engine_log=CLEAN_ENGINE),
+        evidence.classify_rank(1, engine_log=XID_FATAL),
+        evidence.classify_rank(
+            2, engine_log=ENGINE_PER_LAYER_ISO,
+            kernel_log=KERNEL_RM_IN_WINDOW,
+            rm_event_bound=10, cluster_ready=False,
+        ),
+    ]
+    report = evidence.aggregate_report(ranks)
+    assert report["verdict"] == "fatal"
+
+
+# ---------------------------------------------------------------------------
+# Provenance and notes
+# ---------------------------------------------------------------------------
+
+
+def test_sha256_provenance():
+    assert len(evidence.classify_log(CLEAN_ENGINE)["sha256"]) == 64
+
+
+def test_kernel_sha256_present():
+    result = evidence.classify_log(
+        CLEAN_ENGINE, kernel_log=KERNEL_RM_IN_WINDOW
+    )
+    assert result["kernel_sha256"] is not None
+    assert len(result["kernel_sha256"]) == 64
+
+
+def test_kernel_sha256_none():
+    assert evidence.classify_log(CLEAN_ENGINE)["kernel_sha256"] is None
+
+
+def test_classification_note_states_evidence_scope():
+    ranks = [evidence.classify_rank(0, engine_log=CLEAN_ENGINE)]
+    report = evidence.aggregate_report(ranks)
+    note = report["classification_note"]
+    assert "per-layer materialization window" in note
+    assert "NV_ERR_NO_MEMORY" in note
+    assert "mem_desc.c:1359" in note
+    assert "LMCache server readiness alone" in note
+    assert "window_event_count is a count, not a delta" in note
+    assert "offline-validated" in note
+    assert "never establishes a safe bound" in note
+
+
+def test_evidence_scope_states_count_not_delta():
+    ranks = [evidence.classify_rank(0, engine_log=CLEAN_ENGINE)]
+    report = evidence.aggregate_report(ranks)
+    assert "not a delta" in report["evidence_scope"]
+
+
+# ---------------------------------------------------------------------------
+# Verdict ordering
+# ---------------------------------------------------------------------------
+
+
+def test_worst_verdict_fatal_beats_all():
+    assert evidence._worst_verdict(
+        ["clean", "bounded_rm_retry", "indeterminate", "fatal"]
+    ) == "fatal"
+
+
+def test_worst_verdict_indeterminate_beats_bounded():
+    assert evidence._worst_verdict(
+        ["clean", "bounded_rm_retry", "indeterminate"]
+    ) == "indeterminate"
+
+
+def test_worst_verdict_empty_is_clean():
+    assert evidence._worst_verdict([]) == "clean"
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _write_inspect(
+    tmp_path: Path,
+    name: str,
+    *,
+    running: bool = True,
+    restart_count: int = 0,
+    oom_killed: bool = False,
+    container_id: str | None = None,
+    container_name: str | None = None,
+) -> Path:
+    path = tmp_path / f"{name}-inspect.json"
+    path.write_text(json.dumps([{
+        "Id": container_id or f"sha256:{name}",
+        "Name": container_name or f"/{name}",
+        "State": {"Running": running, "OOMKilled": oom_killed},
+        "RestartCount": restart_count,
+    }]), encoding="utf-8")
+    return path
+
+
+def _engine_cli_args(
+    tmp_path: Path,
+    logs: list[Path],
+    *,
+    states: dict[int, dict[str, object]] | None = None,
+) -> list[str]:
+    all_logs = list(logs)
+    for rank in range(len(all_logs), evidence.EXPECTED_RANKS):
+        path = tmp_path / f"engine-r{rank}-padding.log"
+        path.write_text(CLEAN_ENGINE, encoding="utf-8")
+        all_logs.append(path)
+
+    args: list[str] = []
+    for rank, log in enumerate(all_logs):
+        args.extend(("--engine-log", str(log)))
+        state = (states or {}).get(rank, {})
+        inspect = _write_inspect(tmp_path, f"engine-r{rank}", **state)
+        args.extend(("--engine-inspect", str(inspect)))
+        args.extend(("--engine-container-name", f"engine-r{rank}"))
+    return args
+
+
+def _kernel_cli_args(tmp_path: Path, logs: list[Path]) -> list[str]:
+    all_logs = list(logs)
+    for rank in range(len(all_logs), evidence.EXPECTED_RANKS):
+        path = tmp_path / f"kernel-r{rank}-padding.log"
+        path.write_text("", encoding="utf-8")
+        all_logs.append(path)
+    return [arg for log in all_logs for arg in ("--kernel-log", str(log))]
+
+
+def test_cli_clean(tmp_path, capsys):
+    log = tmp_path / "engine-r0.log"
+    log.write_text(CLEAN_ENGINE, encoding="utf-8")
+    rc = evidence.main(_engine_cli_args(tmp_path, [log]) + ["classify"])
+    assert rc == evidence.EXIT_OK
+
+
+def test_cli_requires_complete_default_four_rank_evidence(tmp_path):
+    log = tmp_path / "engine-r0.log"
+    log.write_text(CLEAN_ENGINE, encoding="utf-8")
+    inspect = _write_inspect(tmp_path, "engine-r0")
+    with pytest.raises(SystemExit):
+        evidence.main([
+            "--engine-log", str(log),
+            "--engine-inspect", str(inspect),
+            "--engine-container-name", "engine-r0",
+            "classify",
+        ])
+
+
+def test_cli_requires_engine_inspect(tmp_path):
+    args: list[str] = []
+    for rank in range(evidence.EXPECTED_RANKS):
+        log = tmp_path / f"engine-r{rank}.log"
+        log.write_text(CLEAN_ENGINE, encoding="utf-8")
+        args.extend(("--engine-log", str(log)))
+        args.extend(("--engine-container-name", f"engine-r{rank}"))
+    with pytest.raises(SystemExit):
+        evidence.main(args + ["classify"])
+
+
+def test_cli_rejects_empty_engine_log(tmp_path):
+    log = tmp_path / "engine-r0.log"
+    log.write_text("", encoding="utf-8")
+    rc = evidence.main(_engine_cli_args(tmp_path, [log]) + ["classify"])
+    assert rc == evidence.EXIT_CONFIG_ERROR
+
+
+def test_cli_rejects_unaligned_rank_logs(tmp_path):
+    engine = tmp_path / "engine-r0.log"
+    kernel0 = tmp_path / "kernel-r0.log"
+    kernel1 = tmp_path / "kernel-r1.log"
+    engine.write_text(CLEAN_ENGINE, encoding="utf-8")
+    kernel0.write_text("", encoding="utf-8")
+    kernel1.write_text("", encoding="utf-8")
+    with pytest.raises(SystemExit):
+        evidence.main(_engine_cli_args(tmp_path, [engine]) + [
+            "--kernel-log", str(kernel0),
+            "--kernel-log", str(kernel1),
+            "classify",
+        ])
+
+
+def test_cli_inspect_restart_is_fatal(tmp_path, capsys):
+    engine = tmp_path / "engine-r0.log"
+    engine.write_text(CLEAN_ENGINE, encoding="utf-8")
+    rc = evidence.main(_engine_cli_args(
+        tmp_path, [engine], states={0: {"restart_count": 1}}
+    ) + ["classify"])
+    assert rc == evidence.EXIT_FATAL
+    report = json.loads(capsys.readouterr().out)
+    assert report["ranks_fatal"] == [0]
+    assert report["ranks"][0]["engine"]["restart_count"] == 1
+
+
+def test_cli_inspect_oom_killed_is_fatal(tmp_path, capsys):
+    engine = tmp_path / "engine-r0.log"
+    engine.write_text(CLEAN_ENGINE, encoding="utf-8")
+    rc = evidence.main(_engine_cli_args(
+        tmp_path, [engine], states={0: {"oom_killed": True}}
+    ) + ["classify"])
+    assert rc == evidence.EXIT_FATAL
+    report = json.loads(capsys.readouterr().out)
+    assert report["ranks"][0]["engine"]["oom_killed"] is True
+
+
+def test_cli_rejects_inspect_name_at_wrong_rank(tmp_path):
+    engine = tmp_path / "engine-r0.log"
+    engine.write_text(CLEAN_ENGINE, encoding="utf-8")
+    args = _engine_cli_args(tmp_path, [engine])
+    expected_name_index = args.index("engine-r0")
+    args[expected_name_index] = "wrong-engine-r0"
+    rc = evidence.main(args + ["classify"])
+    assert rc == evidence.EXIT_CONFIG_ERROR
+
+
+def test_cli_rejects_engine_identity_reused_as_server(tmp_path):
+    engine = tmp_path / "engine-r0.log"
+    engine.write_text(CLEAN_ENGINE, encoding="utf-8")
+    args = _engine_cli_args(tmp_path, [engine])
+    for rank in range(evidence.EXPECTED_RANKS):
+        server_log = tmp_path / f"server-r{rank}.log"
+        server_log.write_text(SERVER_CLEAN, encoding="utf-8")
+        server_inspect = _write_inspect(
+            tmp_path,
+            f"server-r{rank}",
+            container_id=(
+                "sha256:engine-r0" if rank == 0 else f"sha256:server-r{rank}"
+            ),
+        )
+        args.extend(("--server-log", str(server_log)))
+        args.extend(("--server-inspect", str(server_inspect)))
+        args.extend(("--server-container-name", f"server-r{rank}"))
+    rc = evidence.main(args + ["classify"])
+    assert rc == evidence.EXIT_CONFIG_ERROR
+
+
+def test_inspect_requires_container_identity():
+    with pytest.raises(evidence.ConfigError):
+        evidence._parse_container_inspect(json.dumps([{
+            "State": {"Running": True, "OOMKilled": False},
+            "RestartCount": 0,
+        }]))
+
+
+def test_cli_rejects_negative_event_bound(tmp_path):
+    engine = tmp_path / "engine-r0.log"
+    engine.write_text(CLEAN_ENGINE, encoding="utf-8")
+    with pytest.raises(SystemExit):
+        evidence.main(_engine_cli_args(tmp_path, [engine]) + [
+            "--rm-event-bound", "-1",
+            "classify",
+        ])
+
+
+def test_parse_tz_rejects_out_of_range_offset():
+    with pytest.raises(evidence.ConfigError):
+        evidence._parse_tz("+24:00")
+
+
+def test_cli_fatal(tmp_path, capsys):
+    log = tmp_path / "engine-r0.log"
+    log.write_text(XID_FATAL, encoding="utf-8")
+    rc = evidence.main(_engine_cli_args(tmp_path, [log]) + ["classify"])
+    assert rc == evidence.EXIT_FATAL
+
+
+def test_cli_bounded_rm_retry(tmp_path, capsys):
+    engine = tmp_path / "engine-r0.log"
+    kernel = tmp_path / "kernel-r0.log"
+    engine.write_text(ENGINE_PER_LAYER_ISO, encoding="utf-8")
+    kernel.write_text(KERNEL_RM_IN_WINDOW, encoding="utf-8")
+    rc = evidence.main(
+        _engine_cli_args(tmp_path, [engine])
+        + _kernel_cli_args(tmp_path, [kernel])
+        + [
+        "--rm-event-bound", "10",
+        "--cluster-ready",
+        "classify",
+        ]
+    )
+    assert rc == evidence.EXIT_OK
+
+
+def test_cli_indeterminate_no_cluster_ready(tmp_path, capsys):
+    engine = tmp_path / "engine-r0.log"
+    kernel = tmp_path / "kernel-r0.log"
+    engine.write_text(ENGINE_PER_LAYER_ISO, encoding="utf-8")
+    kernel.write_text(KERNEL_RM_IN_WINDOW, encoding="utf-8")
+    rc = evidence.main(
+        _engine_cli_args(tmp_path, [engine])
+        + _kernel_cli_args(tmp_path, [kernel])
+        + ["--rm-event-bound", "10", "classify"]
+    )
+    assert rc == evidence.EXIT_FATAL
+
+
+def test_cli_missing_bound_indeterminate(tmp_path, capsys):
+    engine = tmp_path / "engine-r0.log"
+    kernel = tmp_path / "kernel-r0.log"
+    engine.write_text(ENGINE_PER_LAYER_ISO, encoding="utf-8")
+    kernel.write_text(KERNEL_RM_IN_WINDOW, encoding="utf-8")
+    rc = evidence.main(
+        _engine_cli_args(tmp_path, [engine])
+        + _kernel_cli_args(tmp_path, [kernel])
+        + ["--cluster-ready", "classify"]
+    )
+    assert rc == evidence.EXIT_FATAL
+
+
+def test_cli_vllm_year_tz(tmp_path, capsys):
+    engine = tmp_path / "engine-r0.log"
+    kernel = tmp_path / "kernel-r0.log"
+    engine.write_text(ENGINE_PER_LAYER_MATERIALIZATION, encoding="utf-8")
+    kernel.write_text(KERNEL_RM_IN_WINDOW, encoding="utf-8")
+    rc = evidence.main(
+        _engine_cli_args(tmp_path, [engine])
+        + _kernel_cli_args(tmp_path, [kernel])
+        + [
+        "--rm-event-bound", "10",
+        "--cluster-ready",
+        "--engine-log-year", "2026",
+        "--engine-log-tz=-05:00",
+        "classify",
+        ]
+    )
+    assert rc == evidence.EXIT_OK
+
+
+def test_cli_year_without_tz_indeterminate(tmp_path, capsys):
+    engine = tmp_path / "engine-r0.log"
+    kernel = tmp_path / "kernel-r0.log"
+    engine.write_text(ENGINE_PER_LAYER_MATERIALIZATION, encoding="utf-8")
+    kernel.write_text(KERNEL_RM_IN_WINDOW, encoding="utf-8")
+    rc = evidence.main(
+        _engine_cli_args(tmp_path, [engine])
+        + _kernel_cli_args(tmp_path, [kernel])
+        + [
+        "--rm-event-bound", "10",
+        "--cluster-ready",
+        "--engine-log-year", "2026",
+        "classify",
+        ]
+    )
+    assert rc == evidence.EXIT_FATAL
+
+
+def test_cli_requires_log(capsys):
+    with pytest.raises(SystemExit):
+        evidence.main(["classify"])
+
+
+def test_cli_multi_rank(tmp_path, capsys):
+    logs = []
+    for rank, content in enumerate(
+        [CLEAN_ENGINE, XID_FATAL, CLEAN_ENGINE, CLEAN_ENGINE]
+    ):
+        path = tmp_path / f"engine-r{rank}.log"
+        path.write_text(content, encoding="utf-8")
+        logs.append(path)
+    rc = evidence.main(_engine_cli_args(tmp_path, logs) + ["classify"])
+    assert rc == evidence.EXIT_FATAL
+
+
+def test_cli_kernel_not_found(tmp_path, capsys):
+    engine = tmp_path / "engine-r0.log"
+    engine.write_text(CLEAN_ENGINE, encoding="utf-8")
+    rc = evidence.main(
+        _engine_cli_args(tmp_path, [engine])
+        + _kernel_cli_args(tmp_path, [Path("nonexistent.log")])
+        + ["classify"]
+    )
+    assert rc == evidence.EXIT_CONFIG_ERROR
+
+
+def test_cli_per_rank_bounds(tmp_path, capsys):
+    engine0 = tmp_path / "engine-r0.log"
+    engine1 = tmp_path / "engine-r1.log"
+    kernel0 = tmp_path / "kernel-r0.log"
+    kernel1 = tmp_path / "kernel-r1.log"
+    engine0.write_text(ENGINE_PER_LAYER_ISO, encoding="utf-8")
+    engine1.write_text(ENGINE_PER_LAYER_ISO, encoding="utf-8")
+    kernel0.write_text(KERNEL_RM_3_EVENTS, encoding="utf-8")
+    kernel1.write_text(KERNEL_RM_36_EVENTS, encoding="utf-8")
+    rc = evidence.main(
+        _engine_cli_args(tmp_path, [engine0, engine1])
+        + _kernel_cli_args(tmp_path, [kernel0, kernel1])
+        + [
+        "--rm-event-bound", "3",
+        "--cluster-ready",
+        "classify",
+        ]
+    )
+    assert rc == evidence.EXIT_FATAL
+
+
+# ---------------------------------------------------------------------------
+# TZ parsing
+# ---------------------------------------------------------------------------
+
+
+def test_parse_tz_utc():
+    assert evidence._parse_tz("UTC") == timezone.utc
+
+
+def test_parse_tz_offset():
+    tz = evidence._parse_tz("-05:00")
+    assert tz.utcoffset(None) == -timedelta(hours=5)
+
+
+def test_parse_tz_invalid():
+    with pytest.raises(evidence.ConfigError):
+        evidence._parse_tz("garbage")
+
+
+# ---------------------------------------------------------------------------
+# Schema
+# ---------------------------------------------------------------------------
+
+
+def test_schema_is_v1():
+    assert evidence.SCHEMA == "sparkring-startup-evidence/v1"
+
+
+# ---------------------------------------------------------------------------
+# window_event_count is a count, not a delta
+# ---------------------------------------------------------------------------
+
+
+def test_report_uses_window_event_count_not_rm_event_count():
+    """The report field must be 'window_event_count', not 'rm_event_count'
+    or 'delta'."""
+    result = evidence.classify_log(
+        ENGINE_PER_LAYER_ISO,
+        container_running=True,
+        kernel_log=KERNEL_RM_3_EVENTS,
+        rm_event_bound=10,
+        cluster_ready=True,
+    )
+    assert "window_event_count" in result
+    assert "rm_event_count" not in result


### PR DESCRIPTION
## Result

Adds an offline startup-evidence classifier for the four-rank EXL3 + LMCache public-functional workflow.

The classifier:

- requires all four engine logs and matching Docker inspection receipts;
- binds every receipt to an explicit role/rank container name and rejects reused identities;
- treats stopped, restarted, or OOM-killed containers as fatal;
- scans container and kernel logs for fatal startup signatures;
- permits `bounded_rm_retry` only for the identified `NV_ERR_NO_MEMORY` callsite inside an ordered per-layer materialization window, under an operator-reviewed count bound and separate readiness fact;
- treats unknown RM callsites, missing timestamps, reordered evidence, partial ranks, and incomplete state as indeterminate with fatal exit policy; and
- emits a hashed `sparkring-startup-evidence/v1` report without contacting or mutating a Spark.

The acceptance runbook documents the offline interface and its limits. Maturity remains `offline-validated`; this PR does not claim a live result or change the running/default model configuration.

## Validation

- `python -m pytest scripts/test_sparkring_startup_evidence.py -q` — 100 passed
- `python -m pytest spark_transport sparkcache runtime scripts -q` — 2580 passed, 14 skipped
- `ruff check --select E,F,W --ignore E501 .` — passed
- repository Markdown link/anchor checker — 169 links passed
- independent standards review — passed
- independent correctness/fail-closed review — passed