### PR TITLE
Add fail-closed benchmark evidence comparator

### DIFF
--- a/docs/EVIDENCE_COMPARISON_CHECKLIST.md
+++ b/docs/EVIDENCE_COMPARISON_CHECKLIST.md
@@ -1,0 +1,128 @@
+# Evidence-analysis checklist: matched 16K sustained decode
+
+`scripts/compare_benchmark_evidence.py` compares two offline
+`llm_decode_bench.py` v0.4.31 JSON documents. The implemented scope is one
+16,384-token context at C1, C2, C4, and C8 under duration-based decode. The
+tool does not contact a cluster, launch a model, or run a benchmark.
+
+The comparator is an implemented evidence-analysis utility. A successful
+report means that the two input documents are structurally valid and directly
+comparable within the fields they record. It does not promote either serving
+configuration or turn two independently collected runs into a sealed A/B.
+
+## Comparison contract
+
+Both documents must meet every condition below before the tool emits throughput
+deltas.
+
+### Benchmark type
+
+- `metadata.version` identifies `llm_decode_bench.py` v0.4.31.
+- `metadata.decode_mode` and every result `benchmark_mode` are `duration`.
+- `duration_per_test` is at least 10 seconds.
+- `max_tokens` is at least 256.
+- Bounded gates and indeterminate documents are rejected, including a pair of
+  two bounded documents.
+
+### Runtime and workload identity
+
+The following recorded fields must be present, valid, and equal between the
+baseline and candidate:
+
+| Field group | Compared values |
+|---|---|
+| Runtime identity | engine, model, harness version, primary decode layer, decode mode |
+| Shape | context lengths, concurrency levels, DCP size, KV token budget |
+| Measurement | cell duration, maximum output tokens, temperature, ignore-EOS behavior |
+| Warmup | warmup duration, warmup context, warmup concurrency, cell timeout |
+| Prompt mix | unique-context percentage, shared-context percentage, prefill-skip behavior |
+
+Unique- and shared-context percentages must each be within 0–100 and sum to
+100. Numeric metadata must be finite. Boolean metadata must be actual JSON
+booleans rather than numeric substitutes.
+
+### Coverage and cell validity
+
+Each document must contain exactly one 16,384-token context and exactly one
+result for C1, C2, C4, and C8. Metadata, results, and an optional
+`summary_table` must agree. Missing, duplicated, unexpected, or multi-context
+cells fail closed.
+
+Every result must satisfy:
+
+- `aggregate_tps` is finite and positive;
+- `num_errors == 0`;
+- `effective_concurrency` equals the requested concurrency;
+- `measurement_seconds` is finite and positive;
+- `underfilled`, `warmup_timed_out`, and `capacity_limited` are false;
+- `benchmark_mode == "duration"`.
+
+Missing fields are invalid. The comparator never invents defaults. If a
+`summary_table` is present, it is checked against `results`; it cannot override
+the result records.
+
+### Distinct inputs
+
+Semantically identical benchmark documents are rejected as an invalid comparison.
+The CLI records the SHA-256 digest of both input files in its report so the
+comparison is traceable to exact evidence.
+
+## Reported result
+
+After every gate passes, the tool emits, for each concurrency:
+
+- baseline and candidate aggregate tokens per second;
+- absolute candidate-minus-baseline delta;
+- percentage delta relative to the baseline.
+
+No numeric deltas are emitted for type, metadata, settings, coverage, cell
+validity, or non-finite derived-value failures. A negative percentage is a
+throughput regression signal, not a statistical conclusion.
+
+Every report carries this scope statement:
+
+> Cross-document comparison with matched sustained-16K settings. Not a sealed
+> A/B unless both documents were produced under controlled conditions with
+> identical configuration except for the declared experimental variable.
+
+## Conditions outside the JSON schema
+
+The v0.4.31 benchmark document does not prove image digest, model revision,
+launch arguments, transport path, hardware identity, competing traffic,
+thermal state, or run ordering. Preserve those facts in a separate launch and
+telemetry receipt. Declare one experimental variable before collecting the
+pair; the comparator cannot infer which external variable changed.
+
+For cache comparisons, name the mechanism precisely:
+
+| Cache mechanism | Implementation |
+|---|---|
+| Native automatic prefix cache | vLLM prefix-caching configuration |
+| LMCache | LMCache connector and one local cache service per rank |
+| SparkCache | `sparkcache/` and `SPARK_CONTEXT_CACHE_ENABLE` |
+
+Changing more than one cache mechanism produces a combined cache comparison,
+not evidence attributable to one implementation.
+
+## Limitations
+
+- One measurement per cell is a point observation, not a confidence interval.
+- The tool does not compare prefill scouts, coding-peak runs, bounded gates, or
+  multi-context matrices.
+- A sealed A/B requires a controlled collection protocol, stable external
+  receipts, and an ordering strategy such as alternating runs.
+
+## Usage
+
+```bash
+python scripts/compare_benchmark_evidence.py \
+    --baseline evidence/baseline-16k.json \
+    --candidate evidence/candidate-16k.json
+```
+
+| Exit code | Meaning |
+|---:|---|
+| 0 | Both documents are valid and comparable; deltas were emitted |
+| 2 | Document type, matched settings, or distinct-input requirement failed |
+| 3 | An input file is missing or is not valid JSON |
+| 4 | Metadata, coverage, result cells, or derived deltas are invalid |

--- a/docs/RESULTS.md
+++ b/docs/RESULTS.md
@@ -217,6 +217,10 @@ These are **transport-level** measurements: no model in the loop unless a row sa
 
 ## 4. Methodology: the claim discipline
 
+Use the [matched 16K sustained-decode checklist](EVIDENCE_COMPARISON_CHECKLIST.md)
+and `scripts/compare_benchmark_evidence.py` for fail-closed offline comparison
+of two `llm_decode_bench.py` v0.4.31 matrix documents.
+
 The numbers above are only as good as the rules used to produce and report them. Those rules are part of the result, so they are stated here in full.
 
 **Every number carries a full label.** A performance claim in this repository is not a bare number — it names the topology, the checkpoint, the parallelism configuration (TP/DCP degree), the execution mode (eager vs. CUDA-graph, custom vs. fallback transport), the workload and concurrency, the statistic (p50, median-of-N, single sample, log-window observation), and the gate the run had to pass. A number quoted without its label is considered misquoted.

