### PR TITLE
Publish accepted EXL3 R7 3.5-bpw results

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,36 +22,46 @@ SparkRing’s contribution is to adapt, integrate, and extend those foundations 
 Detailed project and contributor credits are maintained in the acknowledgements and provenance documentation.
 ## Featured model: EXL3 R7 3.5-bpw fixed-MTP4
 
-The operator-running SparkRing research profile uses
+The operator's accepted 3.5-bpw SparkRing profile uses
 [`brandonmusic/GLM-5.2-EXL3-TR3v4-3.5bpw-MTP78`](https://huggingface.co/brandonmusic/GLM-5.2-EXL3-TR3v4-3.5bpw-MTP78)
 at immutable revision `9ab9579774cc432df91567a36f6e9e863e0d4c9f`. Four directly
 cabled DGX Sparks serve it with TP4/DCP4, fixed MTP4, 9.25 GB of KV memory per
 rank, dynamic per-token NVFP4 latent KV plus FP8 RoPE, a 262,144-token request
 limit, a 4,096-token prefill ceiling, and native SparkRing TP transport through
 Q40. Eligible pure-prefill work uses the B12X transient full-CKV DCP gather.
+The target-only exact-Q40 routed-MoE state uses capacity 40 and route block 8;
+Q1-Q32, other prefill shapes, and the draft model retain their prior states.
 
-| Measurement | Bounded result |
-|---|---:|
-| 8K / 16K unique cold prefill | **500 / 608 tok/s** |
-| 64K / 128K unique cold prefill | **563 / 551 tok/s** |
-| Unique-16K C8 sustained decode | **48 tok/s aggregate** |
-| Reported KV capacity | **1,156,864 tokens** |
+| Measurement | TTFT | Bounded result | Samples |
+|---|---:|---:|---:|
+| 8K standalone-cold C1 prefill | 12.273 s | **668 tok/s** | 2 |
+| 16K standalone-cold C1 prefill | 24.875 s | **659 tok/s** | 1 |
+| 32K standalone-cold C1 prefill | 50.172 s | **653 tok/s** | 1 |
+| Unique-16K C8 warm sustained decode | - | **73.208 tok/s aggregate** | 2 candidate arms |
+| Reported KV capacity | - | **1,156,864 tokens** | all four ranks |
 
-Compared with the otherwise identical dynamic-NVFP4 control, CKV gather
-improved the matched single-sample prefill rows by 14.85%-39.16%. CKV gather is
-not active during decode, so the positive C8 difference is treated only as a
-no-regression observation. Repeated 128-token and 256-token greedy outputs
-matched the MTP-disabled control, requested logprobs were finite, all four
-speculative positions were active, and the four-rank transport audit passed.
+The matched exact-Q40 decode bracket replayed the same eight unique 16K
+payloads with full 8/8 residency and a 25-second measurement window. Its
+73.208 tok/s candidate mean was 19.341% above the 61.344 tok/s control mean;
+the slower candidate repeat exceeded the fastest control repeat by 14.93%.
+All 75 target layers passed exact BF16 parity, deterministic 16K and 32K output
+equality passed, and final graph, API, transport, and capacity gates passed.
 
-This configuration is an **operator-running, live-validated research
-candidate**, not the reproducible public default or an accepted support
-matrix. Its larger NVFP4 pool has not repeated the predecessor FP8 profile's
-near-capacity residency gate. Its sanitized profile-generation chain is not
-yet published. Read the
+The 8K-32K prefill rows are client-timed `llm_decode_bench` v0.4.31
+observations with 100% unique generated contexts. Their low sample counts and
+unavailable server-side cached-token accounting make them bounded operating
+snapshots, not throughput distributions or independently proven cache misses.
+The predeclared exact-Q40 prefill reducer separately remains a machine failure:
+its sole primary miss was 0.1215% at 64K. Operator acceptance treats that
+bounded difference as measurement-neutral without relabelling the machine
+result as a pass.
+
+This configuration is the **accepted operator default for 3.5-bpw EXL3**. Its
+acceptance scope is one four-Spark appliance; it is not the reproducible
+public-functional default or an accepted public deployment matrix. Read the
 [fixed-MTP4 specification](docs/EXL3_R7_FIXED_MTP4_PROFILE.md),
 [optimization record](docs/EXL3_R7_OPTIMIZATION_20260811.md), and
-[machine-readable evidence](docs/configurations/glm52-exl3-r7-mtp4-nvfp4-ckv-gather-20260811.json)
+[machine-readable operator acceptance](docs/configurations/glm52-exl3-r7-mtp4-q40-block8-20260812.json)
 before reproducing or extending it.
 
 ## Public default: EXL3 3.25-bpw with LMCache CS512

--- a/docs/EXL3_R7_FIXED_MTP4_PROFILE.md
+++ b/docs/EXL3_R7_FIXED_MTP4_PROFILE.md
@@ -1,23 +1,25 @@
-# GLM-5.2 R7 3.5-bpw fixed-MTP4 dynamic-NVFP4 candidate
+# GLM-5.2 R7 3.5-bpw fixed-MTP4 operator default
 
 ## Status and evidence scope
 
-This configuration is the operator's **3.5-bpw quantization baseline** and a
-**public-functional-lane, live-validated candidate** for four directly cabled
-NVIDIA DGX Sparks / GB10 GPUs. Its baseline role identifies the comparison
-configuration for 3.5-bpw research; it does not make the profile the repository
-default, an accepted public-functional matrix, or a transferable result for
-other hardware. The advertised default remains EXL3 3.25-bpw plus LMCache
-CS512.
+This configuration is the **accepted operator default for 3.5-bpw EXL3** on
+four directly cabled NVIDIA DGX Sparks / GB10 GPUs. It is live-validated in the
+public-functional lane, but its acceptance scope is the operator's four-Spark
+appliance. It is not the repository-wide public-functional default, an
+accepted public deployment matrix, or a transferable result for other
+hardware. The advertised public-functional default remains EXL3 3.25-bpw plus
+LMCache CS512.
 
-The candidate serves
+The operator profile serves
 `brandonmusic/GLM-5.2-EXL3-TR3v4-3.5bpw-MTP78` at immutable revision
 `9ab9579774cc432df91567a36f6e9e863e0d4c9f`. It combines TP4, DCP4,
 fixed-depth-four MTP, dynamic per-token NVFP4 latent KV, FP8 RoPE storage, a
 262,144-token request limit, a 4,096-token prefill ceiling, and a transient
 full-CKV DCP gather for pure prefill. The exact four-rank startup, graph,
 bounded correctness, speculative-decoding, transport, and matched
-prefill/decode A/B gates described below passed on 2026-08-11.
+prefill/decode A/B gates described below passed on 2026-08-11. On 2026-08-12,
+the operator accepted the target-only exact-Q40 block-8 policy described below
+as the default extension to this profile.
 
 The sanitized machine-readable result is
 [glm52-exl3-r7-mtp4-nvfp4-ckv-gather-20260811.json](configurations/glm52-exl3-r7-mtp4-nvfp4-ckv-gather-20260811.json).
@@ -25,6 +27,8 @@ The raw endpoint, rank-status, and benchmark artifacts are maintainer-held and
 identified by SHA-256 in that record. The earlier FP8, 65,536-token fixed-MTP4
 qualification remains separately preserved in
 [glm52-exl3-r7-mtp4-kv925-20260811.json](configurations/glm52-exl3-r7-mtp4-kv925-20260811.json).
+The exact-Q40 acceptance result is
+[glm52-exl3-r7-mtp4-q40-block8-20260812.json](configurations/glm52-exl3-r7-mtp4-q40-block8-20260812.json).
 
 ## Serving contract
 
@@ -37,6 +41,7 @@ qualification remains separately preserved in
 | Speculation | fixed MTP4, greedy draft sampling, adaptive depth disabled |
 | Maximum sequences | 8 |
 | Query-row contract | Q1 through Q40; `8 * (4 + 1) = 40` verification rows |
+| Exact-Q40 routed-MoE policy | Target mixed-EXL3 layers use capacity 40 and route block 8 only at exactly 40 rows; Q1-Q32, other prefill shapes, and the draft model retain their prior states |
 | KV representation | `nvfp4_ds_mla`, dynamic per-token scale, FP8 RoPE, 368-byte record |
 | KV allocation | 9,250,000,000 bytes/rank; 37,000,000,000 bytes aggregate |
 | Reported KV capacity | 1,156,864 tokens |
@@ -59,6 +64,56 @@ One process-and-device CUDA stream is shared across target, draft-prefill, and
 draft-decode graph managers. Their graph-capture contexts and channel IDs stay
 distinct. This preserves the Spark TP4 graph session's stable-caller-stream
 invariant without merging graph ownership.
+
+## Accepted exact-Q40 routed-MoE policy
+
+The accepted operator profile adds one target-only EXL3 runtime state for
+exactly 40 routed rows. That state uses capacity 40, route block 8, and the
+existing prefill tiers and tile configuration. The insertion-only source delta
+does not change Q1-Q32 decode dispatch, general prefill dispatch for row counts
+other than 40, or the uniform draft-model path. The two unique Q40 arenas add
+32,268,384 bytes per rank and leave the reported KV capacity unchanged at
+1,156,864 tokens.
+
+All four ranks attested all 75 routed target layers before graph capture. Each
+layer produced exact BF16 equality between the new Q40 state and the deployed
+general-prefill comparator. Deterministic 16K and 32K application requests also
+matched the sealed control response and completion-token hashes, with finite
+log probabilities and zero differences. Graph capture, API health, transport
+sequence convergence, and the full 9.25 GB/rank KV allocation passed after the
+measurements.
+
+The matched warm C8 bracket replayed the same eight unique 16K request payloads
+with a 25-second measurement window and full 8/8 residency:
+
+| Arm | Aggregate tokens/s |
+|---|---:|
+| Baseline A1 | 59.656 |
+| Baseline A2 | 61.468 |
+| Baseline C2 | 62.907 |
+| Baseline mean | 61.344 |
+| Exact-Q40 candidate B2 | 74.119 |
+| Exact-Q40 candidate B3 | 72.297 |
+| Exact-Q40 candidate mean | **73.208** |
+| Candidate change from baseline mean | **+19.341%** |
+
+The slower candidate repeat exceeded the fastest baseline repeat by 14.93%.
+A post-prefill durability replay measured 66.685 aggregate tokens/s with all
+eight requests resident and no queue, request error, capacity limit, fatal
+transport state, or overflow.
+
+The predeclared prefill reducer remains recorded as a machine failure. Its sole
+primary-gate miss was the 64K median: 618.246 tokens/s versus the lower sealed
+baseline median of 618.998 tokens/s, or -0.1215%. The operator accepts that
+difference as measurement-neutral rather than a material regression. The 16K
+and 128K primary prefill gates passed; the 32K median was inside the baseline
+envelope. This is an explicit engineering waiver of the literal threshold, not
+a rewritten gate or a claim that the machine result passed.
+
+Fixed-prompt non-Q40 checks measured C1 at 22.218 versus 22.362 tokens/s
+(-0.65%) and C4 at 45.703 versus 46.578 tokens/s (-1.88%). These
+source-identical paths are treated as bounded measurement noise, not as
+optimization results.
 
 ## Exact CKV-gather delta and rollback
 
@@ -189,8 +244,14 @@ contract, not for the exact dynamic-NVFP4/262K/CKV-gather profile. The larger
 
 ## Limitations
 
-- This is a live-validated candidate on one four-Spark appliance, not an
-  accepted or default public-functional configuration.
+- This is the accepted operator default on one four-Spark appliance, not the
+  repository-wide public-functional default or an accepted public deployment
+  matrix.
+- The exact-Q40 acceptance is an explicit engineering decision over a
+  predeclared machine prefill failure at 64K of -0.1215%. The failure remains
+  preserved in the machine-readable evidence.
+- The +19.341% decode result applies to fixed-MTP4 Q40 at 16K with eight fully
+  resident requests. It is not an all-shape or all-concurrency speed claim.
 - The current exact profile has bounded startup, output-equivalence,
   speculative-decoding, transport, and matched prefill/decode evidence. Its
   262,144-token request boundary and near-capacity concurrent residency remain

--- a/docs/RESULTS.md
+++ b/docs/RESULTS.md
@@ -4,7 +4,7 @@
 > NF3 has a smaller accepted sanity set in [README.md](../README.md).
 > EXL3+LMCache CS512 is the main advertised public-functional configuration and
 > has the bounded clean-checkout gate below. The operator's running EXL3 R7
-> fixed-MTP4 service is a separately labelled candidate.
+> fixed-MTP4 service is the separately scoped operator default.
 > Results are not interchangeable between checkpoints or evidence origins.
 
 ## Current EXL3+LMCache public-path gate
@@ -92,6 +92,50 @@ open capacity gates are in the
 [fixed-MTP4 dynamic-NVFP4 candidate specification](EXL3_R7_FIXED_MTP4_PROFILE.md)
 and
 [sanitized machine-readable evidence](configurations/glm52-exl3-r7-mtp4-nvfp4-ckv-gather-20260811.json).
+
+### 2026-08-12 EXL3 R7 exact-Q40 operator acceptance
+
+The accepted operator 3.5-bpw profile adds a target-only routed-MoE state for
+exactly 40 rows. It uses capacity 40 and route block 8 without changing Q1-Q32,
+other prefill shapes, or the uniform draft path. The matched decode bracket
+replayed the same eight unique 16K payloads with full 8/8 residency and a
+25-second measurement window.
+
+| Measurement | Control | Exact-Q40 profile | Change |
+|---|---:|---:|---:|
+| Warm C8 mean | 61.344 tok/s | **73.208 tok/s** | **+19.341%** |
+| Slowest candidate versus fastest control | 62.907 tok/s | **72.297 tok/s** | **+14.93%** |
+| Reported KV capacity | 1,156,864 tokens | **1,156,864 tokens** | unchanged |
+
+One later bounded operator snapshot used `llm_decode_bench` v0.4.31 in
+standalone-cold C1 mode with 100% unique generated contexts:
+
+| Context | Client TTFT | Client-timed prefill | Samples |
+|---|---:|---:|---:|
+| 8K | 12.273 s | **668 tok/s** | 2 |
+| 16K | 24.875 s | **659 tok/s** | 1 |
+| 32K | 50.172 s | **653 tok/s** | 1 |
+
+The complete benchmark JSON has SHA-256
+`feed67820caf37cc016473a38584b11b4205a628183f64e2b48b082a7bad2854`.
+These are low-sample client observations. The benchmark did not return
+server-side cached-token accounting for these cells, so they are not presented
+as distributions or independently proven cache misses.
+
+The exact-Q40 prefill non-regression bracket measured medians of 526.449,
+623.599, 615.930, 618.246, and 619.807 tok/s at 8K, 16K, 32K, 64K, and 128K.
+The predeclared reducer returned failure only at 64K: 618.246 tok/s was 0.1215%
+below the lower 618.998 tok/s baseline-envelope median. The operator accepted
+that bounded difference as measurement-neutral without relabelling the machine
+failure as a pass. All-rank runtime attestation, exact BF16 parity across all
+75 target layers, deterministic 16K/32K output equality, graph capture,
+transport convergence, API health, and final capacity passed.
+
+This result is accepted only as the operator's four-Spark 3.5-bpw default. It
+does not replace the clean-checkout 3.25-bpw public-functional default. The
+complete contract and immutable receipt hashes are in the
+[fixed-MTP4 specification](EXL3_R7_FIXED_MTP4_PROFILE.md) and
+[operator-acceptance summary](configurations/glm52-exl3-r7-mtp4-q40-block8-20260812.json).
 
 ### 2026-08-11 EXL3 R7 fixed-MTP4 FP8 predecessor
 

--- a/docs/STATUS.json
+++ b/docs/STATUS.json
@@ -93,14 +93,16 @@
       "full_live_bundle_exists": false,
       "entrypoint": "docs/EXL3_ACCEPTANCE_RUNBOOK.md"
     },
