### PR TITLE
Publish the EXL3 R7 ARM64 builder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,3 +95,6 @@ desktop.ini
 compile_commands.json
 CMakeCache.txt
 CMakeFiles/
+.omp-task.md
+.omp-error.log
+.omp-output.log

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -99,3 +99,85 @@ notices.
 After the exclusions described above, no file in this snapshot carries a
 third-party SPDX identifier or copyright header. Any file that bears such a
 header must retain it verbatim.
+
+## 9. EXL3 R7 runtime builder components
+
+The `runtime/exl3-r7/` builder package assembles an ARM64/SM121 container image
+from the following upstream components. Each is identified by an exact Git
+commit in `runtime/exl3-r7/pins.json` or `runtime/exl3-r7/prepare_build_deps.py`
+and embedded as an OCI label in the built image. None of these components'
+source code is distributed in this repository; the builder fetches them at
+build time from their public repositories.
+
+### 9a. local-inference-lab vLLM fork
+
+- Repository: `https://github.com/local-inference-lab/vllm.git`
+- Exact commit: `e2666d9a65f41fc376607531453cbd57c4c71016`
+- License: Apache License 2.0 (inherited from `vllm-project/vllm`)
+- Role: Built into the image as the serving engine; patched with a receipt-gated
+  integration patch (SHA-256 pinned in `pins.json`).
+
+### 9b. B12X (local-inference-lab/b12x)
+
+- Repository: `https://github.com/local-inference-lab/b12x.git`
+- Exact commit: `7cecbb2c4819636ae7f05f8b116f2c45ee2cff7b`
+- License: Apache License 2.0
+- Role: SM120/SM121 CuTe DSL kernel library for mixed-Trellis MoE, MLA
+  attention, and fused GEMM. Built into the image as a pip package from source.
+
+### 9c. ExLlamaV3 (brandonmmusic-max/exllamav3)
+
+- Repository: `https://github.com/brandonmmusic-max/exllamav3.git`
+- Exact commit: `704aefd743b390af4bd0fb429d1906f9b964c7d8`
+- License: MIT License
+- Role: EXL3 quantization encoder and extension. Cloned at build time, patched
+  with the inherited ARM64 external-collectives patch (SHA-256 pinned in the
+  Containerfile), and built in place.
+
+### 9d. InstantTensor (voipmonitor/InstantTensor)
+
+- Repository: `https://github.com/voipmonitor/InstantTensor.git`
+- Exact commit: `49b4010afc1cae0441e71fe0b0bffc24fa05e932`
+- License: Apache License 2.0
+- Role: Ultra-fast distributed Safetensors weight loader. Cloned and installed
+  as a pip package from source.
+
+### 9e. NVIDIA CUTLASS
+
+- Repository: `https://github.com/NVIDIA/cutlass.git`
+- Exact commit: `da5e086dab31d63815acafdac9a9c5893b1c69e2`
+- License: BSD-3-Clause
+- Role: CUDA Templates for high-performance linear algebra; consumed as a source
+  dependency by the vLLM build. Staged locally via
+  `prepare_build_deps.py` with a receipt-gated inventory.
+
+### 9f. Triton kernels (triton-lang/triton)
+
+- Repository: `https://github.com/triton-lang/triton.git`
+- Exact commit: `0add68262ab0a2e33b84524346cb27cbb2787356`
+- Subdirectory: `python/triton_kernels/triton_kernels`
+- License: MIT License
+- Role: Triton kernel sources consumed by the vLLM build. Staged locally via
+  `prepare_build_deps.py` with a receipt-gated inventory.
+
+### 9g. Inherited base image
+
+The R7 image is built from an operator-supplied ARM64 parent image. The parent
+is identified by an immutable sha256 image ID (`BASE_IMAGE_ID`), never a
+mutable tag alone, and the build uses the resolved image ID. This repository
+does not establish one universal parent-image license: the builder therefore
+requires the audited SPDX expression for the exact parent as
+`BASE_IMAGE_LICENSES`. The value is recorded as
+`org.sparkring.parent.licenses` and included in the image's combined OCI
+license expression. A registry publisher must audit the parent image's source,
+license, and redistribution terms before publishing a derived image.
+
+### 9h. OCI provenance labels
+
+The built image carries these OCI labels for every component: exact upstream
+revision (`org.sparkring.*.commit`), source repository
+(`org.opencontainers.image.source`), license
+(`org.opencontainers.image.licenses`), and the parent image's immutable ID
+(`org.sparkring.parent.image-id`). Building or distributing the image requires
+compliance with each component's license, including preservation of copyright
+notices and license texts.