--- a/scripts/compare_benchmark_evidence.py
+++ b/scripts/compare_benchmark_evidence.py
@@ -1,0 +1,978 @@
+#!/usr/bin/env python3
+"""Offline evidence-comparison tool for matched 16K decode benchmarks.
+
+Compares two sustained-decode 16K C1/C2/C4/C8 benchmark JSON documents
+produced by ``llm_decode_bench.py`` v0.4.31 and reports per-concurrency
+deltas, but ONLY when document type, workload settings, validity, and exact
+cell coverage ALL pass. Never mixes bounded 128-token gate figures with
+sustained-duration matrix figures.
+
+This tool is **purely offline**: it reads two JSON files supplied by
+the operator and produces a structured comparison report.  It does not
+contact the cluster, run benchmarks, or mutate anything.
+
+## Raw schema (llm_decode_bench v0.4.31)
+
+- ``metadata``: top-level object with ``version``, ``decode_mode``,
+  ``duration_per_test``, ``max_tokens``, ``temperature``,
+  ``decode_warmup_seconds``, ``cell_warmup_timeout_seconds``,
+  ``unique_context_percent``, ``shared_context_percent``, ``dcp_size``,
+  ``max_total_tokens``, ``skip_prefill``, ``ignore_eos``,
+  ``concurrency_levels``, ``context_lengths``.
+- ``results``: array of per-cell objects, each with ``concurrency``,
+  ``context_tokens``, ``aggregate_tps``, ``num_errors``,
+  ``effective_concurrency``, ``benchmark_mode``, ``measurement_seconds``,
+  ``underfilled``, ``warmup_timed_out``, ``capacity_limited``.
+- ``summary_table``: ``{context_tokens: {concurrency: aggregate_tps}}``.
+
+## Fail-closed rules
+
+1. Both documents must be ``sustained_matrix``.  Two ``bounded_gate``
+   or two ``indeterminate`` documents must NOT compare.
+2. ``metadata.concurrency_levels`` must exactly match ``[8, 4, 2, 1]``
+   as a set.  Each document must have exactly one 16K context and exactly
+   C1/C2/C4/C8 result coverage consistent with metadata.  Absent,
+   duplicated, or unexpected/multi-context results fail closed.
+3. Missing ``num_errors``, ``effective_concurrency``, ``underfilled``,
+   ``warmup_timed_out``, ``capacity_limited``, ``benchmark_mode``,
+   ``measurement_seconds``, or ``aggregate_tps`` is indeterminate/invalid,
+   never default-zero/true.  ``aggregate_tps`` must be finite, numeric,
+   positive, and not bool.  ``num_errors`` must be int (not bool) and 0.
+   ``effective_concurrency`` must be int (not bool) and equal requested.
+   ``measurement_seconds`` must be finite and > 0.  Boolean flags must
+   be actual booleans and false.
+4. No numeric deltas are computed or emitted until document type,
+   complete settings, validity, and exact cell coverage all pass.
+5. Classification requires ``metadata.decode_mode == "duration"`` and
+   each result ``benchmark_mode == "duration"``, and requires both
+   ``duration_per_test`` and ``max_tokens`` (no inference from one).
+6. Multi-context documents and any mismatch between metadata context
+   list, result contexts, and summary table are rejected.  If
+   ``summary_table`` is present, its values must agree with results
+   ``aggregate_tps`` within a tiny float tolerance.  Results are
+   canonical after consistency validation.
+
+## Usage::
+
+    python scripts/compare_benchmark_evidence.py \\
+        --baseline evidence/cache-off.json \\
+        --candidate evidence/cache-on.json
+
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import sys
+from pathlib import Path
+from typing import Any, Sequence
+
+SCHEMA = "sparkring-benchmark-comparison/v1"
+SUPPORTED_HARNESS_VERSION = "0.4.31"
+SUPPORTED_DECODE_LAYER = "sustained_decode"
+EXIT_OK = 0
+EXIT_MISMATCH = 2
+EXIT_CONFIG_ERROR = 3
+EXIT_INVALID = 4
+
+# Required concurrency cells for a valid 16K matrix comparison.
+REQUIRED_CONCURRENCIES = [1, 2, 4, 8]
+REQUIRED_CONTEXT = 16384
+REQUIRED_CONCURRENCY_LEVELS = [8, 4, 2, 1]
+
+# Tolerance for summary_table vs results aggregate_tps agreement.
+# Accounts for float serialization round-trip; values are tok/s
+# measured to full double precision so 1e-9 relative is generous.
+SUMMARY_TOLERANCE_RELATIVE = 1e-9
+
+# Settings that must match exactly before any delta is claimed.
+MATCHED_SETTINGS: list[tuple[str, str]] = [
+    ("engine", "engine"),
+    ("model", "model"),
+    ("version", "harness_version"),
+    ("primary_decode_layer", "decode_layer"),
+    ("decode_mode", "decode_mode"),
+    ("context_lengths", "context_tokens"),
+    ("concurrency_levels", "concurrencies"),
+    ("duration_per_test", "duration_seconds"),
+    ("decode_warmup_seconds", "decode_warmup_seconds"),
+    ("decode_warmup_context", "decode_warmup_context"),
+    ("decode_warmup_concurrency", "decode_warmup_concurrency"),
+    ("max_tokens", "max_output_tokens"),
+    ("temperature", "temperature"),
+    ("unique_context_percent", "unique_context_percent"),
+    ("shared_context_percent", "shared_context_percent"),
+    ("dcp_size", "dcp_size"),
+    ("max_total_tokens", "kv_budget_tokens"),
+    ("ignore_eos", "ignore_eos"),
+    ("skip_prefill", "skip_prefill"),
+    ("cell_warmup_timeout_seconds", "cell_warmup_timeout_seconds"),
+]
+
+
+class ConfigError(ValueError):
+    """The operator supplied an invalid argument."""
+
+
+class EvidenceError(ValueError):
+    """A benchmark document is malformed or settings mismatch."""
+
+
+# ---------------------------------------------------------------------------
+# Type-check helpers
+# ---------------------------------------------------------------------------
+
+
+def _is_int_not_bool(val: Any) -> bool:
+    """True if val is an int but not a bool (bool is a subclass of int)."""
+    return isinstance(val, int) and not isinstance(val, bool)
+
+
+def _is_finite_number(val: Any) -> bool:
+    """True if val is a finite int or float but not a bool."""
+    if isinstance(val, bool):
+        return False
+    if isinstance(val, (int, float)):
+        try:
+            return math.isfinite(float(val))
+        except OverflowError:
+            return False
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Metadata extraction
+# ---------------------------------------------------------------------------
+
+
+def _get_metadata(doc: dict[str, Any]) -> dict[str, Any]:
+    """Return the ``metadata`` object from a raw benchmark document."""
+    meta = doc.get("metadata")
+    if not isinstance(meta, dict):
+        raise EvidenceError(
+            "document has no 'metadata' object or it is not a dict; "
+            "cannot extract workload settings"
+        )
+    return meta
+
+
+def _first_context_length(meta: dict[str, Any]) -> int | None:
+    """Extract the first (primary) context length from metadata."""
+    cls = meta.get("context_lengths")
+    if isinstance(cls, list) and len(cls) >= 1 and isinstance(cls[0], int):
+        return cls[0]
+    return None
+
+
+def extract_settings(doc: dict[str, Any]) -> dict[str, Any]:
+    """Extract workload settings from a raw benchmark document's metadata."""
+    meta = _get_metadata(doc)
+    settings: dict[str, Any] = {}
+    for meta_key, display_name in MATCHED_SETTINGS:
+        if meta_key == "context_lengths":
+            settings[display_name] = _first_context_length(meta)
+        else:
+            settings[display_name] = meta.get(meta_key)
+    return settings
+
+
+def validate_metadata(doc: dict[str, Any]) -> dict[str, Any]:
+    """Validate metadata fields required for a comparable sustained run."""
+    try:
+        meta = _get_metadata(doc)
+    except EvidenceError as exc:
+        return {"valid": False, "reason": str(exc)}
+
+    for key in ("version", "engine", "model", "primary_decode_layer"):
+        value = meta.get(key)
+        if not isinstance(value, str) or not value.strip():
+            return {"valid": False, "reason": f"metadata.{key} must be a non-empty string"}
+
+    if meta["version"] != SUPPORTED_HARNESS_VERSION:
+        return {
+            "valid": False,
+            "reason": (
+                f"metadata.version must be {SUPPORTED_HARNESS_VERSION!r}, "
+                f"got {meta['version']!r}"
+            ),
+        }
+
+    if meta["primary_decode_layer"] != SUPPORTED_DECODE_LAYER:
+        return {
+            "valid": False,
+            "reason": (
+                f"metadata.primary_decode_layer must be {SUPPORTED_DECODE_LAYER!r}, "
+                f"got {meta['primary_decode_layer']!r}"
+            ),
+        }
+
+    if meta.get("decode_mode") != "duration":
+        return {"valid": False, "reason": "metadata.decode_mode must be 'duration'"}
+
+    for key, minimum, inclusive in (
+        ("duration_per_test", 10.0, True),
+        ("decode_warmup_seconds", 0.0, True),
+        ("cell_warmup_timeout_seconds", 0.0, False),
+    ):
+        value = meta.get(key)
+        if not _is_finite_number(value):
+            return {"valid": False, "reason": f"metadata.{key} must be finite numeric"}
+        if (inclusive and float(value) < minimum) or (
+            not inclusive and float(value) <= minimum
+        ):
+            relation = ">=" if inclusive else ">"
+            return {"valid": False, "reason": f"metadata.{key} must be {relation} {minimum:g}"}
+
+    for key, minimum in (
+        ("max_tokens", 256),
+        ("dcp_size", 1),
+        ("max_total_tokens", 1),
+    ):
+        value = meta.get(key)
+        if not _is_int_not_bool(value) or value < minimum:
+            return {"valid": False, "reason": f"metadata.{key} must be an integer >= {minimum}"}
+
+    for key in ("decode_warmup_context", "decode_warmup_concurrency"):
+        value = meta.get(key)
+        if not _is_int_not_bool(value) or value < 0:
+            return {"valid": False, "reason": f"metadata.{key} must be a non-negative integer"}
+
+    temperature = meta.get("temperature")
+    if not _is_finite_number(temperature) or float(temperature) < 0:
+        return {"valid": False, "reason": "metadata.temperature must be finite and non-negative"}
+
+    percentages: dict[str, float] = {}
+    for key in ("unique_context_percent", "shared_context_percent"):
+        value = meta.get(key)
+        if not _is_finite_number(value) or not 0 <= float(value) <= 100:
+            return {"valid": False, "reason": f"metadata.{key} must be between 0 and 100"}
+        percentages[key] = float(value)
+    if not math.isclose(sum(percentages.values()), 100.0, abs_tol=1e-9):
+        return {
+            "valid": False,
+            "reason": "metadata unique/shared context percentages must sum to 100",
+        }
+
+    for key in ("ignore_eos", "skip_prefill"):
+        if not isinstance(meta.get(key), bool):
+            return {"valid": False, "reason": f"metadata.{key} must be boolean"}
+
+    return {"valid": True}
+
+
+def classify_document_type(doc: dict[str, Any]) -> str:
+    """Classify a benchmark document as sustained_matrix or bounded_gate.
+
+    sustained_matrix requires ALL of:
+    - metadata.decode_mode == "duration"
+    - metadata.duration_per_test >= 10 (present and numeric)
+    - metadata.max_tokens >= 256 (present and numeric)
+    - every result cell has benchmark_mode == "duration"
+
+    bounded_gate: max_tokens < 256 or duration_per_test < 10.
+    indeterminate: metadata missing, decode_mode wrong, fields missing,
+    or cannot determine.
+    """
+    try:
+        meta = _get_metadata(doc)
+    except EvidenceError:
+        return "indeterminate"
+
+    decode_mode = meta.get("decode_mode")
+    max_tokens = meta.get("max_tokens")
+    duration = meta.get("duration_per_test")
+
+    # Require both duration and max_tokens — no inference from one
+    if max_tokens is None or duration is None:
+        return "indeterminate"
+    if not isinstance(max_tokens, (int, float)) or isinstance(max_tokens, bool):
+        return "indeterminate"
+    if not isinstance(duration, (int, float)) or isinstance(duration, bool):
+        return "indeterminate"
+
+    # If either suggests bounded, classify as bounded_gate
+    if max_tokens < 256:
+        return "bounded_gate"
+    if duration < 10:
+        return "bounded_gate"
+
+    # For sustained_matrix, also require decode_mode == "duration"
+    if decode_mode != "duration":
+        return "indeterminate"
+
+    # Verify every result cell has benchmark_mode == "duration"
+    results = doc.get("results")
+    if isinstance(results, list):
+        for cell in results:
+            if isinstance(cell, dict):
+                bmode = cell.get("benchmark_mode")
+                if bmode is not None and bmode != "duration":
+                    return "indeterminate"
+
+    if max_tokens >= 256 and duration >= 10:
+        return "sustained_matrix"
+
+    return "indeterminate"
+
+
+# ---------------------------------------------------------------------------
+# Context and cell coverage validation
+# ---------------------------------------------------------------------------
+
+
+def validate_context_coverage(doc: dict[str, Any]) -> dict[str, Any]:
+    """Validate that a document has exactly one context and exact cell coverage.
+
+    Checks:
+    - metadata.concurrency_levels exactly matches REQUIRED_CONCURRENCY_LEVELS as a set
+    - metadata.context_lengths has exactly one entry == REQUIRED_CONTEXT
+    - every result has context_tokens present and == REQUIRED_CONTEXT (missing fails)
+    - summary_table has exactly one key == str(REQUIRED_CONTEXT)
+    - if summary_table present, its values agree with results aggregate_tps within tolerance
+    - no mismatch between metadata, results, and summary_table
+    - exactly the REQUIRED_CONCURRENCIES are present, no duplicates, no extras
+    """
+    try:
+        meta = _get_metadata(doc)
+    except EvidenceError:
+        return {"valid": False, "reason": "no metadata"}
+
+    # Validate concurrency_levels item-by-item before any set conversion.
+    # bool (True/False) is a subclass of int in Python, so set([True,2,4,8])
+    # silently equals {1,2,4,8} — we must reject bool explicitly.
+    # Unhashable types (dict, list) would crash set() — reject first.
+    conc_levels = meta.get("concurrency_levels")
+    if not isinstance(conc_levels, list):
+        return {"valid": False, "reason": f"concurrency_levels must be a list, got {type(conc_levels).__name__}"}
+    if len(conc_levels) != len(REQUIRED_CONCURRENCIES):
+        return {"valid": False, "reason": f"concurrency_levels must have exactly {len(REQUIRED_CONCURRENCIES)} items, got {len(conc_levels)}: {conc_levels}"}
+    allowed = set(REQUIRED_CONCURRENCIES)
+    seen_meta_concs: set[int] = set()
+    for item in conc_levels:
+        if not _is_int_not_bool(item):
+            return {"valid": False, "reason": f"concurrency_levels item {item!r} is not integer-not-bool (got {type(item).__name__})"}
+        if item not in allowed:
+            return {"valid": False, "reason": f"concurrency_levels item {item} is not one of {sorted(allowed)}"}
+        if item in seen_meta_concs:
+            return {"valid": False, "reason": f"concurrency_levels has duplicate value {item}"}
+        seen_meta_concs.add(item)
+    # Now safe to compare as a set — all items validated as int-not-bool
+    if seen_meta_concs != allowed:
+        return {"valid": False, "reason": f"concurrency_levels {conc_levels} does not match required {sorted(allowed)} as a set"}
+
+    # Check context_lengths
+    ctx_lengths = meta.get("context_lengths")
+    if not isinstance(ctx_lengths, list) or len(ctx_lengths) != 1:
+        return {"valid": False, "reason": f"context_lengths must have exactly one entry, got {ctx_lengths}"}
+    if not _is_int_not_bool(ctx_lengths[0]):
+        return {
+            "valid": False,
+            "reason": "context_lengths[0] must be an integer, not a numeric alias",
+        }
+    if ctx_lengths[0] != REQUIRED_CONTEXT:
+        return {"valid": False, "reason": f"context_lengths[0]={ctx_lengths[0]} != {REQUIRED_CONTEXT}"}
+
+    # Check results — validate each concurrency before building maps/sets
+    results = doc.get("results")
+    if not isinstance(results, list) or len(results) == 0:
+        return {"valid": False, "reason": "no results"}
+
+    seen_concurrencies: set[int] = set()
+    results_tps: dict[str, float] = {}
+    for cell in results:
+        if not isinstance(cell, dict):
+            return {"valid": False, "reason": "non-dict result entry"}
+        # context_tokens must be present and exactly REQUIRED_CONTEXT
+        ctx = cell.get("context_tokens")
+        if ctx is None:
+            return {"valid": False, "reason": "result missing context_tokens (must be present)"}
+        if not _is_int_not_bool(ctx):
+            return {
+                "valid": False,
+                "reason": "result context_tokens must be an integer, not a numeric alias",
+            }
+        if ctx != REQUIRED_CONTEXT:
+            return {"valid": False, "reason": f"result context_tokens={ctx} != {REQUIRED_CONTEXT}"}
+        # concurrency must be present, integer-not-bool, one of allowed,
+        # and unique — validated BEFORE any set membership test
+        conc = cell.get("concurrency")
+        if conc is None:
+            return {"valid": False, "reason": "result missing concurrency (must be present)"}
+        if not _is_int_not_bool(conc):
+            return {"valid": False, "reason": f"result concurrency {conc!r} is not integer-not-bool (got {type(conc).__name__})"}
+        if conc not in allowed:
+            return {"valid": False, "reason": f"result concurrency {conc} is not one of {sorted(allowed)}"}
+        if conc in seen_concurrencies:
+            return {"valid": False, "reason": f"duplicate concurrency C{conc}"}
+        seen_concurrencies.add(conc)
+        # Collect ALL numeric tps for summary comparison — validity
+        # (sign/finiteness/positivity) is checked separately by
+        # extract_validity, not by coverage.
+        agg = cell.get("aggregate_tps")
+        if _is_finite_number(agg):
+            results_tps[f"C{int(conc)}"] = float(agg)
+
+    # Check exact coverage
+    expected = set(REQUIRED_CONCURRENCIES)
+    if seen_concurrencies != expected:
+        missing = expected - seen_concurrencies
+        extra = seen_concurrencies - expected
+        parts = []
+        if missing:
+            parts.append(f"missing {[f'C{c}' for c in sorted(missing)]}")
+        if extra:
+            parts.append(f"unexpected {[f'C{c}' for c in sorted(extra)]}")
+        return {"valid": False, "reason": "; ".join(parts)}
+
+    # Check summary_table consistency — if present, all four numeric values
+    # must be present, finite, and agree with results aggregate_tps within
+    # tolerance.  Summary never silently overrides results.
+    if "summary_table" in doc:
+        summary = doc["summary_table"]
+        if not isinstance(summary, dict) or not summary:
+            return {
+                "valid": False,
+                "reason": "summary_table must be a non-empty object when present",
+            }
+        ctx_keys = set(summary.keys())
+        expected_ctx_key = str(REQUIRED_CONTEXT)
+        if len(ctx_keys) > 1:
+            return {"valid": False, "reason": f"summary_table has multiple context keys: {sorted(ctx_keys)}"}
+        if expected_ctx_key not in ctx_keys:
+            return {"valid": False, "reason": f"summary_table missing key '{expected_ctx_key}'"}
+        conc_map = summary[expected_ctx_key]
+        if not isinstance(conc_map, dict):
+            return {"valid": False, "reason": "summary_table context entry is not a dict"}
+        expected_summary_keys = {str(conc) for conc in REQUIRED_CONCURRENCIES}
+        actual_summary_keys = set(conc_map.keys())
+        if actual_summary_keys != expected_summary_keys:
+            return {
+                "valid": False,
+                "reason": (
+                    "summary_table concurrency keys must be exactly "
+                    f"{sorted(expected_summary_keys)}, got "
+                    f"{sorted(str(key) for key in actual_summary_keys)}"
+                ),
+            }
+        summary_concs: set[int] = set()
+        for k, v in conc_map.items():
+            conc_int = int(k)
+            summary_concs.add(conc_int)
+            nk = f"C{conc_int}"
+            if nk not in results_tps:
+                # Result tps was non-finite/missing — skip summary check
+                # for this entry; extract_validity will flag it as invalid.
+                continue
+            if not _is_finite_number(v):
+                return {"valid": False, "reason": f"summary_table {nk} value is not finite numeric, got {type(v).__name__}"}
+            summary_val = float(v)
+            results_val = results_tps[nk]
+            if abs(summary_val - results_val) > abs(results_val) * SUMMARY_TOLERANCE_RELATIVE:
+                return {"valid": False, "reason": f"summary_table {nk}={summary_val} disagrees with results {nk}={results_val} beyond tolerance"}
+        if summary_concs != expected:
+            missing = expected - summary_concs
+            extra = summary_concs - expected
+            parts = []
+            if missing:
+                parts.append(f"summary missing {[f'C{c}' for c in sorted(missing)]}")
+            if extra:
+                parts.append(f"summary unexpected {[f'C{c}' for c in sorted(extra)]}")
+            if parts:
+                return {"valid": False, "reason": "; ".join(parts)}
+
+    return {"valid": True, "concurrencies": sorted(seen_concurrencies)}
+
+
+# ---------------------------------------------------------------------------
+# Throughput extraction (results are canonical)
+# ---------------------------------------------------------------------------
+
+
+def extract_throughput(doc: dict[str, Any]) -> dict[str, float]:
+    """Extract aggregate throughput per concurrency from results[].
+
+    Results are canonical.  Summary table is validated for consistency
+    in ``validate_context_coverage`` but never silently overrides results.
+    Only returns cells for the REQUIRED_CONCURRENCIES.
+    """
+    tps: dict[str, float] = {}
+    required_labels = {f"C{c}" for c in REQUIRED_CONCURRENCIES}
+
+    # Scan results[] for aggregate_tps (canonical source)
+    results = doc.get("results")
+    if isinstance(results, list):
+        for cell in results:
+            if not isinstance(cell, dict):
+                continue
+            conc = cell.get("concurrency")
+            agg = cell.get("aggregate_tps")
+            if conc is not None and agg is not None:
+                if not _is_int_not_bool(conc):
+                    continue
+                try:
+                    nk = f"C{int(conc)}"
+                    val = float(agg)
+                except (ValueError, TypeError):
+                    continue
+                if nk in required_labels and nk not in tps:
+                    tps[nk] = val
+
+    # Fallback: summary_table (only if results didn't provide a value)
+    summary = doc.get("summary_table")
+    if isinstance(summary, dict):
+        for _ctx_key, conc_map in summary.items():
+            if not isinstance(conc_map, dict):
+                continue
+            for k, v in conc_map.items():
+                try:
+                    nk = f"C{int(k)}"
+                    val = float(v)
+                except (ValueError, TypeError):
+                    continue
+                if nk in required_labels and nk not in tps:
+                    tps[nk] = val
+
+    return tps
+
+
+# ---------------------------------------------------------------------------
+# Validity extraction
+# ---------------------------------------------------------------------------
+
+
+def extract_validity(doc: dict[str, Any]) -> dict[str, Any]:
+    """Extract per-cell validity information from a raw benchmark document.
+
+    Every validity field must be present and correctly typed:
+    - ``num_errors``: int (not bool), exactly 0
+    - ``effective_concurrency``: int (not bool), exactly requested
+    - ``underfilled``: actual bool, must be false
+    - ``warmup_timed_out``: actual bool, must be false
+    - ``capacity_limited``: actual bool, must be false
+    - ``benchmark_mode``: str, must be "duration"
+    - ``measurement_seconds``: finite number, must be > 0
+    - ``aggregate_tps``: finite number, must be > 0 (not bool, not NaN/inf, not zero/negative)
+
+    Missing or wrong-typed fields make the cell invalid, never default.
+    """
+    info: dict[str, Any] = {"cells": {}, "missing_fields": [], "invalid_fields": []}
+    results = doc.get("results")
+    if not isinstance(results, list) or len(results) == 0:
+        info["zero_cells"] = True
+        return info
+
+    info["zero_cells"] = False
+    all_valid = True
+    for cell in results:
+        if not isinstance(cell, dict):
+            all_valid = False
+            continue
+        conc = cell.get("concurrency")
+        if conc is None:
+            continue
+        if not _is_int_not_bool(conc):
+            # Bool or non-int concurrency — skip cell; coverage will
+            # reject it with a structured failure.
+            continue
+        nk = f"C{int(conc)}"
+
+        cell_info: dict[str, Any] = {
+            "requested_concurrency": conc,
+        }
+        cell_valid = True
+
+        # --- num_errors: int (not bool), exactly 0 ---
+        val = cell.get("num_errors")
+        cell_info["num_errors"] = val
+        if val is None:
+            info["missing_fields"].append((nk, "num_errors"))
+            cell_valid = False
+        elif not _is_int_not_bool(val):
+            info["invalid_fields"].append((nk, "num_errors", f"expected int, got {type(val).__name__}"))
+            cell_valid = False
+        elif val != 0:
+            info["invalid_fields"].append((nk, "num_errors", f"expected 0, got {val}"))
+            cell_valid = False
+
+        # --- effective_concurrency: int (not bool), == requested ---
+        val = cell.get("effective_concurrency")
+        cell_info["effective_concurrency"] = val
+        if val is None:
+            info["missing_fields"].append((nk, "effective_concurrency"))
+            cell_valid = False
+        elif not _is_int_not_bool(val):
+            info["invalid_fields"].append((nk, "effective_concurrency", f"expected int, got {type(val).__name__}"))
+            cell_valid = False
+        elif val != conc:
+            info["invalid_fields"].append((nk, "effective_concurrency", f"expected {conc}, got {val}"))
+            cell_valid = False
+
+        # --- measurement_seconds: finite number, > 0 ---
+        val = cell.get("measurement_seconds")
+        cell_info["measurement_seconds"] = val
+        if val is None:
+            info["missing_fields"].append((nk, "measurement_seconds"))
+            cell_valid = False
+        elif not _is_finite_number(val):
+            info["invalid_fields"].append((nk, "measurement_seconds", f"expected finite number, got {type(val).__name__}"))
+            cell_valid = False
+        elif float(val) <= 0:
+            info["invalid_fields"].append((nk, "measurement_seconds", f"expected > 0, got {val}"))
+            cell_valid = False
+
+        # --- underfilled: actual bool, must be false ---
+        val = cell.get("underfilled")
+        cell_info["underfilled"] = val
+        if val is None:
+            info["missing_fields"].append((nk, "underfilled"))
+            cell_valid = False
+        elif not isinstance(val, bool):
+            info["invalid_fields"].append((nk, "underfilled", f"expected bool, got {type(val).__name__}"))
+            cell_valid = False
+        elif val is True:
+            cell_valid = False
+
+        # --- warmup_timed_out: actual bool, must be false ---
+        val = cell.get("warmup_timed_out")
+        cell_info["warmup_timed_out"] = val
+        if val is None:
+            info["missing_fields"].append((nk, "warmup_timed_out"))
+            cell_valid = False
+        elif not isinstance(val, bool):
+            info["invalid_fields"].append((nk, "warmup_timed_out", f"expected bool, got {type(val).__name__}"))
+            cell_valid = False
+        elif val is True:
+            cell_valid = False
+
+        # --- capacity_limited: actual bool, must be false ---
+        val = cell.get("capacity_limited")
+        cell_info["capacity_limited"] = val
+        if val is None:
+            info["missing_fields"].append((nk, "capacity_limited"))
+            cell_valid = False
+        elif not isinstance(val, bool):
+            info["invalid_fields"].append((nk, "capacity_limited", f"expected bool, got {type(val).__name__}"))
+            cell_valid = False
+        elif val is True:
+            cell_valid = False
+
+        # --- benchmark_mode: str, must be "duration" ---
+        val = cell.get("benchmark_mode")
+        cell_info["benchmark_mode"] = val
+        if val is None:
+            info["missing_fields"].append((nk, "benchmark_mode"))
+            cell_valid = False
+        elif not isinstance(val, str):
+            info["invalid_fields"].append((nk, "benchmark_mode", f"expected str, got {type(val).__name__}"))
+            cell_valid = False
+        elif val != "duration":
+            cell_valid = False
+
+        # --- aggregate_tps: finite number, > 0, not bool ---
+        val = cell.get("aggregate_tps")
+        cell_info["aggregate_tps"] = val
+        if val is None:
+            info["missing_fields"].append((nk, "aggregate_tps"))
+            cell_valid = False
+        elif not _is_finite_number(val):
+            info["invalid_fields"].append((nk, "aggregate_tps", f"expected finite number, got {type(val).__name__}"))
+            cell_valid = False
+        elif float(val) <= 0:
+            info["invalid_fields"].append((nk, "aggregate_tps", f"expected > 0, got {val}"))
+            cell_valid = False
+
+        cell_info["valid"] = cell_valid
+        info["cells"][nk] = cell_info
+        if not cell_valid:
+            all_valid = False
+
+    info["all_cells_valid"] = all_valid
+    return info
+
+
+# ---------------------------------------------------------------------------
+# Comparison
+# ---------------------------------------------------------------------------
+
+
+def compare_settings(
+    baseline: dict[str, Any], candidate: dict[str, Any]
+) -> dict[str, Any]:
+    """Compare workload settings between two documents.
+
+    Missing-on-both settings count as a mismatch (fail-closed).
+    """
+    try:
+        base_settings = extract_settings(baseline)
+    except EvidenceError:
+        base_settings = {}
+    try:
+        cand_settings = extract_settings(candidate)
+    except EvidenceError:
+        cand_settings = {}
+
+    matches: list[dict[str, Any]] = []
+    mismatches: list[dict[str, Any]] = []
+    missing_both: list[str] = []
+
+    for _meta_key, display_name in MATCHED_SETTINGS:
+        base_val = base_settings.get(display_name)
+        cand_val = cand_settings.get(display_name)
+
+        if base_val is None and cand_val is None:
+            missing_both.append(display_name)
+            mismatches.append({
+                "setting": display_name,
+                "baseline": None,
+                "candidate": None,
+                "reason": "missing on both documents",
+            })
+        elif base_val is None or cand_val is None:
+            mismatches.append({
+                "setting": display_name,
+                "baseline": base_val,
+                "candidate": cand_val,
+                "reason": "one side is missing",
+            })
+        elif base_val != cand_val:
+            mismatches.append({
+                "setting": display_name,
+                "baseline": base_val,
+                "candidate": cand_val,
+                "reason": "values differ",
+            })
+        else:
+            matches.append({"setting": display_name, "value": base_val})
+
+    return {
+        "matched": matches,
+        "mismatched": mismatches,
+        "missing_in_both": missing_both,
+        "all_matched": len(mismatches) == 0,
+    }
+
+
+def _compute_deltas(
+    baseline: dict[str, Any], candidate: dict[str, Any]
+) -> dict[str, Any]:
+    """Compute per-concurrency throughput deltas. Only called when all preconditions pass."""
+    base_tps = extract_throughput(baseline)
+    cand_tps = extract_throughput(candidate)
+
+    cells: list[dict[str, Any]] = []
+    for conc in [f"C{c}" for c in REQUIRED_CONCURRENCIES]:
+        base_val = base_tps.get(conc)
+        cand_val = cand_tps.get(conc)
+        entry: dict[str, Any] = {"concurrency": conc}
+
+        if base_val is None or cand_val is None:
+            entry["baseline_tps"] = base_val
+            entry["candidate_tps"] = cand_val
+            entry["delta"] = None
+            entry["delta_percent"] = None
+            entry["status"] = "missing"
+        else:
+            entry["baseline_tps"] = base_val
+            entry["candidate_tps"] = cand_val
+            delta = cand_val - base_val
+            if base_val > 0:
+                delta_percent = (delta / base_val) * 100.0
+                if math.isfinite(delta) and math.isfinite(delta_percent):
+                    entry["delta"] = delta
+                    entry["delta_percent"] = delta_percent
+                    entry["status"] = "compared"
+                else:
+                    entry["delta"] = None
+                    entry["delta_percent"] = None
+                    entry["status"] = "non_finite_derived_value"
+            else:
+                entry["delta"] = None
+                entry["delta_percent"] = None
+                entry["status"] = "baseline_zero"
+        cells.append(entry)
+
+    return {
+        "cells": cells,
+        "baseline_tps": base_tps,
+        "candidate_tps": cand_tps,
+    }
+
+
+def _empty_throughput() -> dict[str, Any]:
+    """Return an empty throughput structure with no deltas."""
+    return {"cells": [], "baseline_tps": {}, "candidate_tps": {}}
+
+
+def compare_documents(
+    baseline: dict[str, Any], candidate: dict[str, Any]
+) -> dict[str, Any]:
+    """Full comparison of two benchmark documents.
+
+    Deltas are ONLY computed and emitted when ALL of the following pass:
+    1. Both documents are sustained_matrix
+    2. All matched settings are identical
+    3. Both documents have valid cells (no errors, underfilled, etc.)
+    4. Both documents have exact C1/C2/C4/C8 coverage at 16K
+    """
+    base_type = classify_document_type(baseline)
+    cand_type = classify_document_type(candidate)
+
+    type_mismatch = None
+    if base_type != cand_type:
+        type_mismatch = (
+            f"document type mismatch: baseline={base_type}, "
+            f"candidate={cand_type}. "
+            "Only two sustained_matrix documents can be compared."
+        )
+    elif base_type != "sustained_matrix":
+        type_mismatch = (
+            f"both documents are {base_type}; "
+            "only sustained_matrix documents can be compared."
+        )
+
+    settings_comparison = compare_settings(baseline, candidate)
+    base_metadata = validate_metadata(baseline)
+    cand_metadata = validate_metadata(candidate)
+    base_validity = extract_validity(baseline)
+    cand_validity = extract_validity(candidate)
+    base_coverage = validate_context_coverage(baseline)
+    cand_coverage = validate_context_coverage(candidate)
+
+    # Determine overall status — deltas are NOT computed until all pass
+    if type_mismatch:
+        status = "type_mismatch"
+    elif baseline == candidate:
+        status = "identical_documents"
+    elif not base_metadata["valid"] or not cand_metadata["valid"]:
+        status = "invalid_metadata"
+    elif not settings_comparison["all_matched"]:
+        status = "settings_mismatch"
+    elif base_validity.get("zero_cells") or cand_validity.get("zero_cells"):
+        status = "no_cells"
+    elif not base_coverage["valid"] or not cand_coverage["valid"]:
+        status = "coverage_error"
+    elif not base_validity.get("all_cells_valid", False) or not cand_validity.get(
+        "all_cells_valid", False
+    ):
+        status = "invalid_cells"
+    else:
+        status = "compared"
+
+    # Only compute deltas when all preconditions pass
+    if status == "compared":
+        throughput_comparison = _compute_deltas(baseline, candidate)
+        if any(cell["status"] != "compared" for cell in throughput_comparison["cells"]):
+            status = "invalid_delta"
+            throughput_comparison = _empty_throughput()
+    else:
+        throughput_comparison = _empty_throughput()
+
+    return {
+        "schema": SCHEMA,
+        "status": status,
+        "baseline_type": base_type,
+        "candidate_type": cand_type,
+        "type_mismatch": type_mismatch,
+        "settings": settings_comparison,
+        "baseline_metadata": base_metadata,
+        "candidate_metadata": cand_metadata,
+        "throughput": throughput_comparison,
+        "baseline_validity": base_validity,
+        "candidate_validity": cand_validity,
+        "baseline_coverage": base_coverage,
+        "candidate_coverage": cand_coverage,
+        "evidence_scope": (
+            "Offline comparison of two benchmark JSON documents. "
+            "Deltas are claimed only when document type, workload settings, "
+            "validity, and exact C1/C2/C4/C8 cell coverage all pass. "
+            "Bounded 128-token gate figures are never compared against "
+            "sustained-duration matrix figures. This tool is scoped to "
+            "one 16K context and C1/C2/C4/C8 cells. Results are canonical; "
+            "summary_table is validated for consistency but never overrides "
+            "results. This tool does not contact the cluster or run benchmarks."
+        ),
+        "claim_note": (
+            "A 'compared' status with delta_percent values is a valid "
+            "cross-document comparison only when all_matched is true and "
+            "both documents are sustained_matrix type. It is not a sealed "
+            "A/B unless both documents were produced under controlled "
+            "conditions with identical configuration except for the "
+            "declared experimental variable."
+        ),
+    }
+
+
+def load_document(path: Path) -> dict[str, Any]:
+    if not path.is_file():
+        raise ConfigError(f"file not found: {path}")
+    try:
+        doc = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise ConfigError(f"invalid JSON in {path}: {exc}") from exc
+    if not isinstance(doc, dict):
+        raise ConfigError(f"top-level JSON in {path} is not an object")
+    return doc
+
+
+def _sha256_file(path: Path) -> str:
+    """Return the SHA-256 digest of an input evidence file."""
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--baseline", required=True, help="path to baseline JSON")
+    parser.add_argument("--candidate", required=True, help="path to candidate JSON")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    try:
+        baseline_path = Path(args.baseline)
+        candidate_path = Path(args.candidate)
+        baseline = load_document(baseline_path)
+        candidate = load_document(candidate_path)
+    except ConfigError as exc:
+        print(f"compare-benchmark-evidence: CONFIG ERROR: {exc}", file=sys.stderr)
+        return EXIT_CONFIG_ERROR
+
+    try:
+        report = compare_documents(baseline, candidate)
+    except EvidenceError as exc:
+        print(f"compare-benchmark-evidence: EVIDENCE ERROR: {exc}", file=sys.stderr)
+        return EXIT_INVALID
+
+    report["inputs"] = {
+        "baseline_sha256": _sha256_file(baseline_path),
+        "candidate_sha256": _sha256_file(candidate_path),
+    }
+
+    print(json.dumps(report, indent=2, sort_keys=True))
+
+    if report["status"] in (
+        "type_mismatch",
+        "settings_mismatch",
+        "identical_documents",
+    ):
+        return EXIT_MISMATCH
+
+    if report["status"] in (
+        "invalid_metadata",
+        "invalid_delta",
+        "no_cells",
+        "coverage_error",
+        "invalid_cells",
+    ):
+        return EXIT_INVALID
+
+    return EXIT_OK
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_compare_benchmark_evidence.py
+++ b/scripts/test_compare_benchmark_evidence.py
@@ -1,0 +1,1819 @@
+"""Tests for the offline benchmark evidence comparison tool.
+
+Fixtures use the actual llm_decode_bench v0.4.31 raw JSON schema:
+``metadata``, ``results[]``, and ``summary_table``. Adversarial tests cover
+every fail-closed comparison requirement.
+"""
+
+from __future__ import annotations
+
+import json
+import hashlib
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "scripts"))
+
+import compare_benchmark_evidence as cmp  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Fixtures — actual llm_decode_bench v0.4.31 raw schema
+# ---------------------------------------------------------------------------
+
+def _make_meta(
+    *,
+    version: str = "0.4.31",
+    context_lengths: list[int] | None = None,
+    concurrency_levels: list[int] | None = None,
+    duration_per_test: float = 25.0,
+    decode_warmup_seconds: float = 0.0,
+    max_tokens: int = 1024,
+    temperature: float = 0.0,
+    unique_context_percent: float = 0.0,
+    shared_context_percent: float = 100.0,
+    dcp_size: int = 4,
+    max_total_tokens: int = 562688,
+    ignore_eos: bool = True,
+    skip_prefill: bool = True,
+    cell_warmup_timeout_seconds: float = 600.0,
+    decode_mode: str = "duration",
+) -> dict:
+    return {
+        "version": version,
+        "engine": "vllm",
+        "model": "glm-5.2-exl3-tr3-3.25bpw",
+        "timestamp": "2026-08-09T06:02:17.088583",
+        "decode_mode": decode_mode,
+        "primary_decode_layer": "sustained_decode",
+        "duration_per_test": duration_per_test,
+        "decode_warmup_seconds": decode_warmup_seconds,
+        "decode_warmup_context": 0 if decode_warmup_seconds == 0 else 16384,
+        "decode_warmup_concurrency": 0 if decode_warmup_seconds == 0 else 1,
+        "cell_warmup_timeout_seconds": cell_warmup_timeout_seconds,
+        "max_tokens": max_tokens,
+        "temperature": temperature,
+        "ignore_eos": ignore_eos,
+        "max_total_tokens": max_total_tokens,
+        "dcp_size": dcp_size,
+        "unique_context_percent": unique_context_percent,
+        "shared_context_percent": shared_context_percent,
+        "concurrency_levels": concurrency_levels or [8, 4, 2, 1],
+        "context_lengths": context_lengths or [16384],
+        "skip_prefill": skip_prefill,
+    }
+
+
+def _make_result(
+    conc: int,
+    aggregate_tps: float,
+    *,
+    num_errors: int = 0,
+    effective_concurrency: int | None = None,
+    context_tokens: int = 16384,
+    benchmark_mode: str = "duration",
+    measurement_seconds: float = 24.9,
+    underfilled: bool = False,
+    warmup_timed_out: bool = False,
+    capacity_limited: bool = False,
+) -> dict:
+    return {
+        "concurrency": conc,
+        "context_tokens": context_tokens,
+        "benchmark_mode": benchmark_mode,
+        "measurement_seconds": measurement_seconds,
+        "aggregate_tps": aggregate_tps,
+        "num_errors": num_errors,
+        "effective_concurrency": effective_concurrency if effective_concurrency is not None else conc,
+        "underfilled": underfilled,
+        "warmup_timed_out": warmup_timed_out,
+        "capacity_limited": capacity_limited,
+        "request_count": conc,
+        "completed_request_count": 0,
+    }
+
+
+_OMIT = object()  # sentinel to skip auto summary_table generation
+
+
+def _make_doc(
+    meta: dict | None = None,
+    results: list[dict] | None = None,
+    summary_table: Any = None,
+) -> dict:
+    if meta is None:
+        meta = _make_meta()
+    if results is None:
+        results = [
+            _make_result(8, 64.56),
+            _make_result(4, 45.13),
+            _make_result(2, 29.29),
+            _make_result(1, 15.89),
+        ]
+    if summary_table is None:
+        summary: dict[str, dict[str, float]] = {}
+        for r in results:
+            ctx = str(r["context_tokens"])
+            if ctx not in summary:
+                summary[ctx] = {}
+            summary[ctx][str(r["concurrency"])] = r["aggregate_tps"]
+        summary_table = summary
+    elif summary_table is _OMIT:
+        pass  # no summary_table key in output
+    return {
+        "metadata": meta,
+        "results": results,
+        **({"summary_table": summary_table} if summary_table is not _OMIT else {}),
+    }
+
+
+# Standard valid documents
+SUSTAINED_BASELINE = _make_doc(
+    results=[
+        _make_result(8, 64.56),
+        _make_result(4, 45.13),
+        _make_result(2, 29.29),
+        _make_result(1, 15.89),
+    ],
+)
+
+SUSTAINED_CANDIDATE = _make_doc(
+    results=[
+        _make_result(8, 62.00),
+        _make_result(4, 44.00),
+        _make_result(2, 28.50),
+        _make_result(1, 15.50),
+    ],
+)
+
+# Bounded gate: 128 tokens, 5s duration
+BOUNDED_GATE = _make_doc(
+    meta=_make_meta(
+        max_tokens=128,
+        duration_per_test=5,
+        concurrency_levels=[1, 2, 8],
+        context_lengths=[512],
+        cell_warmup_timeout_seconds=60,
+    ),
+    results=[
+        _make_result(1, 21.94, context_tokens=512),
+        _make_result(2, 30.25, context_tokens=512),
+        _make_result(8, 69.39, context_tokens=512),
+    ],
+)
+
+# Older protocol variant
+OLDER_PROTOCOL = _make_doc(
+    meta=_make_meta(
+        max_tokens=2048,
+        decode_warmup_seconds=3.0,
+        cell_warmup_timeout_seconds=300.0,
+        unique_context_percent=100.0,
+        shared_context_percent=0.0,
+        max_total_tokens=1125632,
+    ),
+)
+
+NO_METADATA: dict = {}
+
+NO_RESULTS = {
+    "metadata": _make_meta(),
+    "results": [],
+    "summary_table": {},
+}
+
+INVALID_CELLS = _make_doc(
+    results=[
+        _make_result(8, 64.56, num_errors=2),
+        _make_result(4, 45.13),
+        _make_result(2, 29.29),
+        _make_result(1, 15.89),
+    ],
+)
+
+UNDERFILLED = _make_doc(
+    results=[
+        _make_result(8, 30.0, effective_concurrency=3),
+        _make_result(4, 45.13),
+        _make_result(2, 29.29),
+        _make_result(1, 15.89),
+    ],
+)
+
+
+# ---------------------------------------------------------------------------
+# Classification
+# ---------------------------------------------------------------------------
+
+
+def test_classify_sustained_matrix():
+    assert cmp.classify_document_type(SUSTAINED_BASELINE) == "sustained_matrix"
+
+
+def test_classify_bounded_gate():
+    assert cmp.classify_document_type(BOUNDED_GATE) == "bounded_gate"
+
+
+def test_classify_indeterminate_empty():
+    assert cmp.classify_document_type({}) == "indeterminate"
+
+
+def test_classify_indeterminate_no_metadata():
+    assert cmp.classify_document_type(NO_METADATA) == "indeterminate"
+
+
+def test_classify_bounded_low_max_tokens():
+    doc = _make_doc(meta=_make_meta(max_tokens=128, duration_per_test=25))
+    assert cmp.classify_document_type(doc) == "bounded_gate"
+
+
+def test_classify_bounded_low_duration():
+    doc = _make_doc(meta=_make_meta(max_tokens=2048, duration_per_test=5))
+    assert cmp.classify_document_type(doc) == "bounded_gate"
+
+
+def test_classify_requires_both_duration_and_max_tokens():
+    """Missing one of duration/max_tokens → indeterminate, not inferred."""
+    doc = {"metadata": _make_meta(max_tokens=1024, duration_per_test=0)}
+    # duration_per_test=0 is < 10 → bounded_gate (not sustained)
+    assert cmp.classify_document_type(doc) == "bounded_gate"
+
+
+def test_classify_requires_decode_mode_duration():
+    """decode_mode != duration → indeterminate."""
+    doc = _make_doc(meta=_make_meta(decode_mode="burst"))
+    assert cmp.classify_document_type(doc) == "indeterminate"
+
+
+def test_classify_requires_result_benchmark_mode_duration():
+    """A result with benchmark_mode != duration → indeterminate."""
+    doc = _make_doc(
+        results=[
+            _make_result(8, 64.56, benchmark_mode="burst"),
+            _make_result(4, 45.13),
+            _make_result(2, 29.29),
+            _make_result(1, 15.89),
+        ],
+    )
+    assert cmp.classify_document_type(doc) == "indeterminate"
+
+
+# ---------------------------------------------------------------------------
+# Settings extraction and matching
+# ---------------------------------------------------------------------------
+
+
+def test_extract_settings_from_metadata():
+    settings = cmp.extract_settings(SUSTAINED_BASELINE)
+    assert settings["engine"] == "vllm"
+    assert settings["model"] == "glm-5.2-exl3-tr3-3.25bpw"
+    assert settings["harness_version"] == "0.4.31"
+    assert settings["decode_layer"] == "sustained_decode"
+    assert settings["decode_mode"] == "duration"
+    assert settings["context_tokens"] == 16384
+    assert settings["concurrencies"] == [8, 4, 2, 1]
+    assert settings["duration_seconds"] == 25.0
+    assert settings["max_output_tokens"] == 1024
+    assert settings["temperature"] == 0.0
+    assert settings["unique_context_percent"] == 0.0
+    assert settings["shared_context_percent"] == 100.0
+    assert settings["dcp_size"] == 4
+    assert settings["kv_budget_tokens"] == 562688
+    assert settings["ignore_eos"] is True
+    assert settings["skip_prefill"] is True
+    assert settings["cell_warmup_timeout_seconds"] == 600.0
+
+
+def test_extract_settings_no_metadata_raises():
+    with pytest.raises(cmp.EvidenceError):
+        cmp.extract_settings({})
+
+
+def test_settings_match_identical():
+    result = cmp.compare_settings(SUSTAINED_BASELINE, SUSTAINED_CANDIDATE)
+    assert result["all_matched"] is True
+    assert len(result["mismatched"]) == 0
+
+
+def test_settings_mismatch_duration():
+    candidate = json.loads(json.dumps(SUSTAINED_CANDIDATE))
+    candidate["metadata"]["duration_per_test"] = 15.0
+    result = cmp.compare_settings(SUSTAINED_BASELINE, candidate)
+    assert result["all_matched"] is False
+    assert any(m["setting"] == "duration_seconds" for m in result["mismatched"])
+
+
+def test_settings_mismatch_concurrencies():
+    candidate = json.loads(json.dumps(SUSTAINED_CANDIDATE))
+    candidate["metadata"]["concurrency_levels"] = [1, 2, 4]
+    result = cmp.compare_settings(SUSTAINED_BASELINE, candidate)
+    assert result["all_matched"] is False
+
+
+def test_settings_mismatch_temperature():
+    candidate = json.loads(json.dumps(SUSTAINED_CANDIDATE))
+    candidate["metadata"]["temperature"] = 0.7
+    result = cmp.compare_settings(SUSTAINED_BASELINE, candidate)
+    assert result["all_matched"] is False
+
+
+@pytest.mark.parametrize("field", ["engine", "model"])
+def test_settings_mismatch_runtime_identity(field):
+    candidate = json.loads(json.dumps(SUSTAINED_CANDIDATE))
+    candidate["metadata"][field] = f"different-{field}"
+    result = cmp.compare_documents(SUSTAINED_BASELINE, candidate)
+    assert result["status"] == "settings_mismatch"
+    assert result["throughput"]["cells"] == []
+    assert any(item["setting"] == field for item in result["settings"]["mismatched"])
+
+
+def test_settings_missing_on_both_counts_as_mismatch():
+    """Two documents missing the same setting must NOT count as matched."""
+    base = json.loads(json.dumps(SUSTAINED_BASELINE))
+    cand = json.loads(json.dumps(SUSTAINED_CANDIDATE))
+    del base["metadata"]["ignore_eos"]
+    del cand["metadata"]["ignore_eos"]
+    result = cmp.compare_settings(base, cand)
+    assert result["all_matched"] is False
+    assert any(
+        m["reason"] == "missing on both documents" for m in result["mismatched"]
+    )
+
+
+def test_settings_mismatch_max_tokens():
+    """Older protocol (2048) vs post-upgrade (1024) must mismatch."""
+    result = cmp.compare_settings(SUSTAINED_BASELINE, OLDER_PROTOCOL)
+    assert result["all_matched"] is False
+
+
+# ---------------------------------------------------------------------------
+# Throughput extraction
+# ---------------------------------------------------------------------------
+
+
+def test_extract_throughput_summary_table():
+    tps = cmp.extract_throughput(SUSTAINED_BASELINE)
+    assert tps["C1"] == 15.89
+    assert tps["C8"] == 64.56
+    assert tps["C4"] == 45.13
+    assert tps["C2"] == 29.29
+
+
+def test_extract_throughput_from_results_no_summary():
+    """If summary_table is missing, results[] should be used."""
+    doc = {
+        "metadata": _make_meta(),
+        "results": [
+            _make_result(1, 10.0),
+            _make_result(2, 20.0),
+            _make_result(4, 30.0),
+            _make_result(8, 40.0),
+        ],
+        "summary_table": {},
+    }
+    tps = cmp.extract_throughput(doc)
+    assert tps == {"C1": 10.0, "C2": 20.0, "C4": 30.0, "C8": 40.0}
+
+
+def test_extract_throughput_empty():
+    assert cmp.extract_throughput({}) == {}
+
+
+def test_extract_throughput_ignores_non_required_concurrencies():
+    """Concurrencies outside C1/C2/C4/C8 are ignored."""
+    doc = {
+        "metadata": _make_meta(concurrency_levels=[1, 2, 4, 8, 16]),
+        "results": [
+            _make_result(1, 10.0),
+            _make_result(2, 20.0),
+            _make_result(4, 30.0),
+            _make_result(8, 40.0),
+            _make_result(16, 50.0),
+        ],
+        "summary_table": {},
+    }
+    tps = cmp.extract_throughput(doc)
+    assert "C16" not in tps
+
+
+# ---------------------------------------------------------------------------
+# Validity extraction
+# ---------------------------------------------------------------------------
+
+
+def test_extract_validity_all_valid():
+    v = cmp.extract_validity(SUSTAINED_BASELINE)
+    assert v["all_cells_valid"] is True
+    assert v["zero_cells"] is False
+    assert len(v["missing_fields"]) == 0
+
+
+def test_extract_validity_errors():
+    v = cmp.extract_validity(INVALID_CELLS)
+    assert v["all_cells_valid"] is False
+    assert v["cells"]["C8"]["num_errors"] == 2
+
+
+def test_extract_validity_underfilled():
+    v = cmp.extract_validity(UNDERFILLED)
+    assert v["all_cells_valid"] is False
+
+
+def test_extract_validity_no_results():
+    v = cmp.extract_validity(NO_RESULTS)
+    assert v["zero_cells"] is True
+    assert "all_cells_valid" not in v
+
+
+def test_extract_validity_empty():
+    v = cmp.extract_validity({})
+    assert v["zero_cells"] is True
+    assert "all_cells_valid" not in v
+
+
+def test_extract_validity_missing_num_errors():
+    """Missing num_errors is invalid, not default-zero."""
+    doc = _make_doc(
+        results=[
+            {"concurrency": 8, "context_tokens": 16384, "benchmark_mode": "duration",
+             "measurement_seconds": 24.9, "aggregate_tps": 64.56,
+             "effective_concurrency": 8, "underfilled": False,
+             "warmup_timed_out": False, "capacity_limited": False},
+            _make_result(4, 45.13),
+            _make_result(2, 29.29),
+            _make_result(1, 15.89),
+        ],
+    )
+    v = cmp.extract_validity(doc)
+    assert v["all_cells_valid"] is False
+    assert ("C8", "num_errors") in v["missing_fields"]
+
+
+def test_extract_validity_missing_effective_concurrency():
+    """Missing effective_concurrency is invalid."""
+    doc = _make_doc(
+        results=[
+            {"concurrency": 8, "context_tokens": 16384, "benchmark_mode": "duration",
+             "measurement_seconds": 24.9, "aggregate_tps": 64.56,
+             "num_errors": 0, "underfilled": False,
+             "warmup_timed_out": False, "capacity_limited": False},
+            _make_result(4, 45.13),
+            _make_result(2, 29.29),
+            _make_result(1, 15.89),
+        ],
+    )
+    v = cmp.extract_validity(doc)
+    assert v["all_cells_valid"] is False
+    assert ("C8", "effective_concurrency") in v["missing_fields"]
+
+
+def test_extract_validity_missing_underfilled():
+    """Missing underfilled is invalid, not default-false."""
+    doc = _make_doc(
+        results=[
+            {"concurrency": 8, "context_tokens": 16384, "benchmark_mode": "duration",
+             "measurement_seconds": 24.9, "aggregate_tps": 64.56,
+             "num_errors": 0, "effective_concurrency": 8,
+             "warmup_timed_out": False, "capacity_limited": False},
+            _make_result(4, 45.13),
+            _make_result(2, 29.29),
+            _make_result(1, 15.89),
+        ],
+    )
+    v = cmp.extract_validity(doc)
+    assert v["all_cells_valid"] is False
+    assert ("C8", "underfilled") in v["missing_fields"]
+
+
+def test_extract_validity_missing_benchmark_mode():
+    """Missing benchmark_mode is invalid."""
+    doc = _make_doc(
+        results=[
+            {"concurrency": 8, "context_tokens": 16384,
+             "measurement_seconds": 24.9, "aggregate_tps": 64.56,
+             "num_errors": 0, "effective_concurrency": 8,
+             "underfilled": False, "warmup_timed_out": False,
+             "capacity_limited": False},
+            _make_result(4, 45.13),
+            _make_result(2, 29.29),
+            _make_result(1, 15.89),
+        ],
+    )
+    v = cmp.extract_validity(doc)
+    assert v["all_cells_valid"] is False
+    assert ("C8", "benchmark_mode") in v["missing_fields"]
+
+
+def test_extract_validity_warmup_timed_out():
+    """warmup_timed_out=True makes cell invalid."""
+    doc = _make_doc(
+        results=[
+            _make_result(8, 30.0, warmup_timed_out=True),
+            _make_result(4, 45.13),
+            _make_result(2, 29.29),
+            _make_result(1, 15.89),
+        ],
+    )
+    v = cmp.extract_validity(doc)
+    assert v["all_cells_valid"] is False
+
+
+def test_extract_validity_capacity_limited():
+    """capacity_limited=True makes cell invalid."""
+    doc = _make_doc(
+        results=[
+            _make_result(8, 30.0, capacity_limited=True),
+            _make_result(4, 45.13),
+            _make_result(2, 29.29),
+            _make_result(1, 15.89),
+        ],
+    )
+    v = cmp.extract_validity(doc)
+    assert v["all_cells_valid"] is False
+
+
+# ---------------------------------------------------------------------------
+# Context coverage validation
+# ---------------------------------------------------------------------------
+
+
+def test_coverage_valid():
+    result = cmp.validate_context_coverage(SUSTAINED_BASELINE)
+    assert result["valid"] is True
+
+
+def test_coverage_no_metadata():
+    result = cmp.validate_context_coverage({})
+    assert result["valid"] is False
+
+
+def test_coverage_no_results():
+    result = cmp.validate_context_coverage(NO_RESULTS)
+    assert result["valid"] is False
+
+
+def test_coverage_multi_context():
+    """Multi-context document (two context_lengths) is rejected."""
+    doc = _make_doc(
+        meta=_make_meta(context_lengths=[16384, 32768]),
+        results=[
+            _make_result(8, 64.56, context_tokens=16384),
+            _make_result(4, 45.13, context_tokens=32768),
+            _make_result(2, 29.29),
+            _make_result(1, 15.89),
+        ],
+    )
+    result = cmp.validate_context_coverage(doc)
+    assert result["valid"] is False
+
+
+def test_coverage_wrong_context():
+    """Result with wrong context_tokens is rejected."""
+    doc = _make_doc(
+        results=[
+            _make_result(8, 64.56, context_tokens=8192),
+            _make_result(4, 45.13),
+            _make_result(2, 29.29),
+            _make_result(1, 15.89),
+        ],
+    )
+    result = cmp.validate_context_coverage(doc)
+    assert result["valid"] is False
+
+
+def test_coverage_missing_concurrency():
+    """Missing a required concurrency fails."""
+    doc = _make_doc(
+        results=[
+            _make_result(8, 64.56),
+            _make_result(4, 45.13),
+            _make_result(2, 29.29),
+            # C1 missing
+        ],
+    )
+    result = cmp.validate_context_coverage(doc)
+    assert result["valid"] is False
+    assert "missing" in result["reason"].lower()
+
+
+def test_coverage_extra_concurrency_metadata():
+    """Extra concurrency in metadata concurrency_levels fails at metadata check."""
+    doc = _make_doc(
+        meta=_make_meta(concurrency_levels=[1, 2, 4, 8, 16]),
+        results=[
+            _make_result(8, 64.56),
+            _make_result(4, 45.13),
+            _make_result(2, 29.29),
+            _make_result(1, 15.89),
+            _make_result(16, 80.0),
+        ],
+    )
+    result = cmp.validate_context_coverage(doc)
+    assert result["valid"] is False
+    assert "concurrency_levels" in result["reason"]
+
+
+def test_coverage_extra_concurrency_results_only():
+    """Extra concurrency in results (metadata correct) fails at results check."""
+    doc = _make_doc(
+        meta=_make_meta(concurrency_levels=[8, 4, 2, 1]),
+        results=[
+            _make_result(8, 64.56),
+            _make_result(4, 45.13),
+            _make_result(2, 29.29),
+            _make_result(1, 15.89),
+            _make_result(16, 80.0),
+        ],
+    )
+    result = cmp.validate_context_coverage(doc)
+    assert result["valid"] is False
+    assert "not one of" in result["reason"].lower()
+
+
+def test_coverage_duplicate_concurrency():
+    """Duplicate concurrency fails."""
+    doc = _make_doc(
+        results=[
+            _make_result(8, 64.56),
+            _make_result(8, 60.0),
+            _make_result(4, 45.13),
+            _make_result(2, 29.29),
+            _make_result(1, 15.89),
+        ],
+    )
+    result = cmp.validate_context_coverage(doc)
+    assert result["valid"] is False
+    assert "duplicate" in result["reason"].lower()
+
+
+def test_coverage_summary_table_multi_context():
+    """Summary table with multiple context keys fails."""
+    doc = {
+        "metadata": _make_meta(),
+        "results": [
+            _make_result(8, 64.56),
+            _make_result(4, 45.13),
+            _make_result(2, 29.29),
+            _make_result(1, 15.89),
+        ],
+        "summary_table": {
+            "16384": {"8": 64.56, "4": 45.13, "2": 29.29, "1": 15.89},
+            "32768": {"8": 50.0},
+        },
+    }
+    result = cmp.validate_context_coverage(doc)
+    assert result["valid"] is False
+    assert "multiple" in result["reason"].lower()
+
+
+def test_coverage_summary_table_missing_concurrency():
+    """Summary table missing a concurrency that results have fails."""
+    doc = {
+        "metadata": _make_meta(),
+        "results": [
+            _make_result(8, 64.56),
+            _make_result(4, 45.13),
+            _make_result(2, 29.29),
+            _make_result(1, 15.89),
+        ],
+        "summary_table": {
+            "16384": {"8": 64.56, "4": 45.13, "2": 29.29},
+            # C1 missing from summary
+        },
+    }
+    result = cmp.validate_context_coverage(doc)
+    assert result["valid"] is False
+
+
+# ---------------------------------------------------------------------------
+# Full document comparison — no deltas on failure
+# ---------------------------------------------------------------------------
+
+
+def test_compare_matched_sustained():
+    result = cmp.compare_documents(SUSTAINED_BASELINE, SUSTAINED_CANDIDATE)
+    assert result["status"] == "compared"
+    assert result["baseline_type"] == "sustained_matrix"
+    assert result["candidate_type"] == "sustained_matrix"
+    assert result["settings"]["all_matched"] is True
+    assert len(result["throughput"]["cells"]) == 4
+
+
+def test_compare_identical_sustained_documents_rejected():
+    result = cmp.compare_documents(SUSTAINED_BASELINE, SUSTAINED_BASELINE)
+    assert result["status"] == "identical_documents"
+    assert result["throughput"]["cells"] == []
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "expected_status"),
+    [
+        ("engine", "", "invalid_metadata"),
+        ("duration_per_test", float("nan"), "type_mismatch"),
+        ("max_tokens", True, "type_mismatch"),
+        ("ignore_eos", 1, "invalid_metadata"),
+    ],
+)
+def test_compare_invalid_metadata_emits_no_deltas(field, value, expected_status):
+    candidate = json.loads(json.dumps(SUSTAINED_CANDIDATE))
+    candidate["metadata"][field] = value
+    result = cmp.compare_documents(SUSTAINED_BASELINE, candidate)
+    assert result["status"] == expected_status
+    assert result["candidate_metadata"]["valid"] is False
+    assert result["throughput"]["cells"] == []
+
+
+def test_compare_context_percentages_must_sum_to_100():
+    candidate = json.loads(json.dumps(SUSTAINED_CANDIDATE))
+    candidate["metadata"]["unique_context_percent"] = 25.0
+    candidate["metadata"]["shared_context_percent"] = 25.0
+    result = cmp.compare_documents(SUSTAINED_BASELINE, candidate)
+    assert result["status"] == "invalid_metadata"
+    assert "sum to 100" in result["candidate_metadata"]["reason"]
+
+
+def test_compare_unsupported_harness_version_emits_no_deltas():
+    candidate = json.loads(json.dumps(SUSTAINED_CANDIDATE))
+    candidate["metadata"]["version"] = "0.5.0"
+    result = cmp.compare_documents(SUSTAINED_BASELINE, candidate)
+    assert result["status"] == "invalid_metadata"
+    assert "0.4.31" in result["candidate_metadata"]["reason"]
+    assert result["throughput"]["cells"] == []
+
+
+def test_compare_unsupported_decode_layer_emits_no_deltas():
+    candidate = json.loads(json.dumps(SUSTAINED_CANDIDATE))
+    candidate["metadata"]["primary_decode_layer"] = "prefill"
+    result = cmp.compare_documents(SUSTAINED_BASELINE, candidate)
+    assert result["status"] == "invalid_metadata"
+    assert "sustained_decode" in result["candidate_metadata"]["reason"]
+    assert result["throughput"]["cells"] == []
+
+
+def test_compare_huge_integer_metadata_fails_without_exception():
+    candidate = json.loads(json.dumps(SUSTAINED_CANDIDATE))
+    candidate["metadata"]["duration_per_test"] = 10**1000
+    result = cmp.compare_documents(SUSTAINED_BASELINE, candidate)
+    assert result["status"] == "invalid_metadata"
+    assert result["throughput"]["cells"] == []
+
+
+def test_compare_huge_integer_throughput_fails_without_exception():
+    candidate = _make_doc(
+        results=[
+            _make_result(8, 10**1000),
+            _make_result(4, 44.0),
+            _make_result(2, 28.5),
+            _make_result(1, 15.5),
+        ],
+    )
+    result = cmp.compare_documents(SUSTAINED_BASELINE, candidate)
+    assert result["status"] == "invalid_cells"
+    assert result["throughput"]["cells"] == []
+
+
+def test_compare_non_finite_derived_percentage_emits_no_deltas():
+    baseline = _make_doc(
+        results=[_make_result(conc, 1e-308) for conc in (8, 4, 2, 1)],
+    )
+    candidate = _make_doc(
+        results=[_make_result(conc, 1e308) for conc in (8, 4, 2, 1)],
+    )
+    result = cmp.compare_documents(baseline, candidate)
+    assert result["status"] == "invalid_delta"
+    assert result["throughput"]["cells"] == []
+
+
+def test_compare_type_mismatch_bounded_vs_sustained():
+    """Bounded gate vs sustained matrix must produce type_mismatch."""
+    result = cmp.compare_documents(SUSTAINED_BASELINE, BOUNDED_GATE)
+    assert result["status"] == "type_mismatch"
+
+
+def test_compare_type_mismatch_indeterminate():
+    """Indeterminate vs sustained must produce type_mismatch."""
+    result = cmp.compare_documents(SUSTAINED_BASELINE, NO_METADATA)
+    assert result["status"] == "type_mismatch"
+
+
+def test_compare_two_bounded_gate_rejected():
+    """Two bounded_gate documents must NOT compare."""
+    result = cmp.compare_documents(BOUNDED_GATE, BOUNDED_GATE)
+    assert result["status"] == "type_mismatch"
+    assert "both documents are bounded_gate" in result["type_mismatch"]
+
+
+def test_compare_two_indeterminate_rejected():
+    """Two indeterminate documents must NOT compare."""
+    result = cmp.compare_documents({}, {})
+    assert result["status"] == "type_mismatch"
+
+
+def test_compare_settings_mismatch_no_deltas():
+    """Settings mismatch must NOT emit any deltas."""
+    candidate = json.loads(json.dumps(SUSTAINED_CANDIDATE))
+    candidate["metadata"]["temperature"] = 1.0
+    result = cmp.compare_documents(SUSTAINED_BASELINE, candidate)
+    assert result["status"] == "settings_mismatch"
+    assert len(result["throughput"]["cells"]) == 0
+
+
+def test_compare_protocol_mismatch_no_deltas():
+    """Post-upgrade vs older protocol: settings_mismatch, no deltas."""
+    result = cmp.compare_documents(SUSTAINED_BASELINE, OLDER_PROTOCOL)
+    assert result["status"] == "settings_mismatch"
+    assert len(result["throughput"]["cells"]) == 0
+
+
+def test_compare_invalid_cells_no_deltas():
+    """Invalid cells must NOT emit deltas."""
+    result = cmp.compare_documents(SUSTAINED_BASELINE, INVALID_CELLS)
+    assert result["status"] == "invalid_cells"
+    assert len(result["throughput"]["cells"]) == 0
+
+
+def test_compare_underfilled_no_deltas():
+    """Underfilled cells must NOT emit deltas."""
+    result = cmp.compare_documents(SUSTAINED_BASELINE, UNDERFILLED)
+    assert result["status"] == "invalid_cells"
+    assert len(result["throughput"]["cells"]) == 0
+
+
+def test_compare_no_cells_no_deltas():
+    """No results → no_cells, no deltas."""
+    result = cmp.compare_documents(SUSTAINED_BASELINE, NO_RESULTS)
+    assert result["status"] == "no_cells"
+    assert len(result["throughput"]["cells"]) == 0
+
+
+def test_compare_coverage_error_no_deltas():
+    """Coverage error must NOT emit deltas."""
+    doc_missing_c1 = _make_doc(
+        results=[
+            _make_result(8, 64.56),
+            _make_result(4, 45.13),
+            _make_result(2, 29.29),
+        ],
+    )
+    result = cmp.compare_documents(SUSTAINED_BASELINE, doc_missing_c1)
+    assert result["status"] == "coverage_error"
+    assert len(result["throughput"]["cells"]) == 0
+
+
+def test_compare_multi_context_no_deltas():
+    """Multi-context document must NOT produce deltas."""
+    multi_ctx = _make_doc(
+        meta=_make_meta(context_lengths=[16384, 32768]),
+        results=[
+            _make_result(8, 64.56, context_tokens=16384),
+            _make_result(4, 45.13, context_tokens=32768),
+            _make_result(2, 29.29),
+            _make_result(1, 15.89),
+        ],
+    )
+    result = cmp.compare_documents(SUSTAINED_BASELINE, multi_ctx)
+    assert result["status"] == "coverage_error"
+    assert len(result["throughput"]["cells"]) == 0
+
+
+def test_compare_claim_note_present():
+    result = cmp.compare_documents(SUSTAINED_BASELINE, SUSTAINED_CANDIDATE)
+    assert "claim_note" in result
+    assert "sealed A/B" in result["claim_note"]
+
+
+def test_compare_coverage_in_report():
+    """Coverage validation results are included in the report."""
+    result = cmp.compare_documents(SUSTAINED_BASELINE, SUSTAINED_CANDIDATE)
+    assert "baseline_coverage" in result
+    assert "candidate_coverage" in result
+    assert result["baseline_coverage"]["valid"] is True
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def test_cli_matched(tmp_path, capsys):
+    base = tmp_path / "base.json"
+    cand = tmp_path / "cand.json"
+    base.write_text(json.dumps(SUSTAINED_BASELINE))
+    cand.write_text(json.dumps(SUSTAINED_CANDIDATE))
+    rc = cmp.main(["--baseline", str(base), "--candidate", str(cand)])
+    captured = capsys.readouterr()
+    report = json.loads(captured.out)
+    assert rc == cmp.EXIT_OK
+    assert report["status"] == "compared"
+    assert report["inputs"]["baseline_sha256"] == hashlib.sha256(base.read_bytes()).hexdigest()
+    assert report["inputs"]["candidate_sha256"] == hashlib.sha256(cand.read_bytes()).hexdigest()
+
+
+def test_cli_identical_documents_exit_mismatch(tmp_path, capsys):
+    base = tmp_path / "base.json"
+    cand = tmp_path / "cand.json"
+    payload = json.dumps(SUSTAINED_BASELINE)
+    base.write_text(payload)
+    cand.write_text(payload)
+    rc = cmp.main(["--baseline", str(base), "--candidate", str(cand)])
+    report = json.loads(capsys.readouterr().out)
+    assert rc == cmp.EXIT_MISMATCH
+    assert report["status"] == "identical_documents"
+
+
+def test_cli_type_mismatch(tmp_path, capsys):
+    base = tmp_path / "base.json"
+    cand = tmp_path / "cand.json"
+    base.write_text(json.dumps(SUSTAINED_BASELINE))
+    cand.write_text(json.dumps(BOUNDED_GATE))
+    rc = cmp.main(["--baseline", str(base), "--candidate", str(cand)])
+    assert rc == cmp.EXIT_MISMATCH
+
+
+def test_cli_two_bounded_rejected(tmp_path, capsys):
+    """CLI: two bounded_gate documents exit MISMATCH."""
+    base = tmp_path / "base.json"
+    cand = tmp_path / "cand.json"
+    base.write_text(json.dumps(BOUNDED_GATE))
+    cand.write_text(json.dumps(BOUNDED_GATE))
+    rc = cmp.main(["--baseline", str(base), "--candidate", str(cand)])
+    assert rc == cmp.EXIT_MISMATCH
+
+
+def test_cli_settings_mismatch(tmp_path, capsys):
+    candidate = json.loads(json.dumps(SUSTAINED_CANDIDATE))
+    candidate["metadata"]["temperature"] = 1.0
+    base = tmp_path / "base.json"
+    cand = tmp_path / "cand.json"
+    base.write_text(json.dumps(SUSTAINED_BASELINE))
+    cand.write_text(json.dumps(candidate))
+    rc = cmp.main(["--baseline", str(base), "--candidate", str(cand)])
+    assert rc == cmp.EXIT_MISMATCH
+
+
+def test_cli_coverage_error(tmp_path, capsys):
+    """CLI: coverage error exits INVALID."""
+    doc_missing_c1 = _make_doc(
+        results=[
+            _make_result(8, 64.56),
+            _make_result(4, 45.13),
+            _make_result(2, 29.29),
+        ],
+    )
+    base = tmp_path / "base.json"
+    cand = tmp_path / "cand.json"
+    base.write_text(json.dumps(SUSTAINED_BASELINE))
+    cand.write_text(json.dumps(doc_missing_c1))
+    rc = cmp.main(["--baseline", str(base), "--candidate", str(cand)])
+    assert rc == cmp.EXIT_INVALID
+
+
+def test_cli_invalid_cells(tmp_path, capsys):
+    base = tmp_path / "base.json"
+    cand = tmp_path / "cand.json"
+    base.write_text(json.dumps(SUSTAINED_BASELINE))
+    cand.write_text(json.dumps(INVALID_CELLS))
+    rc = cmp.main(["--baseline", str(base), "--candidate", str(cand)])
+    assert rc == cmp.EXIT_INVALID
+
+
+def test_cli_no_cells(tmp_path, capsys):
+    base = tmp_path / "base.json"
+    cand = tmp_path / "cand.json"
+    base.write_text(json.dumps(SUSTAINED_BASELINE))
+    cand.write_text(json.dumps(NO_RESULTS))
+    rc = cmp.main(["--baseline", str(base), "--candidate", str(cand)])
+    assert rc == cmp.EXIT_INVALID
+
+
+def test_cli_missing_file(capsys):
+    rc = cmp.main([
+        "--baseline", "nonexistent.json",
+        "--candidate", "also-nonexistent.json",
+    ])
+    assert rc == cmp.EXIT_CONFIG_ERROR
+
+
+def test_cli_invalid_json(tmp_path, capsys):
+    bad = tmp_path / "bad.json"
+    bad.write_text("not valid json {{{")
+    good = tmp_path / "good.json"
+    good.write_text(json.dumps(SUSTAINED_BASELINE))
+    rc = cmp.main(["--baseline", str(bad), "--candidate", str(good)])
+    assert rc == cmp.EXIT_CONFIG_ERROR
+
+
+def test_cli_no_metadata(tmp_path, capsys):
+    """Document with no metadata → indeterminate type → mismatch."""
+    base = tmp_path / "base.json"
+    cand = tmp_path / "cand.json"
+    base.write_text(json.dumps(SUSTAINED_BASELINE))
+    cand.write_text(json.dumps(NO_METADATA))
+    rc = cmp.main(["--baseline", str(base), "--candidate", str(cand)])
+    assert rc == cmp.EXIT_MISMATCH
+
+
+# ---------------------------------------------------------------------------
+# Schema
+# ---------------------------------------------------------------------------
+
+
+def test_schema():
+    assert cmp.SCHEMA == "sparkring-benchmark-comparison/v1"
+
+# ---------------------------------------------------------------------------
+# Adversarial coverage and validity mutations
+# ---------------------------------------------------------------------------
+
+
+# --- concurrency_levels set/order contract ---
+
+
+def test_metadata_concurrencies_subset_fails():
+    """Metadata concurrency_levels [1,2] with four result cells must fail closed."""
+    doc = _make_doc(
+        meta=_make_meta(concurrency_levels=[1, 2]),
+        results=[
+            _make_result(8, 64.56),
+            _make_result(4, 45.13),
+            _make_result(2, 29.29),
+            _make_result(1, 15.89),
+        ],
+    )
+    result = cmp.validate_context_coverage(doc)
+    assert result["valid"] is False
+    assert "concurrency_levels" in result["reason"]
+
+
+def test_metadata_concurrencies_superset_fails():
+    """Metadata concurrency_levels with extra entries fails closed."""
+    doc = _make_doc(
+        meta=_make_meta(concurrency_levels=[8, 4, 2, 1, 16]),
+        results=[
+            _make_result(8, 64.56),
+            _make_result(4, 45.13),
+            _make_result(2, 29.29),
+            _make_result(1, 15.89),
+        ],
+    )
+    result = cmp.validate_context_coverage(doc)
+    assert result["valid"] is False
+    assert "concurrency_levels" in result["reason"]
+
+
+def test_metadata_concurrencies_wrong_order_passes():
+    """Metadata concurrency_levels [1,2,4,8] still passes (set comparison, order irrelevant)."""
+    doc = _make_doc(
+        meta=_make_meta(concurrency_levels=[1, 2, 4, 8]),
+        results=[
+            _make_result(8, 64.56),
+            _make_result(4, 45.13),
+            _make_result(2, 29.29),
+            _make_result(1, 15.89),
+        ],
+    )
+    result = cmp.validate_context_coverage(doc)
+    assert result["valid"] is True
+
+
+def test_results_metadata_concurrencies_mismatch_fails():
+    """Metadata says [8,4,2,1] but results only have C1/C2 — fail closed."""
+    doc = _make_doc(
+        meta=_make_meta(concurrency_levels=[8, 4, 2, 1]),
+        results=[
+            _make_result(2, 29.29),
+            _make_result(1, 15.89),
+        ],
+    )
+    result = cmp.validate_context_coverage(doc)
+    assert result["valid"] is False
+    assert "missing" in result["reason"].lower()
+
+
+# --- context_tokens present and exactly 16384 ---
+
+
+def test_missing_context_tokens_fails():
+    """Result missing context_tokens must fail closed, not default."""
+    doc = _make_doc(
+        summary_table=_OMIT,
+        results=[
+            {"concurrency": 8, "benchmark_mode": "duration",
+             "measurement_seconds": 24.9, "aggregate_tps": 64.56,
+             "num_errors": 0, "effective_concurrency": 8,
+             "underfilled": False, "warmup_timed_out": False,
+             "capacity_limited": False},
+            _make_result(4, 45.13),
+            _make_result(2, 29.29),
+            _make_result(1, 15.89),
+        ],
+    )
+    result = cmp.validate_context_coverage(doc)
+    assert result["valid"] is False
+    assert "context_tokens" in result["reason"]
+
+
+
+def test_wrong_context_tokens_fails():
+    """Result with context_tokens != 16384 fails closed."""
+    doc = _make_doc(
+        results=[
+            _make_result(8, 64.56, context_tokens=8192),
+            _make_result(4, 45.13),
+            _make_result(2, 29.29),
+            _make_result(1, 15.89),
+        ],
+    )
+    result = cmp.validate_context_coverage(doc)
+    assert result["valid"] is False
+    assert "context_tokens" in result["reason"]
+
+
+@pytest.mark.parametrize("context", [16384.0, True, "16384"])
+def test_result_context_numeric_alias_fails(context):
+    doc = _make_doc(
+        results=[
+            _make_result(8, 64.56, context_tokens=context),
+            _make_result(4, 45.13),
+            _make_result(2, 29.29),
+            _make_result(1, 15.89),
+        ],
+    )
+    result = cmp.validate_context_coverage(doc)
+    assert result["valid"] is False
+    assert "integer" in result["reason"]
+
+
+@pytest.mark.parametrize("context", [16384.0, True, "16384"])
+def test_metadata_context_numeric_alias_fails(context):
+    doc = _make_doc(meta=_make_meta(context_lengths=[context]))
+    result = cmp.validate_context_coverage(doc)
+    assert result["valid"] is False
+    assert "integer" in result["reason"]
+
+
+def test_all_context_tokens_correct_passes():
+    """All results with context_tokens=16384 passes."""
+    result = cmp.validate_context_coverage(SUSTAINED_BASELINE)
+    assert result["valid"] is True
+
+
+# --- summary_table agrees with results within tolerance ---
+
+
+def test_summary_disagrees_with_results_fails():
+    """Summary table value that disagrees with results beyond tolerance fails."""
+    doc = {
+        "metadata": _make_meta(),
+        "results": [
+            _make_result(8, 64.56),
+            _make_result(4, 45.13),
+            _make_result(2, 29.29),
+            _make_result(1, 15.89),
+        ],
+        "summary_table": {
+            "16384": {"8": 999.0, "4": 45.13, "2": 29.29, "1": 15.89},
+        },
+    }
+    result = cmp.validate_context_coverage(doc)
+    assert result["valid"] is False
+    assert "disagrees" in result["reason"].lower()
+
+
+def test_summary_within_tolerance_passes():
+    """Summary table values within tolerance of results pass."""
+    doc = {
+        "metadata": _make_meta(),
+        "results": [
+            _make_result(8, 64.56),
+            _make_result(4, 45.13),
+            _make_result(2, 29.29),
+            _make_result(1, 15.89),
+        ],
+        "summary_table": {
+            "16384": {"8": 64.560000001, "4": 45.13, "2": 29.29, "1": 15.89},
+        },
+    }
+    result = cmp.validate_context_coverage(doc)
+    assert result["valid"] is True
+
+
+def test_summary_non_numeric_value_fails():
+    """Summary table with non-numeric value fails."""
+    doc = {
+        "metadata": _make_meta(),
+        "results": [
+            _make_result(8, 64.56),
+            _make_result(4, 45.13),
+            _make_result(2, 29.29),
+            _make_result(1, 15.89),
+        ],
+        "summary_table": {
+            "16384": {"8": "not_a_number", "4": 45.13, "2": 29.29, "1": 15.89},
+        },
+    }
+    result = cmp.validate_context_coverage(doc)
+    assert result["valid"] is False
+    assert "not finite numeric" in result["reason"].lower()
+
+
+def test_summary_missing_concurrency_fails():
+    """Summary table missing a concurrency that results have fails."""
+    doc = {
+        "metadata": _make_meta(),
+        "results": [
+            _make_result(8, 64.56),
+            _make_result(4, 45.13),
+            _make_result(2, 29.29),
+            _make_result(1, 15.89),
+        ],
+        "summary_table": {
+            "16384": {"8": 64.56, "4": 45.13, "2": 29.29},
+        },
+    }
+    result = cmp.validate_context_coverage(doc)
+    assert result["valid"] is False
+
+
+def test_summary_no_override_of_results():
+    """Summary table never silently overrides results — extract_throughput prefers results."""
+    doc = {
+        "metadata": _make_meta(),
+        "results": [
+            _make_result(8, 64.56),
+            _make_result(4, 45.13),
+            _make_result(2, 29.29),
+            _make_result(1, 15.89),
+        ],
+        "summary_table": {
+            "16384": {"8": 999.0, "4": 45.13, "2": 29.29, "1": 15.89},
+        },
+    }
+    tps = cmp.extract_throughput(doc)
+    assert tps["C8"] == 64.56  # results value, not summary
+
+
+def test_summary_absent_passes():
+    """If summary_table is absent, coverage validation still passes."""
+    doc = {
+        "metadata": _make_meta(),
+        "results": [
+            _make_result(8, 64.56),
+            _make_result(4, 45.13),
+            _make_result(2, 29.29),
+            _make_result(1, 15.89),
+        ],
+    }
+    result = cmp.validate_context_coverage(doc)
+    assert result["valid"] is True
+
+
+@pytest.mark.parametrize("summary", [{}, [], None, "not-an-object"])
+def test_summary_present_but_empty_or_malformed_fails(summary):
+    doc = _make_doc(summary_table=_OMIT)
+    doc["summary_table"] = summary
+    result = cmp.validate_context_coverage(doc)
+    assert result["valid"] is False
+    assert "non-empty object" in result["reason"]
+
+
+def test_summary_noncanonical_duplicate_concurrency_alias_fails():
+    doc = _make_doc(summary_table=_OMIT)
+    doc["summary_table"] = {
+        "16384": {
+            "1": 15.89,
+            "01": 15.89,
+            "2": 29.29,
+            "4": 45.13,
+            "8": 64.56,
+        },
+    }
+    result = cmp.validate_context_coverage(doc)
+    assert result["valid"] is False
+    assert "exactly" in result["reason"]
+
+
+# --- finite numeric aggregate_tps required ---
+
+
+def test_missing_aggregate_tps_fails():
+    """Missing aggregate_tps fails validity."""
+    doc = _make_doc(
+        summary_table=_OMIT,
+        results=[
+            {"concurrency": 8, "context_tokens": 16384, "benchmark_mode": "duration",
+             "measurement_seconds": 24.9,
+             "num_errors": 0, "effective_concurrency": 8,
+             "underfilled": False, "warmup_timed_out": False,
+             "capacity_limited": False},
+            _make_result(4, 45.13),
+            _make_result(2, 29.29),
+            _make_result(1, 15.89),
+        ],
+    )
+    v = cmp.extract_validity(doc)
+    assert v["all_cells_valid"] is False
+    assert ("C8", "aggregate_tps") in v["missing_fields"]
+
+
+def test_nan_aggregate_tps_fails():
+    """NaN aggregate_tps fails validity."""
+    doc = _make_doc(
+        results=[
+            _make_result(8, float("nan")),
+            _make_result(4, 45.13),
+            _make_result(2, 29.29),
+            _make_result(1, 15.89),
+        ],
+    )
+    v = cmp.extract_validity(doc)
+    assert v["all_cells_valid"] is False
+    assert any(f[0] == "C8" and f[1] == "aggregate_tps" for f in v["invalid_fields"])
+
+
+def test_inf_aggregate_tps_fails():
+    """Infinity aggregate_tps fails validity."""
+    doc = _make_doc(
+        results=[
+            _make_result(8, float("inf")),
+            _make_result(4, 45.13),
+            _make_result(2, 29.29),
+            _make_result(1, 15.89),
+        ],
+    )
+    v = cmp.extract_validity(doc)
+    assert v["all_cells_valid"] is False
+    assert any(f[0] == "C8" and f[1] == "aggregate_tps" for f in v["invalid_fields"])
+
+
+def test_boolean_aggregate_tps_fails():
+    """Boolean aggregate_tps fails validity (bool is not a valid number)."""
+    doc = _make_doc(
+        results=[
+            _make_result(8, True),  # type: ignore
+            _make_result(4, 45.13),
+            _make_result(2, 29.29),
+            _make_result(1, 15.89),
+        ],
+    )
+    v = cmp.extract_validity(doc)
+    assert v["all_cells_valid"] is False
+    assert any(f[0] == "C8" and f[1] == "aggregate_tps" for f in v["invalid_fields"])
+
+
+def test_negative_aggregate_tps_fails():
+    """Negative aggregate_tps fails validity."""
+    doc = _make_doc(
+        results=[
+            _make_result(8, -10.0),
+            _make_result(4, 45.13),
+            _make_result(2, 29.29),
+            _make_result(1, 15.89),
+        ],
+    )
+    v = cmp.extract_validity(doc)
+    assert v["all_cells_valid"] is False
+    assert any(f[0] == "C8" and f[1] == "aggregate_tps" for f in v["invalid_fields"])
+
+
+def test_zero_aggregate_tps_fails():
+    """Zero aggregate_tps fails validity."""
+    doc = _make_doc(
+        results=[
+            _make_result(8, 0.0),
+            _make_result(4, 45.13),
+            _make_result(2, 29.29),
+            _make_result(1, 15.89),
+        ],
+    )
+    v = cmp.extract_validity(doc)
+    assert v["all_cells_valid"] is False
+    assert any(f[0] == "C8" and f[1] == "aggregate_tps" for f in v["invalid_fields"])
+
+
+def test_zero_tps_emits_no_deltas():
+    """Zero throughput in one doc → invalid_cells, no deltas, even in normal mode."""
+    doc = _make_doc(
+        results=[
+            _make_result(8, 0.0),
+            _make_result(4, 45.13),
+            _make_result(2, 29.29),
+            _make_result(1, 15.89),
+        ],
+    )
+    result = cmp.compare_documents(SUSTAINED_BASELINE, doc)
+    assert result["status"] == "invalid_cells"
+    assert len(result["throughput"]["cells"]) == 0
+
+
+# --- strict type checks ---
+
+
+def test_num_errors_bool_fails():
+    """num_errors as bool (True) fails — bool is not a valid int."""
+    doc = _make_doc(
+        results=[
+            _make_result(8, 64.56, num_errors=True),  # type: ignore
+            _make_result(4, 45.13),
+            _make_result(2, 29.29),
+            _make_result(1, 15.89),
+        ],
+    )
+    v = cmp.extract_validity(doc)
+    assert v["all_cells_valid"] is False
+    assert any(f[0] == "C8" and f[1] == "num_errors" for f in v["invalid_fields"])
+
+
+def test_num_errors_nonzero_fails():
+    """num_errors=1 fails validity."""
+    doc = _make_doc(
+        results=[
+            _make_result(8, 64.56, num_errors=1),
+            _make_result(4, 45.13),
+            _make_result(2, 29.29),
+            _make_result(1, 15.89),
+        ],
+    )
+    v = cmp.extract_validity(doc)
+    assert v["all_cells_valid"] is False
+    assert any(f[0] == "C8" and f[1] == "num_errors" for f in v["invalid_fields"])
+
+
+def test_effective_concurrency_bool_fails():
+    """effective_concurrency as bool fails — bool is not a valid int."""
+    doc = _make_doc(
+        results=[
+            _make_result(8, 64.56, effective_concurrency=True),  # type: ignore
+            _make_result(4, 45.13),
+            _make_result(2, 29.29),
+            _make_result(1, 15.89),
+        ],
+    )
+    v = cmp.extract_validity(doc)
+    assert v["all_cells_valid"] is False
+    assert any(f[0] == "C8" and f[1] == "effective_concurrency" for f in v["invalid_fields"])
+
+
+def test_effective_concurrency_mismatch_fails():
+    """effective_concurrency != requested concurrency fails."""
+    doc = _make_doc(
+        results=[
+            _make_result(8, 64.56, effective_concurrency=3),
+            _make_result(4, 45.13),
+            _make_result(2, 29.29),
+            _make_result(1, 15.89),
+        ],
+    )
+    v = cmp.extract_validity(doc)
+    assert v["all_cells_valid"] is False
+    assert any(f[0] == "C8" and f[1] == "effective_concurrency" for f in v["invalid_fields"])
+
+
+def test_measurement_seconds_zero_fails():
+    """measurement_seconds=0 fails (must be > 0)."""
+    doc = _make_doc(
+        results=[
+            _make_result(8, 64.56, measurement_seconds=0.0),
+            _make_result(4, 45.13),
+            _make_result(2, 29.29),
+            _make_result(1, 15.89),
+        ],
+    )
+    v = cmp.extract_validity(doc)
+    assert v["all_cells_valid"] is False
+    assert any(f[0] == "C8" and f[1] == "measurement_seconds" for f in v["invalid_fields"])
+
+
+def test_measurement_seconds_negative_fails():
+    """measurement_seconds < 0 fails."""
+    doc = _make_doc(
+        results=[
+            _make_result(8, 64.56, measurement_seconds=-1.0),
+            _make_result(4, 45.13),
+            _make_result(2, 29.29),
+            _make_result(1, 15.89),
+        ],
+    )
+    v = cmp.extract_validity(doc)
+    assert v["all_cells_valid"] is False
+    assert any(f[0] == "C8" and f[1] == "measurement_seconds" for f in v["invalid_fields"])
+
+
+def test_measurement_seconds_nan_fails():
+    """NaN measurement_seconds fails."""
+    doc = _make_doc(
+        results=[
+            _make_result(8, 64.56, measurement_seconds=float("nan")),
+            _make_result(4, 45.13),
+            _make_result(2, 29.29),
+            _make_result(1, 15.89),
+        ],
+    )
+    v = cmp.extract_validity(doc)
+    assert v["all_cells_valid"] is False
+    assert any(f[0] == "C8" and f[1] == "measurement_seconds" for f in v["invalid_fields"])
+
+
+def test_underfilled_not_bool_fails():
+    """underfilled as non-bool (e.g. int 0) fails."""
+    doc = _make_doc(
+        results=[
+            _make_result(8, 64.56),  # can't pass non-bool via fixture, use raw dict
+            _make_result(4, 45.13),
+            _make_result(2, 29.29),
+            _make_result(1, 15.89),
+        ],
+    )
+    doc["results"][0]["underfilled"] = 0  # int, not bool
+    v = cmp.extract_validity(doc)
+    assert v["all_cells_valid"] is False
+    assert any(f[0] == "C8" and f[1] == "underfilled" for f in v["invalid_fields"])
+
+
+def test_warmup_timed_out_not_bool_fails():
+    """warmup_timed_out as non-bool fails."""
+    doc = _make_doc(
+        results=[
+            _make_result(8, 64.56),
+            _make_result(4, 45.13),
+            _make_result(2, 29.29),
+            _make_result(1, 15.89),
+        ],
+    )
+    doc["results"][0]["warmup_timed_out"] = 1  # int, not bool
+    v = cmp.extract_validity(doc)
+    assert v["all_cells_valid"] is False
+    assert any(f[0] == "C8" and f[1] == "warmup_timed_out" for f in v["invalid_fields"])
+
+
+def test_capacity_limited_not_bool_fails():
+    """capacity_limited as non-bool fails."""
+    doc = _make_doc(
+        results=[
+            _make_result(8, 64.56),
+            _make_result(4, 45.13),
+            _make_result(2, 29.29),
+            _make_result(1, 15.89),
+        ],
+    )
+    doc["results"][0]["capacity_limited"] = 0  # int, not bool
+    v = cmp.extract_validity(doc)
+    assert v["all_cells_valid"] is False
+    assert any(f[0] == "C8" and f[1] == "capacity_limited" for f in v["invalid_fields"])
+
+
+def test_underfilled_true_fails():
+    """underfilled=True fails validity."""
+    doc = _make_doc(
+        results=[
+            _make_result(8, 64.56, underfilled=True),
+            _make_result(4, 45.13),
+            _make_result(2, 29.29),
+            _make_result(1, 15.89),
+        ],
+    )
+    v = cmp.extract_validity(doc)
+    assert v["all_cells_valid"] is False
+
+
+def test_all_flags_false_valid():
+    """All boolean flags false, all int fields correct → valid."""
+    v = cmp.extract_validity(SUSTAINED_BASELINE)
+    assert v["all_cells_valid"] is True
+    assert len(v["invalid_fields"]) == 0
+
+
+# ---------------------------------------------------------------------------
+# Concurrency is validated before set conversion
+# ---------------------------------------------------------------------------
+
+
+def test_metadata_bool_true_concurrency_fails():
+    """metadata.concurrency_levels=[True,2,4,8] must fail (bool not int)."""
+    doc = _make_doc(
+        meta=_make_meta(concurrency_levels=[True, 2, 4, 8]),
+        results=[
+            _make_result(8, 64.56),
+            _make_result(4, 45.13),
+            _make_result(2, 29.29),
+            _make_result(1, 15.89),
+        ],
+    )
+    result = cmp.validate_context_coverage(doc)
+    assert result["valid"] is False
+    assert "not integer-not-bool" in result["reason"]
+
+
+def test_result_bool_true_concurrency_fails():
+    """Result concurrency=True must fail (bool not int)."""
+    doc = _make_doc(
+        summary_table=_OMIT,
+        results=[
+            {"concurrency": True, "context_tokens": 16384, "benchmark_mode": "duration",
+             "measurement_seconds": 24.9, "aggregate_tps": 15.89,
+             "num_errors": 0, "effective_concurrency": 1,
+             "underfilled": False, "warmup_timed_out": False,
+             "capacity_limited": False},
+            _make_result(8, 64.56),
+            _make_result(4, 45.13),
+            _make_result(2, 29.29),
+        ],
+    )
+    result = cmp.validate_context_coverage(doc)
+    assert result["valid"] is False
+    assert "not integer-not-bool" in result["reason"]
+
+
+def test_metadata_duplicate_concurrency_fails():
+    """metadata.concurrency_levels=[8,4,1,1] must fail (duplicate, 4 items)."""
+    doc = _make_doc(
+        meta=_make_meta(concurrency_levels=[8, 4, 1, 1]),
+        results=[
+            _make_result(8, 64.56),
+            _make_result(4, 45.13),
+            _make_result(2, 29.29),
+            _make_result(1, 15.89),
+        ],
+    )
+    result = cmp.validate_context_coverage(doc)
+    assert result["valid"] is False
+    assert "duplicate" in result["reason"].lower()
+
+
+def test_metadata_object_concurrency_fails():
+    """metadata.concurrency_levels=[8,4,2,{}] must fail (unhashable, not exception)."""
+    doc = _make_doc(
+        meta=_make_meta(concurrency_levels=[8, 4, 2, {}]),
+        results=[
+            _make_result(8, 64.56),
+            _make_result(4, 45.13),
+            _make_result(2, 29.29),
+            _make_result(1, 15.89),
+        ],
+    )
+    result = cmp.validate_context_coverage(doc)
+    assert result["valid"] is False
+    assert "not integer-not-bool" in result["reason"]
+
+
+def test_result_object_concurrency_fails():
+    """Result concurrency={} must fail (unhashable, not exception)."""
+    doc = _make_doc(
+        summary_table=_OMIT,
+        results=[
+            {"concurrency": {}, "context_tokens": 16384, "benchmark_mode": "duration",
+             "measurement_seconds": 24.9, "aggregate_tps": 64.56,
+             "num_errors": 0, "effective_concurrency": 8,
+             "underfilled": False, "warmup_timed_out": False,
+             "capacity_limited": False},
+            _make_result(4, 45.13),
+            _make_result(2, 29.29),
+            _make_result(1, 15.89),
+        ],
+    )
+    result = cmp.validate_context_coverage(doc)
+    assert result["valid"] is False
+    assert "not integer-not-bool" in result["reason"]
+
+
+def test_metadata_float_concurrency_fails():
+    """metadata.concurrency_levels=[8.0,4,2,1] must fail (float not int)."""
+    doc = _make_doc(
+        meta=_make_meta(concurrency_levels=[8.0, 4, 2, 1]),
+        results=[
+            _make_result(8, 64.56),
+            _make_result(4, 45.13),
+            _make_result(2, 29.29),
+            _make_result(1, 15.89),
+        ],
+    )
+    result = cmp.validate_context_coverage(doc)
+    assert result["valid"] is False
+    assert "not integer-not-bool" in result["reason"]
+
+
+def test_metadata_string_concurrency_fails():
+    """metadata.concurrency_levels=['8','4','2','1'] must fail (string not int)."""
+    doc = _make_doc(
+        meta=_make_meta(concurrency_levels=["8", "4", "2", "1"]),
+        results=[
+            _make_result(8, 64.56),
+            _make_result(4, 45.13),
+            _make_result(2, 29.29),
+            _make_result(1, 15.89),
+        ],
+    )
+    result = cmp.validate_context_coverage(doc)
+    assert result["valid"] is False
+    assert "not integer-not-bool" in result["reason"]
+
+
+def test_metadata_null_concurrency_fails():
+    """metadata.concurrency_levels=[8,4,2,None] must fail (null not int)."""
+    doc = _make_doc(
+        meta=_make_meta(concurrency_levels=[8, 4, 2, None]),
+        results=[
+            _make_result(8, 64.56),
+            _make_result(4, 45.13),
+            _make_result(2, 29.29),
+            _make_result(1, 15.89),
+        ],
+    )
+    result = cmp.validate_context_coverage(doc)
+    assert result["valid"] is False
+    assert "not integer-not-bool" in result["reason"]
+
+
+def test_result_missing_concurrency_fails():
+    """Result missing concurrency key must fail closed."""
+    doc = _make_doc(
+        summary_table=_OMIT,
+        results=[
+            {"context_tokens": 16384, "benchmark_mode": "duration",
+             "measurement_seconds": 24.9, "aggregate_tps": 64.56,
+             "num_errors": 0, "effective_concurrency": 8,
+             "underfilled": False, "warmup_timed_out": False,
+             "capacity_limited": False},
+            _make_result(4, 45.13),
+            _make_result(2, 29.29),
+            _make_result(1, 15.89),
+        ],
+    )
+    result = cmp.validate_context_coverage(doc)
+    assert result["valid"] is False
+    assert "missing concurrency" in result["reason"].lower()
+
+
+def test_metadata_wrong_concurrency_count_fails():
+    """metadata.concurrency_levels=[8,4,2] (3 items) must fail."""
+    doc = _make_doc(
+        meta=_make_meta(concurrency_levels=[8, 4, 2]),
+        results=[
+            _make_result(8, 64.56),
+            _make_result(4, 45.13),
+            _make_result(2, 29.29),
+            _make_result(1, 15.89),
+        ],
+    )
+    result = cmp.validate_context_coverage(doc)
+    assert result["valid"] is False
+    assert "exactly 4" in result["reason"]
+
+
+def test_result_duplicate_concurrency_fails():
+    """Duplicate result concurrency must fail before building sets."""
+    doc = _make_doc(
+        summary_table=_OMIT,
+        results=[
+            _make_result(8, 64.56),
+            _make_result(8, 60.0),
+            _make_result(4, 45.13),
+            _make_result(2, 29.29),
+            _make_result(1, 15.89),
+        ],
+    )
+    result = cmp.validate_context_coverage(doc)
+    assert result["valid"] is False
+    assert "duplicate" in result["reason"].lower()
+
+
+def test_bool_concurrency_no_exception_in_compare():
+    """Full compare_documents with bool concurrency must not raise."""
+    doc = _make_doc(
+        meta=_make_meta(concurrency_levels=[True, 2, 4, 8]),
+        results=[
+            _make_result(8, 64.56),
+            _make_result(4, 45.13),
+            _make_result(2, 29.29),
+            _make_result(1, 15.89),
+        ],
+    )
+    result = cmp.compare_documents(SUSTAINED_BASELINE, doc)
+    assert result["status"] != "compared"
+    assert len(result["throughput"]["cells"]) == 0
+
+
+def test_object_concurrency_no_exception_in_compare():
+    """Full compare_documents with object concurrency must not raise."""
+    doc = _make_doc(
+        meta=_make_meta(concurrency_levels=[8, 4, 2, {}]),
+        results=[
+            _make_result(8, 64.56),
+            _make_result(4, 45.13),
+            _make_result(2, 29.29),
+            _make_result(1, 15.89),
+        ],
+    )
+    result = cmp.compare_documents(SUSTAINED_BASELINE, doc)
+    assert result["status"] != "compared"
+    assert len(result["throughput"]["cells"]) == 0
+
+
+def test_valid_concurrencies_pass():
+    """Normal valid document still passes after stricter validation."""
+    result = cmp.validate_context_coverage(SUSTAINED_BASELINE)
+    assert result["valid"] is True


### PR DESCRIPTION
## Resulting behavior

- adds an offline comparator for matched llm_decode_bench.py v0.4.31 sustained 16K C1/C2/C4/C8 evidence
- requires exact runtime/workload identity, canonical coverage, valid cells, distinct inputs, and finite derived deltas before reporting performance changes
- records SHA-256 digests for both input documents and emits no deltas on any failed predicate
- publishes a present-state comparison checklist and links it from the measured-results methodology

## Scope and maturity

The utility is implemented and offline-only. A successful comparison is not a sealed A/B and does not promote a serving configuration.

## Validation

- 139 focused comparator tests passed
- full suite: 2,719 passed, 14 skipped
- Ruff E/F/W passed
- 170 repo-relative Markdown links and anchors resolved
- independent spec and standards reviews passed