-    "exl3_r7_mtp4_nvfp4_ckv_candidate": {
-      "maturity": "live-validated",
+    "exl3_r7_mtp4_nvfp4_ckv_operator_default": {
+      "maturity": "accepted",
       "lane": "public-functional",
-      "configuration_status": "candidate",
-      "accepted": false,
+      "configuration_status": "accepted-operator-default",
+      "accepted": true,
       "default": false,
+      "operator_default": true,
+      "public_functional_default": false,
       "operator_running_configuration": true,
-      "comparison_role": "operator-3.5-bpw-quantization-baseline",
+      "acceptance_scope": "operator-3.5-bpw-four-spark-profile",
       "hardware": "four directly cabled NVIDIA DGX Sparks / GB10 GPUs",
       "model": "brandonmusic/GLM-5.2-EXL3-TR3v4-3.5bpw-MTP78@9ab9579774cc432df91567a36f6e9e863e0d4c9f",
       "topology": "TP4/DCP4",
@@ -122,10 +124,30 @@
       "matched_ckv_gather_ab_complete": true,
       "matched_prefill_gain_percent_range": [14.85, 39.16],
       "matched_decode_regression_observed": false,
+      "exact_q40_policy": {
+        "status": "accepted-operator-default",
+        "scope": "target mixed-EXL3 layers at exactly 40 routed rows",
+        "capacity_rows": 40,
+        "route_block_rows": 8,
+        "q1_q32_unchanged": true,
+        "other_prefill_shapes_unchanged": true,
+        "uniform_draft_unchanged": true,
+        "all_75_layer_exact_bf16_parity_passed": true,
+        "reported_kv_capacity_unchanged": true,
+        "warm_c8_baseline_mean_tok_s": 61.343758379897,
+        "warm_c8_candidate_mean_tok_s": 73.20831541406938,
+        "warm_c8_gain_percent": 19.341098992820307,
+        "prefill_machine_gate": "fail",
+        "prefill_machine_gate_failure_context_tokens": 65536,
+        "prefill_machine_gate_delta_percent": -0.12150089352351845,
+        "prefill_engineering_interpretation": "measurement-neutral",
+        "acceptance_basis": "explicit operator engineering waiver; the machine failure remains preserved"
+      },
       "long_context_capacity_gate_passed": false,
       "long_context_capacity_gate_scope": "The predecessor FP8 profile passed the 512,000-token residency gate; the exact dynamic-NVFP4 CKV-gather profile has not repeated it.",
       "entrypoint": "docs/EXL3_R7_FIXED_MTP4_PROFILE.md",
-      "machine_readable_evidence": "docs/configurations/glm52-exl3-r7-mtp4-nvfp4-ckv-gather-20260811.json"
+      "machine_readable_evidence": "docs/configurations/glm52-exl3-r7-mtp4-q40-block8-20260812.json",
+      "predecessor_machine_readable_evidence": "docs/configurations/glm52-exl3-r7-mtp4-nvfp4-ckv-gather-20260811.json"
     },
     "nf3_recipe": {
       "maturity": "accepted",

--- a/docs/configurations/glm52-exl3-r7-mtp4-q40-block8-20260812.json
+++ b/docs/configurations/glm52-exl3-r7-mtp4-q40-block8-20260812.json
@@ -1,0 +1,101 @@
+{
+  "schema": "sparkring-exl3-r7-mtp4-q40-block8-operator-acceptance/v1",
+  "date": "2026-08-12",
+  "lane": "public-functional",
+  "maturity": "accepted",
+  "configuration_status": "accepted-operator-default",
+  "accepted": true,
+  "operator_default": true,
+  "public_functional_default": false,
+  "acceptance_scope": "operator-3.5-bpw-four-spark-profile",
+  "hardware": "four directly cabled NVIDIA DGX Sparks / GB10 GPUs",
+  "policy": {
+    "model": "brandonmusic/GLM-5.2-EXL3-TR3v4-3.5bpw-MTP78@9ab9579774cc432df91567a36f6e9e863e0d4c9f",
+    "image_id": "sha256:02881d5229d4f4d1cbba0cf40537492a2a505b9d4e43bbfe9a0b2a7bd0584513",
+    "parallelism": "TP4/DCP4 fixed-MTP4",
+    "target_scope": "75 mixed-EXL3 routed layers",
+    "dispatch": "exactly 40 routed rows",
+    "capacity_rows": 40,
+    "route_block_rows": 8,
+    "q1_q32_unchanged": true,
+    "other_prefill_shapes_unchanged": true,
+    "uniform_draft_unchanged": true,
+    "additional_unique_arena_bytes_per_rank": 32268384,
+    "kv_cache_bytes_per_rank": 9250000000,
+    "reported_kv_capacity_tokens": 1156864
+  },
+  "identity": {
+    "live_profile_sha256": "47a9f825b00c0399fcdf5313c2bf3cee00feb775c0a02c5bbb6d888fb609add1",
+    "site_sha256": "a1c62b5b42c98d75830a8a30ef71c33953fd8d28bd4dce28aecd0d133e81fe4c",
+    "patched_exl3_sha256": "8fad5330c88f55dc57e4d8e298f2af23e16390b97153b569a2e572e0fb5065c2",
+    "model_runner_sha256": "0e2e0150702029b3c09bd117c33101d90d8197386d278dc6008973b314ae9997",
+    "engineering_verdict_sha256": "3a73652f72ee9d969bc864e0c56ae3bf52aa5167ad6ef5e2fe4678674039b261",
+    "prefill_machine_verdict_sha256": "315a71d20d1ee4394e5adefe408c5e0382105dbb9038e84a48ce0a7b301037ce",
+    "post_health_sha256": "99a629e02f636b3e03fe1bab20038786ada6a183eeb2e83f5dd8e96de5f5f52b",
+    "complete_benchmark_sha256": "feed67820caf37cc016473a38584b11b4205a628183f64e2b48b082a7bad2854"
+  },
+  "correctness_and_health": {
+    "all_rank_runtime_attestation": "pass",
+    "all_75_target_layer_exact_bf16_parity": "pass",
+    "long_context_16k_32k_equality": "pass",
+    "finite_logprobs": "pass",
+    "graph_capture": "pass",
+    "api_health_http": 200,
+    "transport_caught_up_all_ranks": true,
+    "fatal": false,
+    "overflow": 0,
+    "reported_kv_capacity_tokens": 1156864
+  },
+  "matched_q40_c8": {
+    "context_tokens": 16384,
+    "concurrency": 8,
+    "measurement_seconds": 25,
+    "exact_payload_replay": true,
+    "fully_resident": true,
+    "request_errors": 0,
+    "baseline_warm_arms_tok_s": [59.65646244821571, 61.46800048209391, 62.906812209381364],
+    "candidate_warm_arms_tok_s": [74.11922467382195, 72.29740615431679],
+    "baseline_warm_mean_tok_s": 61.343758379897,
+    "candidate_warm_mean_tok_s": 73.20831541406938,
+    "candidate_gain_percent": 19.341098992820307,
+    "slowest_candidate_vs_fastest_baseline_percent": 14.93
+  },
+  "bounded_client_prefill_snapshot": {
+    "benchmark": "llm_decode_bench v0.4.31",
+    "timestamp": "2026-08-12T18:07:13.253185",
+    "mode": "standalone_cold",
+    "concurrency": 1,
+    "unique_context_percent": 100.0,
+    "rows": [
+      {"context_tokens": 8192, "client_ttft_seconds": 12.273, "client_tokens_per_second": 668.0, "samples": 2},
+      {"context_tokens": 16384, "client_ttft_seconds": 24.875, "client_tokens_per_second": 659.0, "samples": 1},
+      {"context_tokens": 32768, "client_ttft_seconds": 50.172, "client_tokens_per_second": 653.0, "samples": 1}
+    ],
+    "limitations": [
+      "The rows are low-sample client observations, not throughput distributions.",
+      "Server-side cached-token accounting was unavailable, so cache misses are not independently proven."
+    ]
+  },
+  "prefill_nonregression": {
+    "machine_verdict": "fail",
+    "operator_engineering_interpretation": "measurement-neutral",
+    "medians_tok_s": {"8192": 526.4485751946287, "16384": 623.5990015489044, "32768": 615.929764382798, "65536": 618.2459159068494, "131072": 619.8070239362987},
+    "sole_primary_failure": {
+      "context_tokens": 65536,
+      "candidate_median_tok_s": 618.2459159068494,
+      "baseline_envelope_low_tok_s": 618.9980040126175,
+      "candidate_vs_envelope_low_percent": -0.12150089352351845
+    },
+    "acceptance_treatment": "explicit operator waiver; the declared machine failure is preserved and was not relabelled as pass"
+  },
+  "decision": {
+    "accepted_as_operator_default": true,
+    "public_functional_default_changed": false,
+    "unsupported_claims": [
+      "blanket correctness",
+      "all-shape speedup",
+      "transferability beyond the qualified four-Spark appliance",
+      "public-functional default promotion"
+    ]
+  }
+}


### PR DESCRIPTION
## Resulting behavior

- updates the featured 3.5-bpw profile to the accepted operator-default scope
- publishes the sealed exact-Q40 C8 result: 73.208 aggregate tok/s, +19.341% versus the matched control mean
- publishes the bounded client-timed 8K/16K/32K prefill snapshot: 668/659/653 tok/s
- preserves the predeclared 64K prefill machine-gate miss of 0.1215% and its explicit operator waiver
- adds machine-readable exact-Q40 acceptance evidence and aligns STATUS.json

## Validation

- both JSON documents parse
- git diff --check passes
- all 173 tracked repository-relative Markdown links and anchors resolve

The 3.25-bpw clean-checkout public-functional default is unchanged.