--- a/docs/STATUS.json
+++ b/docs/STATUS.json
@@ -1,6 +1,6 @@
 {
   "schema": "sparkring-repository-status/v1",
-  "last_reviewed": "2026-08-11",
+  "last_reviewed": "2026-08-13",
   "lanes": {
     "reference": {
       "maturity": "live-validated",
@@ -61,6 +61,19 @@
       "accepted": false,
       "native_arm64_build_passed": true,
       "entrypoint": "runtime/README.md"
+    },
+    "exl3_r7_arm64_builder": {
+      "maturity": "offline-validated",
+      "lane": "public-functional",
+      "accepted": false,
+      "hardware_target": "linux/arm64, NVIDIA GB10 / SM121",
+      "immutable_public_source_pins": true,
+      "prepared_source_receipt_verification": true,
+      "private_material_audit_passed": true,
+      "clean_checkout_image_live_gate_passed": false,
+      "includes_model_weights": false,
+      "includes_operator_exact_q40_overlay": false,
+      "entrypoint": "runtime/exl3-r7/README.md"
     },
     "faststart_builder": {
       "maturity": "live-validated",

--- a/runtime/README.md
+++ b/runtime/README.md
@@ -34,6 +34,12 @@ prerequisite for the NF3 alternative. Its operator procedure is
 [`docs/NF3_QUICKSTART.md`](../docs/NF3_QUICKSTART.md). The default EXL3 path is
 [`docs/QUICKSTART.md`](../docs/QUICKSTART.md).
 
+The operator's separately scoped EXL3 R7 3.5-bpw component lineage has its own
+reviewable ARM64 builder at [`runtime/exl3-r7/`](exl3-r7/README.md). That
+builder consumes immutable public source pins and emits a locally tagged image;
+it does not include model weights, a registry push, site configuration, or the
+operator's accepted exact-Q40 serving overlay.
+
 ## The two-lane model
 
 - **Public lane (this directory):** everything needed to rebuild the *public

--- a/runtime/exl3-r7/Containerfile
+++ b/runtime/exl3-r7/Containerfile
@@ -1,0 +1,112 @@
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE}
+
+ARG TARGETARCH
+ARG CUDA_ARCH=121
+ARG MAX_JOBS=8
+ARG BASE_IMAGE_ID
+ARG BASE_IMAGE_LICENSES
+ARG IMAGE_LICENSES
+ARG SPARKRING_REVISION
+ARG SOURCE_RECEIPT_SHA256
+ARG VLLM_COMMIT=e2666d9a65f41fc376607531453cbd57c4c71016
+ARG B12X_COMMIT=7cecbb2c4819636ae7f05f8b116f2c45ee2cff7b
+ARG CUTLASS_COMMIT=da5e086dab31d63815acafdac9a9c5893b1c69e2
+ARG TRITON_KERNELS_COMMIT=0add68262ab0a2e33b84524346cb27cbb2787356
+ARG EXLLAMAV3_REPOSITORY=https://github.com/brandonmmusic-max/exllamav3.git
+ARG EXLLAMAV3_COMMIT=704aefd743b390af4bd0fb429d1906f9b964c7d8
+ARG EXLLAMAV3_ARM64_PATCH_SHA256=9fdf5f6fdd2f8bef395c068ce53a360066afbda3a23e1dc8a99852bf48eff975
+ARG EXLLAMAV3_ARM64_TREE=581d6fd7b5d39f6890d8a7a5c6b3e6e519a73a2a
+ARG INSTANTTENSOR_REPOSITORY=https://github.com/voipmonitor/InstantTensor.git
+ARG INSTANTTENSOR_COMMIT=49b4010afc1cae0441e71fe0b0bffc24fa05e932
+
+# OCI provenance labels: every component built into the image is identified by
+# its exact upstream revision and license. The parent image ID is embedded
+# so post-build inspection can confirm the immutable base.
+LABEL org.opencontainers.image.source="https://github.com/FujitsuPolycom/sparkring" \
+      org.opencontainers.image.revision="${SPARKRING_REVISION}" \
+      org.opencontainers.image.licenses="${IMAGE_LICENSES}" \
+      org.sparkring.parent.image-id="${BASE_IMAGE_ID}" \
+      org.sparkring.parent.licenses="${BASE_IMAGE_LICENSES}" \
+      org.sparkring.source-receipt-sha256="${SOURCE_RECEIPT_SHA256}" \
+      org.sparkring.vllm.commit="${VLLM_COMMIT}" \
+      org.sparkring.b12x.commit="${B12X_COMMIT}" \
+      org.sparkring.exllamav3.commit="${EXLLAMAV3_COMMIT}" \
+      org.sparkring.instanttensor.commit="${INSTANTTENSOR_COMMIT}" \
+      org.sparkring.cutlass.commit="${CUTLASS_COMMIT}" \
+      org.sparkring.triton-kernels.commit="${TRITON_KERNELS_COMMIT}"
+
+RUN test "${TARGETARCH}" = arm64 \
+ && test "${CUDA_ARCH}" = 121 \
+ && apt-get update \
+ && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+      build-essential ccache git ninja-build python3-dev \
+ && rm -rf /var/lib/apt/lists/*
+
+COPY bundle /opt/r7-src
+
+ENV TORCH_CUDA_ARCH_LIST=12.1a \
+    CMAKE_CUDA_ARCHITECTURES=121 \
+    CUTE_DSL_ARCH=sm_121a \
+    FLASHINFER_CUDA_ARCH_LIST=12.1f \
+    MAX_JOBS=${MAX_JOBS} \
+    VLLM_TARGET_DEVICE=cuda \
+    VLLM_CUTLASS_SRC_DIR=/opt/r7-src/deps/cutlass \
+    TRITON_KERNELS_SRC_DIR=/opt/r7-src/deps/triton_kernels \
+    VLLM_EXL3_ENCODER_SOURCE=/opt/exllamav3-python/exllamav3 \
+    VLLM_EXL3_EXT_PATH=/opt/exllamav3-python
+
+# Commit the expensive vLLM build as its own layer. Later ARM-specific
+# extension failures must not force the 397-edge CUDA build to run again.
+RUN --mount=type=cache,id=sparkring-r7-ccache,target=/cache/jit/ccache,sharing=locked \
+    rm -f /opt/venv/lib/python3.12/site-packages/sparkring_nf3_hybrid.pth \
+ && /opt/venv/bin/python /opt/r7-src/patch_sm121_cmake.py \
+      /opt/r7-src/vllm/CMakeLists.txt \
+ && /opt/venv/bin/pip install --no-build-isolation --no-deps /opt/r7-src/b12x \
+ && /opt/venv/bin/pip install --no-build-isolation --no-deps /opt/r7-src/vllm
+
+# ExLlamaV3's native CPU collective sources are x86-only. The inherited
+# SparkRing patch supplies ARM64 stubs because distributed collectives are
+# provided by SIRCL instead of ExLlamaV3's CPU backend.
+RUN --mount=type=cache,id=sparkring-r7-ccache,target=/cache/jit/ccache,sharing=locked \
+    git clone --filter=blob:none --no-checkout \
+      "${EXLLAMAV3_REPOSITORY}" /opt/exllamav3-python \
+ && git -C /opt/exllamav3-python config core.autocrlf false \
+ && git -C /opt/exllamav3-python fetch --depth 1 origin "${EXLLAMAV3_COMMIT}" \
+ && git -C /opt/exllamav3-python checkout --detach "${EXLLAMAV3_COMMIT}" \
+ && test "$(git -C /opt/exllamav3-python rev-parse HEAD)" = "${EXLLAMAV3_COMMIT}" \
+ && test "$(sha256sum /opt/r7-src/exllamav3-arm64-external-collectives.patch | cut -d' ' -f1)" = \
+      "${EXLLAMAV3_ARM64_PATCH_SHA256}" \
+ && git -C /opt/exllamav3-python apply --binary --index \
+      /opt/r7-src/exllamav3-arm64-external-collectives.patch \
+ && test "$(git -C /opt/exllamav3-python write-tree)" = "${EXLLAMAV3_ARM64_TREE}" \
+ && cd /opt/exllamav3-python \
+ && /opt/venv/bin/python setup.py build_ext --inplace \
+ && test "$(find /opt/exllamav3-python -maxdepth 1 -type f -name 'exllamav3_ext*.so' | wc -l)" = 1
+
+RUN git clone --filter=blob:none --no-checkout \
+      "${INSTANTTENSOR_REPOSITORY}" /opt/instanttensor-src \
+ && git -C /opt/instanttensor-src config core.autocrlf false \
+ && git -C /opt/instanttensor-src fetch --depth 1 origin "${INSTANTTENSOR_COMMIT}" \
+ && git -C /opt/instanttensor-src checkout --detach "${INSTANTTENSOR_COMMIT}" \
+ && test "$(git -C /opt/instanttensor-src rev-parse HEAD)" = "${INSTANTTENSOR_COMMIT}" \
+ && git -C /opt/instanttensor-src submodule update --init --recursive \
+ && /opt/venv/bin/pip install --no-build-isolation --no-deps /opt/instanttensor-src \
+ && rm -rf /root/.cache/pip \
+ && install -D -m 0755 /opt/r7-src/runtime/entrypoint.sh \
+      /usr/local/bin/sparkring-r7-entrypoint \
+ && install -D -m 0644 /opt/r7-src/runtime/verify_runtime.py \
+      /opt/sparkring-r7/verify_runtime.py \
+ && PYTHONPATH=/opt/spark-vllm \
+      /opt/venv/bin/python /opt/sparkring-r7/verify_runtime.py --installed-only
+
+ENV VLLM_EXL3_ONLINE_TRELLIS_BITS=6 \
+    VLLM_EXL3_ONLINE_CACHE_DIR=/cache/exl3-online \
+    VLLM_EXL3_ONLINE_CACHE_MODE=readwrite \
+    VLLM_EXL3_PREFILL_CAPACITY=2048 \
+    INSTANTTENSOR_BACKEND=BUFFERED \
+    INSTANTTENSOR_BUFFER_SIZE=536870912 \
+    INSTANTTENSOR_COPY=0 \
+    INSTANTTENSOR_MAX_FREE_MEM_USAGE=0.05
+
+ENTRYPOINT ["/usr/local/bin/sparkring-r7-entrypoint"]

--- a/runtime/exl3-r7/README.md
+++ b/runtime/exl3-r7/README.md
@@ -6,10 +6,11 @@ candidate runtime documented in
 It builds an ARM64/SM121 container image from pinned public source trees with
 fail-closed receipt verification.
 
-**Maturity:** public-functional-lane, live-validated **candidate**. It is
-not the repository default, not an accepted public-functional matrix, and not
-registry-available. The advertised default remains EXL3 3.25-bpw plus
-LMCache CS512.
+**Maturity:** public-functional-lane, **offline-validated builder candidate**.
+The operator configuration assembled from the same pinned component lineage is
+live-validated, but an image built from this clean-checkout builder has not yet
+passed that live gate. It is not the repository default, not an accepted
+public-functional matrix, and not registry-available.
 
 ## Platform
 
@@ -101,10 +102,12 @@ BASE_IMAGE=... BASE_IMAGE_ID=... BASE_IMAGE_LICENSES=... \
 
 ## Maturity
 
-This builder is a **public-functional-lane candidate**. It is:
+This builder is a **public-functional-lane, offline-validated candidate**. It
+is:
 
-- **live-validated** on four directly cabled DGX Sparks per the evidence in
-  `docs/EXL3_R7_FIXED_MTP4_PROFILE.md`;
+- derived from the component lineage used by the four-Spark operator result in
+  `docs/EXL3_R7_FIXED_MTP4_PROFILE.md`, without claiming that a clean-checkout
+  image built here has passed that live gate;
 - **not accepted** as a public-functional matrix;
 - **not the default** advertised configuration;
 - **not registry-available** — the image is built and used locally;

--- a/runtime/exl3-r7/README.md
+++ b/runtime/exl3-r7/README.md
@@ -1,0 +1,116 @@
+# EXL3 R7 3.5-bpw fixed-MTP4 ARM64 builder
+
+This directory is a **reviewable public builder package** for the EXL3 R7
+candidate runtime documented in
+[`docs/EXL3_R7_FIXED_MTP4_PROFILE.md`](../../docs/EXL3_R7_FIXED_MTP4_PROFILE.md).
+It builds an ARM64/SM121 container image from pinned public source trees with
+fail-closed receipt verification.
+
+**Maturity:** public-functional-lane, live-validated **candidate**. It is
+not the repository default, not an accepted public-functional matrix, and not
+registry-available. The advertised default remains EXL3 3.25-bpw plus
+LMCache CS512.
+
+## Platform
+
+| Property | Value |
+|---|---|
+| Architecture | `linux/arm64` |
+| GPU target | SM121 (NVIDIA GB10 / DGX Spark, CUDA 13.2) |
+| Python | 3.12 |
+| Parent image | `sparkring/glm52-exl3-tr3-3.25bpw` (EXL3 3.25-bpw public-functional) |
+
+## Inputs
+
+- `pins.json` — authoritative pin set: release repository/commit, component
+  base commits, patch paths, patch SHA-256 hashes, and result Git tree hashes.
+- `prepare_build_deps.py` — CUTLASS and Triton kernel source pins with
+  receipt-gated inventory verification.
+- `Containerfile` — multi-stage build that clones ExLlamaV3 and InstantTensor
+  at pinned commits, applies the ARM64 external-collectives patch, builds
+  vLLM and B12X from the prepared source bundle, and runs `verify_runtime.py`.
+- `PREPARED_SOURCES` environment variable (optional) — a pre-verified source
+  directory whose receipt is checked by `prepare_context.py --verify`.
+
+## Outputs
+
+- A local container image tagged `${IMAGE:-sparkring-r7:arm64-sm121}`.
+- The image's immutable ID is printed by `build-image.sh` on success.
+- OCI labels embedded in the image record every component's upstream commit,
+  the parent image ID, the source receipt SHA-256, and the license.
+
+## Build command
+
+```bash
+BASE_IMAGE=<parent-image-tag> \
+BASE_IMAGE_ID=<parent-image-sha256-id> \
+BASE_IMAGE_LICENSES=<parent-image-spdx-expression> \
+  ./runtime/exl3-r7/build-image.sh
+```
+
+`BASE_IMAGE`, `BASE_IMAGE_ID`, and `BASE_IMAGE_LICENSES` are **required**.
+The script resolves the parent image to its immutable ID, builds from that
+resolved ID rather than the mutable name, and fails closed if the observed ID
+does not match `BASE_IMAGE_ID`. The license value must be the audited SPDX
+expression for the exact parent image; it is combined with the licenses of the
+components added by this builder in the standard OCI license label.
+
+To use pre-prepared sources instead of fetching at build time:
+
+```bash
+PREPARED_SOURCES=/path/to/prepared/sources \
+BASE_IMAGE=... BASE_IMAGE_ID=... BASE_IMAGE_LICENSES=... \
+  ./runtime/exl3-r7/build-image.sh
+```
+
+## Immutable identity contract
+
+1. **Parent image:** identified by `BASE_IMAGE_ID` (sha256 image ID), never a
+   mutable tag alone. The script compares the engine-resolved ID against the
+   required value and exits 78 on drift.
+2. **Source trees:** `prepare_context.py` fetches each component at its
+   pinned commit, applies the pinned patch, and verifies the Git `write-tree`
+   hash matches `result_tree` in `pins.json`. A `receipt.json` is written
+   and self-verified before returning.
+3. **Prepared sources:** when `PREPARED_SOURCES` is set, the receipt is
+   verified by `prepare_context.py --verify` — not just checked for
+   existence. The verifier re-checks schema, release commit, every component's
+   `base_commit`, `patch_sha256`, and `result_tree` against `pins.json`,
+   re-computes the actual Git tree of each checked-out component, and rejects
+   unstaged or untracked content not represented by that tree.
+4. **Build dependencies:** `prepare_build_deps.py` stages CUTLASS and
+   Triton kernel sources with a per-file SHA-256 inventory receipt. The
+   `--verify` flag re-checks the inventory against the receipt.
+5. **OCI labels:** the built image carries
+   `org.sparkring.parent.image-id`, `org.opencontainers.image.source`,
+   `org.opencontainers.image.revision`, `org.opencontainers.image.licenses`,
+   and per-component commit labels for vLLM, B12X, ExLlamaV3, InstantTensor,
+   CUTLASS, and Triton kernels.
+
+## What is excluded
+
+- No model weights, checkpoints, or safetensors files are included.
+- No site addresses, SSH keys, credentials, or private host paths.
+- No registry push step. The image is local only.
+- The SM121 diagnostic probes (`sm121_shared_dense_probe.py`,
+  `sm121_routed_expert_probe.py`) and qualification harnesses
+  (`mtp*_qualification.py`, `endpoint_benchmark.py`) are GPU-only tools
+  for live validation; they are not part of the build.
+- The nonfinite-trace and shared-capture overlay builders are vLLM source
+  patch generators for live runtime overlays; they are not built into the image.
+
+## Maturity
+
+This builder is a **public-functional-lane candidate**. It is:
+
+- **live-validated** on four directly cabled DGX Sparks per the evidence in
+  `docs/EXL3_R7_FIXED_MTP4_PROFILE.md`;
+- **not accepted** as a public-functional matrix;
+- **not the default** advertised configuration;
+- **not registry-available** — the image is built and used locally;
+- **not claimed** to be correct for hardware other than the four-Spark
+  appliance it was validated on.
+
+See [`docs/STATUS.json`](../../docs/STATUS.json) for the machine-readable
+maturity record and [`AGENTS.md`](../../AGENTS.md) for the lane and maturity
+terminology.

--- a/runtime/exl3-r7/build-image.sh
+++ b/runtime/exl3-r7/build-image.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# Build the receipt-gated EXL3 R7 ARM64 image over an immutable parent image.
+#
+# The parent image is identified by an immutable digest/image ID, never a
+# mutable tag alone. The script fails closed if the observed image ID drifts
+# from the required value.
+set -euo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+engine="${CONTAINER_ENGINE:-docker}"
+image="${IMAGE:-sparkring-r7:arm64-sm121}"
+
+# The parent image tag is accepted for resolution, but the build proceeds only
+# after the engine resolves it to an immutable content-addressed ID that
+# matches the required value.
+base_image="${BASE_IMAGE:?BASE_IMAGE is required (parent image tag or digest)}"
+base_image_id="${BASE_IMAGE_ID:?BASE_IMAGE_ID is required (immutable sha256 image ID)}"
+base_image_licenses="${BASE_IMAGE_LICENSES:?BASE_IMAGE_LICENSES is required (SPDX expression for the parent image)}"
+
+context="$(mktemp -d)"
+trap 'rm -rf -- "${context}"' EXIT
+deps_cache="${R7_DEPS_CACHE:-${here}/../../.sparkring/r7-build-deps}"
+
+fatal() {
+  printf 'FATAL: %s\n' "$*" >&2
+  exit 78
+}
+
+# Resolve the parent image to its immutable ID and fail closed on drift.
+observed_base="$("${engine}" image inspect --format '{{.Id}}' "${base_image}" 2>/dev/null || true)"
+if [[ -z "${observed_base}" ]]; then
+  fatal "parent image not found: ${base_image}"
+fi
+if [[ "${observed_base}" != "${base_image_id}" ]]; then
+  fatal "parent image identity drift: expected ${base_image_id}, got ${observed_base}"
+fi
+
+repo_root="$(git -C "${here}" rev-parse --show-toplevel 2>/dev/null)" ||
+  fatal "builder must run from a Git checkout"
+sparkring_revision="$(git -C "${repo_root}" rev-parse HEAD)"
+if ! git -C "${repo_root}" diff --quiet HEAD -- \
+  runtime/exl3-r7 runtime/exl3/patches/exllamav3-arm64-external-collectives.patch; then
+  fatal "builder inputs differ from SparkRing revision ${sparkring_revision}"
+fi
+untracked_inputs="$(git -C "${repo_root}" ls-files --others --exclude-standard -- \
+  runtime/exl3-r7 runtime/exl3/patches/exllamav3-arm64-external-collectives.patch)"
+if [[ -n "${untracked_inputs}" ]]; then
+  fatal "builder inputs include untracked files: ${untracked_inputs%%$'\n'*}"
+fi
+image_licenses="${base_image_licenses} AND Apache-2.0 AND MIT AND BSD-3-Clause"
+
+if [[ -n "${PREPARED_SOURCES:-}" ]]; then
+  [[ -d "${PREPARED_SOURCES}" ]] || fatal "PREPARED_SOURCES is not a directory: ${PREPARED_SOURCES}"
+  [[ -f "${PREPARED_SOURCES}/receipt.json" ]] || fatal "missing prepared-source receipt: ${PREPARED_SOURCES}/receipt.json"
+  # Verify the receipt content, not just its existence.
+  python3 "${here}/prepare_context.py" --verify "${PREPARED_SOURCES}" >/dev/null
+  cp -a "${PREPARED_SOURCES}" "${context}/sources"
+else
+  python3 "${here}/prepare_context.py" "${context}/sources"
+fi
+
+cp "${here}/Containerfile" "${context}/Containerfile"
+python3 "${here}/prepare_build_deps.py" "${deps_cache}"
+python3 "${here}/prepare_build_deps.py" --verify "${deps_cache}"
+mkdir -p "${context}/bundle/deps" "${context}/bundle/runtime"
+cp -a "${deps_cache}/cutlass" "${context}/bundle/deps/cutlass"
+cp -a "${deps_cache}/triton_kernels" "${context}/bundle/deps/triton_kernels"
+cp "${here}/verify_runtime.py" "${context}/bundle/runtime/verify_runtime.py"
+cp "${here}/entrypoint.sh" "${context}/bundle/runtime/entrypoint.sh"
+cp "${here}/patch_sm121_cmake.py" "${context}/bundle/patch_sm121_cmake.py"
+cp "${here}/../exl3/patches/exllamav3-arm64-external-collectives.patch" \
+  "${context}/bundle/exllamav3-arm64-external-collectives.patch"
+mv "${context}/sources/vllm" "${context}/bundle/vllm"
+mv "${context}/sources/b12x" "${context}/bundle/b12x"
+# Compute the source receipt hash for the OCI label before removing sources.
+source_receipt_sha="$(sha256sum "${context}/sources/receipt.json" | awk '{print $1}')"
+rm -rf -- "${context}/sources"
+
+"${engine}" build \
+  --platform linux/arm64 \
+  --file "${context}/Containerfile" \
+  --tag "${image}" \
+  --build-arg "BASE_IMAGE=${observed_base}" \
+  --build-arg "BASE_IMAGE_ID=${observed_base}" \
+  --build-arg "BASE_IMAGE_LICENSES=${base_image_licenses}" \
+  --build-arg "IMAGE_LICENSES=${image_licenses}" \
+  --build-arg "SPARKRING_REVISION=${sparkring_revision}" \
+  --build-arg "SOURCE_RECEIPT_SHA256=${source_receipt_sha}" \
+  --build-arg "VLLM_COMMIT=e2666d9a65f41fc376607531453cbd57c4c71016" \
+  --build-arg "B12X_COMMIT=7cecbb2c4819636ae7f05f8b116f2c45ee2cff7b" \
+  --build-arg "CUTLASS_COMMIT=da5e086dab31d63815acafdac9a9c5893b1c69e2" \
+  --build-arg "TRITON_KERNELS_COMMIT=0add68262ab0a2e33b84524346cb27cbb2787356" \
+  --build-arg CUDA_ARCH=121 \
+  --build-arg "MAX_JOBS=${MAX_JOBS:-8}" \
+  "${context}"
+
+"${engine}" image inspect --format '{{.Id}}' "${image}"

--- a/runtime/exl3-r7/build_mla_nonfinite_trace_overlay.py
+++ b/runtime/exl3-r7/build_mla_nonfinite_trace_overlay.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""Build a graph-safe internal MLA nonfinite-trace vLLM overlay.
+
+The generated ``mla.py`` records device-side nonfinite counts for the fused
+Q/KV projection, Q up-projection, normalized KV latent, raw MLA output, local
+output projection, and post-TP-reduction output. A paired ``deepseek_v2.py``
+overlay owns the persistent count buffer and performs the only host sync.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+from pathlib import Path
+
+
+EXPECTED_SOURCE_SHA256 = "0cbbcc412238d27afe1e2980d14b29c973bfa5a38d90bc8e78dedba3e7a3526d"
+
+
+def _replace_once(source: str, old: str, new: str, *, label: str) -> str:
+    count = source.count(old)
+    if count != 1:
+        raise RuntimeError(
+            f"{label} preimage must occur exactly once, found {count}; "
+            "the composed vLLM source has drifted"
+        )
+    return source.replace(old, new, 1)
+
+
+def patch_source(source: str) -> str:
+    source = _replace_once(
+        source,
+        "from vllm.config import CacheConfig, get_current_vllm_config\n",
+        "from vllm.config import CacheConfig, get_current_vllm_config\n"
+        "from vllm.distributed import tensor_model_parallel_all_reduce\n",
+        label="TP all-reduce import",
+    )
+    source = _replace_once(
+        source,
+        '''        self.prefix = prefix
+
+    def forward(''',
+        '''        self.prefix = prefix
+        self._r7_nonfinite_counts: torch.Tensor | None = None
+        self._r7_nonfinite_base = -1
+
+    def _r7_nonfinite_record(self, offset: int, value: torch.Tensor) -> None:
+        counts = self._r7_nonfinite_counts
+        if counts is not None:
+            counts.select(0, self._r7_nonfinite_base + offset).copy_(
+                torch.count_nonzero(~torch.isfinite(value))
+            )
+
+    def forward(''',
+        label="MLA trace state",
+    )
+    source = _replace_once(
+        source,
+        '''            qkv_lora = self.fused_qkv_a_proj(hidden_states)[0]
+            q_c, kv_lora = qkv_lora.split(''',
+        '''            qkv_lora = self.fused_qkv_a_proj(hidden_states)[0]
+            self._r7_nonfinite_record(2, qkv_lora)
+            q_c, kv_lora = qkv_lora.split(''',
+        label="fused QKV trace",
+    )
+    source = _replace_once(
+        source,
+        '''            q_c = self.q_a_layernorm(q_c)
+            q = self.q_b_proj(q_c)[0]
+        else:''',
+        '''            q_c = self.q_a_layernorm(q_c)
+            q = self.q_b_proj(q_c)[0]
+            self._r7_nonfinite_record(3, q)
+        else:''',
+        label="Q up-projection trace",
+    )
+    source = _replace_once(
+        source,
+        '''        kv_c_normed = self.kv_a_layernorm(kv_c)
+        # Normalize only the 512-D compressed latent before the cache writer.''',
+        '''        kv_c_normed = self.kv_a_layernorm(kv_c)
+        self._r7_nonfinite_record(4, kv_c_normed)
+        # Normalize only the 512-D compressed latent before the cache writer.''',
+        label="KV latent trace",
+    )
+    source = _replace_once(
+        source,
+        '''        attn_out = self.mla_attn(
+            q,
+            kv_c_for_cache,
+            k_pe,
+            output_shape=(hidden_states.shape[0], self.num_heads * self.v_head_dim),
+        )
+
+        return self.o_proj(attn_out)[0]''',
+        '''        attn_out = self.mla_attn(
+            q,
+            kv_c_for_cache,
+            k_pe,
+            output_shape=(hidden_states.shape[0], self.num_heads * self.v_head_dim),
+        )
+        self._r7_nonfinite_record(5, attn_out)
+
+        if self._r7_nonfinite_counts is None:
+            return self.o_proj(attn_out)[0]
+
+        # Mirror RowParallelLinear.forward exactly so the diagnostic can see
+        # the local projection before its normal tensor-parallel reduction.
+        if not self.o_proj.input_is_parallel:
+            raise RuntimeError(
+                "R7 MLA nonfinite trace requires an input-parallel o_proj"
+            )
+        bias = (
+            None
+            if self.o_proj.tp_rank > 0 or self.o_proj.skip_bias_add
+            else self.o_proj.bias
+        )
+        output_parallel = self.o_proj.quant_method.apply(self.o_proj, attn_out, bias)
+        self._r7_nonfinite_record(6, output_parallel)
+        if self.o_proj.reduce_results and self.o_proj.tp_size > 1:
+            output = tensor_model_parallel_all_reduce(output_parallel)
+        else:
+            output = output_parallel
+        self._r7_nonfinite_record(7, output)
+        return output''',
+        label="MLA core and output projection trace",
+    )
+    return source
+
+
+def build(source_path: Path, output_path: Path, expected_sha256: str) -> None:
+    source_bytes = source_path.read_bytes()
+    actual_sha256 = hashlib.sha256(source_bytes).hexdigest()
+    if actual_sha256 != expected_sha256:
+        raise RuntimeError(
+            "mla.py SHA-256 mismatch: "
+            f"expected {expected_sha256}, got {actual_sha256}"
+        )
+    patched = patch_source(source_bytes.decode("utf-8"))
+    compile(patched, str(output_path), "exec")
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(patched, encoding="utf-8", newline="\n")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("source", type=Path)
+    parser.add_argument("output", type=Path)
+    parser.add_argument(
+        "--expected-sha256",
+        default=EXPECTED_SOURCE_SHA256,
+        help="fail-closed SHA-256 for the composed mla.py preimage",
+    )
+    args = parser.parse_args()
+    build(args.source, args.output, args.expected_sha256.lower())
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/runtime/exl3-r7/build_nonfinite_trace_overlay.py
+++ b/runtime/exl3-r7/build_nonfinite_trace_overlay.py
@@ -1,0 +1,396 @@
+#!/usr/bin/env python3
+"""Build a fail-closed GLM-5.2 nonfinite-trace vLLM overlay.
+
+The generated ``deepseek_v2.py`` records one device-side nonfinite count at
+each model boundary. Counts are reset and updated inside the compiled model,
+so FULL_AND_PIECEWISE CUDA-graph replay remains supported. ``compute_logits``
+performs the only host synchronization, reports the first failing rank/layer
+boundary, and raises before sampling can serialize NaN logits.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+from pathlib import Path
+
+
+EXPECTED_SOURCE_SHA256 = "27cf047c09c829174025c7372403ae2607315acbb063463582dbb43607eebf04"
+DEBUG_TAG = "DEBUG-r7nf-7c1d"
+
+
+def _replace_once(source: str, old: str, new: str, *, label: str) -> str:
+    count = source.count(old)
+    if count != 1:
+        raise RuntimeError(
+            f"{label} preimage must occur exactly once, found {count}; "
+            "the composed vLLM source has drifted"
+        )
+    return source.replace(old, new, 1)
+
+
+def patch_source(source: str, *, detailed: bool = True) -> str:
+    source = _replace_once(
+        source,
+        "import operator\nimport re\n",
+        "import operator\nimport os\nimport re\n",
+        label="os import",
+    )
+    source = _replace_once(
+        source,
+        "logger = init_logger(__name__)\n\n\ndef _get_moe_router_dtype(",
+        '''logger = init_logger(__name__)
+
+_R7_NONFINITE_TRACE_ENV = "VLLM_SPARK_R7_NONFINITE_TRACE"
+_R7_NONFINITE_LAYER_STAGES = (
+    "attention_input",
+    "residual_before_attention",
+    "mla_fused_qkv_a_output",
+    "mla_q_b_proj_output",
+    "mla_kv_a_norm_output",
+    "mla_attention_core_output",
+    "mla_o_proj_local_output",
+    "attention_output",
+    "mlp_input",
+    "residual_before_mlp",
+    "mlp_output",
+)
+
+
+def _r7_nonfinite_trace_enabled() -> bool:
+    raw = os.environ.get(_R7_NONFINITE_TRACE_ENV, "0").strip()
+    if raw not in ("0", "1"):
+        raise ValueError(f"{_R7_NONFINITE_TRACE_ENV} must be 0 or 1, got {raw!r}")
+    return raw == "1"
+
+
+def _r7_nonfinite_trace_record(
+    counts: torch.Tensor | None,
+    slot: int,
+    value: torch.Tensor | None,
+) -> None:
+    if counts is None or value is None:
+        return
+    counts.select(0, slot).copy_(torch.count_nonzero(~torch.isfinite(value)))
+
+
+def _r7_nonfinite_trace_report(model, hidden_states, logits) -> None:
+    counts = model._r7_nonfinite_counts
+    if counts is None:
+        return
+    if logits is not None:
+        _r7_nonfinite_trace_record(counts, model._r7_nonfinite_logits_slot, logits)
+
+    # This is the probe's only device-to-host synchronization. Every layer
+    # boundary above records into persistent graph-owned storage.
+    host_counts = counts.detach().cpu().tolist()
+    failures = [
+        (model._r7_nonfinite_names[index], int(count))
+        for index, count in enumerate(host_counts)
+        if count
+    ]
+    rank = os.environ.get("RANK", "unknown")
+    if failures:
+        first_name, first_count = failures[0]
+        summary = ",".join(
+            f"{name}:{count}" for name, count in failures[:12]
+        )
+        if len(failures) > 12:
+            summary += f",...(+{len(failures) - 12})"
+        logger.error(
+            "[DEBUG-r7nf-7c1d] rank=%s first_nonfinite=%s count=%d "
+            "failed=%s hidden_shape=%s hidden_dtype=%s logits_shape=%s",
+            rank,
+            first_name,
+            first_count,
+            summary,
+            tuple(hidden_states.shape),
+            hidden_states.dtype,
+            None if logits is None else tuple(logits.shape),
+        )
+        raise RuntimeError(
+            "[DEBUG-r7nf-7c1d] nonfinite model state: "
+            f"rank={rank}, first={first_name}, count={first_count}"
+        )
+
+    if not model._r7_nonfinite_reported_finite:
+        logger.warning(
+            "[DEBUG-r7nf-7c1d] rank=%s all %d model boundaries finite; "
+            "hidden_shape=%s logits_shape=%s",
+            rank,
+            len(host_counts),
+            tuple(hidden_states.shape),
+            None if logits is None else tuple(logits.shape),
+        )
+        model._r7_nonfinite_reported_finite = True
+
+
+def _get_moe_router_dtype(''',
+        label="trace helpers",
+    )
+    source = _replace_once(
+        source,
+        '''        self.routed_scaling_factor = getattr(config, "routed_scaling_factor", 1.0)
+
+    def forward(''',
+        '''        self.routed_scaling_factor = getattr(config, "routed_scaling_factor", 1.0)
+        self._r7_nonfinite_counts: torch.Tensor | None = None
+        self._r7_nonfinite_base = -1
+
+    def forward(''',
+        label="decoder trace state",
+    )
+    source = _replace_once(
+        source,
+        '''        else:
+            hidden_states, residual = self.input_layernorm(hidden_states, residual)
+
+        if input_is_sequence_parallel:''',
+        '''        else:
+            hidden_states, residual = self.input_layernorm(hidden_states, residual)
+
+        trace_counts = self._r7_nonfinite_counts
+        if trace_counts is not None:
+            trace_base = self._r7_nonfinite_base
+            _r7_nonfinite_trace_record(trace_counts, trace_base, hidden_states)
+            _r7_nonfinite_trace_record(trace_counts, trace_base + 1, residual)
+
+        if input_is_sequence_parallel:''',
+        label="attention input trace",
+    )
+    source = _replace_once(
+        source,
+        '''        # Fully Connected
+        hidden_states, residual = self.post_attention_layernorm(hidden_states, residual)
+        if self.use_sequence_parallel_moe:''',
+        '''        if trace_counts is not None:
+            _r7_nonfinite_trace_record(trace_counts, trace_base + 7, hidden_states)
+
+        # Fully Connected
+        hidden_states, residual = self.post_attention_layernorm(hidden_states, residual)
+        if trace_counts is not None:
+            _r7_nonfinite_trace_record(trace_counts, trace_base + 8, hidden_states)
+            _r7_nonfinite_trace_record(trace_counts, trace_base + 9, residual)
+        if self.use_sequence_parallel_moe:''',
+        label="attention and MLP input trace",
+    )
+    source = _replace_once(
+        source,
+        '''            hidden_states *= 1.0 / self.routed_scaling_factor
+
+        return hidden_states, residual
+
+
+@support_torch_compile''',
+        '''            hidden_states *= 1.0 / self.routed_scaling_factor
+
+        if trace_counts is not None:
+            _r7_nonfinite_trace_record(trace_counts, trace_base + 10, hidden_states)
+
+        return hidden_states, residual
+
+
+@support_torch_compile''',
+        label="MLP output trace",
+    )
+    source = _replace_once(
+        source,
+        '''        self.make_empty_intermediate_tensors = make_empty_intermediate_tensors_factory(
+            ["hidden_states", "residual"], self.hidden_size
+        )
+
+        self.aux_hidden_state_layers = tuple[int, ...]()''',
+        '''        self.make_empty_intermediate_tensors = make_empty_intermediate_tensors_factory(
+            ["hidden_states", "residual"], self.hidden_size
+        )
+
+        self._r7_nonfinite_names: tuple[str, ...] = ()
+        self._r7_nonfinite_logits_slot = -1
+        self._r7_nonfinite_reported_finite = False
+        if _r7_nonfinite_trace_enabled():
+            names = ["model_input"]
+            for layer_idx in range(int(config.num_hidden_layers)):
+                names.extend(
+                    f"layers.{layer_idx}.{stage}"
+                    for stage in _R7_NONFINITE_LAYER_STAGES
+                )
+            names.extend(("final_norm", "logits"))
+            self._r7_nonfinite_names = tuple(names)
+            self._r7_nonfinite_logits_slot = len(names) - 1
+            self.register_buffer(
+                "_r7_nonfinite_counts",
+                torch.zeros(len(names), dtype=torch.int64, device=self.device),
+                persistent=False,
+            )
+            for layer_idx, layer in enumerate(self.layers):
+                if isinstance(layer, DeepseekV2DecoderLayer):
+                    object.__setattr__(
+                        layer, "_r7_nonfinite_counts", self._r7_nonfinite_counts
+                    )
+                    layer._r7_nonfinite_base = 1 + layer_idx * len(
+                        _R7_NONFINITE_LAYER_STAGES
+                    )
+                    mla_wrapper = layer.self_attn.mla_attn
+                    object.__setattr__(
+                        mla_wrapper,
+                        "_r7_nonfinite_counts",
+                        self._r7_nonfinite_counts,
+                    )
+                    mla_wrapper._r7_nonfinite_base = layer._r7_nonfinite_base
+        else:
+            self._r7_nonfinite_counts = None
+
+        self.aux_hidden_state_layers = tuple[int, ...]()''',
+        label="model trace allocation",
+    )
+    source = _replace_once(
+        source,
+        '''            hidden_states = intermediate_tensors["hidden_states"]
+            residual = intermediate_tensors["residual"]
+
+        # Compute llama 4 scaling once per forward pass if enabled''',
+        '''            hidden_states = intermediate_tensors["hidden_states"]
+            residual = intermediate_tensors["residual"]
+
+        trace_counts = self._r7_nonfinite_counts
+        if trace_counts is not None:
+            trace_counts.zero_()
+            _r7_nonfinite_trace_record(trace_counts, 0, hidden_states)
+
+        # Compute llama 4 scaling once per forward pass if enabled''',
+        label="model input trace",
+    )
+    source = _replace_once(
+        source,
+        '''        hidden_states, _ = self.norm(hidden_states, residual)
+        if len(aux_hidden_states) > 0:''',
+        '''        hidden_states, _ = self.norm(hidden_states, residual)
+        if trace_counts is not None:
+            final_norm_slot = 1 + int(self.config.num_hidden_layers) * len(
+                _R7_NONFINITE_LAYER_STAGES
+            )
+            _r7_nonfinite_trace_record(trace_counts, final_norm_slot, hidden_states)
+        if len(aux_hidden_states) > 0:''',
+        label="final norm trace",
+    )
+    source = _replace_once(
+        source,
+        '''        logits = self.logits_processor(self.lm_head, hidden_states)
+        return logits''',
+        '''        logits = self.logits_processor(self.lm_head, hidden_states)
+        _r7_nonfinite_trace_report(self.model, hidden_states, logits)
+        return logits''',
+        label="logits report",
+    )
+    if not detailed:
+        source = _replace_once(
+            source,
+            '''_R7_NONFINITE_LAYER_STAGES = (
+    "attention_input",
+    "residual_before_attention",
+    "mla_fused_qkv_a_output",
+    "mla_q_b_proj_output",
+    "mla_kv_a_norm_output",
+    "mla_attention_core_output",
+    "mla_o_proj_local_output",
+    "attention_output",
+    "mlp_input",
+    "residual_before_mlp",
+    "mlp_output",
+)''',
+            '''_R7_NONFINITE_LAYER_STAGES = (
+    "attention_input",
+    "residual_before_attention",
+    "attention_output",
+    "mlp_input",
+    "residual_before_mlp",
+    "mlp_output",
+)''',
+            label="basic trace stage set",
+        )
+        source = _replace_once(
+            source,
+            "_r7_nonfinite_trace_record(trace_counts, trace_base + 7, hidden_states)",
+            "_r7_nonfinite_trace_record(trace_counts, trace_base + 2, hidden_states)",
+            label="basic attention output slot",
+        )
+        source = _replace_once(
+            source,
+            "_r7_nonfinite_trace_record(trace_counts, trace_base + 8, hidden_states)",
+            "_r7_nonfinite_trace_record(trace_counts, trace_base + 3, hidden_states)",
+            label="basic MLP input slot",
+        )
+        source = _replace_once(
+            source,
+            "_r7_nonfinite_trace_record(trace_counts, trace_base + 9, residual)",
+            "_r7_nonfinite_trace_record(trace_counts, trace_base + 4, residual)",
+            label="basic MLP residual slot",
+        )
+        source = _replace_once(
+            source,
+            "_r7_nonfinite_trace_record(trace_counts, trace_base + 10, hidden_states)",
+            "_r7_nonfinite_trace_record(trace_counts, trace_base + 5, hidden_states)",
+            label="basic MLP output slot",
+        )
+        source = _replace_once(
+            source,
+            '''                    mla_wrapper = layer.self_attn.mla_attn
+                    object.__setattr__(
+                        mla_wrapper,
+                        "_r7_nonfinite_counts",
+                        self._r7_nonfinite_counts,
+                    )
+                    mla_wrapper._r7_nonfinite_base = layer._r7_nonfinite_base
+''',
+            "",
+            label="basic trace MLA attachment",
+        )
+    return source
+
+
+def build(
+    source_path: Path,
+    output_path: Path,
+    expected_sha256: str,
+    *,
+    detailed: bool = True,
+) -> None:
+    source_bytes = source_path.read_bytes()
+    actual_sha256 = hashlib.sha256(source_bytes).hexdigest()
+    if actual_sha256 != expected_sha256:
+        raise RuntimeError(
+            "deepseek_v2.py SHA-256 mismatch: "
+            f"expected {expected_sha256}, got {actual_sha256}"
+        )
+    patched = patch_source(source_bytes.decode("utf-8"), detailed=detailed)
+    compile(patched, str(output_path), "exec")
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(patched, encoding="utf-8", newline="\n")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("source", type=Path)
+    parser.add_argument("output", type=Path)
+    parser.add_argument(
+        "--expected-sha256",
+        default=EXPECTED_SOURCE_SHA256,
+        help="fail-closed SHA-256 for the composed deepseek_v2.py preimage",
+    )
+    parser.add_argument(
+        "--basic",
+        action="store_true",
+        help="emit the original decoder-boundary-only trace overlay",
+    )
+    args = parser.parse_args()
+    build(
+        args.source,
+        args.output,
+        args.expected_sha256.lower(),
+        detailed=not args.basic,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/runtime/exl3-r7/build_parallel_state_shared_capture_overlay.py
+++ b/runtime/exl3-r7/build_parallel_state_shared_capture_overlay.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+"""Build the R7 vLLM shared CUDA-capture-stream overlay.
+
+Spark TP4 graph sessions require one stable caller stream. vLLM captures the
+target model and each speculative-draft manager in separate graph-capture
+contexts, so the stock context constructor creates a different stream for each
+manager. The generated overlay retains one dedicated stream per process and
+CUDA device while constructing a fresh ``GraphCaptureContext`` for every
+manager. Distinct channel identities and manager-owned graph pools therefore
+remain independent.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+from pathlib import Path
+
+
+EXPECTED_SOURCE_SHA256 = "df8560a9568eb45d9b52939db847854f3ed67cd2ee1cbd50ccccf278366a710f"
+
+
+def _replace_once(source: str, old: str, new: str, *, label: str) -> str:
+    count = source.count(old)
+    if count != 1:
+        raise RuntimeError(
+            f"{label} preimage must occur exactly once, found {count}; "
+            "the composed vLLM source has drifted"
+        )
+    return source.replace(old, new, 1)
+
+
+def patch_source(source: str) -> str:
+    source = _replace_once(
+        source,
+        "import contextlib\nimport gc\nimport pickle\nimport weakref\n",
+        "import contextlib\nimport gc\nimport os\nimport pickle\nimport threading\nimport weakref\n",
+        label="import",
+    )
+    source = _replace_once(
+        source,
+        "\n\n@contextmanager\ndef graph_capture(\n",
+        '''
+
+_SPARK_SHARED_CAPTURE_STREAMS: dict[tuple[int, int], torch.cuda.Stream] = {}
+_SPARK_ACTIVE_CAPTURE_STREAMS: set[tuple[int, int]] = set()
+_SPARK_CAPTURE_STREAM_LOCK = threading.Lock()
+
+
+@contextmanager
+def _spark_graph_capture_context(
+    device: torch.device,
+    graph_capture_context: GraphCaptureContext | None,
+    channel_id: str | None,
+):
+    """Return one fresh capture context on the process/device shared stream."""
+    shared_key: tuple[int, int] | None = None
+    shared_guard_acquired = False
+    try:
+        if graph_capture_context is None:
+            canonical_device = torch.device(device)
+            shared = os.getenv("VLLM_SPARK_SHARED_CAPTURE_STREAM", "0") == "1"
+            if shared:
+                device_index = canonical_device.index
+                if device_index is None:
+                    device_index = torch.cuda.current_device()
+                shared_key = (os.getpid(), int(device_index))
+                with _SPARK_CAPTURE_STREAM_LOCK:
+                    if shared_key in _SPARK_ACTIVE_CAPTURE_STREAMS:
+                        raise RuntimeError(
+                            "overlapping Spark shared CUDA graph capture is unsupported"
+                        )
+                    _SPARK_ACTIVE_CAPTURE_STREAMS.add(shared_key)
+                    shared_guard_acquired = True
+                    stream = _SPARK_SHARED_CAPTURE_STREAMS.get(shared_key)
+                    if stream is None:
+                        stream = torch.cuda.Stream(device=canonical_device)
+                        _SPARK_SHARED_CAPTURE_STREAMS[shared_key] = stream
+            else:
+                stream = torch.cuda.Stream(device=canonical_device)
+            context = GraphCaptureContext(stream, channel_id=channel_id)
+        else:
+            context = graph_capture_context
+            if channel_id is not None:
+                if context.channel_id is not None and context.channel_id != channel_id:
+                    raise ValueError(
+                        "graph capture context and argument specify different "
+                        "semantic channel IDs"
+                    )
+                if context.channel_id is None:
+                    context = GraphCaptureContext(context.stream, channel_id=channel_id)
+        yield context
+    finally:
+        if shared_guard_acquired:
+            assert shared_key is not None
+            with _SPARK_CAPTURE_STREAM_LOCK:
+                _SPARK_ACTIVE_CAPTURE_STREAMS.discard(shared_key)
+
+
+@contextmanager
+def graph_capture(
+''',
+        label="shared context insertion",
+    )
+    old_body = '''    if graph_capture_context is None:
+        context = GraphCaptureContext(
+            torch.cuda.Stream(device=device),
+            channel_id=channel_id,
+        )
+    else:
+        context = graph_capture_context
+        if channel_id is not None:
+            if context.channel_id is not None and context.channel_id != channel_id:
+                raise ValueError(
+                    "graph capture context and argument specify different "
+                    "semantic channel IDs"
+                )
+            if context.channel_id is None:
+                context = GraphCaptureContext(context.stream, channel_id=channel_id)
+    maybe_dcp_capture = (
+        get_dcp_group().graph_capture(context)
+        if _DCP is not None and get_dcp_group().world_size > 1
+        else nullcontext()
+    )
+    maybe_b12x_dcp_capture: contextlib.AbstractContextManager[Any]
+    if _DCP is not None and get_dcp_group().world_size > 1:
+        # Import locally to avoid making distributed initialization depend on
+        # attention modules. The helper is a no-op until DCP warmup creates a
+        # B12X pool for this process group.
+        from vllm.v1.attention.ops.dcp_alltoall import capture_b12x_dcp_a2a
+
+        maybe_b12x_dcp_capture = capture_b12x_dcp_a2a(
+            get_dcp_group(),
+            context.stream,
+            channel_id=context.channel_id,
+        )
+    else:
+        maybe_b12x_dcp_capture = nullcontext()
+    with (
+        get_tp_group().graph_capture(context),
+        get_pp_group().graph_capture(context),
+        maybe_dcp_capture,
+        maybe_b12x_dcp_capture,
+    ):
+        yield context
+'''
+    new_body = '''    with _spark_graph_capture_context(
+        device,
+        graph_capture_context,
+        channel_id,
+    ) as context:
+        maybe_dcp_capture = (
+            get_dcp_group().graph_capture(context)
+            if _DCP is not None and get_dcp_group().world_size > 1
+            else nullcontext()
+        )
+        maybe_b12x_dcp_capture: contextlib.AbstractContextManager[Any]
+        if _DCP is not None and get_dcp_group().world_size > 1:
+            # Import locally to avoid making distributed initialization depend on
+            # attention modules. The helper is a no-op until DCP warmup creates a
+            # B12X pool for this process group.
+            from vllm.v1.attention.ops.dcp_alltoall import capture_b12x_dcp_a2a
+
+            maybe_b12x_dcp_capture = capture_b12x_dcp_a2a(
+                get_dcp_group(),
+                context.stream,
+                channel_id=context.channel_id,
+            )
+        else:
+            maybe_b12x_dcp_capture = nullcontext()
+        with (
+            get_tp_group().graph_capture(context),
+            get_pp_group().graph_capture(context),
+            maybe_dcp_capture,
+            maybe_b12x_dcp_capture,
+        ):
+            yield context
+'''
+    return _replace_once(
+        source,
+        old_body,
+        new_body,
+        label="graph_capture body",
+    )
+
+
+def build(source_path: Path, output_path: Path) -> str:
+    source_bytes = source_path.read_bytes()
+    actual = hashlib.sha256(source_bytes).hexdigest()
+    if actual != EXPECTED_SOURCE_SHA256:
+        raise RuntimeError(
+            "parallel_state.py SHA-256 mismatch: "
+            f"expected {EXPECTED_SOURCE_SHA256}, got {actual}"
+        )
+    patched = patch_source(source_bytes.decode("utf-8"))
+    compile(patched, str(output_path), "exec")
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(patched, encoding="utf-8", newline="")
+    return hashlib.sha256(patched.encode("utf-8")).hexdigest()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--source", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+    print(build(args.source, args.output))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/runtime/exl3-r7/endpoint_benchmark.py
+++ b/runtime/exl3-r7/endpoint_benchmark.py
@@ -1,0 +1,542 @@
+"""Run a bounded correctness and throughput check against an OpenAI API server.
+
+The harness keeps warmup outside the measured request.  It reports client-side
+prompt tokens per time-to-first-token and inter-token decode throughput using
+the server's final usage counters.  The result is diagnostic evidence for one
+endpoint invocation; it is not an acceptance result or a reference-lane claim.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import re
+import time
+import urllib.error
+import urllib.request
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+SCHEMA = "sparkring-r7-endpoint-benchmark/v1"
+DEFAULT_SEED = 20260811
+EXPECTED_ANSWER = re.compile(r"(?<!\d)42(?!\d)")
+
+
+class BenchmarkError(RuntimeError):
+    """The endpoint did not satisfy the benchmark contract."""
+
+
+@dataclass(frozen=True)
+class StreamResult:
+    started: float
+    first_token_at: float
+    last_token_at: float
+    finished: float
+    usage: dict[str, Any]
+    finish_reason: str | None
+    text: str
+    content_events: int
+
+
+def _request_json(
+    url: str,
+    *,
+    payload: dict[str, Any] | None = None,
+    timeout: float,
+) -> tuple[int, Any, float]:
+    data = None if payload is None else json.dumps(payload).encode("utf-8")
+    request = urllib.request.Request(
+        url,
+        data=data,
+        headers={"Content-Type": "application/json"} if data is not None else {},
+        method="POST" if data is not None else "GET",
+    )
+    started = time.monotonic()
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            status = int(response.status)
+            raw = response.read().decode("utf-8", "replace")
+    except urllib.error.HTTPError as exc:
+        status = int(exc.code)
+        raw = exc.read().decode("utf-8", "replace")
+    except (urllib.error.URLError, OSError, TimeoutError) as exc:
+        raise BenchmarkError(f"request to {url} failed: {exc}") from exc
+    elapsed = time.monotonic() - started
+    try:
+        body = json.loads(raw)
+    except json.JSONDecodeError:
+        body = raw
+    return status, body, elapsed
+
+
+def _require_success(status: int, body: Any, operation: str) -> dict[str, Any]:
+    if status != 200 or not isinstance(body, dict):
+        snippet = str(body).replace("\n", " ")[:500]
+        raise BenchmarkError(f"{operation} returned HTTP {status}: {snippet}")
+    return body
+
+
+def _positive_int(value: Any, name: str) -> int:
+    if not isinstance(value, int) or isinstance(value, bool) or value <= 0:
+        raise BenchmarkError(f"{name} must be a positive integer, got {value!r}")
+    return value
+
+
+def validate_completion_logprobs(
+    body: dict[str, Any], expected_completion_tokens: int
+) -> dict[str, Any]:
+    """Validate OpenAI completion logprobs and return bounded statistics."""
+    choices = body.get("choices")
+    if not isinstance(choices, list) or not choices or not isinstance(choices[0], dict):
+        raise BenchmarkError("completion response has no first choice")
+    logprobs = choices[0].get("logprobs")
+    if not isinstance(logprobs, dict):
+        raise BenchmarkError("completion response omitted requested logprobs")
+    chosen = logprobs.get("token_logprobs")
+    tops = logprobs.get("top_logprobs")
+    tokens = logprobs.get("tokens")
+    if not all(isinstance(value, list) for value in (chosen, tops, tokens)):
+        raise BenchmarkError("completion logprob arrays are malformed")
+    if not (len(chosen) == len(tops) == len(tokens) == expected_completion_tokens):
+        raise BenchmarkError(
+            "completion logprob lengths disagree with usage: "
+            f"chosen={len(chosen)}, top={len(tops)}, tokens={len(tokens)}, "
+            f"expected={expected_completion_tokens}"
+        )
+
+    finite_values: list[float] = []
+    for index, value in enumerate(chosen):
+        if not isinstance(value, (int, float)) or isinstance(value, bool):
+            raise BenchmarkError(f"chosen logprob {index} is not numeric: {value!r}")
+        numeric = float(value)
+        if not math.isfinite(numeric):
+            raise BenchmarkError(f"chosen logprob {index} is nonfinite: {value!r}")
+        finite_values.append(numeric)
+    for index, top in enumerate(tops):
+        if not isinstance(top, dict) or not top:
+            raise BenchmarkError(f"top_logprobs[{index}] is not a non-empty object")
+        for token, value in top.items():
+            if not isinstance(value, (int, float)) or isinstance(value, bool):
+                raise BenchmarkError(
+                    f"top_logprobs[{index}][{token!r}] is not numeric: {value!r}"
+                )
+            numeric = float(value)
+            if not math.isfinite(numeric):
+                raise BenchmarkError(
+                    f"top_logprobs[{index}][{token!r}] is nonfinite: {value!r}"
+                )
+            finite_values.append(numeric)
+    return {
+        "completion_tokens": expected_completion_tokens,
+        "finite_logprob_values": len(finite_values),
+        "minimum_logprob": min(finite_values),
+        "maximum_logprob": max(finite_values),
+        "token_sequence_sha256": hashlib.sha256(
+            json.dumps(tokens, ensure_ascii=False, separators=(",", ":")).encode("utf-8")
+        ).hexdigest(),
+    }
+
+
+def validate_chat_answer(body: dict[str, Any]) -> dict[str, Any]:
+    choices = body.get("choices")
+    if not isinstance(choices, list) or not choices or not isinstance(choices[0], dict):
+        raise BenchmarkError("chat response has no first choice")
+    message = choices[0].get("message")
+    if not isinstance(message, dict):
+        raise BenchmarkError("chat response has no message")
+    fields = {
+        name: value
+        for name in ("reasoning", "reasoning_content", "content")
+        if isinstance((value := message.get(name)), str)
+    }
+    combined = "\n".join(fields.values())
+    if not EXPECTED_ANSWER.search(combined):
+        raise BenchmarkError(
+            "semantic canary did not contain the expected integer 42; "
+            f"message={json.dumps(fields, ensure_ascii=False)[:500]}"
+        )
+    usage = body.get("usage")
+    if not isinstance(usage, dict):
+        raise BenchmarkError("chat response omitted usage")
+    return {
+        "answer_present": True,
+        "finish_reason": choices[0].get("finish_reason"),
+        "prompt_tokens": _positive_int(usage.get("prompt_tokens"), "chat prompt_tokens"),
+        "completion_tokens": _positive_int(
+            usage.get("completion_tokens"), "chat completion_tokens"
+        ),
+        "response_sha256": hashlib.sha256(combined.encode("utf-8")).hexdigest(),
+        "message_fields": sorted(fields),
+    }
+
+
+def _stream_completion(url: str, payload: dict[str, Any], timeout: float) -> StreamResult:
+    body = dict(payload)
+    body["stream"] = True
+    body["stream_options"] = {
+        "include_usage": True,
+        "continuous_usage_stats": True,
+    }
+    request = urllib.request.Request(
+        url,
+        data=json.dumps(body).encode("utf-8"),
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    started = time.monotonic()
+    first_token_at: float | None = None
+    last_token_at: float | None = None
+    usage: dict[str, Any] | None = None
+    finish_reason: str | None = None
+    text_parts: list[str] = []
+    content_events = 0
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            if int(response.status) != 200:
+                raise BenchmarkError(f"streaming completion returned HTTP {response.status}")
+            for raw_line in response:
+                line = raw_line.decode("utf-8", "replace").strip()
+                if not line.startswith("data:"):
+                    continue
+                encoded = line[5:].strip()
+                if encoded == "[DONE]":
+                    break
+                try:
+                    event = json.loads(encoded)
+                except json.JSONDecodeError as exc:
+                    raise BenchmarkError(f"stream emitted malformed JSON: {encoded[:200]}") from exc
+                candidate_usage = event.get("usage")
+                if isinstance(candidate_usage, dict):
+                    usage = candidate_usage
+                choices = event.get("choices")
+                if not isinstance(choices, list) or not choices:
+                    continue
+                choice = choices[0]
+                if not isinstance(choice, dict):
+                    continue
+                if choice.get("finish_reason") is not None:
+                    finish_reason = str(choice["finish_reason"])
+                token_text = choice.get("text")
+                if not isinstance(token_text, str) or not token_text:
+                    continue
+                now = time.monotonic()
+                if first_token_at is None:
+                    first_token_at = now
+                last_token_at = now
+                content_events += 1
+                text_parts.append(token_text)
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode("utf-8", "replace")[:500]
+        raise BenchmarkError(f"streaming completion returned HTTP {exc.code}: {detail}") from exc
+    except (urllib.error.URLError, OSError, TimeoutError) as exc:
+        raise BenchmarkError(f"streaming completion failed: {exc}") from exc
+    finished = time.monotonic()
+    if first_token_at is None or last_token_at is None:
+        raise BenchmarkError("streaming completion emitted no text tokens")
+    if usage is None:
+        raise BenchmarkError("streaming completion omitted final usage")
+    return StreamResult(
+        started=started,
+        first_token_at=first_token_at,
+        last_token_at=last_token_at,
+        finished=finished,
+        usage=usage,
+        finish_reason=finish_reason,
+        text="".join(text_parts),
+        content_events=content_events,
+    )
+
+
+def stream_metrics(result: StreamResult, requested_decode_tokens: int) -> dict[str, Any]:
+    prompt_tokens = _positive_int(result.usage.get("prompt_tokens"), "prompt_tokens")
+    completion_tokens = _positive_int(
+        result.usage.get("completion_tokens"), "completion_tokens"
+    )
+    if completion_tokens != requested_decode_tokens:
+        raise BenchmarkError(
+            f"stream returned {completion_tokens} completion tokens, "
+            f"expected {requested_decode_tokens} with ignore_eos=true"
+        )
+    ttft = result.first_token_at - result.started
+    decode_window = result.last_token_at - result.first_token_at
+    total = result.finished - result.started
+    if ttft <= 0 or decode_window <= 0 or total <= 0:
+        raise BenchmarkError(
+            f"invalid timings: ttft={ttft}, decode_window={decode_window}, total={total}"
+        )
+    return {
+        "prompt_tokens": prompt_tokens,
+        "completion_tokens": completion_tokens,
+        "time_to_first_token_seconds": ttft,
+        "client_prompt_tokens_per_ttft_second": prompt_tokens / ttft,
+        "decode_window_seconds": decode_window,
+        "inter_token_decode_tokens_per_second": (completion_tokens - 1) / decode_window,
+        "request_wall_seconds": total,
+        "end_to_end_completion_tokens_per_second": completion_tokens / total,
+        "content_events": result.content_events,
+        "finish_reason": result.finish_reason,
+        "response_sha256": hashlib.sha256(result.text.encode("utf-8")).hexdigest(),
+    }
+
+
+def _tokenize_exact_prompt(
+    base_url: str,
+    model: str,
+    target_tokens: int,
+    nonce: str,
+    timeout: float,
+) -> tuple[list[int], str]:
+    sentence = (
+        "Each numbered observation describes a stable synthetic benchmark fact: "
+        "the copper ring remains connected, the measured value is recorded, and "
+        "the next observation follows in numerical order. "
+    )
+    text = f"Unique benchmark nonce {nonce}.\n" + "".join(
+        f"Observation {index}: {sentence}" for index in range(target_tokens // 12 + 32)
+    )
+    status, body, _ = _request_json(
+        f"{base_url}/tokenize",
+        payload={"model": model, "prompt": text, "add_special_tokens": False},
+        timeout=timeout,
+    )
+    document = _require_success(status, body, "tokenize benchmark prompt")
+    tokens = document.get("tokens")
+    if not isinstance(tokens, list) or not all(
+        isinstance(value, int) and not isinstance(value, bool) for value in tokens
+    ):
+        raise BenchmarkError("tokenize response did not contain integer token IDs")
+    if len(tokens) < target_tokens:
+        raise BenchmarkError(
+            f"constructed prompt has only {len(tokens)} tokens, target is {target_tokens}"
+        )
+    selected = tokens[:target_tokens]
+    digest = hashlib.sha256(
+        json.dumps(selected, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()
+    return selected, digest
+
+
+def run(args: argparse.Namespace) -> dict[str, Any]:
+    base_url = args.base_url.rstrip("/")
+    status, models_body, _ = _request_json(
+        f"{base_url}/v1/models", timeout=args.readiness_timeout
+    )
+    models = _require_success(status, models_body, "model discovery").get("data")
+    if not isinstance(models, list) or not models or not isinstance(models[0], dict):
+        raise BenchmarkError("model discovery returned no models")
+    model = args.model or models[0].get("id")
+    if not isinstance(model, str) or not model:
+        raise BenchmarkError("model discovery did not provide a usable model ID")
+
+    chat_payload = {
+        "model": model,
+        "messages": [
+            {
+                "role": "system",
+                "content": "You are a calculator. Reply with only the integer answer.",
+            },
+            {"role": "user", "content": "What is 17 + 25?"},
+        ],
+        "temperature": 0.0,
+        "top_p": 1.0,
+        "seed": args.seed,
+        "max_tokens": args.chat_max_tokens,
+        "chat_template_kwargs": {"reasoning_effort": "low"},
+    }
+    status, chat_body, chat_seconds = _request_json(
+        f"{base_url}/v1/chat/completions",
+        payload=chat_payload,
+        timeout=args.timeout,
+    )
+    chat_document = _require_success(status, chat_body, "semantic warmup canary")
+    chat_result = validate_chat_answer(chat_document)
+    chat_result["wall_seconds"] = chat_seconds
+
+    logprob_payload = {
+        "model": model,
+        "prompt": "Continue the even integers: 2, 4, 6, 8,",
+        "max_tokens": args.logprob_tokens,
+        "temperature": 0.0,
+        "top_p": 1.0,
+        "seed": args.seed,
+        "ignore_eos": True,
+        "logprobs": 5,
+    }
+    status, logprob_body, logprob_seconds = _request_json(
+        f"{base_url}/v1/completions",
+        payload=logprob_payload,
+        timeout=args.timeout,
+    )
+    logprob_document = _require_success(status, logprob_body, "finite-logprobs warmup")
+    usage = logprob_document.get("usage")
+    if not isinstance(usage, dict):
+        raise BenchmarkError("finite-logprobs warmup omitted usage")
+    completion_tokens = _positive_int(
+        usage.get("completion_tokens"), "logprob completion_tokens"
+    )
+    if completion_tokens != args.logprob_tokens:
+        raise BenchmarkError(
+            f"finite-logprobs warmup returned {completion_tokens} tokens, "
+            f"expected {args.logprob_tokens}"
+        )
+    logprob_result = validate_completion_logprobs(logprob_document, completion_tokens)
+    logprob_result["wall_seconds"] = logprob_seconds
+
+    nonce = args.nonce or uuid.uuid4().hex
+    shape_warmup_ids, shape_warmup_sha256 = _tokenize_exact_prompt(
+        base_url,
+        model,
+        args.prompt_tokens,
+        f"{nonce}-shape-warmup",
+        args.timeout,
+    )
+    shape_warmup_payload = {
+        "model": model,
+        "prompt": shape_warmup_ids,
+        "add_special_tokens": False,
+        "max_tokens": args.shape_warmup_decode_tokens,
+        "temperature": 0.0,
+        "top_p": 1.0,
+        "seed": args.seed,
+        "ignore_eos": True,
+    }
+    status, shape_warmup_body, shape_warmup_seconds = _request_json(
+        f"{base_url}/v1/completions",
+        payload=shape_warmup_payload,
+        timeout=args.timeout,
+    )
+    shape_warmup_document = _require_success(
+        status, shape_warmup_body, "exact-shape prefill warmup"
+    )
+    shape_warmup_usage = shape_warmup_document.get("usage")
+    if not isinstance(shape_warmup_usage, dict):
+        raise BenchmarkError("exact-shape prefill warmup omitted usage")
+    shape_warmup_prompt_tokens = _positive_int(
+        shape_warmup_usage.get("prompt_tokens"), "shape warmup prompt_tokens"
+    )
+    shape_warmup_completion_tokens = _positive_int(
+        shape_warmup_usage.get("completion_tokens"), "shape warmup completion_tokens"
+    )
+    if shape_warmup_prompt_tokens != args.prompt_tokens:
+        raise BenchmarkError(
+            f"exact-shape warmup reported {shape_warmup_prompt_tokens} prompt tokens, "
+            f"expected {args.prompt_tokens}"
+        )
+    if shape_warmup_completion_tokens != args.shape_warmup_decode_tokens:
+        raise BenchmarkError(
+            "exact-shape warmup returned "
+            f"{shape_warmup_completion_tokens} completion tokens, expected "
+            f"{args.shape_warmup_decode_tokens}"
+        )
+
+    prompt_ids, prompt_sha256 = _tokenize_exact_prompt(
+        base_url,
+        model,
+        args.prompt_tokens,
+        f"{nonce}-measurement",
+        args.timeout,
+    )
+    measured_payload = {
+        "model": model,
+        "prompt": prompt_ids,
+        "add_special_tokens": False,
+        "max_tokens": args.decode_tokens,
+        "temperature": 0.0,
+        "top_p": 1.0,
+        "seed": args.seed,
+        "ignore_eos": True,
+    }
+    stream = _stream_completion(
+        f"{base_url}/v1/completions", measured_payload, args.timeout
+    )
+    measured = stream_metrics(stream, args.decode_tokens)
+    if measured["prompt_tokens"] != args.prompt_tokens:
+        raise BenchmarkError(
+            f"measured usage reported {measured['prompt_tokens']} prompt tokens, "
+            f"expected the exact token-ID prompt length {args.prompt_tokens}"
+        )
+
+    return {
+        "schema": SCHEMA,
+        "created_at": datetime.now(timezone.utc).isoformat(),
+        "scope": {
+            "lane": "public-functional",
+            "maturity": "diagnostic",
+            "statement": (
+                "One warm endpoint invocation. Rates are client-side diagnostics, "
+                "not acceptance or reference-lane results."
+            ),
+        },
+        "endpoint": base_url,
+        "model": model,
+        "seed": args.seed,
+        "warmup": {
+            "semantic_chat": chat_result,
+            "finite_completion_logprobs": logprob_result,
+            "exact_shape_prefill": {
+                "prompt_tokens": shape_warmup_prompt_tokens,
+                "completion_tokens": shape_warmup_completion_tokens,
+                "wall_seconds": shape_warmup_seconds,
+                "prompt_token_ids_sha256": shape_warmup_sha256,
+            },
+        },
+        "measurement": {
+            "requested_prompt_tokens": args.prompt_tokens,
+            "requested_decode_tokens": args.decode_tokens,
+            "unique_prompt_nonce": nonce,
+            "prompt_token_ids_sha256": prompt_sha256,
+            **measured,
+        },
+    }
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base-url", default="http://127.0.0.1:8000")
+    parser.add_argument("--model")
+    parser.add_argument("--prompt-tokens", type=int, default=1024)
+    parser.add_argument("--decode-tokens", type=int, default=128)
+    parser.add_argument("--logprob-tokens", type=int, default=16)
+    parser.add_argument("--chat-max-tokens", type=int, default=128)
+    parser.add_argument("--shape-warmup-decode-tokens", type=int, default=1)
+    parser.add_argument("--seed", type=int, default=DEFAULT_SEED)
+    parser.add_argument("--nonce")
+    parser.add_argument("--timeout", type=float, default=1800.0)
+    parser.add_argument("--readiness-timeout", type=float, default=10.0)
+    parser.add_argument("--output", type=Path)
+    args = parser.parse_args()
+    for name in (
+        "prompt_tokens",
+        "decode_tokens",
+        "logprob_tokens",
+        "chat_max_tokens",
+        "shape_warmup_decode_tokens",
+    ):
+        if getattr(args, name) <= 0:
+            parser.error(f"--{name.replace('_', '-')} must be positive")
+    return args
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        result = run(args)
+    except BenchmarkError as exc:
+        print(f"endpoint-benchmark: FAIL: {exc}")
+        return 2
+    encoded = json.dumps(result, indent=2, sort_keys=True, allow_nan=False) + "\n"
+    if args.output is not None:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(encoded, encoding="utf-8")
+    print(encoded, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/runtime/exl3-r7/entrypoint.sh
+++ b/runtime/exl3-r7/entrypoint.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+fail() {
+  echo "FATAL: $*" >&2
+  exit 2
+}
+
+if [[ -n "${SPARKRING_EXPLICITLY_UNSET:-}" ]]; then
+  IFS=',' read -r -a unset_names <<<"${SPARKRING_EXPLICITLY_UNSET}"
+  for name in "${unset_names[@]}"; do
+    if [[ ! "${name}" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]]; then
+      fail "invalid explicitly-unset environment name: ${name}"
+    fi
+    unset "${name}"
+  done
+  unset SPARKRING_EXPLICITLY_UNSET
+fi
+
+/opt/venv/bin/python /opt/sparkring-r7/verify_runtime.py
+
+if [[ "$#" -eq 0 ]]; then
+  fail "pass a launcher or vLLM command to the R7 image"
+fi
+
+if [[ "$1" == "serve" ]]; then
+  set -- /opt/venv/bin/vllm "$@"
+fi
+
+exec "$@"

--- a/runtime/exl3-r7/mtp2_qualification.py
+++ b/runtime/exl3-r7/mtp2_qualification.py
@@ -1,0 +1,718 @@
+"""Qualify fixed-depth MTP2 against a matching MTP0 endpoint.
+
+The HTTP mode captures or compares deterministic greedy outputs and verifies
+that speculative-decoding counters behave as configured.  The transport mode
+checks four before/after SparkRing graph-status snapshots and rejects stock
+capture for every query width required by eight-way fixed-MTP2 decode.
+
+This tool sends inference requests but does not start, stop, or modify a model
+service.  Capture the MTP0 baseline and MTP2 candidate from the same checkpoint,
+runtime, parallelism, cache, graph, and transport configuration.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import re
+import time
+import urllib.error
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+SCHEMA = "sparkring-r7-fixed-mtp2-qualification/v1"
+TRANSPORT_SCHEMA = "sparkring-r7-mtp2-transport-audit/v1"
+SEED = 20260811
+PROMPT_TOKENS = 512
+OUTPUT_LENGTHS = (128, 256)
+REPEATS = 3
+MAX_CONCURRENT_SEQUENCES = 8
+FIXED_MTP_DEPTH = 2
+MAX_QUERY_ROWS = MAX_CONCURRENT_SEQUENCES * (FIXED_MTP_DEPTH + 1)
+# The target graph captures model forward only. Vocabulary collectives belong
+# to the speculator's full prefill and decode graphs, each captured once for
+# C1 through C8. Query-width coverage is enforced separately by rejecting
+# stock vocabulary capture signatures for Q1 through Q24.
+MIN_VOCABULARY_CAPTURED_NODES = 2 * MAX_CONCURRENT_SEQUENCES
+EXPECTED_ANSWER = re.compile(r"(?<!\d)42(?!\d)")
+SPEC_COUNTERS = (
+    "vllm:spec_decode_num_drafts_total",
+    "vllm:spec_decode_num_draft_tokens_total",
+    "vllm:spec_decode_num_accepted_tokens_total",
+)
+POSITION_COUNTER = "vllm:spec_decode_num_accepted_tokens_per_pos_total"
+
+
+class QualificationError(RuntimeError):
+    """A required correctness, speculation, or transport invariant failed."""
+
+
+def _request(
+    url: str,
+    *,
+    payload: dict[str, Any] | None = None,
+    timeout: float,
+) -> tuple[int, str]:
+    data = None if payload is None else json.dumps(payload).encode("utf-8")
+    request = urllib.request.Request(
+        url,
+        data=data,
+        headers={"Content-Type": "application/json"} if data is not None else {},
+        method="POST" if data is not None else "GET",
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            return int(response.status), response.read().decode("utf-8", "replace")
+    except urllib.error.HTTPError as exc:
+        return int(exc.code), exc.read().decode("utf-8", "replace")
+    except (urllib.error.URLError, OSError, TimeoutError) as exc:
+        raise QualificationError(f"request to {url} failed: {exc}") from exc
+
+
+def _json_request(
+    url: str,
+    *,
+    payload: dict[str, Any] | None = None,
+    timeout: float,
+) -> dict[str, Any]:
+    status, raw = _request(url, payload=payload, timeout=timeout)
+    if status != 200:
+        raise QualificationError(
+            f"request to {url} returned HTTP {status}: {raw[:500]}"
+        )
+    try:
+        body = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise QualificationError(f"request to {url} returned non-JSON data") from exc
+    if not isinstance(body, dict):
+        raise QualificationError(f"request to {url} returned a non-object JSON value")
+    return body
+
+
+def _hash_json(value: Any) -> str:
+    return hashlib.sha256(
+        json.dumps(value, ensure_ascii=False, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()
+
+
+def _positive_int(value: Any, name: str) -> int:
+    if not isinstance(value, int) or isinstance(value, bool) or value <= 0:
+        raise QualificationError(f"{name} must be a positive integer, got {value!r}")
+    return value
+
+
+def discover_model(base_url: str, expected_model: str | None, timeout: float) -> str:
+    health_status, _ = _request(f"{base_url}/health", timeout=timeout)
+    if health_status != 200:
+        raise QualificationError(f"health returned HTTP {health_status}")
+    body = _json_request(f"{base_url}/v1/models", timeout=timeout)
+    models = body.get("data")
+    if not isinstance(models, list) or not models or not isinstance(models[0], dict):
+        raise QualificationError("model discovery returned no models")
+    served = models[0].get("id")
+    if not isinstance(served, str) or not served:
+        raise QualificationError("model discovery returned an invalid model ID")
+    if expected_model is not None and served != expected_model:
+        raise QualificationError(
+            f"served model {served!r} does not match expected {expected_model!r}"
+        )
+    return served
+
+
+def _metric_labels(raw: str) -> dict[str, str]:
+    labels: dict[str, str] = {}
+    if not raw:
+        return labels
+    for item in re.findall(r'(\w+)="((?:\\.|[^"\\])*)"', raw):
+        labels[item[0]] = bytes(item[1], "utf-8").decode("unicode_escape")
+    return labels
+
+
+def parse_spec_metrics(text: str, expected_model: str | None = None) -> dict[str, Any]:
+    totals = {name: 0.0 for name in SPEC_COUNTERS}
+    positions: dict[int, float] = {}
+    seen: set[str] = set()
+    pattern = re.compile(
+        r"^(vllm:spec_decode_[a-z0-9_]+_total)(?:\{([^}]*)\})?\s+"
+        r"([-+]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][-+]?\d+)?)$"
+    )
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        match = pattern.match(line)
+        if match is None:
+            continue
+        name, labels_raw, value_raw = match.groups()
+        labels = _metric_labels(labels_raw or "")
+        if expected_model is not None and (
+            labels.get("model_name") != expected_model
+            or labels.get("engine") != "0"
+        ):
+            continue
+        value = float(value_raw)
+        if not math.isfinite(value) or value < 0:
+            raise QualificationError(f"invalid speculative metric {name}={value_raw}")
+        seen.add(name)
+        if name == POSITION_COUNTER:
+            if "position" not in labels:
+                raise QualificationError(f"{POSITION_COUNTER} omitted position label")
+            position = int(labels["position"])
+            positions[position] = positions.get(position, 0.0) + value
+        elif name in totals:
+            totals[name] += value
+    return {"totals": totals, "positions": positions, "seen": sorted(seen)}
+
+
+def metric_delta(before: dict[str, Any], after: dict[str, Any]) -> dict[str, Any]:
+    totals = {
+        name: after["totals"].get(name, 0.0) - before["totals"].get(name, 0.0)
+        for name in SPEC_COUNTERS
+    }
+    all_positions = set(before["positions"]) | set(after["positions"])
+    positions = {
+        position: after["positions"].get(position, 0.0)
+        - before["positions"].get(position, 0.0)
+        for position in sorted(all_positions)
+    }
+    if any(value < 0 for value in (*totals.values(), *positions.values())):
+        raise QualificationError("speculative counters decreased during qualification")
+    return {
+        "totals": totals,
+        "positions": positions,
+        "position_keys": sorted(after["positions"]),
+    }
+
+
+def validate_mtp2_metrics(delta: dict[str, Any]) -> dict[str, Any]:
+    drafts = delta["totals"][SPEC_COUNTERS[0]]
+    drafted = delta["totals"][SPEC_COUNTERS[1]]
+    accepted = delta["totals"][SPEC_COUNTERS[2]]
+    pos0 = delta["positions"].get(0, 0.0)
+    pos1 = delta["positions"].get(1, 0.0)
+    if delta.get("position_keys") != [0, 1]:
+        raise QualificationError(
+            "fixed MTP2 must expose exactly zero-based draft positions 0 and 1"
+        )
+    if drafts <= 0 or drafted <= 0 or accepted <= 0 or pos0 <= 0 or pos1 <= 0:
+        raise QualificationError(
+            "MTP2 counters must advance for drafts, drafted tokens, accepted tokens, "
+            "and both draft positions"
+        )
+    if drafted > 2 * drafts or accepted > drafted:
+        raise QualificationError(
+            f"invalid MTP2 totals: drafts={drafts}, drafted={drafted}, accepted={accepted}"
+        )
+    if pos1 > pos0 or pos0 > drafts or not math.isclose(accepted, pos0 + pos1):
+        raise QualificationError(
+            f"invalid MTP2 position counters: accepted={accepted}, pos0={pos0}, pos1={pos1}"
+        )
+    return {
+        "drafts": int(drafts),
+        "draft_tokens": int(drafted),
+        "accepted_tokens": int(accepted),
+        "accepted_tokens_per_position": [int(pos0), int(pos1)],
+        "draft_acceptance_rate": accepted / drafted,
+        "mean_acceptance_length_including_bonus": 1 + accepted / drafts,
+    }
+
+
+def validate_mtp0_metrics(delta: dict[str, Any]) -> None:
+    if any(value != 0 for value in delta["totals"].values()) or any(
+        value != 0 for value in delta["positions"].values()
+    ):
+        raise QualificationError("MTP0 baseline unexpectedly advanced speculation counters")
+
+
+def semantic_canary(base_url: str, model: str, timeout: float) -> dict[str, Any]:
+    body = _json_request(
+        f"{base_url}/v1/chat/completions",
+        payload={
+            "model": model,
+            "messages": [
+                {
+                    "role": "system",
+                    "content": "You are a calculator. Reply with only the integer answer.",
+                },
+                {"role": "user", "content": "What is 17 + 25?"},
+            ],
+            "temperature": 0.0,
+            "top_p": 1.0,
+            "seed": SEED,
+            "max_tokens": 128,
+            "chat_template_kwargs": {"reasoning_effort": "low"},
+        },
+        timeout=timeout,
+    )
+    choices = body.get("choices")
+    if not isinstance(choices, list) or not choices or not isinstance(choices[0], dict):
+        raise QualificationError("semantic canary returned no choice")
+    message = choices[0].get("message")
+    if not isinstance(message, dict):
+        raise QualificationError("semantic canary returned no message")
+    fields = [
+        value
+        for name in ("reasoning", "reasoning_content", "content")
+        if isinstance((value := message.get(name)), str)
+    ]
+    combined = "\n".join(fields)
+    if not EXPECTED_ANSWER.search(combined):
+        raise QualificationError("semantic canary did not contain the integer 42")
+    return {"answer_present": True, "response_sha256": hashlib.sha256(combined.encode()).hexdigest()}
+
+
+def finite_logprob_canary(base_url: str, model: str, timeout: float) -> dict[str, Any]:
+    expected = 16
+    body = _json_request(
+        f"{base_url}/v1/completions",
+        payload={
+            "model": model,
+            "prompt": "Continue the even integers: 2, 4, 6, 8,",
+            "max_tokens": expected,
+            "temperature": 0.0,
+            "top_p": 1.0,
+            "seed": SEED,
+            "ignore_eos": True,
+            "logprobs": 5,
+        },
+        timeout=timeout,
+    )
+    choices = body.get("choices")
+    if not isinstance(choices, list) or not choices or not isinstance(choices[0], dict):
+        raise QualificationError("logprob canary returned no choice")
+    logprobs = choices[0].get("logprobs")
+    if not isinstance(logprobs, dict):
+        raise QualificationError("logprob canary omitted logprobs")
+    chosen = logprobs.get("token_logprobs")
+    tops = logprobs.get("top_logprobs")
+    tokens = logprobs.get("tokens")
+    if not all(isinstance(value, list) for value in (chosen, tops, tokens)):
+        raise QualificationError("logprob arrays are malformed")
+    if not (len(chosen) == len(tops) == len(tokens) == expected):
+        raise QualificationError("logprob arrays do not contain exactly 16 tokens")
+    finite: list[float] = []
+    for value in chosen:
+        if not isinstance(value, (int, float)) or not math.isfinite(float(value)):
+            raise QualificationError("chosen logprob is nonfinite")
+        finite.append(float(value))
+    for top in tops:
+        if not isinstance(top, dict) or not top:
+            raise QualificationError("top-logprob entry is empty")
+        for value in top.values():
+            if not isinstance(value, (int, float)) or not math.isfinite(float(value)):
+                raise QualificationError("top logprob is nonfinite")
+            finite.append(float(value))
+    return {
+        "completion_tokens": expected,
+        "finite_logprob_values": len(finite),
+        "token_sequence_sha256": _hash_json(tokens),
+        "minimum_logprob": min(finite),
+        "maximum_logprob": max(finite),
+    }
+
+
+def exact_prompt(base_url: str, model: str, timeout: float) -> tuple[list[int], str]:
+    sentence = (
+        "Each observation is part of a deterministic model-equivalence test. "
+        "Preserve the numbered order and continue with a concise technical analysis. "
+    )
+    text = "Fixed SparkRing MTP equivalence corpus v1.\n" + "".join(
+        f"Observation {index}: {sentence}" for index in range(128)
+    )
+    body = _json_request(
+        f"{base_url}/tokenize",
+        payload={"model": model, "prompt": text, "add_special_tokens": False},
+        timeout=timeout,
+    )
+    tokens = body.get("tokens")
+    if not isinstance(tokens, list) or not all(
+        isinstance(token, int) and not isinstance(token, bool) for token in tokens
+    ):
+        raise QualificationError("tokenize did not return integer token IDs")
+    if len(tokens) < PROMPT_TOKENS:
+        raise QualificationError("equivalence prompt is shorter than 512 tokens")
+    selected = tokens[:PROMPT_TOKENS]
+    return selected, _hash_json(selected)
+
+
+def greedy_equivalence_canaries(
+    base_url: str,
+    model: str,
+    timeout: float,
+) -> dict[str, Any]:
+    prompt, prompt_hash = exact_prompt(base_url, model, timeout)
+    results: dict[str, Any] = {}
+    for output_tokens in OUTPUT_LENGTHS:
+        runs: list[dict[str, Any]] = []
+        for repeat in range(REPEATS):
+            started = time.monotonic()
+            body = _json_request(
+                f"{base_url}/v1/completions",
+                payload={
+                    "model": model,
+                    "prompt": prompt,
+                    "add_special_tokens": False,
+                    "max_tokens": output_tokens,
+                    "temperature": 0.0,
+                    "top_p": 1.0,
+                    "seed": SEED,
+                    "ignore_eos": True,
+                },
+                timeout=timeout,
+            )
+            elapsed = time.monotonic() - started
+            choices = body.get("choices")
+            usage = body.get("usage")
+            if not isinstance(choices, list) or not choices or not isinstance(choices[0], dict):
+                raise QualificationError(f"{output_tokens}-token greedy run returned no choice")
+            if not isinstance(usage, dict):
+                raise QualificationError(f"{output_tokens}-token greedy run omitted usage")
+            text = choices[0].get("text")
+            if not isinstance(text, str):
+                raise QualificationError(f"{output_tokens}-token greedy run omitted text")
+            prompt_count = _positive_int(usage.get("prompt_tokens"), "prompt_tokens")
+            completion_count = _positive_int(
+                usage.get("completion_tokens"), "completion_tokens"
+            )
+            if prompt_count != PROMPT_TOKENS or completion_count != output_tokens:
+                raise QualificationError(
+                    f"greedy run usage mismatch: prompt={prompt_count}, "
+                    f"completion={completion_count}"
+                )
+            runs.append(
+                {
+                    "repeat": repeat,
+                    "completion_tokens": completion_count,
+                    "response_sha256": hashlib.sha256(text.encode("utf-8")).hexdigest(),
+                    "finish_reason": choices[0].get("finish_reason"),
+                    "wall_seconds": elapsed,
+                }
+            )
+        hashes = {run["response_sha256"] for run in runs}
+        if len(hashes) != 1:
+            raise QualificationError(
+                f"{output_tokens}-token greedy outputs are not repeatable: {sorted(hashes)}"
+            )
+        results[str(output_tokens)] = {
+            "reference_response_sha256": runs[0]["response_sha256"],
+            "runs": runs,
+        }
+    return {"prompt_token_ids_sha256": prompt_hash, "lengths": results}
+
+
+def compare_greedy(candidate: dict[str, Any], baseline: dict[str, Any]) -> None:
+    baseline_canaries = baseline.get("greedy_equivalence")
+    if not isinstance(baseline_canaries, dict):
+        raise QualificationError("baseline omitted greedy-equivalence evidence")
+    if candidate["prompt_token_ids_sha256"] != baseline_canaries.get(
+        "prompt_token_ids_sha256"
+    ):
+        raise QualificationError("candidate and baseline prompt token IDs differ")
+    baseline_lengths = baseline_canaries.get("lengths")
+    if not isinstance(baseline_lengths, dict):
+        raise QualificationError("baseline omitted greedy output lengths")
+    for length in OUTPUT_LENGTHS:
+        key = str(length)
+        candidate_hash = candidate["lengths"][key]["reference_response_sha256"]
+        baseline_entry = baseline_lengths.get(key)
+        if not isinstance(baseline_entry, dict):
+            raise QualificationError(f"baseline omitted {length}-token output")
+        if candidate_hash != baseline_entry.get("reference_response_sha256"):
+            raise QualificationError(
+                f"MTP2 {length}-token greedy output differs from MTP0: "
+                f"candidate={candidate_hash}, "
+                f"baseline={baseline_entry.get('reference_response_sha256')}"
+            )
+
+
+def run_http(args: argparse.Namespace) -> dict[str, Any]:
+    base_url = args.base_url.rstrip("/")
+    model = discover_model(base_url, args.model, args.timeout)
+    metrics_before_status, metrics_before_raw = _request(
+        f"{base_url}/metrics", timeout=args.timeout
+    )
+    if metrics_before_status != 200:
+        raise QualificationError(
+            f"metrics-before returned HTTP {metrics_before_status}"
+        )
+    metrics_before = parse_spec_metrics(metrics_before_raw, model)
+    semantic = semantic_canary(base_url, model, args.timeout)
+    logprobs = finite_logprob_canary(base_url, model, args.timeout)
+    greedy = greedy_equivalence_canaries(base_url, model, args.timeout)
+    metrics_after_status, metrics_after_raw = _request(
+        f"{base_url}/metrics", timeout=args.timeout
+    )
+    if metrics_after_status != 200:
+        raise QualificationError(f"metrics-after returned HTTP {metrics_after_status}")
+    metrics_after = parse_spec_metrics(metrics_after_raw, model)
+    delta = metric_delta(metrics_before, metrics_after)
+
+    baseline_sha256: str | None = None
+    speculation: dict[str, Any]
+    if args.mode == "capture-mtp0":
+        validate_mtp0_metrics(delta)
+        speculation = {"enabled": False, "counter_delta": delta}
+    else:
+        baseline_path = Path(args.baseline)
+        baseline_bytes = baseline_path.read_bytes()
+        baseline_sha256 = hashlib.sha256(baseline_bytes).hexdigest()
+        baseline = json.loads(baseline_bytes)
+        if not isinstance(baseline, dict) or baseline.get("status") != "pass":
+            raise QualificationError("MTP0 baseline is not a passing qualification artifact")
+        if baseline.get("model") != model:
+            raise QualificationError("candidate and MTP0 baseline model IDs differ")
+        compare_greedy(greedy, baseline)
+        speculation = {
+            "enabled": True,
+            "counter_delta": delta,
+            **validate_mtp2_metrics(delta),
+        }
+
+    return {
+        "schema": SCHEMA,
+        "created_at": datetime.now(timezone.utc).isoformat(),
+        "status": "pass",
+        "mode": args.mode,
+        "scope": {
+            "lane": "public-functional",
+            "maturity": "diagnostic",
+            "statement": (
+                "Bounded endpoint equivalence and speculative-counter evidence. "
+                "Performance and transport are qualified by separate artifacts."
+            ),
+        },
+        "endpoint": base_url,
+        "model": model,
+        "seed": SEED,
+        "baseline_sha256": baseline_sha256,
+        "semantic_chat": semantic,
+        "finite_completion_logprobs": logprobs,
+        "greedy_equivalence": greedy,
+        "speculation": speculation,
+    }
+
+
+def _rank_session(snapshot: dict[str, Any], family: str, rank: int) -> dict[str, Any]:
+    family_snapshot = snapshot.get(family)
+    if not isinstance(family_snapshot, dict):
+        raise QualificationError(f"rank {rank} status omitted {family}")
+    sessions = family_snapshot.get("sessions")
+    if not isinstance(sessions, dict):
+        raise QualificationError(f"rank {rank} {family} status omitted sessions")
+    session = sessions.get(str(rank), sessions.get(rank))
+    if not isinstance(session, dict):
+        raise QualificationError(f"rank {rank} {family} status omitted its local session")
+    return session
+
+
+def _load_status(path: str, expected_rank: int) -> dict[str, Any]:
+    payload = json.loads(Path(path).read_text(encoding="utf-8"))
+    if not isinstance(payload, dict) or payload.get("schema_version") != 3:
+        raise QualificationError(f"{path} is not a graph-status v3 snapshot")
+    if payload.get("rank") != expected_rank:
+        raise QualificationError(
+            f"{path} reports rank {payload.get('rank')}, expected {expected_rank}"
+        )
+    snapshot = payload.get("snapshot")
+    if not isinstance(snapshot, dict):
+        raise QualificationError(f"{path} omitted snapshot")
+    return payload
+
+
+def _validate_transport_session(
+    before: dict[str, Any],
+    after: dict[str, Any],
+    *,
+    family: str,
+    rank: int,
+    minimum_captured_nodes: int,
+) -> dict[str, Any]:
+    required_true = (
+        "capture_configured",
+        "polling_enabled",
+        "host_native_atomics",
+        "submit_affinity_verified",
+        "progress_affinity_verified",
+    )
+    for name in required_true:
+        if after.get(name) is not True:
+            raise QualificationError(f"rank {rank} {family} did not prove {name}")
+    captured = after.get("captured_nodes")
+    if not isinstance(captured, int) or captured < minimum_captured_nodes:
+        raise QualificationError(
+            f"rank {rank} {family} captured only {captured!r} nodes; "
+            f"at least {minimum_captured_nodes} are required"
+        )
+    for name in ("published_sequence", "consumed_sequence", "completed_sequence"):
+        if not isinstance(after.get(name), int):
+            raise QualificationError(f"rank {rank} {family} omitted {name}")
+    published = after["published_sequence"]
+    if not (
+        published > before.get("published_sequence", -1)
+        and published == after["consumed_sequence"] == after["completed_sequence"]
+    ):
+        raise QualificationError(f"rank {rank} {family} replay did not advance and catch up")
+    if after.get("overflow_sequence") != 0 or after.get("fatal") is True:
+        raise QualificationError(f"rank {rank} {family} reported overflow or fatal state")
+    return {
+        "captured_nodes": captured,
+        "minimum_captured_nodes": minimum_captured_nodes,
+        "published_before": before.get("published_sequence"),
+        "published_after": published,
+        "published_delta": published - before.get("published_sequence", 0),
+    }
+
+
+def _forbidden_stock_signatures(snapshot: dict[str, Any]) -> list[dict[str, Any]]:
+    stock = snapshot.get("stock_collectives")
+    if not isinstance(stock, dict):
+        raise QualificationError("transport status omitted stock-collective audit")
+    dropped = stock.get("signature_dropped_calls", {})
+    if not isinstance(dropped, dict):
+        raise QualificationError("stock-signature dropped-call audit is malformed")
+    for phase in ("capture", "eager"):
+        if dropped.get(phase, 0) != 0:
+            raise QualificationError(
+                f"{phase} stock-signature audit dropped calls"
+            )
+    signatures = stock.get("signatures", {})
+    if not isinstance(signatures, dict):
+        raise QualificationError("stock-signature audit is malformed")
+    forbidden: list[dict[str, Any]] = []
+    for phase in ("capture", "eager"):
+        phase_signatures = signatures.get(phase, [])
+        if not isinstance(phase_signatures, list):
+            raise QualificationError(
+                f"{phase} stock-signature audit is malformed"
+            )
+        for signature in phase_signatures:
+            if not isinstance(signature, dict):
+                continue
+            shape = signature.get("shape")
+            if (
+                not isinstance(shape, list)
+                or len(shape) != 2
+                or not isinstance(shape[0], int)
+            ):
+                continue
+            q = shape[0]
+            if not 1 <= q <= MAX_QUERY_ROWS:
+                continue
+            if shape in ([q, 6144], [q, 38720]):
+                forbidden.append({"phase": phase, **signature})
+    return forbidden
+
+
+def run_transport(args: argparse.Namespace) -> dict[str, Any]:
+    if len(args.before_status) != 4 or len(args.after_status) != 4:
+        raise QualificationError("transport audit requires four before and four after files")
+    ranks: list[dict[str, Any]] = []
+    for rank, (before_path, after_path) in enumerate(
+        zip(args.before_status, args.after_status, strict=True)
+    ):
+        before_payload = _load_status(before_path, rank)
+        after_payload = _load_status(after_path, rank)
+        if before_payload.get("pid") != after_payload.get("pid"):
+            raise QualificationError(f"rank {rank} worker PID changed during transport audit")
+        before_end = before_payload.get("snapshot_end_unix_ns")
+        after_start = after_payload.get("snapshot_start_unix_ns")
+        if not isinstance(before_end, int) or not isinstance(after_start, int):
+            raise QualificationError(f"rank {rank} status omitted collection intervals")
+        if after_start <= before_end:
+            raise QualificationError(f"rank {rank} after-status does not follow before-status")
+        before_snapshot = before_payload["snapshot"]
+        after_snapshot = after_payload["snapshot"]
+        all_reduce = _validate_transport_session(
+            _rank_session(before_snapshot, "all_reduce", rank),
+            _rank_session(after_snapshot, "all_reduce", rank),
+            family="all_reduce",
+            rank=rank,
+            minimum_captured_nodes=MAX_QUERY_ROWS,
+        )
+        vocabulary = _validate_transport_session(
+            _rank_session(before_snapshot, "vocabulary", rank),
+            _rank_session(after_snapshot, "vocabulary", rank),
+            family="vocabulary",
+            rank=rank,
+            minimum_captured_nodes=MIN_VOCABULARY_CAPTURED_NODES,
+        )
+        forbidden = _forbidden_stock_signatures(after_snapshot)
+        if forbidden:
+            raise QualificationError(
+                f"rank {rank} used stock collectives for required "
+                f"Q1-Q{MAX_QUERY_ROWS} signatures: "
+                f"{forbidden[:3]}"
+            )
+        ranks.append(
+            {
+                "rank": rank,
+                "all_reduce": all_reduce,
+                "vocabulary": vocabulary,
+                "required_query_rows": list(range(1, MAX_QUERY_ROWS + 1)),
+                "audited_stock_phases": ["capture", "eager"],
+                "required_stock_capture_signatures": 0,
+                "required_stock_eager_signatures": 0,
+            }
+        )
+    return {
+        "schema": TRANSPORT_SCHEMA,
+        "created_at": datetime.now(timezone.utc).isoformat(),
+        "status": "pass",
+        "fixed_mtp_depth": FIXED_MTP_DEPTH,
+        "maximum_sequences": MAX_CONCURRENT_SEQUENCES,
+        "maximum_query_rows": MAX_QUERY_ROWS,
+        "ranks": ranks,
+    }
+
+
+def _write_report(path: str, report: dict[str, Any]) -> None:
+    target = Path(path)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="mode", required=True)
+    for mode in ("capture-mtp0", "qualify-mtp2"):
+        command = subparsers.add_parser(mode)
+        command.add_argument("--base-url", default="http://127.0.0.1:8000")
+        command.add_argument("--model")
+        command.add_argument("--timeout", type=float, default=1800.0)
+        command.add_argument("--output", required=True)
+        if mode == "qualify-mtp2":
+            command.add_argument("--baseline", required=True)
+    transport = subparsers.add_parser("audit-transport")
+    transport.add_argument("--before-status", action="append", required=True)
+    transport.add_argument("--after-status", action="append", required=True)
+    transport.add_argument("--output", required=True)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    try:
+        report = run_transport(args) if args.mode == "audit-transport" else run_http(args)
+    except Exception as exc:
+        report = {
+            "schema": TRANSPORT_SCHEMA if args.mode == "audit-transport" else SCHEMA,
+            "created_at": datetime.now(timezone.utc).isoformat(),
+            "status": "fail",
+            "mode": args.mode,
+            "failures": [f"{type(exc).__name__}: {exc}"],
+        }
+        _write_report(args.output, report)
+        print(json.dumps(report, indent=2, sort_keys=True))
+        return 1
+    _write_report(args.output, report)
+    print(json.dumps(report, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/runtime/exl3-r7/mtp3_qualification.py
+++ b/runtime/exl3-r7/mtp3_qualification.py
@@ -1,0 +1,733 @@
+"""Qualify fixed-depth MTP3 against a matching MTP0 endpoint.
+
+The HTTP mode captures or compares deterministic greedy outputs and verifies
+that speculative-decoding counters behave as configured.  The transport mode
+checks four before/after SparkRing graph-status snapshots and rejects stock
+capture and eager fallback for every query width required by eight-way
+fixed-MTP3 decode.
+
+This tool sends inference requests but does not start, stop, or modify a model
+service.  Capture the MTP0 baseline and MTP3 candidate from the same checkpoint,
+runtime, parallelism, cache, graph, and transport configuration.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import re
+import time
+import urllib.error
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+SCHEMA = "sparkring-r7-fixed-mtp3-qualification/v1"
+TRANSPORT_SCHEMA = "sparkring-r7-mtp3-transport-audit/v1"
+SEED = 20260811
+PROMPT_TOKENS = 512
+OUTPUT_LENGTHS = (128, 256)
+REPEATS = 3
+MAX_CONCURRENT_SEQUENCES = 8
+FIXED_MTP_DEPTH = 3
+MAX_QUERY_ROWS = MAX_CONCURRENT_SEQUENCES * (FIXED_MTP_DEPTH + 1)
+# The target graph captures model forward only. Vocabulary collectives belong
+# to the speculator's full prefill and decode graphs, each captured once for
+# C1 through C8. Query-width coverage is enforced separately by rejecting
+# stock vocabulary signatures through the fixed-depth maximum query width.
+MIN_VOCABULARY_CAPTURED_NODES = 2 * MAX_CONCURRENT_SEQUENCES
+EXPECTED_ANSWER = re.compile(r"(?<!\d)42(?!\d)")
+SPEC_COUNTERS = (
+    "vllm:spec_decode_num_drafts_total",
+    "vllm:spec_decode_num_draft_tokens_total",
+    "vllm:spec_decode_num_accepted_tokens_total",
+)
+POSITION_COUNTER = "vllm:spec_decode_num_accepted_tokens_per_pos_total"
+
+
+class QualificationError(RuntimeError):
+    """A required correctness, speculation, or transport invariant failed."""
+
+
+def _request(
+    url: str,
+    *,
+    payload: dict[str, Any] | None = None,
+    timeout: float,
+) -> tuple[int, str]:
+    data = None if payload is None else json.dumps(payload).encode("utf-8")
+    request = urllib.request.Request(
+        url,
+        data=data,
+        headers={"Content-Type": "application/json"} if data is not None else {},
+        method="POST" if data is not None else "GET",
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            return int(response.status), response.read().decode("utf-8", "replace")
+    except urllib.error.HTTPError as exc:
+        return int(exc.code), exc.read().decode("utf-8", "replace")
+    except (urllib.error.URLError, OSError, TimeoutError) as exc:
+        raise QualificationError(f"request to {url} failed: {exc}") from exc
+
+
+def _json_request(
+    url: str,
+    *,
+    payload: dict[str, Any] | None = None,
+    timeout: float,
+) -> dict[str, Any]:
+    status, raw = _request(url, payload=payload, timeout=timeout)
+    if status != 200:
+        raise QualificationError(
+            f"request to {url} returned HTTP {status}: {raw[:500]}"
+        )
+    try:
+        body = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise QualificationError(f"request to {url} returned non-JSON data") from exc
+    if not isinstance(body, dict):
+        raise QualificationError(f"request to {url} returned a non-object JSON value")
+    return body
+
+
+def _hash_json(value: Any) -> str:
+    return hashlib.sha256(
+        json.dumps(value, ensure_ascii=False, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()
+
+
+def _positive_int(value: Any, name: str) -> int:
+    if not isinstance(value, int) or isinstance(value, bool) or value <= 0:
+        raise QualificationError(f"{name} must be a positive integer, got {value!r}")
+    return value
+
+
+def discover_model(base_url: str, expected_model: str | None, timeout: float) -> str:
+    health_status, _ = _request(f"{base_url}/health", timeout=timeout)
+    if health_status != 200:
+        raise QualificationError(f"health returned HTTP {health_status}")
+    body = _json_request(f"{base_url}/v1/models", timeout=timeout)
+    models = body.get("data")
+    if not isinstance(models, list) or not models or not isinstance(models[0], dict):
+        raise QualificationError("model discovery returned no models")
+    served = models[0].get("id")
+    if not isinstance(served, str) or not served:
+        raise QualificationError("model discovery returned an invalid model ID")
+    if expected_model is not None and served != expected_model:
+        raise QualificationError(
+            f"served model {served!r} does not match expected {expected_model!r}"
+        )
+    return served
+
+
+def _metric_labels(raw: str) -> dict[str, str]:
+    labels: dict[str, str] = {}
+    if not raw:
+        return labels
+    for item in re.findall(r'(\w+)="((?:\\.|[^"\\])*)"', raw):
+        labels[item[0]] = bytes(item[1], "utf-8").decode("unicode_escape")
+    return labels
+
+
+def parse_spec_metrics(text: str, expected_model: str | None = None) -> dict[str, Any]:
+    totals = {name: 0.0 for name in SPEC_COUNTERS}
+    positions: dict[int, float] = {}
+    seen: set[str] = set()
+    pattern = re.compile(
+        r"^(vllm:spec_decode_[a-z0-9_]+_total)(?:\{([^}]*)\})?\s+"
+        r"([-+]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][-+]?\d+)?)$"
+    )
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        match = pattern.match(line)
+        if match is None:
+            continue
+        name, labels_raw, value_raw = match.groups()
+        labels = _metric_labels(labels_raw or "")
+        if expected_model is not None and (
+            labels.get("model_name") != expected_model
+            or labels.get("engine") != "0"
+        ):
+            continue
+        value = float(value_raw)
+        if not math.isfinite(value) or value < 0:
+            raise QualificationError(f"invalid speculative metric {name}={value_raw}")
+        seen.add(name)
+        if name == POSITION_COUNTER:
+            if "position" not in labels:
+                raise QualificationError(f"{POSITION_COUNTER} omitted position label")
+            position = int(labels["position"])
+            positions[position] = positions.get(position, 0.0) + value
+        elif name in totals:
+            totals[name] += value
+    return {"totals": totals, "positions": positions, "seen": sorted(seen)}
+
+
+def metric_delta(before: dict[str, Any], after: dict[str, Any]) -> dict[str, Any]:
+    totals = {
+        name: after["totals"].get(name, 0.0) - before["totals"].get(name, 0.0)
+        for name in SPEC_COUNTERS
+    }
+    all_positions = set(before["positions"]) | set(after["positions"])
+    positions = {
+        position: after["positions"].get(position, 0.0)
+        - before["positions"].get(position, 0.0)
+        for position in sorted(all_positions)
+    }
+    if any(value < 0 for value in (*totals.values(), *positions.values())):
+        raise QualificationError("speculative counters decreased during qualification")
+    return {
+        "totals": totals,
+        "positions": positions,
+        "position_keys": sorted(after["positions"]),
+    }
+
+
+def validate_mtp3_metrics(delta: dict[str, Any]) -> dict[str, Any]:
+    drafts = delta["totals"][SPEC_COUNTERS[0]]
+    drafted = delta["totals"][SPEC_COUNTERS[1]]
+    accepted = delta["totals"][SPEC_COUNTERS[2]]
+    pos0 = delta["positions"].get(0, 0.0)
+    pos1 = delta["positions"].get(1, 0.0)
+    pos2 = delta["positions"].get(2, 0.0)
+    if delta.get("position_keys") != [0, 1, 2]:
+        raise QualificationError(
+            "fixed MTP3 must expose exactly zero-based draft positions 0, 1, and 2"
+        )
+    if (
+        drafts <= 0
+        or drafted <= 0
+        or accepted <= 0
+        or pos0 <= 0
+        or pos1 <= 0
+        or pos2 <= 0
+    ):
+        raise QualificationError(
+            "MTP3 counters must advance for drafts, drafted tokens, accepted tokens, "
+            "and all three draft positions"
+        )
+    if drafted > FIXED_MTP_DEPTH * drafts or accepted > drafted:
+        raise QualificationError(
+            f"invalid MTP3 totals: drafts={drafts}, drafted={drafted}, accepted={accepted}"
+        )
+    if (
+        pos2 > pos1
+        or pos1 > pos0
+        or pos0 > drafts
+        or not math.isclose(accepted, pos0 + pos1 + pos2)
+    ):
+        raise QualificationError(
+            "invalid MTP3 position counters: "
+            f"accepted={accepted}, pos0={pos0}, pos1={pos1}, pos2={pos2}"
+        )
+    return {
+        "drafts": int(drafts),
+        "draft_tokens": int(drafted),
+        "accepted_tokens": int(accepted),
+        "accepted_tokens_per_position": [int(pos0), int(pos1), int(pos2)],
+        "draft_acceptance_rate": accepted / drafted,
+        "mean_acceptance_length_including_bonus": 1 + accepted / drafts,
+    }
+
+
+def validate_mtp0_metrics(delta: dict[str, Any]) -> None:
+    if any(value != 0 for value in delta["totals"].values()) or any(
+        value != 0 for value in delta["positions"].values()
+    ):
+        raise QualificationError("MTP0 baseline unexpectedly advanced speculation counters")
+
+
+def semantic_canary(base_url: str, model: str, timeout: float) -> dict[str, Any]:
+    body = _json_request(
+        f"{base_url}/v1/chat/completions",
+        payload={
+            "model": model,
+            "messages": [
+                {
+                    "role": "system",
+                    "content": "You are a calculator. Reply with only the integer answer.",
+                },
+                {"role": "user", "content": "What is 17 + 25?"},
+            ],
+            "temperature": 0.0,
+            "top_p": 1.0,
+            "seed": SEED,
+            "max_tokens": 128,
+            "chat_template_kwargs": {"reasoning_effort": "low"},
+        },
+        timeout=timeout,
+    )
+    choices = body.get("choices")
+    if not isinstance(choices, list) or not choices or not isinstance(choices[0], dict):
+        raise QualificationError("semantic canary returned no choice")
+    message = choices[0].get("message")
+    if not isinstance(message, dict):
+        raise QualificationError("semantic canary returned no message")
+    fields = [
+        value
+        for name in ("reasoning", "reasoning_content", "content")
+        if isinstance((value := message.get(name)), str)
+    ]
+    combined = "\n".join(fields)
+    if not EXPECTED_ANSWER.search(combined):
+        raise QualificationError("semantic canary did not contain the integer 42")
+    return {"answer_present": True, "response_sha256": hashlib.sha256(combined.encode()).hexdigest()}
+
+
+def finite_logprob_canary(base_url: str, model: str, timeout: float) -> dict[str, Any]:
+    expected = 16
+    body = _json_request(
+        f"{base_url}/v1/completions",
+        payload={
+            "model": model,
+            "prompt": "Continue the even integers: 2, 4, 6, 8,",
+            "max_tokens": expected,
+            "temperature": 0.0,
+            "top_p": 1.0,
+            "seed": SEED,
+            "ignore_eos": True,
+            "logprobs": 5,
+        },
+        timeout=timeout,
+    )
+    choices = body.get("choices")
+    if not isinstance(choices, list) or not choices or not isinstance(choices[0], dict):
+        raise QualificationError("logprob canary returned no choice")
+    logprobs = choices[0].get("logprobs")
+    if not isinstance(logprobs, dict):
+        raise QualificationError("logprob canary omitted logprobs")
+    chosen = logprobs.get("token_logprobs")
+    tops = logprobs.get("top_logprobs")
+    tokens = logprobs.get("tokens")
+    if not all(isinstance(value, list) for value in (chosen, tops, tokens)):
+        raise QualificationError("logprob arrays are malformed")
+    if not (len(chosen) == len(tops) == len(tokens) == expected):
+        raise QualificationError("logprob arrays do not contain exactly 16 tokens")
+    finite: list[float] = []
+    for value in chosen:
+        if not isinstance(value, (int, float)) or not math.isfinite(float(value)):
+            raise QualificationError("chosen logprob is nonfinite")
+        finite.append(float(value))
+    for top in tops:
+        if not isinstance(top, dict) or not top:
+            raise QualificationError("top-logprob entry is empty")
+        for value in top.values():
+            if not isinstance(value, (int, float)) or not math.isfinite(float(value)):
+                raise QualificationError("top logprob is nonfinite")
+            finite.append(float(value))
+    return {
+        "completion_tokens": expected,
+        "finite_logprob_values": len(finite),
+        "token_sequence_sha256": _hash_json(tokens),
+        "minimum_logprob": min(finite),
+        "maximum_logprob": max(finite),
+    }
+
+
+def exact_prompt(base_url: str, model: str, timeout: float) -> tuple[list[int], str]:
+    sentence = (
+        "Each observation is part of a deterministic model-equivalence test. "
+        "Preserve the numbered order and continue with a concise technical analysis. "
+    )
+    text = "Fixed SparkRing MTP equivalence corpus v1.\n" + "".join(
+        f"Observation {index}: {sentence}" for index in range(128)
+    )
+    body = _json_request(
+        f"{base_url}/tokenize",
+        payload={"model": model, "prompt": text, "add_special_tokens": False},
+        timeout=timeout,
+    )
+    tokens = body.get("tokens")
+    if not isinstance(tokens, list) or not all(
+        isinstance(token, int) and not isinstance(token, bool) for token in tokens
+    ):
+        raise QualificationError("tokenize did not return integer token IDs")
+    if len(tokens) < PROMPT_TOKENS:
+        raise QualificationError("equivalence prompt is shorter than 512 tokens")
+    selected = tokens[:PROMPT_TOKENS]
+    return selected, _hash_json(selected)
+
+
+def greedy_equivalence_canaries(
+    base_url: str,
+    model: str,
+    timeout: float,
+) -> dict[str, Any]:
+    prompt, prompt_hash = exact_prompt(base_url, model, timeout)
+    results: dict[str, Any] = {}
+    for output_tokens in OUTPUT_LENGTHS:
+        runs: list[dict[str, Any]] = []
+        for repeat in range(REPEATS):
+            started = time.monotonic()
+            body = _json_request(
+                f"{base_url}/v1/completions",
+                payload={
+                    "model": model,
+                    "prompt": prompt,
+                    "add_special_tokens": False,
+                    "max_tokens": output_tokens,
+                    "temperature": 0.0,
+                    "top_p": 1.0,
+                    "seed": SEED,
+                    "ignore_eos": True,
+                },
+                timeout=timeout,
+            )
+            elapsed = time.monotonic() - started
+            choices = body.get("choices")
+            usage = body.get("usage")
+            if not isinstance(choices, list) or not choices or not isinstance(choices[0], dict):
+                raise QualificationError(f"{output_tokens}-token greedy run returned no choice")
+            if not isinstance(usage, dict):
+                raise QualificationError(f"{output_tokens}-token greedy run omitted usage")
+            text = choices[0].get("text")
+            if not isinstance(text, str):
+                raise QualificationError(f"{output_tokens}-token greedy run omitted text")
+            prompt_count = _positive_int(usage.get("prompt_tokens"), "prompt_tokens")
+            completion_count = _positive_int(
+                usage.get("completion_tokens"), "completion_tokens"
+            )
+            if prompt_count != PROMPT_TOKENS or completion_count != output_tokens:
+                raise QualificationError(
+                    f"greedy run usage mismatch: prompt={prompt_count}, "
+                    f"completion={completion_count}"
+                )
+            runs.append(
+                {
+                    "repeat": repeat,
+                    "completion_tokens": completion_count,
+                    "response_sha256": hashlib.sha256(text.encode("utf-8")).hexdigest(),
+                    "finish_reason": choices[0].get("finish_reason"),
+                    "wall_seconds": elapsed,
+                }
+            )
+        hashes = {run["response_sha256"] for run in runs}
+        if len(hashes) != 1:
+            raise QualificationError(
+                f"{output_tokens}-token greedy outputs are not repeatable: {sorted(hashes)}"
+            )
+        results[str(output_tokens)] = {
+            "reference_response_sha256": runs[0]["response_sha256"],
+            "runs": runs,
+        }
+    return {"prompt_token_ids_sha256": prompt_hash, "lengths": results}
+
+
+def compare_greedy(candidate: dict[str, Any], baseline: dict[str, Any]) -> None:
+    baseline_canaries = baseline.get("greedy_equivalence")
+    if not isinstance(baseline_canaries, dict):
+        raise QualificationError("baseline omitted greedy-equivalence evidence")
+    if candidate["prompt_token_ids_sha256"] != baseline_canaries.get(
+        "prompt_token_ids_sha256"
+    ):
+        raise QualificationError("candidate and baseline prompt token IDs differ")
+    baseline_lengths = baseline_canaries.get("lengths")
+    if not isinstance(baseline_lengths, dict):
+        raise QualificationError("baseline omitted greedy output lengths")
+    for length in OUTPUT_LENGTHS:
+        key = str(length)
+        candidate_hash = candidate["lengths"][key]["reference_response_sha256"]
+        baseline_entry = baseline_lengths.get(key)
+        if not isinstance(baseline_entry, dict):
+            raise QualificationError(f"baseline omitted {length}-token output")
+        if candidate_hash != baseline_entry.get("reference_response_sha256"):
+            raise QualificationError(
+                f"MTP3 {length}-token greedy output differs from MTP0: "
+                f"candidate={candidate_hash}, "
+                f"baseline={baseline_entry.get('reference_response_sha256')}"
+            )
+
+
+def run_http(args: argparse.Namespace) -> dict[str, Any]:
+    base_url = args.base_url.rstrip("/")
+    model = discover_model(base_url, args.model, args.timeout)
+    metrics_before_status, metrics_before_raw = _request(
+        f"{base_url}/metrics", timeout=args.timeout
+    )
+    if metrics_before_status != 200:
+        raise QualificationError(
+            f"metrics-before returned HTTP {metrics_before_status}"
+        )
+    metrics_before = parse_spec_metrics(metrics_before_raw, model)
+    semantic = semantic_canary(base_url, model, args.timeout)
+    logprobs = finite_logprob_canary(base_url, model, args.timeout)
+    greedy = greedy_equivalence_canaries(base_url, model, args.timeout)
+    metrics_after_status, metrics_after_raw = _request(
+        f"{base_url}/metrics", timeout=args.timeout
+    )
+    if metrics_after_status != 200:
+        raise QualificationError(f"metrics-after returned HTTP {metrics_after_status}")
+    metrics_after = parse_spec_metrics(metrics_after_raw, model)
+    delta = metric_delta(metrics_before, metrics_after)
+
+    baseline_sha256: str | None = None
+    speculation: dict[str, Any]
+    if args.mode == "capture-mtp0":
+        validate_mtp0_metrics(delta)
+        speculation = {"enabled": False, "counter_delta": delta}
+    else:
+        baseline_path = Path(args.baseline)
+        baseline_bytes = baseline_path.read_bytes()
+        baseline_sha256 = hashlib.sha256(baseline_bytes).hexdigest()
+        baseline = json.loads(baseline_bytes)
+        if not isinstance(baseline, dict) or baseline.get("status") != "pass":
+            raise QualificationError("MTP0 baseline is not a passing qualification artifact")
+        if baseline.get("model") != model:
+            raise QualificationError("candidate and MTP0 baseline model IDs differ")
+        compare_greedy(greedy, baseline)
+        speculation = {
+            "enabled": True,
+            "counter_delta": delta,
+            **validate_mtp3_metrics(delta),
+        }
+
+    return {
+        "schema": SCHEMA,
+        "created_at": datetime.now(timezone.utc).isoformat(),
+        "status": "pass",
+        "mode": args.mode,
+        "scope": {
+            "lane": "public-functional",
+            "maturity": "diagnostic",
+            "statement": (
+                "Bounded endpoint equivalence and speculative-counter evidence. "
+                "Performance and transport are qualified by separate artifacts."
+            ),
+        },
+        "endpoint": base_url,
+        "model": model,
+        "seed": SEED,
+        "baseline_sha256": baseline_sha256,
+        "semantic_chat": semantic,
+        "finite_completion_logprobs": logprobs,
+        "greedy_equivalence": greedy,
+        "speculation": speculation,
+    }
+
+
+def _rank_session(snapshot: dict[str, Any], family: str, rank: int) -> dict[str, Any]:
+    family_snapshot = snapshot.get(family)
+    if not isinstance(family_snapshot, dict):
+        raise QualificationError(f"rank {rank} status omitted {family}")
+    sessions = family_snapshot.get("sessions")
+    if not isinstance(sessions, dict):
+        raise QualificationError(f"rank {rank} {family} status omitted sessions")
+    session = sessions.get(str(rank), sessions.get(rank))
+    if not isinstance(session, dict):
+        raise QualificationError(f"rank {rank} {family} status omitted its local session")
+    return session
+
+
+def _load_status(path: str, expected_rank: int) -> dict[str, Any]:
+    payload = json.loads(Path(path).read_text(encoding="utf-8"))
+    if not isinstance(payload, dict) or payload.get("schema_version") != 3:
+        raise QualificationError(f"{path} is not a graph-status v3 snapshot")
+    if payload.get("rank") != expected_rank:
+        raise QualificationError(
+            f"{path} reports rank {payload.get('rank')}, expected {expected_rank}"
+        )
+    snapshot = payload.get("snapshot")
+    if not isinstance(snapshot, dict):
+        raise QualificationError(f"{path} omitted snapshot")
+    return payload
+
+
+def _validate_transport_session(
+    before: dict[str, Any],
+    after: dict[str, Any],
+    *,
+    family: str,
+    rank: int,
+    minimum_captured_nodes: int,
+) -> dict[str, Any]:
+    required_true = (
+        "capture_configured",
+        "polling_enabled",
+        "host_native_atomics",
+        "submit_affinity_verified",
+        "progress_affinity_verified",
+    )
+    for name in required_true:
+        if after.get(name) is not True:
+            raise QualificationError(f"rank {rank} {family} did not prove {name}")
+    captured = after.get("captured_nodes")
+    if not isinstance(captured, int) or captured < minimum_captured_nodes:
+        raise QualificationError(
+            f"rank {rank} {family} captured only {captured!r} nodes; "
+            f"at least {minimum_captured_nodes} are required"
+        )
+    for name in ("published_sequence", "consumed_sequence", "completed_sequence"):
+        if not isinstance(after.get(name), int):
+            raise QualificationError(f"rank {rank} {family} omitted {name}")
+    published = after["published_sequence"]
+    if not (
+        published > before.get("published_sequence", -1)
+        and published == after["consumed_sequence"] == after["completed_sequence"]
+    ):
+        raise QualificationError(f"rank {rank} {family} replay did not advance and catch up")
+    if after.get("overflow_sequence") != 0 or after.get("fatal") is True:
+        raise QualificationError(f"rank {rank} {family} reported overflow or fatal state")
+    return {
+        "captured_nodes": captured,
+        "minimum_captured_nodes": minimum_captured_nodes,
+        "published_before": before.get("published_sequence"),
+        "published_after": published,
+        "published_delta": published - before.get("published_sequence", 0),
+    }
+
+
+def _forbidden_stock_signatures(snapshot: dict[str, Any]) -> list[dict[str, Any]]:
+    stock = snapshot.get("stock_collectives")
+    if not isinstance(stock, dict):
+        raise QualificationError("transport status omitted stock-collective audit")
+    dropped = stock.get("signature_dropped_calls", {})
+    if not isinstance(dropped, dict):
+        raise QualificationError("stock-signature dropped-call audit is malformed")
+    for phase in ("capture", "eager"):
+        if dropped.get(phase, 0) != 0:
+            raise QualificationError(
+                f"{phase} stock-signature audit dropped calls"
+            )
+    signatures = stock.get("signatures", {})
+    if not isinstance(signatures, dict):
+        raise QualificationError("stock-signature audit is malformed")
+    forbidden: list[dict[str, Any]] = []
+    for phase in ("capture", "eager"):
+        phase_signatures = signatures.get(phase, [])
+        if not isinstance(phase_signatures, list):
+            raise QualificationError(
+                f"{phase} stock-signature audit is malformed"
+            )
+        for signature in phase_signatures:
+            if not isinstance(signature, dict):
+                continue
+            shape = signature.get("shape")
+            if (
+                not isinstance(shape, list)
+                or len(shape) != 2
+                or not isinstance(shape[0], int)
+            ):
+                continue
+            q = shape[0]
+            if not 1 <= q <= MAX_QUERY_ROWS:
+                continue
+            if shape in ([q, 6144], [q, 38720]):
+                forbidden.append({"phase": phase, **signature})
+    return forbidden
+
+
+def run_transport(args: argparse.Namespace) -> dict[str, Any]:
+    if len(args.before_status) != 4 or len(args.after_status) != 4:
+        raise QualificationError("transport audit requires four before and four after files")
+    ranks: list[dict[str, Any]] = []
+    for rank, (before_path, after_path) in enumerate(
+        zip(args.before_status, args.after_status, strict=True)
+    ):
+        before_payload = _load_status(before_path, rank)
+        after_payload = _load_status(after_path, rank)
+        if before_payload.get("pid") != after_payload.get("pid"):
+            raise QualificationError(f"rank {rank} worker PID changed during transport audit")
+        before_end = before_payload.get("snapshot_end_unix_ns")
+        after_start = after_payload.get("snapshot_start_unix_ns")
+        if not isinstance(before_end, int) or not isinstance(after_start, int):
+            raise QualificationError(f"rank {rank} status omitted collection intervals")
+        if after_start <= before_end:
+            raise QualificationError(f"rank {rank} after-status does not follow before-status")
+        before_snapshot = before_payload["snapshot"]
+        after_snapshot = after_payload["snapshot"]
+        all_reduce = _validate_transport_session(
+            _rank_session(before_snapshot, "all_reduce", rank),
+            _rank_session(after_snapshot, "all_reduce", rank),
+            family="all_reduce",
+            rank=rank,
+            minimum_captured_nodes=MAX_QUERY_ROWS,
+        )
+        vocabulary = _validate_transport_session(
+            _rank_session(before_snapshot, "vocabulary", rank),
+            _rank_session(after_snapshot, "vocabulary", rank),
+            family="vocabulary",
+            rank=rank,
+            minimum_captured_nodes=MIN_VOCABULARY_CAPTURED_NODES,
+        )
+        forbidden = _forbidden_stock_signatures(after_snapshot)
+        if forbidden:
+            raise QualificationError(
+                f"rank {rank} used stock collectives for required "
+                f"Q1-Q{MAX_QUERY_ROWS} signatures: "
+                f"{forbidden[:3]}"
+            )
+        ranks.append(
+            {
+                "rank": rank,
+                "all_reduce": all_reduce,
+                "vocabulary": vocabulary,
+                "required_query_rows": list(range(1, MAX_QUERY_ROWS + 1)),
+                "audited_stock_phases": ["capture", "eager"],
+                "required_stock_capture_signatures": 0,
+                "required_stock_eager_signatures": 0,
+            }
+        )
+    return {
+        "schema": TRANSPORT_SCHEMA,
+        "created_at": datetime.now(timezone.utc).isoformat(),
+        "status": "pass",
+        "fixed_mtp_depth": FIXED_MTP_DEPTH,
+        "maximum_sequences": MAX_CONCURRENT_SEQUENCES,
+        "maximum_query_rows": MAX_QUERY_ROWS,
+        "ranks": ranks,
+    }
+
+
+def _write_report(path: str, report: dict[str, Any]) -> None:
+    target = Path(path)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="mode", required=True)
+    for mode in ("capture-mtp0", "qualify-mtp3"):
+        command = subparsers.add_parser(mode)
+        command.add_argument("--base-url", default="http://127.0.0.1:8000")
+        command.add_argument("--model")
+        command.add_argument("--timeout", type=float, default=1800.0)
+        command.add_argument("--output", required=True)
+        if mode == "qualify-mtp3":
+            command.add_argument("--baseline", required=True)
+    transport = subparsers.add_parser("audit-transport")
+    transport.add_argument("--before-status", action="append", required=True)
+    transport.add_argument("--after-status", action="append", required=True)
+    transport.add_argument("--output", required=True)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    try:
+        report = run_transport(args) if args.mode == "audit-transport" else run_http(args)
+    except Exception as exc:
+        report = {
+            "schema": TRANSPORT_SCHEMA if args.mode == "audit-transport" else SCHEMA,
+            "created_at": datetime.now(timezone.utc).isoformat(),
+            "status": "fail",
+            "mode": args.mode,
+            "failures": [f"{type(exc).__name__}: {exc}"],
+        }
+        _write_report(args.output, report)
+        print(json.dumps(report, indent=2, sort_keys=True))
+        return 1
+    _write_report(args.output, report)
+    print(json.dumps(report, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/runtime/exl3-r7/mtp4_qualification.py
+++ b/runtime/exl3-r7/mtp4_qualification.py
@@ -1,0 +1,462 @@
+"""Qualify fixed-depth MTP4 against a matching MTP0 endpoint.
+
+The HTTP mode captures or compares deterministic greedy outputs, rejects
+non-finite log probabilities, and verifies that every fixed-MTP4 acceptance
+counter advances coherently. The transport mode checks four before/after
+SparkRing graph-status snapshots and rejects stock capture or eager fallback
+for every query width required by eight-way fixed-MTP4 decode.
+
+This tool sends inference requests but does not start, stop, or modify a model
+service. Capture the MTP0 baseline and MTP4 candidate from the same checkpoint,
+runtime, parallelism, cache, graph, and transport configuration.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import importlib.util
+import json
+import math
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+def _load_common_module() -> Any:
+    """Load the adjacent fixed-MTP3 harness as the shared HTTP implementation."""
+
+    path = Path(__file__).with_name("mtp3_qualification.py")
+    spec = importlib.util.spec_from_file_location(
+        "sparkring_r7_mtp_qualification_common", path
+    )
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot load shared qualification helpers from {path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+_common = _load_common_module()
+
+SCHEMA = "sparkring-r7-fixed-mtp4-qualification/v1"
+TRANSPORT_SCHEMA = "sparkring-r7-mtp4-transport-audit/v1"
+FIXED_MTP_DEPTH = 4
+MAX_CONCURRENT_SEQUENCES = 8
+MAX_QUERY_ROWS = MAX_CONCURRENT_SEQUENCES * (FIXED_MTP_DEPTH + 1)
+# Draft prefill and the reusable single-step draft-decode graph are each
+# captured once for C1 through C8. Increasing fixed depth replays the latter;
+# it does not create another vocabulary graph family.
+MIN_VOCABULARY_CAPTURED_NODES = 2 * MAX_CONCURRENT_SEQUENCES
+_REQUIRED_STOCK_CAPTURE_COUNTS = (
+    "dcp_combine:original",
+    "dcp_lse_all_gather:ineligible_signature",
+    "dcp_query_all_gather:ineligible_signature",
+    "dcp_owner_topk_all_gather:graph_capture_unsupported",
+)
+_REQUIRED_STOCK_EAGER_COUNTS = (
+    "dcp_combine:original",
+    "dcp_lse_all_gather:ineligible_signature",
+    "dcp_query_all_gather:ineligible_signature",
+    "dcp_owner_topk_all_gather:ineligible_signature",
+)
+
+QualificationError = _common.QualificationError
+SPEC_COUNTERS = _common.SPEC_COUNTERS
+POSITION_COUNTER = _common.POSITION_COUNTER
+SEED = _common.SEED
+PROMPT_TOKENS = _common.PROMPT_TOKENS
+OUTPUT_LENGTHS = _common.OUTPUT_LENGTHS
+REPEATS = _common.REPEATS
+
+# Expose the shared, depth-independent primitives for callers and focused
+# tests. Depth-specific validation remains local and fail-closed below.
+_request = _common._request
+_json_request = _common._json_request
+parse_spec_metrics = _common.parse_spec_metrics
+metric_delta = _common.metric_delta
+discover_model = _common.discover_model
+semantic_canary = _common.semantic_canary
+finite_logprob_canary = _common.finite_logprob_canary
+greedy_equivalence_canaries = _common.greedy_equivalence_canaries
+validate_mtp0_metrics = _common.validate_mtp0_metrics
+_rank_session = _common._rank_session
+_load_status = _common._load_status
+_validate_transport_session = _common._validate_transport_session
+
+
+def validate_mtp4_metrics(delta: dict[str, Any]) -> dict[str, Any]:
+    """Require coherent drafts and acceptance at all four fixed positions."""
+
+    drafts = delta["totals"][SPEC_COUNTERS[0]]
+    drafted = delta["totals"][SPEC_COUNTERS[1]]
+    accepted = delta["totals"][SPEC_COUNTERS[2]]
+    positions = [delta["positions"].get(position, 0.0) for position in range(4)]
+    if delta.get("position_keys") != [0, 1, 2, 3]:
+        raise QualificationError(
+            "fixed MTP4 must expose exactly zero-based draft positions 0, 1, 2, "
+            "and 3"
+        )
+    if drafts <= 0 or drafted <= 0 or accepted <= 0 or any(
+        value <= 0 for value in positions
+    ):
+        raise QualificationError(
+            "MTP4 counters must advance for drafts, drafted tokens, accepted "
+            "tokens, and all four draft positions"
+        )
+    if drafted > FIXED_MTP_DEPTH * drafts or accepted > drafted:
+        raise QualificationError(
+            f"invalid MTP4 totals: drafts={drafts}, drafted={drafted}, "
+            f"accepted={accepted}"
+        )
+    if (
+        positions[3] > positions[2]
+        or positions[2] > positions[1]
+        or positions[1] > positions[0]
+        or positions[0] > drafts
+        or not math.isclose(accepted, sum(positions))
+    ):
+        raise QualificationError(
+            f"invalid MTP4 position counters: accepted={accepted}, "
+            f"positions={positions}"
+        )
+    return {
+        "drafts": int(drafts),
+        "draft_tokens": int(drafted),
+        "accepted_tokens": int(accepted),
+        "acceptance_rate": accepted / drafted,
+        "accepted_tokens_per_position": [int(value) for value in positions],
+    }
+
+
+def compare_greedy(candidate: dict[str, Any], baseline: dict[str, Any]) -> None:
+    """Require all repeated candidate outputs to match the sealed MTP0 hashes."""
+
+    baseline_canaries = baseline.get("greedy_equivalence")
+    if not isinstance(baseline_canaries, dict):
+        raise QualificationError("baseline omitted greedy-equivalence evidence")
+    if candidate["prompt_token_ids_sha256"] != baseline_canaries.get(
+        "prompt_token_ids_sha256"
+    ):
+        raise QualificationError("candidate and baseline prompt token IDs differ")
+    baseline_lengths = baseline_canaries.get("lengths")
+    if not isinstance(baseline_lengths, dict):
+        raise QualificationError("baseline omitted greedy output lengths")
+    for length in OUTPUT_LENGTHS:
+        key = str(length)
+        candidate_hash = candidate["lengths"][key]["reference_response_sha256"]
+        baseline_entry = baseline_lengths.get(key)
+        if not isinstance(baseline_entry, dict):
+            raise QualificationError(f"baseline omitted {length}-token output")
+        if candidate_hash != baseline_entry.get("reference_response_sha256"):
+            raise QualificationError(
+                f"MTP4 {length}-token greedy output differs from MTP0: "
+                f"candidate={candidate_hash}, "
+                f"baseline={baseline_entry.get('reference_response_sha256')}"
+            )
+
+
+def run_http(args: argparse.Namespace) -> dict[str, Any]:
+    """Run bounded semantic, finite-logprob, hash, and counter gates."""
+
+    base_url = args.base_url.rstrip("/")
+    model = discover_model(base_url, args.model, args.timeout)
+    metrics_before_status, metrics_before_raw = _request(
+        f"{base_url}/metrics", timeout=args.timeout
+    )
+    if metrics_before_status != 200:
+        raise QualificationError(
+            f"metrics-before returned HTTP {metrics_before_status}"
+        )
+    metrics_before = parse_spec_metrics(metrics_before_raw, model)
+    semantic = semantic_canary(base_url, model, args.timeout)
+    logprobs = finite_logprob_canary(base_url, model, args.timeout)
+    greedy = greedy_equivalence_canaries(base_url, model, args.timeout)
+    metrics_after_status, metrics_after_raw = _request(
+        f"{base_url}/metrics", timeout=args.timeout
+    )
+    if metrics_after_status != 200:
+        raise QualificationError(f"metrics-after returned HTTP {metrics_after_status}")
+    metrics_after = parse_spec_metrics(metrics_after_raw, model)
+    delta = metric_delta(metrics_before, metrics_after)
+
+    baseline_sha256: str | None = None
+    speculation: dict[str, Any]
+    if args.mode == "capture-mtp0":
+        validate_mtp0_metrics(delta)
+        speculation = {"enabled": False, "counter_delta": delta}
+    else:
+        baseline_path = Path(args.baseline)
+        baseline_bytes = baseline_path.read_bytes()
+        baseline_sha256 = hashlib.sha256(baseline_bytes).hexdigest()
+        baseline = json.loads(baseline_bytes)
+        if not isinstance(baseline, dict) or baseline.get("status") != "pass":
+            raise QualificationError(
+                "MTP0 baseline is not a passing qualification artifact"
+            )
+        if baseline.get("model") != model:
+            raise QualificationError("candidate and MTP0 baseline model IDs differ")
+        compare_greedy(greedy, baseline)
+        speculation = {
+            "enabled": True,
+            "counter_delta": delta,
+            **validate_mtp4_metrics(delta),
+        }
+
+    return {
+        "schema": SCHEMA,
+        "created_at": datetime.now(timezone.utc).isoformat(),
+        "status": "pass",
+        "mode": args.mode,
+        "scope": {
+            "lane": "public-functional",
+            "maturity": "diagnostic",
+            "statement": (
+                "Bounded endpoint equivalence and speculative-counter evidence. "
+                "Performance and transport are qualified by separate artifacts."
+            ),
+        },
+        "endpoint": base_url,
+        "model": model,
+        "seed": SEED,
+        "baseline_sha256": baseline_sha256,
+        "semantic_chat": semantic,
+        "finite_completion_logprobs": logprobs,
+        "greedy_equivalence": greedy,
+        "speculation": speculation,
+    }
+
+
+def _forbidden_stock_signatures(snapshot: dict[str, Any]) -> list[dict[str, Any]]:
+    """Return stock TP collective signatures inside fixed-MTP4's Q1-Q40 range."""
+
+    stock = snapshot.get("stock_collectives")
+    if not isinstance(stock, dict):
+        raise QualificationError("transport status omitted stock-collective audit")
+    dropped = stock.get("signature_dropped_calls", {})
+    if not isinstance(dropped, dict):
+        raise QualificationError("stock-signature dropped-call audit is malformed")
+    for phase in ("capture", "eager"):
+        if dropped.get(phase, 0) != 0:
+            raise QualificationError(f"{phase} stock-signature audit dropped calls")
+    signatures = stock.get("signatures", {})
+    if not isinstance(signatures, dict):
+        raise QualificationError("stock-signature audit is malformed")
+    forbidden: list[dict[str, Any]] = []
+    for phase in ("capture", "eager"):
+        phase_signatures = signatures.get(phase, [])
+        if not isinstance(phase_signatures, list):
+            raise QualificationError(f"{phase} stock-signature audit is malformed")
+        for signature in phase_signatures:
+            if not isinstance(signature, dict):
+                continue
+            shape = signature.get("shape")
+            if (
+                not isinstance(shape, list)
+                or len(shape) != 2
+                or not isinstance(shape[0], int)
+            ):
+                continue
+            q = shape[0]
+            if 1 <= q <= MAX_QUERY_ROWS and shape in ([q, 6144], [q, 38720]):
+                forbidden.append({"phase": phase, **signature})
+    return forbidden
+
+
+def _positive_stock_count(
+    counts: dict[str, Any], name: str, *, rank: int, phase: str
+) -> int:
+    value = counts.get(name)
+    if not isinstance(value, int) or isinstance(value, bool) or value <= 0:
+        raise QualificationError(
+            f"rank {rank} stock {phase} audit did not prove {name}"
+        )
+    return value
+
+
+def _validate_stock_dcp_indexer(
+    before: dict[str, Any], after: dict[str, Any], *, rank: int
+) -> dict[str, Any]:
+    """Prove the inherited DCP and sparse-indexer paths remain stock NCCL."""
+
+    dcp = after.get("dcp")
+    if not isinstance(dcp, dict):
+        raise QualificationError(f"rank {rank} status omitted DCP diagnostics")
+    family_selection = dcp.get("family_selection")
+    expected_selection = {
+        "mode": "stock",
+        "query_enabled": False,
+        "combine_enabled": False,
+    }
+    if family_selection != expected_selection or dcp.get("sessions") != {}:
+        raise QualificationError(
+            f"rank {rank} DCP must remain stock with no custom sessions"
+        )
+    indexer = after.get("indexer")
+    if not isinstance(indexer, dict) or indexer.get("sessions") != {}:
+        raise QualificationError(
+            f"rank {rank} indexer must remain stock with no custom sessions"
+        )
+
+    before_stock = before.get("stock_collectives")
+    after_stock = after.get("stock_collectives")
+    if not isinstance(before_stock, dict) or not isinstance(after_stock, dict):
+        raise QualificationError(f"rank {rank} omitted stock-collective counters")
+    after_capture = after_stock.get("capture")
+    before_eager = before_stock.get("eager")
+    after_eager = after_stock.get("eager")
+    if not all(isinstance(value, dict) for value in (after_capture, before_eager, after_eager)):
+        raise QualificationError(
+            f"rank {rank} stock DCP/indexer phase counters are malformed"
+        )
+
+    capture_counts = {
+        name: _positive_stock_count(after_capture, name, rank=rank, phase="capture")
+        for name in _REQUIRED_STOCK_CAPTURE_COUNTS
+    }
+    eager_deltas: dict[str, int] = {}
+    for name in _REQUIRED_STOCK_EAGER_COUNTS:
+        before_value = before_eager.get(name, 0)
+        after_value = after_eager.get(name)
+        if (
+            not isinstance(before_value, int)
+            or isinstance(before_value, bool)
+            or before_value < 0
+            or not isinstance(after_value, int)
+            or isinstance(after_value, bool)
+            or after_value <= before_value
+        ):
+            raise QualificationError(
+                f"rank {rank} stock eager audit did not advance {name}"
+            )
+        eager_deltas[name] = after_value - before_value
+    return {
+        "mode": "stock",
+        "custom_dcp_sessions": 0,
+        "custom_indexer_sessions": 0,
+        "capture_counts": capture_counts,
+        "eager_deltas": eager_deltas,
+    }
+
+
+def run_transport(args: argparse.Namespace) -> dict[str, Any]:
+    """Audit all-rank TP all-reduce/vocabulary native replay through Q40."""
+
+    if len(args.before_status) != 4 or len(args.after_status) != 4:
+        raise QualificationError(
+            "transport audit requires four before and four after files"
+        )
+    ranks: list[dict[str, Any]] = []
+    for rank, (before_path, after_path) in enumerate(
+        zip(args.before_status, args.after_status, strict=True)
+    ):
+        before_payload = _load_status(before_path, rank)
+        after_payload = _load_status(after_path, rank)
+        if before_payload.get("pid") != after_payload.get("pid"):
+            raise QualificationError(
+                f"rank {rank} worker PID changed during transport audit"
+            )
+        before_end = before_payload.get("snapshot_end_unix_ns")
+        after_start = after_payload.get("snapshot_start_unix_ns")
+        if not isinstance(before_end, int) or not isinstance(after_start, int):
+            raise QualificationError(f"rank {rank} status omitted collection intervals")
+        if after_start <= before_end:
+            raise QualificationError(
+                f"rank {rank} after-status does not follow before-status"
+            )
+        before_snapshot = before_payload["snapshot"]
+        after_snapshot = after_payload["snapshot"]
+        all_reduce = _validate_transport_session(
+            _rank_session(before_snapshot, "all_reduce", rank),
+            _rank_session(after_snapshot, "all_reduce", rank),
+            family="all_reduce",
+            rank=rank,
+            minimum_captured_nodes=MAX_QUERY_ROWS,
+        )
+        vocabulary = _validate_transport_session(
+            _rank_session(before_snapshot, "vocabulary", rank),
+            _rank_session(after_snapshot, "vocabulary", rank),
+            family="vocabulary",
+            rank=rank,
+            minimum_captured_nodes=MIN_VOCABULARY_CAPTURED_NODES,
+        )
+        forbidden = _forbidden_stock_signatures(after_snapshot)
+        if forbidden:
+            raise QualificationError(
+                f"rank {rank} used stock collectives for required "
+                f"Q1-Q{MAX_QUERY_ROWS} signatures: {forbidden[:3]}"
+            )
+        dcp_indexer = _validate_stock_dcp_indexer(
+            before_snapshot, after_snapshot, rank=rank
+        )
+        ranks.append(
+            {
+                "rank": rank,
+                "all_reduce": all_reduce,
+                "vocabulary": vocabulary,
+                "dcp_indexer": dcp_indexer,
+                "required_query_rows": list(range(1, MAX_QUERY_ROWS + 1)),
+                "audited_stock_phases": ["capture", "eager"],
+                "required_stock_capture_signatures": 0,
+                "required_stock_eager_signatures": 0,
+            }
+        )
+    return {
+        "schema": TRANSPORT_SCHEMA,
+        "created_at": datetime.now(timezone.utc).isoformat(),
+        "status": "pass",
+        "fixed_mtp_depth": FIXED_MTP_DEPTH,
+        "maximum_sequences": MAX_CONCURRENT_SEQUENCES,
+        "maximum_query_rows": MAX_QUERY_ROWS,
+        "ranks": ranks,
+    }
+
+
+def _write_report(path: str, report: dict[str, Any]) -> None:
+    target = Path(path)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(
+        json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="mode", required=True)
+    for mode in ("capture-mtp0", "qualify-mtp4"):
+        command = subparsers.add_parser(mode)
+        command.add_argument("--base-url", default="http://127.0.0.1:8000")
+        command.add_argument("--model")
+        command.add_argument("--timeout", type=float, default=1800.0)
+        command.add_argument("--output", required=True)
+        if mode == "qualify-mtp4":
+            command.add_argument("--baseline", required=True)
+    transport = subparsers.add_parser("audit-transport")
+    transport.add_argument("--before-status", action="append", required=True)
+    transport.add_argument("--after-status", action="append", required=True)
+    transport.add_argument("--output", required=True)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    try:
+        report = run_transport(args) if args.mode == "audit-transport" else run_http(args)
+    except Exception as exc:
+        report = {
+            "schema": TRANSPORT_SCHEMA if args.mode == "audit-transport" else SCHEMA,
+            "created_at": datetime.now(timezone.utc).isoformat(),
+            "status": "fail",
+            "mode": args.mode,
+            "failures": [f"{type(exc).__name__}: {exc}"],
+        }
+        _write_report(args.output, report)
+        print(json.dumps(report, indent=2, sort_keys=True))
+        return 1
+    _write_report(args.output, report)
+    print(json.dumps(report, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/runtime/exl3-r7/patch_sm121_cmake.py
+++ b/runtime/exl3-r7/patch_sm121_cmake.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+"""Make the composed r34 vLLM build preserve its requested SM121a target."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+
+OLD = (
+    'set(CUDA_SUPPORTED_ARCHS '
+    '"7.5;8.0;8.6;8.7;8.9;9.0;10.0;11.0;12.0")'
+)
+NEW = (
+    'set(CUDA_SUPPORTED_ARCHS '
+    '"7.5;8.0;8.6;8.7;8.9;9.0;10.0;11.0;12.0a;12.1a")'
+)
+
+
+def patch(path: Path) -> None:
+    source = path.read_text(encoding="utf-8")
+    if source.count(OLD) != 1:
+        raise RuntimeError(
+            "r34 CUDA_SUPPORTED_ARCHS preimage is absent or ambiguous; "
+            "refusing an unverified SM121 build patch"
+        )
+    updated = source.replace(OLD, NEW)
+    if updated.count(NEW) != 1 or OLD in updated:
+        raise RuntimeError("SM121 CUDA_SUPPORTED_ARCHS postimage verification failed")
+    path.write_text(updated, encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("cmake_lists", type=Path)
+    args = parser.parse_args()
+    patch(args.cmake_lists)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/runtime/exl3-r7/pins.json
+++ b/runtime/exl3-r7/pins.json
@@ -1,0 +1,31 @@
+{
+  "schema_version": 1,
+  "release": {
+    "repository": "https://github.com/local-inference-lab/blackwell-llm-docker.git",
+    "commit": "98224d1303c1497eec26c7d92f34a6fa9a58fa82",
+    "patch_root": "patches/releases/gilded-gnosis-v20-r34"
+  },
+  "components": {
+    "vllm": {
+      "repository": "https://github.com/local-inference-lab/vllm.git",
+      "base_commit": "e2666d9a65f41fc376607531453cbd57c4c71016",
+      "patch": "vllm/integration.patch",
+      "patch_sha256": "8a7269851ab5bfff8f730db9af6f19ac6c0fc26620ba32108ba17cfe4e51c903",
+      "result_tree": "4d006a43928cdee01306691a766542c1e9bebb59"
+    },
+    "b12x": {
+      "repository": "https://github.com/local-inference-lab/b12x.git",
+      "base_commit": "7cecbb2c4819636ae7f05f8b116f2c45ee2cff7b",
+      "patch": "b12x/integration.patch",
+      "patch_sha256": "406970efd643f5a7d1c989b7d988331b16ab7e84d868cf2d9cbabb7707633687",
+      "result_tree": "cd3ce190f0f1917402cdfd5773724267cc9a63f8"
+    }
+  },
+  "runtime_dependencies": {
+    "flashinfer": "1ac6942776b383c6b03c7a5805a22e72a3e3349f",
+    "instanttensor": "49b4010afc1cae0441e71fe0b0bffc24fa05e932",
+    "launcher": "7302862b8fcfdc7c06a411a61e1f0fb072258880",
+    "exllamav3": "704aefd743b390af4bd0fb429d1906f9b964c7d8",
+    "b12x_package_version": "1.2.1"
+  }
+}

--- a/runtime/exl3-r7/prepare_build_deps.py
+++ b/runtime/exl3-r7/prepare_build_deps.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""Prepare immutable local CUTLASS and Triton-kernel sources for R7 builds."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import shutil
+import stat
+import subprocess
+import tempfile
+from pathlib import Path
+
+
+SCHEMA = "sparkring-r7-build-deps/v1"
+BUNDLED_LICENSE_NAME = "UPSTREAM_LICENSE.txt"
+SOURCES = {
+    "cutlass": {
+        "repository": "https://github.com/NVIDIA/cutlass.git",
+        "commit": "da5e086dab31d63815acafdac9a9c5893b1c69e2",
+        "subdirectory": ".",
+        "license_path": "LICENSE.txt",
+    },
+    "triton_kernels": {
+        "repository": "https://github.com/triton-lang/triton.git",
+        "commit": "0add68262ab0a2e33b84524346cb27cbb2787356",
+        "subdirectory": "python/triton_kernels/triton_kernels",
+        "license_path": "LICENSE",
+    },
+}
+
+
+def sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for block in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def inventory(path: Path) -> list[dict]:
+    rows = []
+    for item in sorted(path.rglob("*")):
+        if item.is_file() and ".git" not in item.relative_to(path).parts:
+            rows.append(
+                {
+                    "path": item.relative_to(path).as_posix(),
+                    "size": item.stat().st_size,
+                    "sha256": sha256(item),
+                }
+            )
+    return rows
+
+
+def verify(output: Path) -> dict:
+    receipt_path = output / "receipt.json"
+    receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
+    if receipt.get("schema") != SCHEMA:
+        raise RuntimeError("wrong R7 build-dependency receipt schema")
+    if receipt.get("sources") != SOURCES:
+        raise RuntimeError("R7 build-dependency source pins do not match")
+    for name in SOURCES:
+        if not (output / name / BUNDLED_LICENSE_NAME).is_file():
+            raise RuntimeError(f"R7 build-dependency license is missing: {name}")
+        observed = inventory(output / name)
+        if observed != receipt.get("inventories", {}).get(name):
+            raise RuntimeError(f"R7 build-dependency inventory mismatch: {name}")
+    return receipt
+
+
+def run(*args: str, cwd: Path | None = None) -> str:
+    result = subprocess.run(args, cwd=cwd, check=True, text=True, capture_output=True)
+    return result.stdout.strip()
+
+
+def remove_tree(path: Path) -> None:
+    """Remove a private staging tree, including read-only Git pack files."""
+
+    def make_writable(function, target, _error):
+        os.chmod(target, stat.S_IWRITE)
+        function(target)
+
+    shutil.rmtree(path, onexc=make_writable)
+
+
+def checkout(source: dict, destination: Path) -> None:
+    run("git", "clone", "--filter=blob:none", "--no-checkout", source["repository"], str(destination))
+    run("git", "-C", str(destination), "config", "core.autocrlf", "false")
+    run("git", "-C", str(destination), "fetch", "--depth", "1", "origin", source["commit"])
+    run("git", "-C", str(destination), "checkout", "--detach", source["commit"])
+    if run("git", "-C", str(destination), "rev-parse", "HEAD") != source["commit"]:
+        raise RuntimeError(f"checkout did not resolve exact commit {source['commit']}")
+
+
+def prepare(output: Path) -> dict:
+    try:
+        return verify(output)
+    except (OSError, ValueError, RuntimeError, json.JSONDecodeError):
+        pass
+    output.parent.mkdir(parents=True, exist_ok=True)
+    staging = Path(tempfile.mkdtemp(prefix=f".{output.name}-", dir=output.parent))
+    try:
+        inventories = {}
+        for name, source in SOURCES.items():
+            clone = staging / f".{name}-checkout"
+            checkout(source, clone)
+            selected = clone / source["subdirectory"]
+            if not selected.is_dir():
+                raise RuntimeError(f"missing expected source directory for {name}: {source['subdirectory']}")
+            shutil.copytree(selected, staging / name, ignore=shutil.ignore_patterns(".git"))
+            license_path = clone / source["license_path"]
+            if not license_path.is_file():
+                raise RuntimeError(
+                    f"missing expected upstream license for {name}: "
+                    f"{source['license_path']}"
+                )
+            shutil.copy2(license_path, staging / name / BUNDLED_LICENSE_NAME)
+            inventories[name] = inventory(staging / name)
+            remove_tree(clone)
+        receipt = {"schema": SCHEMA, "sources": SOURCES, "inventories": inventories}
+        (staging / "receipt.json").write_text(
+            json.dumps(receipt, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+        )
+        verify(staging)
+        if output.exists():
+            replaced = output.with_name(f".{output.name}.replaced-{os.getpid()}")
+            os.replace(output, replaced)
+            os.replace(staging, output)
+            remove_tree(replaced)
+        else:
+            os.replace(staging, output)
+        return verify(output)
+    finally:
+        if staging.exists():
+            remove_tree(staging)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("output", type=Path)
+    parser.add_argument("--verify", action="store_true")
+    args = parser.parse_args()
+    receipt = verify(args.output.resolve()) if args.verify else prepare(args.output.resolve())
+    print(json.dumps({"status": "pass", "schema": receipt["schema"]}, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/runtime/exl3-r7/prepare_context.py
+++ b/runtime/exl3-r7/prepare_context.py
@@ -1,0 +1,225 @@
+#!/usr/bin/env python3
+"""Materialize and verify the immutable EXL3 R7 runtime source trees."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import subprocess
+from pathlib import Path
+
+
+HERE = Path(__file__).resolve().parent
+
+
+class PreparationError(RuntimeError):
+    """Raised when a pinned source context cannot be reproduced exactly."""
+
+
+def run(*args: str, cwd: Path | None = None) -> str:
+    result = subprocess.run(
+        args,
+        cwd=cwd,
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        encoding="utf-8",
+    )
+    if result.returncode:
+        detail = result.stderr.strip() or result.stdout.strip()
+        raise PreparationError(f"{' '.join(args)} failed: {detail}")
+    return result.stdout.strip()
+
+
+def sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def checkout(repository: str, commit: str, destination: Path) -> None:
+    if destination.exists():
+        raise PreparationError(f"destination already exists: {destination}")
+    run("git", "clone", "--filter=blob:none", "--no-checkout", repository, str(destination))
+    # The archived patches can contain binary payloads. Line-ending conversion
+    # would change their preimages and invalidate the recorded result tree.
+    run("git", "config", "core.autocrlf", "false", cwd=destination)
+    run("git", "config", "core.eol", "lf", cwd=destination)
+    run("git", "fetch", "--depth", "1", "origin", commit, cwd=destination)
+    run("git", "checkout", "--detach", commit, cwd=destination)
+
+
+def prepare_component(
+    name: str, spec: dict[str, str], patch_root: Path, output: Path
+) -> dict[str, str]:
+    destination = output / name
+    checkout(spec["repository"], spec["base_commit"], destination)
+    patch = patch_root / spec["patch"]
+    if not patch.is_file():
+        raise PreparationError(f"archived patch is missing: {patch}")
+    actual_patch_hash = sha256(patch)
+    if actual_patch_hash != spec["patch_sha256"]:
+        raise PreparationError(
+            f"{name} patch SHA-256 mismatch: expected {spec['patch_sha256']}, "
+            f"got {actual_patch_hash}"
+        )
+    run("git", "apply", "--binary", "--index", str(patch), cwd=destination)
+    actual_tree = run("git", "write-tree", cwd=destination)
+    if actual_tree != spec["result_tree"]:
+        raise PreparationError(
+            f"{name} tree mismatch: expected {spec['result_tree']}, got {actual_tree}"
+        )
+    return {
+        "base_commit": spec["base_commit"],
+        "patch_sha256": actual_patch_hash,
+        "result_tree": actual_tree,
+    }
+
+
+def verify_component(name: str, spec: dict[str, str], output: Path) -> None:
+    """Re-verify a prepared component against its pinned spec.
+
+    Unlike ``prepare_component``, this does not re-clone or re-apply patches.
+    It checks that the checked-out tree matches the recorded result_tree and
+    that the patch file hash is still correct.
+    """
+    destination = output / name
+    if not destination.is_dir():
+        raise PreparationError(f"verify: component directory missing: {destination}")
+    unstaged = subprocess.run(
+        ["git", "diff", "--quiet", "--no-ext-diff"],
+        cwd=destination,
+        check=False,
+    )
+    if unstaged.returncode == 1:
+        raise PreparationError(f"verify: {name} has unstaged source drift")
+    if unstaged.returncode != 0:
+        raise PreparationError(
+            f"verify: {name} could not check unstaged source drift"
+        )
+    untracked = run(
+        "git", "ls-files", "--others", "--exclude-standard", cwd=destination
+    )
+    if untracked:
+        raise PreparationError(
+            f"verify: {name} has untracked source content: {untracked.splitlines()[0]}"
+        )
+    actual_tree = run("git", "write-tree", cwd=destination)
+    if actual_tree != spec["result_tree"]:
+        raise PreparationError(
+            f"verify: {name} tree mismatch: expected {spec['result_tree']}, "
+            f"got {actual_tree}"
+        )
+    # Verify the checked-out commit matches the pinned base_commit.
+    actual_commit = run("git", "rev-parse", "HEAD", cwd=destination)
+    if actual_commit != spec["base_commit"]:
+        raise PreparationError(
+            f"verify: {name} commit mismatch: expected {spec['base_commit']}, "
+            f"got {actual_commit}"
+        )
+
+
+def verify(output: Path, pins_path: Path | None = None) -> dict:
+    """Verify a prepared source directory against its receipt and pins.
+
+    The receipt is checked for schema version, release commit, and every
+    component's base_commit, patch_sha256, and result_tree. Receipt existence
+    alone is insufficient: each field is compared against the pinned spec
+    in pins.json, and the actual Git tree of each checked-out component is
+    re-computed and compared.
+    """
+    pins_path = pins_path or HERE / "pins.json"
+    pins = json.loads(pins_path.read_text(encoding="utf-8"))
+    receipt_path = output / "receipt.json"
+    if not receipt_path.is_file():
+        raise PreparationError(f"verify: receipt missing: {receipt_path}")
+    receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
+    if receipt.get("schema_version") != 1:
+        raise PreparationError(
+            f"verify: wrong schema_version: expected 1, "
+            f"got {receipt.get('schema_version')!r}"
+        )
+    if receipt.get("release_commit") != pins["release"]["commit"]:
+        raise PreparationError(
+            f"verify: release commit mismatch: expected "
+            f"{pins['release']['commit']}, got {receipt.get('release_commit')}"
+        )
+    receipt_components = receipt.get("components", {})
+    if set(receipt_components) != set(pins["components"]):
+        raise PreparationError(
+            f"verify: component set mismatch: receipt has "
+            f"{sorted(receipt_components)}, pins has "
+            f"{sorted(pins['components'])}"
+        )
+    for name, spec in pins["components"].items():
+        receipt_entry = receipt_components[name]
+        for field in ("base_commit", "patch_sha256", "result_tree"):
+            if receipt_entry.get(field) != spec[field]:
+                raise PreparationError(
+                    f"verify: {name} receipt {field} mismatch: "
+                    f"expected {spec[field]}, got {receipt_entry.get(field)}"
+                )
+        verify_component(name, spec, output)
+    return receipt
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "output",
+        type=Path,
+        nargs="?",
+        help="new directory for verified trees (or directory to verify with --verify)",
+    )
+    parser.add_argument("--pins", type=Path, default=HERE / "pins.json")
+    parser.add_argument(
+        "--verify",
+        action="store_true",
+        help="verify an existing prepared-source directory against its receipt and pins",
+    )
+    args = parser.parse_args()
+
+    if args.verify:
+        if args.output is None:
+            parser.error("--verify requires a directory argument")
+        receipt = verify(args.output.resolve(), args.pins)
+        print(json.dumps({"status": "pass", "schema_version": receipt["schema_version"]}, sort_keys=True))
+        return 0
+
+    if args.output is None:
+        parser.error("output directory is required for preparation")
+    pins = json.loads(args.pins.read_text(encoding="utf-8"))
+    output = args.output.resolve()
+    if output.exists():
+        raise PreparationError(f"output already exists: {output}")
+    output.mkdir(parents=True)
+
+    release = pins["release"]
+    release_checkout = output / "release"
+    checkout(release["repository"], release["commit"], release_checkout)
+    patch_root = release_checkout / release["patch_root"]
+
+    receipt = {
+        "schema_version": 1,
+        "release_commit": release["commit"],
+        "components": {},
+    }
+    for name, spec in pins["components"].items():
+        receipt["components"][name] = prepare_component(
+            name, spec, patch_root, output
+        )
+    # Write the receipt, then self-verify: the prepare path must verify its own
+    # output against the receipt and pins before returning.
+    (output / "receipt.json").write_text(
+        json.dumps(receipt, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    verify(output, args.pins)
+    print(json.dumps(receipt, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/runtime/exl3-r7/sm121_routed_expert_probe.py
+++ b/runtime/exl3-r7/sm121_routed_expert_probe.py
@@ -1,0 +1,295 @@
+#!/usr/bin/env python3
+"""Run a small SM121 differential test of the R7 mixed-Trellis MoE path.
+
+The probe uses deterministic representative K3, K4, and K5 EXL3 payloads. It
+compares the single-grid mixed-Trellis result with both the per-tier B12X path
+and an independently decoded FP16-weight/PyTorch reference. It also verifies
+repeat determinism and CUDA-graph replay without loading a model checkpoint.
+
+The composed B12X source tree is required because its GPU tests contain the
+independent scalar EXL3 decoder used as the reference oracle. The installed
+B12X package supplies the candidate kernels.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import torch
+
+
+def _install_pytest_import_stub() -> None:
+    """Let packaged test oracles import when the runtime omits pytest.
+
+    The probe calls plain helper functions from the composed B12X tests; it
+    does not execute pytest fixtures or assertions. The flattened serving
+    image intentionally omits pytest, so only decorator and import-or-skip
+    behavior is needed while those helper modules are defined.
+    """
+
+    try:
+        __import__("pytest")
+        return
+    except ModuleNotFoundError:
+        pass
+
+    class _Mark:
+        def __getattr__(self, _name: str):
+            def marker(*_args, **_kwargs):
+                return lambda function: function
+
+            return marker
+
+    stub = ModuleType("pytest")
+    stub.mark = _Mark()
+    stub.importorskip = __import__
+    sys.modules["pytest"] = stub
+
+
+def _load_module(name: str, path: Path) -> ModuleType:
+    spec = importlib.util.spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot import probe helper {path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--b12x-source",
+        type=Path,
+        required=True,
+        help="exact composed B12X source root containing tests/moe",
+    )
+    parser.add_argument("--device", type=int, default=0)
+    parser.add_argument("--relative-error-limit", type=float, default=2.0e-2)
+    parser.add_argument("--cosine-limit", type=float, default=0.999)
+    parser.add_argument("--mixed-serial-limit", type=float, default=4.0e-3)
+    return parser.parse_args()
+
+
+def _native_projection(tier, *, projection: str, helper: ModuleType) -> torch.Tensor:
+    experts = int(tier.num_experts)
+    hidden = int(tier.hidden_size)
+    intermediate = int(tier.intermediate_size)
+    bits = int(tier.trellis_bits)
+    if projection in ("gate", "up"):
+        raw = tier.w13.view(torch.int32).reshape(
+            2, experts, hidden // 16, intermediate // 16, 8 * bits
+        )
+        raw = raw.view(torch.int16).reshape(
+            2, experts, hidden // 16, intermediate // 16, 16 * bits
+        )
+        index = 0 if projection == "gate" else 1
+        payloads = raw[index]
+    elif projection == "down":
+        raw = tier.w2.view(torch.int32).reshape(
+            experts, intermediate // 16, hidden // 16, 8 * bits
+        )
+        payloads = raw.view(torch.int16).reshape(
+            experts, intermediate // 16, hidden // 16, 16 * bits
+        )
+    else:
+        raise ValueError(f"unknown projection {projection!r}")
+    return torch.stack(
+        [
+            helper._reconstruct_native(payloads[expert], codebook="mcg")
+            for expert in range(experts)
+        ]
+    )
+
+
+def main() -> int:
+    args = _parse_args()
+    mixed_test = args.b12x_source / "tests/moe/test_w4a16_mixed_trellis.py"
+    reference_test = args.b12x_source / "tests/moe/test_fused_moe_trellis.py"
+    for path in (mixed_test, reference_test):
+        if not path.is_file():
+            raise FileNotFoundError(path)
+
+    _install_pytest_import_stub()
+    mixed = _load_module("_sparkring_b12x_mixed_probe", mixed_test)
+    reference = _load_module("_sparkring_b12x_reference_probe", reference_test)
+
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is unavailable")
+    torch.cuda.set_device(args.device)
+    device = torch.device("cuda", args.device)
+    capability = torch.cuda.get_device_capability(device)
+    if capability != (12, 1):
+        raise RuntimeError(f"the Spark R7 probe requires SM121, found SM{capability[0]}{capability[1]}")
+
+    torch.manual_seed(20260810)
+    m, hidden, intermediate, topk = 2, 128, 128, 3
+    tiers = tuple(
+        mixed._prepared(
+            experts=2,
+            hidden=hidden,
+            intermediate=intermediate,
+            bits=bits,
+            seed=300 + bits,
+            device=device,
+            codebook="mcg",
+        )
+        for bits in (3, 4, 5)
+    )
+    x = (torch.randn((m, hidden), device=device) * 1.0e-3).to(torch.bfloat16)
+    topk_ids = torch.tensor(
+        [[0, 2, 4], [5, 3, 1]], dtype=torch.int32, device=device
+    )
+    topk_weights = torch.tensor(
+        [[0.5, 0.3, 0.2], [0.25, 0.25, 0.5]],
+        dtype=torch.float32,
+        device=device,
+    )
+    tier_maps = tuple(
+        torch.tensor(values, dtype=torch.int32, device=device)
+        for values in (
+            [0, 1, -1, -1, -1, -1],
+            [-1, -1, 0, 1, -1, -1],
+            [-1, -1, -1, -1, 0, 1],
+        )
+    )
+
+    serial = sum(
+        (
+            mixed._serial_tier(x, tier, topk_weights, topk_ids, expert_map)
+            for tier, expert_map in zip(tiers, tier_maps, strict=True)
+        ),
+        torch.zeros((m, hidden), dtype=torch.float32, device=device),
+    )
+
+    props = torch.cuda.get_device_properties(device)
+    launch = mixed.compile_mixed_trellis3(
+        size_m=m,
+        hidden_size=hidden,
+        intermediate_size=intermediate,
+        tier0_num_experts=2,
+        tier1_num_experts=2,
+        tier2_num_experts=2,
+        top_k=topk,
+        max_m_blocks=8,
+        sms=int(props.multi_processor_count),
+        max_shared_mem=int(props.shared_memory_per_block_optin),
+        force_tile_config=(128, 128, 128, 128),
+        trellis_codebook="mcg",
+    )
+    global_to_combined, descriptor = mixed.build_projection_tiered_maps(
+        [0, 0, 1, 1, 2, 2],
+        [0, 0, 1, 1, 2, 2],
+        [0, 0, 1, 1, 2, 2],
+        tier_slots=(2, 2, 2),
+        device=device,
+    )
+    rotations = mixed.combine_trellis_rotations(*tiers)
+    buffers = mixed.make_mixed_trellis3_buffers(
+        launch, device=device, sms=int(props.multi_processor_count)
+    )
+
+    def run() -> torch.Tensor:
+        return mixed.run_mixed_trellis3(
+            x,
+            *tiers,
+            topk_weights,
+            topk_ids,
+            global_to_combined,
+            descriptor,
+            rotations,
+            launch,
+            buffers,
+        )
+
+    actual = run().clone()
+    repeated = run().clone()
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        captured = run()
+    graph.replay()
+    torch.cuda.synchronize(device)
+    captured = captured.clone()
+
+    decoded = {
+        projection: torch.cat(
+            [
+                _native_projection(tier, projection=projection, helper=reference)
+                for tier in tiers
+            ]
+        ).to(device)
+        for projection in ("gate", "up", "down")
+    }
+    reference_output = reference._reference_full_rotation_decoded(
+        x,
+        topk_ids,
+        topk_weights,
+        decoded["gate"],
+        decoded["up"],
+        decoded["down"],
+        torch.cat([tier.gate_suh for tier in tiers]),
+        torch.cat([tier.up_suh for tier in tiers]),
+        torch.cat([tier.intermediate_rotations for tier in tiers]),
+        torch.cat([tier.down_svh for tier in tiers]),
+        activation="silu",
+    )
+    torch.cuda.synchronize(device)
+
+    denominator = reference_output.norm().clamp_min(1.0e-9)
+    relative_error = float((actual - reference_output).norm() / denominator)
+    cosine = float(
+        torch.nn.functional.cosine_similarity(
+            actual.flatten(), reference_output.flatten(), dim=0
+        )
+    )
+    mixed_serial_error = float(
+        (actual - serial).norm() / serial.norm().clamp_min(1.0e-9)
+    )
+    finite = bool(
+        torch.isfinite(actual).all()
+        and torch.isfinite(serial).all()
+        and torch.isfinite(reference_output).all()
+    )
+    repeat_equal = bool(torch.equal(repeated, actual))
+    graph_equal = bool(torch.equal(captured, actual))
+    passed = (
+        finite
+        and repeat_equal
+        and graph_equal
+        and relative_error <= args.relative_error_limit
+        and cosine >= args.cosine_limit
+        and mixed_serial_error <= args.mixed_serial_limit
+    )
+    print(
+        json.dumps(
+            {
+                "device": torch.cuda.get_device_name(device),
+                "capability": list(capability),
+                "payload": "representative EXL3 MCG K3/K4/K5, two experts per tier",
+                "finite": finite,
+                "relative_error_vs_decoded_fp16_reference": relative_error,
+                "cosine_vs_decoded_fp16_reference": cosine,
+                "relative_error_vs_serial_tiers": mixed_serial_error,
+                "repeat_bitwise_equal": repeat_equal,
+                "cuda_graph_replay_bitwise_equal": graph_equal,
+                "limits": {
+                    "relative_error": args.relative_error_limit,
+                    "cosine": args.cosine_limit,
+                    "mixed_serial_error": args.mixed_serial_limit,
+                },
+                "passed": passed,
+            },
+            indent=2,
+            sort_keys=True,
+        )
+    )
+    return 0 if passed else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/runtime/exl3-r7/sm121_shared_dense_probe.py
+++ b/runtime/exl3-r7/sm121_shared_dense_probe.py
@@ -1,0 +1,196 @@
+"""Compare one GLM-5.2 TP-local shared-expert projection across BF16,
+cached online EXL3 K6, and the native B12X MXFP8 path.
+
+This is a diagnostic harness for GB10/SM121.  It loads only one 25 MiB BF16
+weight and one roughly 2.3 MiB K6 cache entry; it never constructs the model.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import torch
+import torch.nn.functional as F
+from safetensors import safe_open
+
+
+def cache_key(path: Path) -> dict[str, object]:
+    with safe_open(path, framework="pt", device="cpu") as handle:
+        return json.loads(handle.metadata()["cache_key"])
+
+
+def find_cache(root: Path, prefix: str, tp_rank: int) -> tuple[Path, dict[str, object]]:
+    matches: list[tuple[Path, dict[str, object]]] = []
+    for path in root.rglob("*.safetensors"):
+        key = cache_key(path)
+        if key.get("prefix") == prefix and int(key.get("tp_rank", -1)) == tp_rank:
+            matches.append((path, key))
+    if len(matches) != 1:
+        raise RuntimeError(
+            f"expected one cache for prefix={prefix!r}, tp_rank={tp_rank}; "
+            f"found {[str(path) for path, _ in matches]}"
+        )
+    return matches[0]
+
+
+def metrics(name: str, output: torch.Tensor, reference: torch.Tensor) -> dict[str, object]:
+    value = output.float()
+    ref = reference.float()
+    finite = torch.isfinite(value)
+    delta = value - ref
+    ref_norm = torch.linalg.vector_norm(ref)
+    rel_f = torch.linalg.vector_norm(delta) / ref_norm
+    return {
+        "name": name,
+        "shape": list(output.shape),
+        "dtype": str(output.dtype),
+        "finite": int(finite.sum().item()),
+        "elements": output.numel(),
+        "nan": int(torch.isnan(value).sum().item()),
+        "posinf": int(torch.isposinf(value).sum().item()),
+        "neginf": int(torch.isneginf(value).sum().item()),
+        "absmax": float(torch.where(finite, value.abs(), 0).max().item()),
+        "rel_f_vs_bf16": float(rel_f.item()),
+        "max_abs_vs_bf16": float(delta.abs().max().item()),
+    }
+
+
+def graph_replay(fn, source: torch.Tensor) -> torch.Tensor:
+    warm_stream = torch.cuda.Stream()
+    warm_stream.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(warm_stream):
+        for _ in range(3):
+            fn(source)
+    torch.cuda.current_stream().wait_stream(warm_stream)
+    torch.cuda.synchronize()
+
+    static_source = source.clone()
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        static_output = fn(static_source)
+    graph.replay()
+    torch.cuda.synchronize()
+    return static_output.clone()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--model-file",
+        type=Path,
+        default=Path("/models/glm52-exl3-r7-3.5bpw/model-sharedbf16.safetensors"),
+    )
+    parser.add_argument(
+        "--cache-root", type=Path, default=Path("/cache/exl3-online")
+    )
+    parser.add_argument(
+        "--prefix", default="model.layers.3.mlp.shared_experts.down_proj"
+    )
+    parser.add_argument("--tp-rank", type=int, default=0)
+    parser.add_argument("--rows", type=int, nargs="+", default=[1, 8, 32])
+    args = parser.parse_args()
+
+    capability = torch.cuda.get_device_capability()
+    if capability != (12, 1):
+        raise RuntimeError(f"this probe targets GB10/SM121, got capability={capability}")
+
+    cache_path, key = find_cache(args.cache_root, args.prefix, args.tp_rank)
+    if int(key["bits"]) != 6 or int(key["tp_world_size"]) != 4:
+        raise RuntimeError(f"expected K6 TP4 cache, got {key}")
+
+    tensor_name = args.prefix + ".weight"
+    with safe_open(args.model_file, framework="pt", device="cpu") as handle:
+        full_weight = handle.get_tensor(tensor_name)
+
+    input_size = int(key["input_size"])
+    output_size = int(key["output_size"])
+    tp_world_size = int(key["tp_world_size"])
+    column_start = args.tp_rank * input_size
+    column_end = column_start + input_size
+    if tuple(full_weight.shape) != (output_size, input_size * tp_world_size):
+        raise RuntimeError(
+            f"probe expects a row-parallel down_proj weight; got "
+            f"{tuple(full_weight.shape)} for cache {key}"
+        )
+    weight = full_weight[:, column_start:column_end].contiguous().cuda()
+    del full_weight
+
+    with safe_open(cache_path, framework="pt", device="cpu") as handle:
+        trellis = handle.get_tensor("trellis").cuda()
+        suh = handle.get_tensor("suh").cuda()
+        svh = handle.get_tensor("svh").cuda()
+
+    from vllm.model_executor.kernels.linear import init_mxfp8_linear_kernel
+    from vllm.model_executor.layers.quantization.exl3 import _b12x_trellis_linear
+    from vllm.model_executor.layers.quantization.utils.mxfp8_utils import (
+        mxfp8_e4m3_quantize,
+    )
+
+    quant_weight, weight_scale = mxfp8_e4m3_quantize(weight.contiguous())
+    mx_layer = torch.nn.Module()
+    mx_layer.prefix = "probe.shared_experts.down_proj"
+    mx_layer.register_parameter(
+        "weight", torch.nn.Parameter(quant_weight, requires_grad=False)
+    )
+    mx_layer.register_parameter(
+        "weight_scale", torch.nn.Parameter(weight_scale, requires_grad=False)
+    )
+    mx_kernel = init_mxfp8_linear_kernel()
+    if type(mx_kernel).__name__ != "B12xMxfp8LinearKernel":
+        raise RuntimeError(f"expected B12X MXFP8 kernel, got {type(mx_kernel).__name__}")
+    mx_kernel.process_weights_after_loading(mx_layer)
+
+    def bf16(source: torch.Tensor) -> torch.Tensor:
+        return F.linear(source, weight)
+
+    def k6(source: torch.Tensor) -> torch.Tensor:
+        result = _b12x_trellis_linear(source.half(), trellis, suh, svh)
+        return result.to(source.dtype)
+
+    def mxfp8(source: torch.Tensor) -> torch.Tensor:
+        return mx_kernel.apply_weights(mx_layer, source)
+
+    print(
+        json.dumps(
+            {
+                "device": torch.cuda.get_device_name(),
+                "capability": capability,
+                "cache": str(cache_path),
+                "cache_key": key,
+                "bf16_weight_shape": list(weight.shape),
+                "mxfp8_kernel": type(mx_kernel).__name__,
+            },
+            sort_keys=True,
+        )
+    )
+
+    torch.manual_seed(0)
+    bad = False
+    with torch.inference_mode():
+        for rows in args.rows:
+            source = torch.randn(
+                rows, input_size, dtype=torch.bfloat16, device="cuda"
+            )
+            reference = bf16(source)
+            eager_k6 = k6(source)
+            eager_mx = mxfp8(source)
+            torch.cuda.synchronize()
+            print(json.dumps(metrics(f"bf16-eager-m{rows}", reference, reference)))
+            print(json.dumps(metrics(f"k6-eager-m{rows}", eager_k6, reference)))
+            print(json.dumps(metrics(f"mxfp8-eager-m{rows}", eager_mx, reference)))
+
+            graph_k6 = graph_replay(k6, source)
+            graph_mx = graph_replay(mxfp8, source)
+            print(json.dumps(metrics(f"k6-graph-m{rows}", graph_k6, reference)))
+            print(json.dumps(metrics(f"mxfp8-graph-m{rows}", graph_mx, reference)))
+            bad |= not bool(torch.isfinite(eager_k6).all().item())
+            bad |= not bool(torch.isfinite(eager_mx).all().item())
+            bad |= not bool(torch.isfinite(graph_k6).all().item())
+            bad |= not bool(torch.isfinite(graph_mx).all().item())
+    raise SystemExit(2 if bad else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/runtime/exl3-r7/test_arm64_dependency_contract.py
+++ b/runtime/exl3-r7/test_arm64_dependency_contract.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+HERE = Path(__file__).resolve().parent
+
+
+def test_build_verifier_can_resolve_inherited_sircl_hooks() -> None:
+    containerfile = (HERE / "Containerfile").read_text(encoding="utf-8")
+
+    assert "rm -f /opt/venv/lib/python3.12/site-packages/sparkring_nf3_hybrid.pth" in containerfile
+    assert (
+        "PYTHONPATH=/opt/spark-vllm \\\n"
+        "      /opt/venv/bin/python /opt/sparkring-r7/verify_runtime.py --installed-only"
+        in containerfile
+    )
+
+
+def test_arm64_native_dependencies_are_receipt_gated() -> None:
+    containerfile = (HERE / "Containerfile").read_text(encoding="utf-8")
+
+    assert 'test "$(git -C /opt/exllamav3-python write-tree)" = "${EXLLAMAV3_ARM64_TREE}"' in containerfile
+    assert "git -C /opt/instanttensor-src submodule update --init --recursive" in containerfile
+    assert 'test "${TARGETARCH}" = arm64' in containerfile

--- a/runtime/exl3-r7/test_audit_private_material.py
+++ b/runtime/exl3-r7/test_audit_private_material.py
@@ -1,0 +1,92 @@
+"""Audit tests: no private paths, site identities, credentials, or model weights
+in the seeded exl3-r7 runtime files."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+HERE = Path(__file__).resolve().parent
+
+# Patterns that indicate private site material, not container-internal conventions.
+# Container-internal paths like /opt/, /cache/, /models/ are expected in a
+# Containerfile and are NOT private site identities.
+PRIVATE_PATTERNS = [
+    # RFC1918 private site addressing (not 10.x which is used as examples)
+    re.compile(r"192\.168\.\d{1,3}\.\d{1,3}"),
+    re.compile(r"(?<![0-9.])172\.(1[6-9]|2[0-9]|3[01])\.\d{1,3}\.\d{1,3}"),
+    # SSH account forms with private IPs
+    re.compile(r"[A-Za-z0-9_.-]+@(192\.168\.|10\.\d|172\.(1[6-9]|2[0-9]|3[01])\.)"),
+    # Private key material
+    re.compile(r"-----BEGIN [A-Z ]*PRIVATE KEY-----"),
+    re.compile(r"ssh-(rsa|ed25519|dss) AAAA"),
+    # Credential assignment shapes
+    re.compile(
+        r"(?i)(password|passwd|secret|api[_-]?key|access[_-]?token|auth[_-]?token"
+        r"|client[_-]?secret|bearer)"
+        r"['\"]?\s*[:=]\s*['\"]?[A-Za-z0-9/+_.-]{12,}"
+    ),
+    # Private host paths (Windows)
+    re.compile(r"Documents[\\/]sparkring"),
+    # Site config file references
+    re.compile(r"site\.yaml|launch\.json|gate\.json"),
+]
+
+
+def _python_files() -> list[Path]:
+    return sorted(HERE.glob("*.py"))
+
+
+def _all_text_files() -> list[Path]:
+    files = list(HERE.glob("*.py"))
+    files.extend(HERE.glob("*.sh"))
+    files.extend(HERE.glob("*.json"))
+    return sorted(files)
+
+
+@pytest.mark.parametrize("filepath", _all_text_files(), ids=lambda p: p.name)
+def test_no_private_site_identifiers(filepath: Path) -> None:
+    """No tracked exl3-r7 file may contain private site addresses, credentials,
+    or private host paths."""
+    text = filepath.read_text(encoding="utf-8", errors="replace")
+    for pattern in PRIVATE_PATTERNS:
+        matches = pattern.findall(text)
+        assert not matches, (
+            f"{filepath.name}: private identifier pattern {pattern.pattern!r} "
+            f"matched {len(matches)} time(s)"
+        )
+
+
+@pytest.mark.parametrize("filepath", _python_files(), ids=lambda p: p.name)
+def test_no_model_weight_references(filepath: Path) -> None:
+    """Python files should not contain hardcoded model weight file paths as
+    defaults. Container-internal /models/ paths in probe scripts are allowed
+    only when they are argparse defaults for diagnostic tools, not build inputs."""
+    text = filepath.read_text(encoding="utf-8", errors="replace")
+    # Model weight files as hardcoded build inputs (not argparse defaults) would
+    # be a leak. The sm121 probes use them as diagnostic argparse defaults,
+    # which is acceptable for offline diagnostic tools.
+    # This test guards against weight references in build/prepare scripts.
+    if filepath.name in ("prepare_context.py", "prepare_build_deps.py", "build-image.sh"):
+        assert ".safetensors" not in text
+        assert ".gguf" not in text
+        assert ".bin" not in text or "binary" in text.lower()
+
+
+def test_pins_json_contains_only_public_repositories() -> None:
+    """pins.json must reference only public GitHub repositories, not private
+    hosts or file:// URLs."""
+    import json
+
+    pins = json.loads((HERE / "pins.json").read_text(encoding="utf-8"))
+    all_text = json.dumps(pins)
+    assert "file://" not in all_text
+    assert "192.168" not in all_text
+    assert "10.0.0" not in all_text
+    # All repositories must be HTTPS GitHub URLs
+    for key in ("release",):
+        assert pins[key]["repository"].startswith("https://github.com/")
+    for name, spec in pins["components"].items():
+        assert spec["repository"].startswith("https://github.com/")

--- a/runtime/exl3-r7/test_build_image_hardening.py
+++ b/runtime/exl3-r7/test_build_image_hardening.py
@@ -1,0 +1,307 @@
+"""Test-first hardening of build-image.sh and prepare_context.py.
+
+These tests assert the immutable identity contract before the implementation
+lands: the parent image must be identified by digest or image ID (never a
+mutable tag alone), PREPARED_SOURCES must be verified against its receipt
+(not just existence), and prepare_context.py must verify its own output.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+HERE = Path(__file__).resolve().parent
+BUILD_SCRIPT = (HERE / "build-image.sh").read_text(encoding="utf-8")
+PINS = json.loads((HERE / "pins.json").read_text(encoding="utf-8"))
+PREPARE_CONTEXT = (HERE / "prepare_context.py").read_text(encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# 1. Parent image identified by immutable digest/image ID, fail closed on drift
+# ---------------------------------------------------------------------------
+
+def test_build_script_requires_base_image_id_env() -> None:
+    """build-image.sh must require an immutable base-image ID, not just a tag."""
+    assert "BASE_IMAGE_ID" in BUILD_SCRIPT
+    assert "BASE_IMAGE" in BUILD_SCRIPT
+
+
+def test_build_script_rejects_mutable_tag_only_identity() -> None:
+    """The default base_image must not be a bare mutable tag without a digest."""
+    # The script must inspect the image by digest/ID, not just trust the tag.
+    assert "image inspect" in BUILD_SCRIPT
+    assert "--format" in BUILD_SCRIPT
+
+
+def test_build_script_fails_closed_on_base_image_drift() -> None:
+    """The script must compare observed vs expected image ID and fail on mismatch."""
+    assert "fatal" in BUILD_SCRIPT.lower() or "exit" in BUILD_SCRIPT.lower()
+    # The comparison must be against an immutable identifier
+    assert ".Id" in BUILD_SCRIPT or "digest" in BUILD_SCRIPT.lower()
+
+
+def test_build_script_passes_base_image_id_as_build_arg() -> None:
+    """The immutable image ID must be forwarded to the Containerfile."""
+    assert '--build-arg "BASE_IMAGE=${observed_base}"' in BUILD_SCRIPT
+
+
+def test_containerfile_labels_parent_image_id() -> None:
+    """Containerfile must embed the parent image ID as an OCI label."""
+    containerfile = (HERE / "Containerfile").read_text(encoding="utf-8")
+    assert "org.sparkring.parent.image-id" in containerfile
+
+
+# ---------------------------------------------------------------------------
+# 2. PREPARED_SOURCES verified against receipt, not just existence
+# ---------------------------------------------------------------------------
+
+def test_build_script_verifies_receipt_content_not_just_existence() -> None:
+    """When PREPARED_SOURCES is set, the script must verify the receipt, not
+    just check that receipt.json exists."""
+    # The script must call a verifier on the prepared sources, not just test -f
+    assert "verify" in BUILD_SCRIPT.lower()
+    assert "receipt.json" in BUILD_SCRIPT
+
+
+def test_prepare_context_verifies_component_trees() -> None:
+    """prepare_context.py must verify patch_sha256 and result_tree, not just
+    write a receipt."""
+    assert "patch_sha256" in PREPARE_CONTEXT
+    assert "result_tree" in PREPARE_CONTEXT
+    assert "write-tree" in PREPARE_CONTEXT
+
+
+def test_prepare_context_verifies_release_commit() -> None:
+    """The release checkout commit must be verified, not just cloned."""
+    assert "release_commit" in PREPARE_CONTEXT
+
+
+def test_pins_json_has_all_required_component_fields() -> None:
+    """Each pinned component must have base_commit, patch, patch_sha256,
+    result_tree — not just a repository reference."""
+    for name, spec in PINS["components"].items():
+        assert "repository" in spec, f"{name} missing repository"
+        assert "base_commit" in spec, f"{name} missing base_commit"
+        assert "patch" in spec, f"{name} missing patch"
+        assert "patch_sha256" in spec, f"{name} missing patch_sha256"
+        assert "result_tree" in spec, f"{name} missing result_tree"
+
+
+def test_pins_json_release_has_required_fields() -> None:
+    """The release pin must have repository, commit, and patch_root."""
+    release = PINS["release"]
+    assert "repository" in release
+    assert "commit" in release
+    assert "patch_root" in release
+
+
+# ---------------------------------------------------------------------------
+# 3. prepare_context.py verifies its own output (self-verification)
+# ---------------------------------------------------------------------------
+
+def test_prepare_context_has_verify_function() -> None:
+    """prepare_context.py must have a verify function that checks a prepared
+    directory against its receipt."""
+    assert "def verify" in PREPARE_CONTEXT
+
+
+def test_prepare_context_verify_checks_schema() -> None:
+    """The verify function must check the schema version."""
+    assert "schema_version" in PREPARE_CONTEXT
+
+
+def test_prepare_context_verify_checks_component_receipts() -> None:
+    """The verify function must re-check patch_sha256 and result_tree from
+    the receipt, not just trust the receipt file."""
+    # The verify path must re-examine the actual checked-out trees
+    assert "verify_component" in PREPARE_CONTEXT or "def verify" in PREPARE_CONTEXT
+
+
+# ---------------------------------------------------------------------------
+# 4. OCI labels in Containerfile
+# ---------------------------------------------------------------------------
+
+def test_containerfile_has_oci_source_labels() -> None:
+    """Containerfile must have OCI source/revision/license labels for every
+    built-in component."""
+    containerfile = (HERE / "Containerfile").read_text(encoding="utf-8")
+    for label in (
+        "org.opencontainers.image.source",
+        "org.opencontainers.image.revision",
+        "org.opencontainers.image.licenses",
+    ):
+        assert label in containerfile, f"missing OCI label: {label}"
+
+
+def test_containerfile_labels_vllm_revision() -> None:
+    """The vLLM commit must be recorded as an OCI label."""
+    containerfile = (HERE / "Containerfile").read_text(encoding="utf-8")
+    vllm_commit = PINS["components"]["vllm"]["base_commit"]
+    assert vllm_commit in containerfile or "VLLM_COMMIT" in containerfile
+
+
+def test_containerfile_labels_b12x_revision() -> None:
+    """The B12X commit must be recorded as an OCI label."""
+    containerfile = (HERE / "Containerfile").read_text(encoding="utf-8")
+    b12x_commit = PINS["components"]["b12x"]["base_commit"]
+    assert b12x_commit in containerfile or "B12X_COMMIT" in containerfile
+
+
+def test_containerfile_labels_exllamav3_revision() -> None:
+    """ExLlamaV3 commit must be in the Containerfile."""
+    containerfile = (HERE / "Containerfile").read_text(encoding="utf-8")
+    exllamav3_commit = PINS["runtime_dependencies"]["exllamav3"]
+    assert exllamav3_commit in containerfile
+
+
+def test_containerfile_labels_instanttensor_revision() -> None:
+    """InstantTensor commit must be in the Containerfile."""
+    containerfile = (HERE / "Containerfile").read_text(encoding="utf-8")
+    instanttensor_commit = PINS["runtime_dependencies"]["instanttensor"]
+    assert instanttensor_commit in containerfile
+
+
+def test_containerfile_labels_cutlass_and_triton() -> None:
+    """CUTLASS and Triton kernel commits must be in the Containerfile or
+    referenced via build-args."""
+    containerfile = (HERE / "Containerfile").read_text(encoding="utf-8")
+    build_deps = (HERE / "prepare_build_deps.py").read_text(encoding="utf-8")
+    # CUTLASS and Triton are pinned in prepare_build_deps.py; the Containerfile
+    # must at least reference their source directories
+    assert "cutlass" in containerfile.lower()
+    assert "triton" in containerfile.lower()
+    # The commits must be pinned somewhere in the build chain
+    assert "da5e086dab31d63815acafdac9a9c5893b1c69e2" in build_deps  # CUTLASS
+    assert "0add68262ab0a2e33b84524346cb27cbb2787356" in build_deps  # Triton
+
+
+# ---------------------------------------------------------------------------
+# 5. Receipt verification with prepare_context verifier
+# ---------------------------------------------------------------------------
+
+def test_prepare_context_verify_rejects_missing_receipt(tmp_path: Path) -> None:
+    """verify() must fail when receipt.json is absent."""
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location(
+        "r7_prepare_context", HERE / "prepare_context.py"
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    with pytest.raises((RuntimeError, FileNotFoundError, KeyError, ValueError)):
+        module.verify(tmp_path)
+
+
+def test_prepare_context_verify_rejects_wrong_schema(tmp_path: Path) -> None:
+    """verify() must fail when the receipt schema_version is wrong."""
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location(
+        "r7_prepare_context", HERE / "prepare_context.py"
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    (tmp_path / "receipt.json").write_text(
+        json.dumps({"schema_version": 999, "release_commit": "x", "components": {}}),
+        encoding="utf-8",
+    )
+    with pytest.raises(RuntimeError, match="schema"):
+        module.verify(tmp_path)
+
+
+def test_prepare_context_verify_rejects_component_count_drift(tmp_path: Path) -> None:
+    """verify() must fail when the receipt has fewer components than pins."""
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location(
+        "r7_prepare_context", HERE / "prepare_context.py"
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    (tmp_path / "receipt.json").write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "release_commit": "x",
+                "components": {"vllm": {"base_commit": "x", "patch_sha256": "x", "result_tree": "x"}},
+            }
+        ),
+        encoding="utf-8",
+    )
+    with pytest.raises((RuntimeError, KeyError)):
+        module.verify(tmp_path)
+
+
+def _git(repo: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", *args], cwd=repo, check=True, capture_output=True, text=True
+    )
+    return result.stdout.strip()
+
+
+def test_verify_component_rejects_unstaged_and_untracked_content(
+    tmp_path: Path,
+) -> None:
+    """The verified index tree must also describe every copied source byte."""
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location(
+        "r7_prepare_context_cleanliness", HERE / "prepare_context.py"
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    repo = tmp_path / "component"
+    repo.mkdir()
+    _git(repo, "init")
+    _git(repo, "config", "user.email", "tests@example.invalid")
+    _git(repo, "config", "user.name", "SparkRing tests")
+    tracked = repo / "tracked.txt"
+    tracked.write_text("base\n", encoding="utf-8")
+    _git(repo, "add", "tracked.txt")
+    _git(repo, "commit", "-m", "base")
+    base_commit = _git(repo, "rev-parse", "HEAD")
+
+    tracked.write_text("patched\n", encoding="utf-8")
+    _git(repo, "add", "tracked.txt")
+    component_spec = {
+        "base_commit": base_commit,
+        "result_tree": _git(repo, "write-tree"),
+    }
+    module.verify_component("component", component_spec, tmp_path)
+
+    tracked.write_text("unstaged drift\n", encoding="utf-8")
+    with pytest.raises(module.PreparationError, match="unstaged"):
+        module.verify_component("component", component_spec, tmp_path)
+
+    tracked.write_text("patched\n", encoding="utf-8")
+    (repo / "untracked.txt").write_text("untracked drift\n", encoding="utf-8")
+    with pytest.raises(module.PreparationError, match="untracked"):
+        module.verify_component("component", component_spec, tmp_path)
+
+
+def test_oci_revision_identifies_sparkring_source_revision() -> None:
+    """The standard revision label must identify the repository in source."""
+    containerfile = (HERE / "Containerfile").read_text(encoding="utf-8")
+    assert "ARG SPARKRING_REVISION" in containerfile
+    assert 'org.opencontainers.image.revision="${SPARKRING_REVISION}"' in containerfile
+
+
+def test_oci_license_expression_covers_bundled_license_families() -> None:
+    """The image combines Apache, MIT, and BSD-licensed components."""
+    containerfile = (HERE / "Containerfile").read_text(encoding="utf-8")
+    assert "ARG IMAGE_LICENSES" in containerfile
+    assert 'org.opencontainers.image.licenses="${IMAGE_LICENSES}"' in containerfile
+    assert "BASE_IMAGE_LICENSES" in BUILD_SCRIPT
+    assert "Apache-2.0 AND MIT AND BSD-3-Clause" in BUILD_SCRIPT

--- a/runtime/exl3-r7/test_build_mla_nonfinite_trace_overlay.py
+++ b/runtime/exl3-r7/test_build_mla_nonfinite_trace_overlay.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+
+HERE = Path(__file__).resolve().parent
+SPEC = importlib.util.spec_from_file_location(
+    "build_mla_nonfinite_trace_overlay",
+    HERE / "build_mla_nonfinite_trace_overlay.py",
+)
+assert SPEC is not None and SPEC.loader is not None
+BUILDER = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(BUILDER)
+
+
+def test_exact_composed_source_generates_compilable_overlay() -> None:
+    source_path = (
+        HERE.parent.parent
+        / ".sparkring/r7-build-context/vllm/vllm/model_executor/layers/mla.py"
+    )
+    if not source_path.is_file():
+        pytest.skip("the optional composed R7 vLLM source tree is absent")
+
+    source_bytes = source_path.read_bytes()
+    assert hashlib.sha256(source_bytes).hexdigest() == BUILDER.EXPECTED_SOURCE_SHA256
+    patched = BUILDER.patch_source(source_bytes.decode("utf-8"))
+    compile(patched, str(source_path), "exec")
+
+    assert "tensor_model_parallel_all_reduce(output_parallel)" in patched
+    assert "self._r7_nonfinite_record(2, qkv_lora)" in patched
+    assert "self._r7_nonfinite_record(3, q)" in patched
+    assert "self._r7_nonfinite_record(4, kv_c_normed)" in patched
+    assert "self._r7_nonfinite_record(5, attn_out)" in patched
+    assert "self._r7_nonfinite_record(6, output_parallel)" in patched
+    assert "self._r7_nonfinite_record(7, output)" in patched
+
+
+def test_build_rejects_unpinned_source(tmp_path: Path) -> None:
+    source = tmp_path / "mla.py"
+    source.write_text("value = 1\n", encoding="utf-8")
+
+    with pytest.raises(RuntimeError, match="SHA-256 mismatch"):
+        BUILDER.build(source, tmp_path / "overlay.py", "0" * 64)
+
+
+def test_patch_rejects_source_drift() -> None:
+    with pytest.raises(RuntimeError, match="TP all-reduce import preimage"):
+        BUILDER.patch_source("from vllm.config import CacheConfig\n")

--- a/runtime/exl3-r7/test_build_nonfinite_trace_overlay.py
+++ b/runtime/exl3-r7/test_build_nonfinite_trace_overlay.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+
+HERE = Path(__file__).resolve().parent
+SPEC = importlib.util.spec_from_file_location(
+    "build_nonfinite_trace_overlay", HERE / "build_nonfinite_trace_overlay.py"
+)
+assert SPEC is not None and SPEC.loader is not None
+BUILDER = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(BUILDER)
+
+
+def test_exact_composed_source_generates_compilable_overlay() -> None:
+    source_path = (
+        HERE.parent.parent
+        / ".sparkring/r7-build-context/vllm/vllm/model_executor/models/deepseek_v2.py"
+    )
+    if not source_path.is_file():
+        pytest.skip("the optional composed R7 vLLM source tree is absent")
+
+    source_bytes = source_path.read_bytes()
+    assert hashlib.sha256(source_bytes).hexdigest() == BUILDER.EXPECTED_SOURCE_SHA256
+    patched = BUILDER.patch_source(source_bytes.decode("utf-8"))
+    compile(patched, str(source_path), "exec")
+
+    assert patched.count(BUILDER.DEBUG_TAG) == 3
+    assert "torch.count_nonzero(~torch.isfinite(value))" in patched
+    assert "_r7_nonfinite_trace_report(self.model, hidden_states, logits)" in patched
+    assert patched.count("_r7_nonfinite_trace_record(trace_counts, trace_base + 10") == 1
+    assert '"mla_attention_core_output"' in patched
+    assert '"mla_o_proj_local_output"' in patched
+    assert 'mla_wrapper = layer.self_attn.mla_attn' in patched
+
+    basic = BUILDER.patch_source(source_bytes.decode("utf-8"), detailed=False)
+    assert (
+        hashlib.sha256(basic.encode("utf-8")).hexdigest()
+        == "90f4591b71bd8da9e2e37c866bcac17c89583db5d70ae2c80b095a7c35eae01b"
+    )
+    assert '"mla_attention_core_output"' not in basic
+    assert "mla_wrapper = layer.self_attn.mla_attn" not in basic
+
+
+def test_build_rejects_unpinned_source(tmp_path: Path) -> None:
+    source = tmp_path / "deepseek_v2.py"
+    source.write_text("value = 1\n", encoding="utf-8")
+
+    with pytest.raises(RuntimeError, match="SHA-256 mismatch"):
+        BUILDER.build(source, tmp_path / "overlay.py", "0" * 64)
+
+
+def test_patch_rejects_source_drift() -> None:
+    with pytest.raises(RuntimeError, match="os import preimage"):
+        BUILDER.patch_source("import operator\n")

--- a/runtime/exl3-r7/test_build_parallel_state_shared_capture_overlay.py
+++ b/runtime/exl3-r7/test_build_parallel_state_shared_capture_overlay.py
@@ -1,0 +1,173 @@
+from __future__ import annotations
+
+import ast
+import hashlib
+import importlib.util
+import os
+import threading
+from contextlib import contextmanager, nullcontext
+from dataclasses import dataclass
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+
+HERE = Path(__file__).resolve().parent
+SPEC = importlib.util.spec_from_file_location(
+    "build_parallel_state_shared_capture_overlay",
+    HERE / "build_parallel_state_shared_capture_overlay.py",
+)
+assert SPEC is not None and SPEC.loader is not None
+BUILDER = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(BUILDER)
+
+
+class _FakeStream:
+    next_id = 1
+
+    def __init__(self, *, device: _FakeDevice) -> None:
+        self.device = device
+        self.stream_id = _FakeStream.next_id
+        _FakeStream.next_id += 1
+
+
+@dataclass(frozen=True)
+class _FakeDevice:
+    index: int | None
+
+
+@dataclass
+class _FakeContext:
+    stream: _FakeStream
+    channel_id: str | None = None
+
+
+class _FakeGroup:
+    def __init__(self) -> None:
+        self.contexts: list[_FakeContext] = []
+
+    @contextmanager
+    def graph_capture(self, context: _FakeContext):
+        self.contexts.append(context)
+        yield context
+
+
+def _load_graph_capture(patched: str) -> dict[str, Any]:
+    tree = ast.parse(patched)
+    selected = [
+        node
+        for node in tree.body
+        if (
+            isinstance(node, (ast.Assign, ast.AnnAssign))
+            and any(
+                name.startswith("_SPARK_")
+                for name in (
+                    [target.id for target in node.targets if isinstance(target, ast.Name)]
+                    if isinstance(node, ast.Assign)
+                    else [node.target.id]
+                    if isinstance(node.target, ast.Name)
+                    else []
+                )
+            )
+        )
+        or (
+            isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+            and node.name in {"_spark_graph_capture_context", "graph_capture"}
+        )
+    ]
+    module = ast.Module(
+        body=[
+            ast.ImportFrom(module="__future__", names=[ast.alias("annotations")], level=0),
+            *selected,
+        ],
+        type_ignores=[],
+    )
+    ast.fix_missing_locations(module)
+
+    group = _FakeGroup()
+    fake_cuda = SimpleNamespace(Stream=_FakeStream, current_device=lambda: 0)
+    namespace: dict[str, Any] = {
+        "Any": Any,
+        "GraphCaptureContext": _FakeContext,
+        "_DCP": None,
+        "contextlib": SimpleNamespace(AbstractContextManager=object),
+        "contextmanager": contextmanager,
+        "get_dcp_group": lambda: (_ for _ in ()).throw(AssertionError("DCP disabled")),
+        "get_pp_group": lambda: group,
+        "get_tp_group": lambda: group,
+        "nullcontext": nullcontext,
+        "os": os,
+        "threading": threading,
+        "torch": SimpleNamespace(
+            cuda=fake_cuda,
+            device=lambda device: device,
+        ),
+    }
+    exec(compile(module, "parallel_state_overlay.py", "exec"), namespace)
+    namespace["_fake_group"] = group
+    return namespace
+
+
+def test_exact_composed_source_generates_shared_stream_overlay(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source_path = (
+        HERE.parent.parent
+        / ".sparkring/r7-build-context/vllm/vllm/distributed/parallel_state.py"
+    )
+    if not source_path.is_file():
+        pytest.skip("the optional composed R7 vLLM source tree is absent")
+
+    source_bytes = source_path.read_bytes()
+    assert hashlib.sha256(source_bytes).hexdigest() == BUILDER.EXPECTED_SOURCE_SHA256
+    patched = BUILDER.patch_source(source_bytes.decode("utf-8"))
+    compile(patched, str(source_path), "exec")
+
+    namespace = _load_graph_capture(patched)
+    graph_capture = namespace["graph_capture"]
+    device = _FakeDevice(index=0)
+    monkeypatch.setenv("VLLM_SPARK_SHARED_CAPTURE_STREAM", "1")
+
+    # These sequential calls model target and speculative-draft graph managers.
+    with graph_capture(device, channel_id="vllm:target:production") as target:
+        with pytest.raises(RuntimeError, match="overlapping Spark shared"):
+            with graph_capture(device, channel_id="vllm:draft:prefill:production"):
+                pass
+    with graph_capture(device, channel_id="vllm:draft:prefill:production") as draft:
+        pass
+
+    assert target is not draft
+    assert target.stream is draft.stream
+    assert target.channel_id == "vllm:target:production"
+    assert draft.channel_id == "vllm:draft:prefill:production"
+    assert not namespace["_SPARK_ACTIVE_CAPTURE_STREAMS"]
+
+    explicit = _FakeContext(_FakeStream(device=device), "explicit")
+    with graph_capture(device, explicit) as observed:
+        assert observed is explicit
+
+    monkeypatch.setenv("VLLM_SPARK_SHARED_CAPTURE_STREAM", "0")
+    with graph_capture(device, channel_id="stock-a") as stock_a:
+        pass
+    with graph_capture(device, channel_id="stock-b") as stock_b:
+        pass
+    assert stock_a.stream is not stock_b.stream
+
+    assert "capture_b12x_dcp_a2a(" in patched
+    assert "maybe_dcp_capture" in patched
+    assert "graph capture context and argument specify different" in patched
+
+
+def test_build_rejects_unpinned_source(tmp_path: Path) -> None:
+    source = tmp_path / "parallel_state.py"
+    source.write_text("value = 1\n", encoding="utf-8")
+
+    with pytest.raises(RuntimeError, match="SHA-256 mismatch"):
+        BUILDER.build(source, tmp_path / "overlay.py")
+
+
+def test_patch_rejects_source_drift() -> None:
+    with pytest.raises(RuntimeError, match="import preimage"):
+        BUILDER.patch_source("import contextlib\n")

--- a/runtime/exl3-r7/test_endpoint_benchmark.py
+++ b/runtime/exl3-r7/test_endpoint_benchmark.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import importlib.util
+import math
+import sys
+from pathlib import Path
+
+import pytest
+
+
+HERE = Path(__file__).resolve().parent
+SPEC = importlib.util.spec_from_file_location(
+    "endpoint_benchmark", HERE / "endpoint_benchmark.py"
+)
+assert SPEC is not None and SPEC.loader is not None
+BENCHMARK = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = BENCHMARK
+SPEC.loader.exec_module(BENCHMARK)
+
+
+def completion_body(values: list[float]) -> dict:
+    return {
+        "choices": [
+            {
+                "logprobs": {
+                    "tokens": [f"t{index}" for index in range(len(values))],
+                    "token_logprobs": values,
+                    "top_logprobs": [
+                        {f"t{index}": value} for index, value in enumerate(values)
+                    ],
+                }
+            }
+        ]
+    }
+
+
+def test_logprob_validation_accepts_only_finite_complete_arrays() -> None:
+    result = BENCHMARK.validate_completion_logprobs(
+        completion_body([-0.25, -1.5]), 2
+    )
+    assert result["completion_tokens"] == 2
+    assert result["finite_logprob_values"] == 4
+    assert result["minimum_logprob"] == -1.5
+
+    with pytest.raises(BENCHMARK.BenchmarkError, match="nonfinite"):
+        BENCHMARK.validate_completion_logprobs(completion_body([-0.25, math.nan]), 2)
+    with pytest.raises(BENCHMARK.BenchmarkError, match="lengths disagree"):
+        BENCHMARK.validate_completion_logprobs(completion_body([-0.25]), 2)
+
+
+def test_chat_canary_requires_expected_answer() -> None:
+    result = BENCHMARK.validate_chat_answer(
+        {
+            "choices": [
+                {
+                    "message": {"reasoning_content": "17 + 25", "content": "42"},
+                    "finish_reason": "stop",
+                }
+            ],
+            "usage": {"prompt_tokens": 12, "completion_tokens": 3},
+        }
+    )
+    assert result["answer_present"] is True
+
+    with pytest.raises(BENCHMARK.BenchmarkError, match="expected integer"):
+        BENCHMARK.validate_chat_answer(
+            {
+                "choices": [{"message": {"content": "41"}}],
+                "usage": {"prompt_tokens": 12, "completion_tokens": 1},
+            }
+        )
+
+
+def test_stream_metrics_excludes_first_token_from_decode_rate() -> None:
+    result = BENCHMARK.StreamResult(
+        started=10.0,
+        first_token_at=12.0,
+        last_token_at=16.0,
+        finished=16.5,
+        usage={"prompt_tokens": 100, "completion_tokens": 9},
+        finish_reason="length",
+        text="answer",
+        content_events=9,
+    )
+    metrics = BENCHMARK.stream_metrics(result, requested_decode_tokens=9)
+    assert metrics["time_to_first_token_seconds"] == 2.0
+    assert metrics["client_prompt_tokens_per_ttft_second"] == 50.0
+    assert metrics["inter_token_decode_tokens_per_second"] == 2.0
+    assert metrics["end_to_end_completion_tokens_per_second"] == pytest.approx(9 / 6.5)

--- a/runtime/exl3-r7/test_exl3_r7_verify_runtime.py
+++ b/runtime/exl3-r7/test_exl3_r7_verify_runtime.py
@@ -1,0 +1,226 @@
+"""Tests for fail-closed EXL3 R7 runtime verification."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+
+_VERIFY_RUNTIME_PATH = Path(__file__).with_name("verify_runtime.py")
+_SPEC = importlib.util.spec_from_file_location(
+    "sparkring_r7_verify_runtime",
+    _VERIFY_RUNTIME_PATH,
+)
+assert _SPEC is not None and _SPEC.loader is not None
+verify_runtime = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(verify_runtime)
+
+
+def test_wrapper_chain_rejects_cycles() -> None:
+    def first(self: object, input_: object) -> None:
+        del self, input_
+
+    def second(self: object, input_: object) -> None:
+        del self, input_
+
+    first._spark_original = second  # type: ignore[attr-defined]
+    second._spark_original = first  # type: ignore[attr-defined]
+
+    with pytest.raises(RuntimeError, match="wrapper chain contains a cycle"):
+        verify_runtime.spark_original_chain(
+            "CudaCommunicator.all_reduce",
+            first,
+        )
+
+
+def test_stacked_wrapper_uses_terminal_signature_and_any_chain_marker() -> None:
+    def terminal(self: object, input_: object, dim: int) -> None:
+        del self, input_, dim
+
+    def vocabulary_wrapper(
+        self: object,
+        input_tensor: object,
+        dim: int,
+    ) -> None:
+        del self, input_tensor, dim
+
+    def dcp_wrapper(
+        self: object,
+        input_tensor: object,
+        dim: int,
+    ) -> None:
+        del self, input_tensor, dim
+
+    vocabulary_wrapper._spark_original = terminal  # type: ignore[attr-defined]
+    vocabulary_wrapper._spark_tp4_vocab_backend = True  # type: ignore[attr-defined]
+    dcp_wrapper._spark_original = vocabulary_wrapper  # type: ignore[attr-defined]
+
+    actual = verify_runtime.verify_hook_chain(
+        "GroupCoordinator._all_gather_out_place",
+        dcp_wrapper,
+        ("self", "input_", "dim"),
+        "_spark_tp4_vocab_backend",
+        True,
+    )
+
+    assert actual == ("self", "input_", "dim")
+
+
+def test_wrapper_chain_rejects_more_than_64_original_links() -> None:
+    def make_wrapper(index: int) -> object:
+        def wrapper(self: object, input_: object) -> None:
+            del self, input_
+
+        wrapper.__name__ = f"wrapper_{index}"
+        return wrapper
+
+    wrappers = [make_wrapper(index) for index in range(66)]
+    for wrapper, original in zip(
+        wrappers[:-1],
+        wrappers[1:],
+        strict=True,
+    ):
+        wrapper._spark_original = original  # type: ignore[attr-defined]
+
+    with pytest.raises(RuntimeError, match="exceeds 64 original links"):
+        verify_runtime.spark_original_chain(
+            "CudaCommunicator.all_reduce",
+            wrappers[0],
+        )
+
+
+def test_wrapper_chain_rejects_non_callable_target() -> None:
+    with pytest.raises(RuntimeError, match="contains a non-callable target"):
+        verify_runtime.spark_original_chain(
+            "CudaCommunicator.all_reduce",
+            object(),
+        )
+
+
+def test_wrapper_chain_rejects_non_callable_original_link() -> None:
+    def wrapper(self: object, input_: object) -> None:
+        del self, input_
+
+    wrapper._spark_original = object()  # type: ignore[attr-defined]
+    with pytest.raises(RuntimeError, match="contains a non-callable original"):
+        verify_runtime.spark_original_chain(
+            "CudaCommunicator.all_reduce",
+            wrapper,
+        )
+
+
+def test_dcp_mode_requires_dcp_marker_in_stacked_group_chain(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    def all_reduce_terminal(self: object, input_: object) -> None:
+        del self, input_
+
+    def all_reduce_wrapper(self: object, input_: object) -> None:
+        del self, input_
+
+    all_reduce_wrapper._spark_original = all_reduce_terminal  # type: ignore[attr-defined]
+    all_reduce_wrapper._spark_tp4_backend = True  # type: ignore[attr-defined]
+
+    def all_gather_terminal(
+        self: object,
+        output_tensor: object,
+        input_tensor: object,
+        stream: object,
+    ) -> None:
+        del self, output_tensor, input_tensor, stream
+
+    def all_gather_wrapper(
+        self: object,
+        output_tensor: object,
+        input_tensor: object,
+        stream: object,
+    ) -> None:
+        del self, output_tensor, input_tensor, stream
+
+    all_gather_wrapper._spark_original = all_gather_terminal  # type: ignore[attr-defined]
+    all_gather_wrapper._spark_tp4_allgather_backend = True  # type: ignore[attr-defined]
+
+    def group_terminal(
+        self: object,
+        input_: object,
+        dim: int,
+    ) -> None:
+        del self, input_, dim
+
+    def vocabulary_wrapper(
+        self: object,
+        input_tensor: object,
+        dim: int,
+    ) -> None:
+        del self, input_tensor, dim
+
+    def dcp_wrapper(
+        self: object,
+        input_tensor: object,
+        dim: int,
+    ) -> None:
+        del self, input_tensor, dim
+
+    vocabulary_wrapper._spark_original = group_terminal  # type: ignore[attr-defined]
+    vocabulary_wrapper._spark_tp4_vocab_backend = True  # type: ignore[attr-defined]
+    dcp_wrapper._spark_original = vocabulary_wrapper  # type: ignore[attr-defined]
+
+    cuda_module = types.ModuleType(
+        "vllm.distributed.device_communicators.cuda_communicator"
+    )
+    cuda_module.CudaCommunicator = types.SimpleNamespace(
+        all_reduce=all_reduce_wrapper
+    )
+    pynccl_module = types.ModuleType(
+        "vllm.distributed.device_communicators.pynccl"
+    )
+    pynccl_module.PyNcclCommunicator = types.SimpleNamespace(
+        all_gather=all_gather_wrapper
+    )
+    parallel_state = types.ModuleType("vllm.distributed.parallel_state")
+    parallel_state.GroupCoordinator = types.SimpleNamespace(
+        _all_gather_out_place=dcp_wrapper
+    )
+    for name, module in {
+        cuda_module.__name__: cuda_module,
+        pynccl_module.__name__: pynccl_module,
+        parallel_state.__name__: parallel_state,
+    }.items():
+        monkeypatch.setitem(sys.modules, name, module)
+
+    monkeypatch.setattr(
+        verify_runtime,
+        "module_source",
+        lambda name: (
+            tmp_path / f"{name}.py",
+            "\n".join(verify_runtime.SIRCL_HOOK_MARKERS[name]),
+        ),
+    )
+    library = tmp_path / "libspark_transport_capi.so"
+    library.write_bytes(b"test")
+    for name in (
+        "VLLM_SPARK_TP4_MODE",
+        "VLLM_SPARK_TP4_ALLGATHER_MODE",
+        "VLLM_SPARK_TP4_VOCAB_MODE",
+        "VLLM_SPARK_TP4_DCP_MODE",
+    ):
+        monkeypatch.setenv(name, "custom")
+    monkeypatch.setenv("SPARK_TP4_LIBRARY", str(library))
+
+    with pytest.raises(
+        RuntimeError,
+        match="_spark_tp4_dcp_backend is absent",
+    ):
+        verify_runtime.verify_sircl_hooks({})
+
+    dcp_wrapper._spark_tp4_dcp_backend = True  # type: ignore[attr-defined]
+    evidence: dict[str, object] = {}
+    verify_runtime.verify_sircl_hooks(evidence)
+    assert evidence["sircl"]["targets"][  # type: ignore[index]
+        "GroupCoordinator._all_gather_out_place[DCP]"
+    ] == ["self", "input_", "dim"]

--- a/runtime/exl3-r7/test_mtp2_qualification.py
+++ b/runtime/exl3-r7/test_mtp2_qualification.py
@@ -1,0 +1,241 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+
+MODULE_PATH = Path(__file__).with_name("mtp2_qualification.py")
+SPEC = importlib.util.spec_from_file_location("mtp2_qualification", MODULE_PATH)
+assert SPEC is not None and SPEC.loader is not None
+module = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(module)
+
+
+def metrics(drafts: int, drafted: int, accepted: int, pos0: int, pos1: int) -> str:
+    return "\n".join(
+        (
+            f'vllm:spec_decode_num_drafts_total{{model_name="m",engine="0"}} {drafts}',
+            f'vllm:spec_decode_num_draft_tokens_total{{model_name="m",engine="0"}} {drafted}',
+            f'vllm:spec_decode_num_accepted_tokens_total{{model_name="m",engine="0"}} {accepted}',
+            f'vllm:spec_decode_num_accepted_tokens_per_pos_total{{model_name="m",engine="0",position="0"}} {pos0}',
+            f'vllm:spec_decode_num_accepted_tokens_per_pos_total{{model_name="m",engine="0",position="1"}} {pos1}',
+        )
+    )
+
+
+def test_mtp2_metric_delta_passes() -> None:
+    before = module.parse_spec_metrics(metrics(10, 20, 15, 9, 6), "m")
+    after = module.parse_spec_metrics(metrics(30, 60, 47, 28, 19), "m")
+    result = module.validate_mtp2_metrics(module.metric_delta(before, after))
+    assert result["drafts"] == 20
+    assert result["draft_tokens"] == 40
+    assert result["accepted_tokens"] == 32
+    assert result["accepted_tokens_per_position"] == [19, 13]
+
+
+def test_mtp2_metric_delta_rejects_missing_second_position() -> None:
+    before = module.parse_spec_metrics(metrics(0, 0, 0, 0, 0), "m")
+    after = module.parse_spec_metrics(metrics(10, 20, 8, 8, 0), "m")
+    with pytest.raises(module.QualificationError, match="both draft positions"):
+        module.validate_mtp2_metrics(module.metric_delta(before, after))
+
+
+def test_metric_parser_filters_model_and_engine() -> None:
+    text = metrics(10, 20, 15, 9, 6) + "\n" + metrics(30, 60, 47, 28, 19).replace(
+        'model_name="m"', 'model_name="other"'
+    )
+    result = module.parse_spec_metrics(text, "m")
+    assert result["totals"][module.SPEC_COUNTERS[0]] == 10
+    assert result["positions"] == {0: 9, 1: 6}
+
+
+def status(
+    rank: int,
+    published: int,
+    *,
+    stock_q: int | None = None,
+    stock_phase: str = "capture",
+    stock_family: str = "all_reduce",
+    stock_width: int = 6144,
+    dropped_capture: int = 0,
+    dropped_eager: int = 0,
+    all_reduce_captured_nodes: int = 24,
+    vocabulary_captured_nodes: int = 16,
+) -> dict:
+    session = {
+        "capture_configured": True,
+        "captured_nodes": all_reduce_captured_nodes,
+        "published_sequence": published,
+        "consumed_sequence": published,
+        "completed_sequence": published,
+        "overflow_sequence": 0,
+        "polling_enabled": True,
+        "host_native_atomics": True,
+        "submit_affinity_verified": True,
+        "progress_affinity_verified": True,
+        "fatal": False,
+    }
+    signatures = {"capture": [], "eager": []}
+    if stock_q is not None:
+        signatures[stock_phase].append(
+            {
+                "family": stock_family,
+                "reason": "ineligible_signature",
+                "shape": [stock_q, stock_width],
+                "dtype": "torch.bfloat16",
+                "count": 1,
+            }
+        )
+    return {
+        "schema_version": 3,
+        "rank": rank,
+        "pid": 1000 + rank,
+        "snapshot_start_unix_ns": published * 10,
+        "snapshot_end_unix_ns": published * 10 + 1,
+        "snapshot": {
+            "all_reduce": {"sessions": {str(rank): session}},
+            "vocabulary": {
+                "sessions": {
+                    str(rank): {
+                        **session,
+                        "captured_nodes": vocabulary_captured_nodes,
+                    }
+                }
+            },
+            "stock_collectives": {
+                "signature_dropped_calls": {
+                    "capture": dropped_capture,
+                    "eager": dropped_eager,
+                },
+                "signatures": signatures,
+            },
+        },
+    }
+
+
+def write_status(path: Path, payload: dict) -> str:
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return str(path)
+
+
+def test_transport_audit_passes(tmp_path: Path) -> None:
+    before = [
+        write_status(tmp_path / f"before-{rank}.json", status(rank, 10))
+        for rank in range(4)
+    ]
+    after = [
+        write_status(tmp_path / f"after-{rank}.json", status(rank, 20))
+        for rank in range(4)
+    ]
+    args = type("Args", (), {"before_status": before, "after_status": after})()
+    report = module.run_transport(args)
+    assert report["status"] == "pass"
+    assert report["maximum_query_rows"] == 24
+    assert report["ranks"][0]["all_reduce"]["minimum_captured_nodes"] == 24
+    assert report["ranks"][0]["vocabulary"]["minimum_captured_nodes"] == 16
+
+
+@pytest.mark.parametrize(
+    ("status_kwargs", "family"),
+    (
+        ({"all_reduce_captured_nodes": 23}, "all_reduce"),
+        ({"vocabulary_captured_nodes": 15}, "vocabulary"),
+    ),
+)
+def test_transport_audit_rejects_incomplete_family_census(
+    tmp_path: Path,
+    status_kwargs: dict[str, int],
+    family: str,
+) -> None:
+    before = [
+        write_status(tmp_path / f"before-{rank}.json", status(rank, 10))
+        for rank in range(4)
+    ]
+    after = [
+        write_status(
+            tmp_path / f"after-{rank}.json",
+            status(rank, 20, **status_kwargs),
+        )
+        for rank in range(4)
+    ]
+    args = type("Args", (), {"before_status": before, "after_status": after})()
+    with pytest.raises(module.QualificationError, match=family):
+        module.run_transport(args)
+
+
+def test_transport_audit_rejects_required_stock_capture(tmp_path: Path) -> None:
+    before = [
+        write_status(tmp_path / f"before-{rank}.json", status(rank, 10))
+        for rank in range(4)
+    ]
+    after = [
+        write_status(
+            tmp_path / f"after-{rank}.json",
+            status(rank, 20, stock_q=24 if rank == 2 else None),
+        )
+        for rank in range(4)
+    ]
+    args = type("Args", (), {"before_status": before, "after_status": after})()
+    with pytest.raises(module.QualificationError, match="Q1-Q24"):
+        module.run_transport(args)
+
+
+@pytest.mark.parametrize(
+    "status_kwargs",
+    (
+        {
+            "stock_q": 24,
+            "stock_phase": "eager",
+            "stock_family": "misclassified",
+            "stock_width": 6144,
+        },
+        {
+            "stock_q": 24,
+            "stock_phase": "eager",
+            "stock_family": "misclassified",
+            "stock_width": 38720,
+        },
+    ),
+)
+def test_transport_audit_rejects_required_stock_shape_in_eager_phase(
+    tmp_path: Path,
+    status_kwargs: dict[str, object],
+) -> None:
+    before = [
+        write_status(tmp_path / f"before-{rank}.json", status(rank, 10))
+        for rank in range(4)
+    ]
+    after = [
+        write_status(
+            tmp_path / f"after-{rank}.json",
+            status(rank, 20, **status_kwargs),
+        )
+        for rank in range(4)
+    ]
+    args = type("Args", (), {"before_status": before, "after_status": after})()
+    with pytest.raises(module.QualificationError, match="Q1-Q24"):
+        module.run_transport(args)
+
+
+@pytest.mark.parametrize("dropped_phase", ("capture", "eager"))
+def test_transport_audit_rejects_dropped_signature_calls(
+    tmp_path: Path,
+    dropped_phase: str,
+) -> None:
+    before = [
+        write_status(tmp_path / f"before-{rank}.json", status(rank, 10))
+        for rank in range(4)
+    ]
+    after = [
+        write_status(
+            tmp_path / f"after-{rank}.json",
+            status(rank, 20, **{f"dropped_{dropped_phase}": 1}),
+        )
+        for rank in range(4)
+    ]
+    args = type("Args", (), {"before_status": before, "after_status": after})()
+    with pytest.raises(module.QualificationError, match="dropped calls"):
+        module.run_transport(args)

--- a/runtime/exl3-r7/test_mtp3_qualification.py
+++ b/runtime/exl3-r7/test_mtp3_qualification.py
@@ -1,0 +1,258 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+
+MODULE_PATH = Path(__file__).with_name("mtp3_qualification.py")
+SPEC = importlib.util.spec_from_file_location("mtp3_qualification", MODULE_PATH)
+assert SPEC is not None and SPEC.loader is not None
+module = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(module)
+
+
+def metrics(
+    drafts: int,
+    drafted: int,
+    accepted: int,
+    pos0: int,
+    pos1: int,
+    pos2: int,
+) -> str:
+    return "\n".join(
+        (
+            f'vllm:spec_decode_num_drafts_total{{model_name="m",engine="0"}} {drafts}',
+            f'vllm:spec_decode_num_draft_tokens_total{{model_name="m",engine="0"}} {drafted}',
+            f'vllm:spec_decode_num_accepted_tokens_total{{model_name="m",engine="0"}} {accepted}',
+            f'vllm:spec_decode_num_accepted_tokens_per_pos_total{{model_name="m",engine="0",position="0"}} {pos0}',
+            f'vllm:spec_decode_num_accepted_tokens_per_pos_total{{model_name="m",engine="0",position="1"}} {pos1}',
+            f'vllm:spec_decode_num_accepted_tokens_per_pos_total{{model_name="m",engine="0",position="2"}} {pos2}',
+        )
+    )
+
+
+def test_mtp3_metric_delta_passes() -> None:
+    before = module.parse_spec_metrics(metrics(10, 30, 24, 10, 8, 6), "m")
+    after = module.parse_spec_metrics(metrics(30, 90, 72, 30, 24, 18), "m")
+    result = module.validate_mtp3_metrics(module.metric_delta(before, after))
+    assert result["drafts"] == 20
+    assert result["draft_tokens"] == 60
+    assert result["accepted_tokens"] == 48
+    assert result["accepted_tokens_per_position"] == [20, 16, 12]
+
+
+def test_mtp3_metric_delta_rejects_missing_third_position() -> None:
+    before = module.parse_spec_metrics(metrics(0, 0, 0, 0, 0, 0), "m")
+    after = module.parse_spec_metrics(metrics(10, 30, 15, 8, 7, 0), "m")
+    with pytest.raises(module.QualificationError, match="all three draft positions"):
+        module.validate_mtp3_metrics(module.metric_delta(before, after))
+
+
+def test_mtp3_metric_delta_rejects_excess_draft_tokens() -> None:
+    before = module.parse_spec_metrics(metrics(0, 0, 0, 0, 0, 0), "m")
+    after = module.parse_spec_metrics(metrics(10, 31, 20, 10, 7, 3), "m")
+    with pytest.raises(module.QualificationError, match="invalid MTP3 totals"):
+        module.validate_mtp3_metrics(module.metric_delta(before, after))
+
+
+def test_metric_parser_filters_model_and_engine() -> None:
+    text = metrics(10, 30, 24, 10, 8, 6) + "\n" + metrics(
+        30, 90, 72, 30, 24, 18
+    ).replace(
+        'model_name="m"', 'model_name="other"'
+    )
+    result = module.parse_spec_metrics(text, "m")
+    assert result["totals"][module.SPEC_COUNTERS[0]] == 10
+    assert result["positions"] == {0: 10, 1: 8, 2: 6}
+
+
+def status(
+    rank: int,
+    published: int,
+    *,
+    stock_q: int | None = None,
+    stock_phase: str = "capture",
+    stock_family: str = "all_reduce",
+    stock_width: int = 6144,
+    dropped_capture: int = 0,
+    dropped_eager: int = 0,
+    all_reduce_captured_nodes: int = 32,
+    vocabulary_captured_nodes: int = 16,
+) -> dict:
+    session = {
+        "capture_configured": True,
+        "captured_nodes": all_reduce_captured_nodes,
+        "published_sequence": published,
+        "consumed_sequence": published,
+        "completed_sequence": published,
+        "overflow_sequence": 0,
+        "polling_enabled": True,
+        "host_native_atomics": True,
+        "submit_affinity_verified": True,
+        "progress_affinity_verified": True,
+        "fatal": False,
+    }
+    signatures = {"capture": [], "eager": []}
+    if stock_q is not None:
+        signatures[stock_phase].append(
+            {
+                "family": stock_family,
+                "reason": "ineligible_signature",
+                "shape": [stock_q, stock_width],
+                "dtype": "torch.bfloat16",
+                "count": 1,
+            }
+        )
+    return {
+        "schema_version": 3,
+        "rank": rank,
+        "pid": 1000 + rank,
+        "snapshot_start_unix_ns": published * 10,
+        "snapshot_end_unix_ns": published * 10 + 1,
+        "snapshot": {
+            "all_reduce": {"sessions": {str(rank): session}},
+            "vocabulary": {
+                "sessions": {
+                    str(rank): {
+                        **session,
+                        "captured_nodes": vocabulary_captured_nodes,
+                    }
+                }
+            },
+            "stock_collectives": {
+                "signature_dropped_calls": {
+                    "capture": dropped_capture,
+                    "eager": dropped_eager,
+                },
+                "signatures": signatures,
+            },
+        },
+    }
+
+
+def write_status(path: Path, payload: dict) -> str:
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return str(path)
+
+
+def test_transport_audit_passes(tmp_path: Path) -> None:
+    before = [
+        write_status(tmp_path / f"before-{rank}.json", status(rank, 10))
+        for rank in range(4)
+    ]
+    after = [
+        write_status(tmp_path / f"after-{rank}.json", status(rank, 20))
+        for rank in range(4)
+    ]
+    args = type("Args", (), {"before_status": before, "after_status": after})()
+    report = module.run_transport(args)
+    assert report["status"] == "pass"
+    assert report["maximum_query_rows"] == 32
+    assert report["ranks"][0]["all_reduce"]["minimum_captured_nodes"] == 32
+    assert report["ranks"][0]["vocabulary"]["minimum_captured_nodes"] == 16
+
+
+@pytest.mark.parametrize(
+    ("status_kwargs", "family"),
+    (
+        ({"all_reduce_captured_nodes": 31}, "all_reduce"),
+        ({"vocabulary_captured_nodes": 15}, "vocabulary"),
+    ),
+)
+def test_transport_audit_rejects_incomplete_family_census(
+    tmp_path: Path,
+    status_kwargs: dict[str, int],
+    family: str,
+) -> None:
+    before = [
+        write_status(tmp_path / f"before-{rank}.json", status(rank, 10))
+        for rank in range(4)
+    ]
+    after = [
+        write_status(
+            tmp_path / f"after-{rank}.json",
+            status(rank, 20, **status_kwargs),
+        )
+        for rank in range(4)
+    ]
+    args = type("Args", (), {"before_status": before, "after_status": after})()
+    with pytest.raises(module.QualificationError, match=family):
+        module.run_transport(args)
+
+
+def test_transport_audit_rejects_required_stock_capture(tmp_path: Path) -> None:
+    before = [
+        write_status(tmp_path / f"before-{rank}.json", status(rank, 10))
+        for rank in range(4)
+    ]
+    after = [
+        write_status(
+            tmp_path / f"after-{rank}.json",
+            status(rank, 20, stock_q=32 if rank == 2 else None),
+        )
+        for rank in range(4)
+    ]
+    args = type("Args", (), {"before_status": before, "after_status": after})()
+    with pytest.raises(module.QualificationError, match="Q1-Q32"):
+        module.run_transport(args)
+
+
+@pytest.mark.parametrize(
+    "status_kwargs",
+    (
+        {
+            "stock_q": 32,
+            "stock_phase": "eager",
+            "stock_family": "misclassified",
+            "stock_width": 6144,
+        },
+        {
+            "stock_q": 32,
+            "stock_phase": "eager",
+            "stock_family": "misclassified",
+            "stock_width": 38720,
+        },
+    ),
+)
+def test_transport_audit_rejects_required_stock_shape_in_eager_phase(
+    tmp_path: Path,
+    status_kwargs: dict[str, object],
+) -> None:
+    before = [
+        write_status(tmp_path / f"before-{rank}.json", status(rank, 10))
+        for rank in range(4)
+    ]
+    after = [
+        write_status(
+            tmp_path / f"after-{rank}.json",
+            status(rank, 20, **status_kwargs),
+        )
+        for rank in range(4)
+    ]
+    args = type("Args", (), {"before_status": before, "after_status": after})()
+    with pytest.raises(module.QualificationError, match="Q1-Q32"):
+        module.run_transport(args)
+
+
+@pytest.mark.parametrize("dropped_phase", ("capture", "eager"))
+def test_transport_audit_rejects_dropped_signature_calls(
+    tmp_path: Path,
+    dropped_phase: str,
+) -> None:
+    before = [
+        write_status(tmp_path / f"before-{rank}.json", status(rank, 10))
+        for rank in range(4)
+    ]
+    after = [
+        write_status(
+            tmp_path / f"after-{rank}.json",
+            status(rank, 20, **{f"dropped_{dropped_phase}": 1}),
+        )
+        for rank in range(4)
+    ]
+    args = type("Args", (), {"before_status": before, "after_status": after})()
+    with pytest.raises(module.QualificationError, match="dropped calls"):
+        module.run_transport(args)

--- a/runtime/exl3-r7/test_mtp4_qualification.py
+++ b/runtime/exl3-r7/test_mtp4_qualification.py
@@ -1,0 +1,287 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+
+MODULE_PATH = Path(__file__).with_name("mtp4_qualification.py")
+SPEC = importlib.util.spec_from_file_location("mtp4_qualification", MODULE_PATH)
+assert SPEC is not None and SPEC.loader is not None
+module = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(module)
+
+
+def metrics(
+    drafts: int,
+    drafted: int,
+    accepted: int,
+    positions: tuple[int, int, int, int],
+) -> str:
+    lines = [
+        f'vllm:spec_decode_num_drafts_total{{model_name="m",engine="0"}} {drafts}',
+        f'vllm:spec_decode_num_draft_tokens_total{{model_name="m",engine="0"}} {drafted}',
+        f'vllm:spec_decode_num_accepted_tokens_total{{model_name="m",engine="0"}} {accepted}',
+    ]
+    lines.extend(
+        f'vllm:spec_decode_num_accepted_tokens_per_pos_total{{model_name="m",engine="0",position="{position}"}} {value}'
+        for position, value in enumerate(positions)
+    )
+    return "\n".join(lines)
+
+
+def test_mtp4_metric_delta_passes_and_reports_all_positions() -> None:
+    before = module.parse_spec_metrics(metrics(10, 40, 28, (10, 8, 6, 4)), "m")
+    after = module.parse_spec_metrics(
+        metrics(30, 120, 84, (30, 24, 18, 12)), "m"
+    )
+    result = module.validate_mtp4_metrics(module.metric_delta(before, after))
+    assert result == {
+        "drafts": 20,
+        "draft_tokens": 80,
+        "accepted_tokens": 56,
+        "acceptance_rate": 0.7,
+        "accepted_tokens_per_position": [20, 16, 12, 8],
+    }
+
+
+def test_mtp4_metric_delta_rejects_missing_fourth_position() -> None:
+    before = module.parse_spec_metrics(metrics(0, 0, 0, (0, 0, 0, 0)), "m")
+    after = module.parse_spec_metrics(metrics(10, 40, 21, (8, 7, 6, 0)), "m")
+    with pytest.raises(module.QualificationError, match="all four draft positions"):
+        module.validate_mtp4_metrics(module.metric_delta(before, after))
+
+
+@pytest.mark.parametrize(
+    ("drafted", "accepted", "positions", "message"),
+    (
+        (41, 20, (10, 6, 3, 1), "invalid MTP4 totals"),
+        (40, 22, (10, 6, 3, 2), "invalid MTP4 position counters"),
+        (40, 20, (9, 10, 1, 0), "all four draft positions"),
+    ),
+)
+def test_mtp4_metric_delta_fails_closed(
+    drafted: int,
+    accepted: int,
+    positions: tuple[int, int, int, int],
+    message: str,
+) -> None:
+    before = module.parse_spec_metrics(metrics(0, 0, 0, (0, 0, 0, 0)), "m")
+    after = module.parse_spec_metrics(metrics(10, drafted, accepted, positions), "m")
+    with pytest.raises(module.QualificationError, match=message):
+        module.validate_mtp4_metrics(module.metric_delta(before, after))
+
+
+def status(
+    rank: int,
+    published: int,
+    *,
+    stock_q: int | None = None,
+    stock_phase: str = "capture",
+    stock_width: int = 6144,
+    dropped_capture: int = 0,
+    dropped_eager: int = 0,
+    all_reduce_captured_nodes: int = 40,
+    vocabulary_captured_nodes: int = 16,
+) -> dict:
+    session = {
+        "capture_configured": True,
+        "captured_nodes": all_reduce_captured_nodes,
+        "published_sequence": published,
+        "consumed_sequence": published,
+        "completed_sequence": published,
+        "overflow_sequence": 0,
+        "polling_enabled": True,
+        "host_native_atomics": True,
+        "submit_affinity_verified": True,
+        "progress_affinity_verified": True,
+        "fatal": False,
+    }
+    signatures = {"capture": [], "eager": []}
+    if stock_q is not None:
+        signatures[stock_phase].append(
+            {
+                "family": "test",
+                "reason": "ineligible_signature",
+                "shape": [stock_q, stock_width],
+                "dtype": "torch.bfloat16",
+                "count": 1,
+            }
+        )
+    capture_counts = {
+        "dcp_combine:original": 1,
+        "dcp_lse_all_gather:ineligible_signature": 1,
+        "dcp_query_all_gather:ineligible_signature": 1,
+        "dcp_owner_topk_all_gather:graph_capture_unsupported": 1,
+    }
+    eager_counts = {
+        "dcp_combine:original": published,
+        "dcp_lse_all_gather:ineligible_signature": published,
+        "dcp_query_all_gather:ineligible_signature": published,
+        "dcp_owner_topk_all_gather:ineligible_signature": published,
+    }
+    return {
+        "schema_version": 3,
+        "rank": rank,
+        "pid": 1000 + rank,
+        "snapshot_start_unix_ns": published * 10,
+        "snapshot_end_unix_ns": published * 10 + 1,
+        "snapshot": {
+            "all_reduce": {"sessions": {str(rank): session}},
+            "vocabulary": {
+                "sessions": {
+                    str(rank): {
+                        **session,
+                        "captured_nodes": vocabulary_captured_nodes,
+                    }
+                }
+            },
+            "dcp": {
+                "family_selection": {
+                    "mode": "stock",
+                    "query_enabled": False,
+                    "combine_enabled": False,
+                },
+                "sessions": {},
+            },
+            "indexer": {"sessions": {}},
+            "stock_collectives": {
+                "capture": capture_counts,
+                "eager": eager_counts,
+                "signature_dropped_calls": {
+                    "capture": dropped_capture,
+                    "eager": dropped_eager,
+                },
+                "signatures": signatures,
+            },
+        },
+    }
+
+
+def write_status(path: Path, payload: dict) -> str:
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return str(path)
+
+
+def transport_args(tmp_path: Path, **after_kwargs: object) -> object:
+    before = [
+        write_status(tmp_path / f"before-{rank}.json", status(rank, 10))
+        for rank in range(4)
+    ]
+    after = [
+        write_status(
+            tmp_path / f"after-{rank}.json",
+            status(rank, 20, **after_kwargs),
+        )
+        for rank in range(4)
+    ]
+    return type("Args", (), {"before_status": before, "after_status": after})()
+
+
+def test_transport_audit_requires_q1_q40_and_depth_independent_vocab_census(
+    tmp_path: Path,
+) -> None:
+    report = module.run_transport(transport_args(tmp_path))
+    assert report["schema"] == "sparkring-r7-mtp4-transport-audit/v1"
+    assert report["fixed_mtp_depth"] == 4
+    assert report["maximum_query_rows"] == 40
+    assert report["ranks"][0]["required_query_rows"] == list(range(1, 41))
+    assert report["ranks"][0]["all_reduce"]["minimum_captured_nodes"] == 40
+    assert report["ranks"][0]["vocabulary"]["minimum_captured_nodes"] == 16
+    assert report["ranks"][0]["dcp_indexer"]["mode"] == "stock"
+    assert report["ranks"][0]["dcp_indexer"]["eager_deltas"] == {
+        "dcp_combine:original": 10,
+        "dcp_lse_all_gather:ineligible_signature": 10,
+        "dcp_query_all_gather:ineligible_signature": 10,
+        "dcp_owner_topk_all_gather:ineligible_signature": 10,
+    }
+
+
+@pytest.mark.parametrize(
+    ("status_kwargs", "family"),
+    (
+        ({"all_reduce_captured_nodes": 39}, "all_reduce"),
+        ({"vocabulary_captured_nodes": 15}, "vocabulary"),
+    ),
+)
+def test_transport_audit_rejects_incomplete_native_census(
+    tmp_path: Path,
+    status_kwargs: dict[str, int],
+    family: str,
+) -> None:
+    with pytest.raises(module.QualificationError, match=family):
+        module.run_transport(transport_args(tmp_path, **status_kwargs))
+
+
+@pytest.mark.parametrize("stock_phase", ("capture", "eager"))
+@pytest.mark.parametrize("stock_width", (6144, 38720))
+def test_transport_audit_rejects_stock_q40_for_both_tp_families(
+    tmp_path: Path,
+    stock_phase: str,
+    stock_width: int,
+) -> None:
+    with pytest.raises(module.QualificationError, match="Q1-Q40"):
+        module.run_transport(
+            transport_args(
+                tmp_path,
+                stock_q=40,
+                stock_phase=stock_phase,
+                stock_width=stock_width,
+            )
+        )
+
+
+def test_transport_audit_ignores_stock_q41_outside_declared_contract(
+    tmp_path: Path,
+) -> None:
+    report = module.run_transport(transport_args(tmp_path, stock_q=41))
+    assert report["status"] == "pass"
+
+
+def test_transport_audit_rejects_custom_indexer_session(tmp_path: Path) -> None:
+    args = transport_args(tmp_path)
+    payload = json.loads(Path(args.after_status[2]).read_text(encoding="utf-8"))
+    payload["snapshot"]["indexer"]["sessions"] = {"2": {"captured_nodes": 1}}
+    Path(args.after_status[2]).write_text(json.dumps(payload), encoding="utf-8")
+    with pytest.raises(module.QualificationError, match="indexer must remain stock"):
+        module.run_transport(args)
+
+
+def test_transport_audit_rejects_nonadvancing_stock_dcp_counter(
+    tmp_path: Path,
+) -> None:
+    args = transport_args(tmp_path)
+    payload = json.loads(Path(args.after_status[1]).read_text(encoding="utf-8"))
+    payload["snapshot"]["stock_collectives"]["eager"][
+        "dcp_query_all_gather:ineligible_signature"
+    ] = 10
+    Path(args.after_status[1]).write_text(json.dumps(payload), encoding="utf-8")
+    with pytest.raises(module.QualificationError, match="did not advance"):
+        module.run_transport(args)
+
+
+@pytest.mark.parametrize("dropped_phase", ("capture", "eager"))
+def test_transport_audit_rejects_dropped_signature_calls(
+    tmp_path: Path,
+    dropped_phase: str,
+) -> None:
+    with pytest.raises(module.QualificationError, match="dropped calls"):
+        module.run_transport(
+            transport_args(tmp_path, **{f"dropped_{dropped_phase}": 1})
+        )
+
+
+def test_cli_declares_mtp4_mode_and_requires_baseline() -> None:
+    args = module.parse_args(
+        [
+            "qualify-mtp4",
+            "--baseline",
+            "mtp0.json",
+            "--output",
+            "mtp4.json",
+        ]
+    )
+    assert args.mode == "qualify-mtp4"
+    assert args.baseline == "mtp0.json"

--- a/runtime/exl3-r7/test_patch_sm121_cmake.py
+++ b/runtime/exl3-r7/test_patch_sm121_cmake.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+
+HERE = Path(__file__).resolve().parent
+SPEC = importlib.util.spec_from_file_location(
+    "patch_sm121_cmake", HERE / "patch_sm121_cmake.py"
+)
+assert SPEC is not None and SPEC.loader is not None
+PATCHER = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(PATCHER)
+
+
+def test_patch_preserves_architecture_specific_sm121_target(tmp_path: Path) -> None:
+    cmake = tmp_path / "CMakeLists.txt"
+    cmake.write_text(f"before\n{PATCHER.OLD}\nafter\n", encoding="utf-8")
+
+    PATCHER.patch(cmake)
+
+    result = cmake.read_text(encoding="utf-8")
+    assert PATCHER.OLD not in result
+    assert "12.0a;12.1a" in result
+    assert result.count(PATCHER.NEW) == 1
+
+
+def test_patch_rejects_source_drift(tmp_path: Path) -> None:
+    cmake = tmp_path / "CMakeLists.txt"
+    cmake.write_text("set(CUDA_SUPPORTED_ARCHS \"12.0f\")\n", encoding="utf-8")
+
+    with pytest.raises(RuntimeError, match="preimage is absent or ambiguous"):
+        PATCHER.patch(cmake)

--- a/runtime/exl3-r7/test_prepare_build_deps.py
+++ b/runtime/exl3-r7/test_prepare_build_deps.py
@@ -1,0 +1,56 @@
+"""Offline tests for R7 build-dependency receipts."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+import prepare_build_deps as deps
+
+
+def fixture(path):
+    for name in deps.SOURCES:
+        directory = path / name
+        directory.mkdir(parents=True)
+        (directory / "source.txt").write_text(name, encoding="utf-8")
+        (directory / deps.BUNDLED_LICENSE_NAME).write_text(
+            f"license for {name}", encoding="utf-8"
+        )
+    receipt = {
+        "schema": deps.SCHEMA,
+        "sources": deps.SOURCES,
+        "inventories": {name: deps.inventory(path / name) for name in deps.SOURCES},
+    }
+    (path / "receipt.json").write_text(json.dumps(receipt), encoding="utf-8")
+
+
+def test_verify_accepts_exact_receipt(tmp_path):
+    fixture(tmp_path)
+    assert deps.verify(tmp_path)["sources"] == deps.SOURCES
+
+
+def test_verify_rejects_changed_source(tmp_path):
+    fixture(tmp_path)
+    (tmp_path / "cutlass" / "source.txt").write_text("changed", encoding="utf-8")
+    with pytest.raises(RuntimeError, match="inventory mismatch: cutlass"):
+        deps.verify(tmp_path)
+
+
+def test_verify_rejects_changed_pin(tmp_path):
+    fixture(tmp_path)
+    receipt_path = tmp_path / "receipt.json"
+    receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
+    receipt["sources"]["triton_kernels"]["commit"] = "0" * 40
+    receipt_path.write_text(json.dumps(receipt), encoding="utf-8")
+    with pytest.raises(RuntimeError, match="source pins do not match"):
+        deps.verify(tmp_path)
+
+
+def test_every_dependency_pins_and_bundles_its_license(tmp_path):
+    for source in deps.SOURCES.values():
+        assert source["license_path"]
+    fixture(tmp_path)
+    (tmp_path / "triton_kernels" / deps.BUNDLED_LICENSE_NAME).unlink()
+    with pytest.raises(RuntimeError, match="license is missing: triton_kernels"):
+        deps.verify(tmp_path)

--- a/runtime/exl3-r7/test_verify_runtime_chain.py
+++ b/runtime/exl3-r7/test_verify_runtime_chain.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+
+MODULE_PATH = Path(__file__).with_name("verify_runtime.py")
+SPEC = importlib.util.spec_from_file_location("exl3_r7_verify_runtime", MODULE_PATH)
+assert SPEC is not None and SPEC.loader is not None
+verify_runtime = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(verify_runtime)
+
+
+def _terminal(self, output_tensor, input_tensor, stream):
+    del self, output_tensor, input_tensor, stream
+
+
+def _wrapper(inner):
+    def wrapped(*args, **kwargs):
+        return inner(*args, **kwargs)
+
+    wrapped._spark_original = inner
+    return wrapped
+
+
+def test_hook_chain_accepts_marker_on_inner_wrapper() -> None:
+    marked = _wrapper(_terminal)
+    marked._spark_tp4_allgather_backend = True
+    outer = _wrapper(marked)
+
+    assert verify_runtime.verify_hook_chain(
+        "PyNcclCommunicator.all_gather",
+        outer,
+        ("self", "output_tensor", "input_tensor", "stream"),
+        "_spark_tp4_allgather_backend",
+        True,
+    ) == ("self", "output_tensor", "input_tensor", "stream")
+
+
+def test_hook_chain_rejects_cycle() -> None:
+    first = _wrapper(_terminal)
+    second = _wrapper(first)
+    first._spark_original = second
+
+    with pytest.raises(RuntimeError, match="wrapper chain cycle"):
+        verify_runtime.spark_original_chain("cyclic", second)
+
+
+def test_hook_chain_rejects_non_callable_original() -> None:
+    wrapper = _wrapper(_terminal)
+    wrapper._spark_original = object()
+
+    with pytest.raises(RuntimeError, match="non-callable original"):
+        verify_runtime.spark_original_chain("invalid", wrapper)
+
+
+def test_hook_chain_validates_terminal_signature() -> None:
+    def wrong(self, input_):
+        del self, input_
+
+    wrapper = _wrapper(wrong)
+    wrapper._spark_tp4_allgather_backend = True
+
+    with pytest.raises(RuntimeError, match="signature drift"):
+        verify_runtime.verify_hook_chain(
+            "PyNcclCommunicator.all_gather",
+            wrapper,
+            ("self", "output_tensor", "input_tensor", "stream"),
+            "_spark_tp4_allgather_backend",
+            True,
+        )
+
+
+def test_hook_chain_requires_marker_when_mode_is_enabled() -> None:
+    wrapper = _wrapper(_terminal)
+
+    with pytest.raises(RuntimeError, match="hook marker.*is absent"):
+        verify_runtime.verify_hook_chain(
+            "PyNcclCommunicator.all_gather",
+            wrapper,
+            ("self", "output_tensor", "input_tensor", "stream"),
+            "_spark_tp4_allgather_backend",
+            True,
+        )
+
+
+def test_hook_chain_rejects_marker_only_on_terminal_callable() -> None:
+    _terminal._spark_tp4_allgather_backend = True
+    wrapper = _wrapper(_terminal)
+    try:
+        with pytest.raises(RuntimeError, match="hook marker.*is absent"):
+            verify_runtime.verify_hook_chain(
+                "PyNcclCommunicator.all_gather",
+                wrapper,
+                ("self", "output_tensor", "input_tensor", "stream"),
+                "_spark_tp4_allgather_backend",
+                True,
+            )
+    finally:
+        del _terminal._spark_tp4_allgather_backend
+
+
+def test_hook_chain_rejects_more_than_64_original_links() -> None:
+    target = _terminal
+    for _ in range(65):
+        target = _wrapper(target)
+
+    with pytest.raises(RuntimeError, match="exceeds 64 original links"):
+        verify_runtime.spark_original_chain("too-deep", target)
+
+
+def test_hook_chain_accepts_exactly_64_original_links() -> None:
+    target = _terminal
+    for _ in range(64):
+        target = _wrapper(target)
+
+    assert len(verify_runtime.spark_original_chain("bounded", target)) == 65
+
+
+def test_hook_chain_allows_absent_marker_when_mode_is_disabled() -> None:
+    wrapper = _wrapper(_terminal)
+
+    assert verify_runtime.verify_hook_chain(
+        "PyNcclCommunicator.all_gather",
+        wrapper,
+        ("self", "output_tensor", "input_tensor", "stream"),
+        "_spark_tp4_allgather_backend",
+        False,
+    ) == ("self", "output_tensor", "input_tensor", "stream")

--- a/runtime/exl3-r7/verify_runtime.py
+++ b/runtime/exl3-r7/verify_runtime.py
@@ -1,0 +1,278 @@
+#!/usr/bin/env python3
+"""Fail-closed checks for the installed EXL3 R7 ARM64 runtime."""
+
+from __future__ import annotations
+
+import argparse
+import importlib
+import inspect
+import json
+import os
+import platform
+import sys
+from pathlib import Path
+
+
+REQUIRED_SOURCE_MARKERS = {
+    "vllm.model_executor.layers.quantization.exl3": (
+        "r7_routed_experts",
+        "VLLM_EXL3_ONLINE_TRELLIS_BITS",
+    ),
+    "vllm.model_executor.layers.quantization.exl3_online_cache": (
+        "VLLM_EXL3_ONLINE_CACHE_DIR",
+        "readwrite",
+    ),
+    "b12x.moe._shared.kernels.w4a16.mixed_trellis": (
+        "K3/K4/K5",
+        "mixed_trellis3",
+    ),
+}
+
+SIRCL_HOOK_MARKERS = {
+    "sitecustomize": (
+        "VLLM_SPARK_TP4_MODE",
+        "VLLM_SPARK_TP4_ALLGATHER_MODE",
+        "VLLM_SPARK_TP4_VOCAB_MODE",
+    ),
+    "spark_tp4_backend": (
+        "CudaCommunicator.all_reduce = spark_all_reduce",
+        "_spark_tp4_backend",
+    ),
+    "spark_tp4_allgather_backend": (
+        "PyNcclCommunicator.all_gather = spark_all_gather",
+        "_spark_tp4_allgather_backend",
+    ),
+    "spark_tp4_vocab_allgather_backend": (
+        "GroupCoordinator._all_gather_out_place = spark_vocab_all_gather",
+        "_spark_tp4_vocab_backend",
+    ),
+    "spark_tp4_dcp_backend": (
+        "GroupCoordinator._all_gather_out_place = spark_dcp_all_gather",
+        "_spark_tp4_dcp_backend",
+    ),
+}
+_MAX_SIRCL_ORIGINAL_LINKS = 64
+
+
+def parameter_names(callable_: object) -> tuple[str, ...]:
+    return tuple(inspect.signature(callable_).parameters)
+
+
+def spark_original_chain(name: str, target: object) -> tuple[object, ...]:
+    """Return the complete wrapper chain and reject malformed ownership.
+
+    Spark wrappers preserve the callable they replace on ``_spark_original``.
+    Multiple integrations may wrap the same vLLM method, so verification must
+    inspect the terminal callable without assuming a fixed wrapper order.
+    """
+
+    if not callable(target):
+        raise RuntimeError(
+            f"SIRCL target {name} wrapper chain contains a non-callable target"
+        )
+
+    chain: list[object] = []
+    seen: set[int] = set()
+    links = 0
+    current = target
+    while True:
+        identity = id(current)
+        if identity in seen:
+            raise RuntimeError(
+                f"SIRCL target {name} wrapper chain contains a cycle; "
+                "wrapper chain cycle detected"
+            )
+        seen.add(identity)
+        chain.append(current)
+        if not hasattr(current, "_spark_original"):
+            return tuple(chain)
+        if links >= _MAX_SIRCL_ORIGINAL_LINKS:
+            raise RuntimeError(
+                f"SIRCL target {name} wrapper chain exceeds "
+                f"{_MAX_SIRCL_ORIGINAL_LINKS} original links"
+            )
+        current = getattr(current, "_spark_original")
+        if not callable(current):
+            raise RuntimeError(
+                f"SIRCL target {name} wrapper chain contains a non-callable original"
+            )
+        links += 1
+
+
+def verify_hook_chain(
+    name: str,
+    target: object,
+    expected: tuple[str, ...],
+    installed_marker: str,
+    mode_enabled: bool,
+) -> tuple[str, ...]:
+    """Validate one possibly multi-wrapper vLLM hook fail closed."""
+
+    chain = spark_original_chain(name, target)
+    actual = parameter_names(chain[-1])
+    if actual != expected:
+        raise RuntimeError(
+            f"SIRCL target {name} signature drift: expected {expected}, got {actual}"
+        )
+    if mode_enabled and not any(
+        bool(getattr(node, installed_marker, False)) for node in chain[:-1]
+    ):
+        raise RuntimeError(
+            f"SIRCL hook marker {installed_marker} is absent from {name} wrapper chain"
+        )
+    return actual
+
+
+def verify_sircl_hooks(evidence: dict[str, object]) -> None:
+    """Prove that the inherited Spark hooks still target the r34 vLLM ABI."""
+
+    hook_paths: dict[str, str] = {}
+    for module, markers in SIRCL_HOOK_MARKERS.items():
+        path, source = module_source(module)
+        missing = [marker for marker in markers if marker not in source]
+        if missing:
+            raise RuntimeError(f"{module} lacks SIRCL marker(s): {', '.join(missing)}")
+        hook_paths[module] = str(path)
+
+    from vllm.distributed.device_communicators.cuda_communicator import (
+        CudaCommunicator,
+    )
+    from vllm.distributed.device_communicators.pynccl import PyNcclCommunicator
+    from vllm.distributed.parallel_state import GroupCoordinator
+
+    contracts = (
+        (
+            "CudaCommunicator.all_reduce",
+            CudaCommunicator.all_reduce,
+            ("self", "input_"),
+            "_spark_tp4_backend",
+            "VLLM_SPARK_TP4_MODE",
+        ),
+        (
+            "PyNcclCommunicator.all_gather",
+            PyNcclCommunicator.all_gather,
+            ("self", "output_tensor", "input_tensor", "stream"),
+            "_spark_tp4_allgather_backend",
+            "VLLM_SPARK_TP4_ALLGATHER_MODE",
+        ),
+        (
+            "GroupCoordinator._all_gather_out_place",
+            GroupCoordinator._all_gather_out_place,
+            ("self", "input_", "dim"),
+            "_spark_tp4_vocab_backend",
+            "VLLM_SPARK_TP4_VOCAB_MODE",
+        ),
+        (
+            "GroupCoordinator._all_gather_out_place[DCP]",
+            GroupCoordinator._all_gather_out_place,
+            ("self", "input_", "dim"),
+            "_spark_tp4_dcp_backend",
+            "VLLM_SPARK_TP4_DCP_MODE",
+        ),
+    )
+    target_signatures: dict[str, list[str]] = {}
+    for name, target, expected, installed_marker, mode_variable in contracts:
+        actual = verify_hook_chain(
+            name,
+            target,
+            expected,
+            installed_marker,
+            bool(os.environ.get(mode_variable)),
+        )
+        target_signatures[name] = list(actual)
+
+    library = Path(
+        os.environ.get(
+            "SPARK_TP4_LIBRARY",
+            "/opt/sparkring/spark_transport/libspark_transport_capi.so",
+        )
+    )
+    if not library.is_file():
+        raise RuntimeError(f"SIRCL native library is missing: {library}")
+    evidence["sircl"] = {
+        "hooks": hook_paths,
+        "library": str(library),
+        "targets": target_signatures,
+    }
+
+
+def module_source(name: str) -> tuple[Path, str]:
+    module = importlib.import_module(name)
+    path_text = inspect.getsourcefile(module)
+    if not path_text:
+        raise RuntimeError(f"cannot locate installed module source: {name}")
+    path = Path(path_text).resolve()
+    return path, path.read_text(encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--installed-only",
+        action="store_true",
+        help="skip checks that require a visible NVIDIA GPU",
+    )
+    args = parser.parse_args()
+
+    if platform.machine().lower() not in {"aarch64", "arm64"}:
+        raise RuntimeError(f"R7 image requires ARM64, found {platform.machine()}")
+
+    evidence: dict[str, object] = {"architecture": platform.machine(), "modules": {}}
+    for module, markers in REQUIRED_SOURCE_MARKERS.items():
+        path, source = module_source(module)
+        missing = [marker for marker in markers if marker not in source]
+        if missing:
+            raise RuntimeError(f"{module} lacks R7 marker(s): {', '.join(missing)}")
+        evidence["modules"][module] = str(path)
+
+    verify_sircl_hooks(evidence)
+
+    instanttensor_path, instanttensor_source = module_source("instanttensor")
+    borrowed_markers = ("BUFFERED",)
+    missing = [marker for marker in borrowed_markers if marker not in instanttensor_source]
+    if missing:
+        # The backend contract may live below the package initializer.
+        package_text = "".join(
+            path.read_text(encoding="utf-8", errors="ignore")
+            for path in instanttensor_path.parent.rglob("*.py")
+        )
+        missing = [marker for marker in borrowed_markers if marker not in package_text]
+    if missing:
+        raise RuntimeError("InstantTensor lacks the BUFFERED backend policy")
+    evidence["instanttensor"] = str(instanttensor_path)
+
+    import torch
+
+    extension_path = os.environ.get("VLLM_EXL3_EXT_PATH")
+    if extension_path:
+        sys.path.insert(0, extension_path)
+    extension = importlib.import_module("exllamav3_ext")
+    required_exports = (
+        "exl3_gemm",
+        "exl3_moe_fused",
+        "exl3_moe_fused_retile",
+        "exl3_moe_max_concurrency",
+    )
+    missing = [name for name in required_exports if not hasattr(extension, name)]
+    if missing:
+        raise RuntimeError(
+            "ExLlamaV3 extension lacks required exports: " + ", ".join(missing)
+        )
+    evidence["exllamav3_ext"] = inspect.getfile(extension)
+
+    evidence["torch"] = torch.__version__
+    evidence["torch_cuda"] = torch.version.cuda
+    if not args.installed_only:
+        if not torch.cuda.is_available():
+            raise RuntimeError("CUDA is not available")
+        capability = torch.cuda.get_device_capability()
+        evidence["cuda_capability"] = list(capability)
+        if capability != (12, 1):
+            raise RuntimeError(f"R7 Spark profile requires SM121, found SM{capability[0]}{capability[1]}")
+
+    print(json.dumps(evidence, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Result

Publishes a reviewable, fail-closed ARM64/SM121 image builder for the component lineage used by the operator's EXL3 R7 3.5-bpw profile.

The builder:
- pins public upstream source identities and result trees;
- validates prepared-source and build-dependency receipts;
- builds vLLM/B12X/ExLlamaV3/InstantTensor inputs for GB10;
- verifies runtime ABI and package identities;
- excludes model weights, site data, registry mutation, and the operator exact-Q40 overlay;
- is explicitly labelled offline-validated until a clean-checkout-built image passes the four-Spark live gate.

## Validation

- python -m pytest spark_transport sparkcache runtime scripts -q -> 2875 passed, 17 skipped
- python -m pytest runtime/exl3-r7 -q -> 156 passed, 3 skipped
- uff check --select E,F,W --ignore E501 . -> passed
- private-material audit -> passed
- git diff --check -> passed

## Compatibility

This does not change the public default, launch a model, contact a Spark, push an image, or claim that a clean-checkout image has reproduced the operator result.