### PR TITLE
Publish the tiered deferred-credit SIRCL runtime

### DIFF
--- a/docs/SIRCL.md
+++ b/docs/SIRCL.md
@@ -38,6 +38,14 @@ The implementation combines:
    replay; and
 6. pinned host progress threads that submit and reap verbs work.
 
+The operator-accepted EXL3 R7 profile uses the versioned
+`two_slot_deferred_ack` graph protocol with the `tiered_64k` kernel selector.
+Two generation-tagged payload slots let graph replay defer acknowledgement
+without permitting premature reuse. The selector keeps small captured Q on
+the fused kernel and uses split 64-KiB work for larger captured Q. Build,
+attestation, qualification, and rollback instructions are in
+[`spark_transport/TIERED_DEFERRED_GRAPH.md`](../spark_transport/TIERED_DEFERRED_GRAPH.md).
+
 The endpoint exchange is explicitly versioned, and the deployed descriptor
 layout is pinned by the attested runtime bundle. A slot cannot be reused
 before its consumer acknowledges the sequence. Publication regression,
@@ -66,6 +74,10 @@ contiguous tensors on fixed two-node and four-node direct-cable topologies,
 with standard PyTorch integration and visible fallback counters. The current
 public snapshot is not yet a drop-in `torch.distributed` backend; model and
 runtime adapters still live beside the transport core.
+
+The dual-port striped schedule and prefill-capacity pool published beside the
+accepted selector are research-only and default off. They are not implied by
+the accepted sequential tiered/deferred result.
 
 The acronym remains an internal technical name because the unrelated
 [Sircl HTML extension library](https://www.getsircl.com/) already uses the

--- a/runtime/exl3-r7/Containerfile
+++ b/runtime/exl3-r7/Containerfile
@@ -40,7 +40,7 @@ RUN test "${TARGETARCH}" = arm64 \
  && test "${CUDA_ARCH}" = 121 \
  && apt-get update \
  && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-      build-essential ccache git ninja-build python3-dev \
+      build-essential ccache cmake git libibverbs-dev ninja-build python3-dev \
  && rm -rf /var/lib/apt/lists/*
 
 COPY bundle /opt/r7-src
@@ -64,6 +64,29 @@ RUN --mount=type=cache,id=sparkring-r7-ccache,target=/cache/jit/ccache,sharing=l
       /opt/r7-src/vllm/CMakeLists.txt \
  && /opt/venv/bin/pip install --no-build-isolation --no-deps /opt/r7-src/b12x \
  && /opt/venv/bin/pip install --no-build-isolation --no-deps /opt/r7-src/vllm
+
+# Build the SparkRing-authored SIRCL runtime from this exact checkout and
+# replace the inherited adapter tree with the manifest-bounded public overlay.
+# The accepted tiered/deferred selector uses an additive C ABI; the legacy
+# serial/fused entry point remains available for explicit rollback profiles.
+RUN cmake -S /opt/r7-src/spark_transport \
+      -B /opt/r7-src/spark_transport-build \
+      -G Ninja \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DCMAKE_CUDA_ARCHITECTURES=121 \
+      -DBUILD_TESTING=OFF \
+ && cmake --build /opt/r7-src/spark_transport-build \
+      --target spark_transport_capi \
+      --parallel "${MAX_JOBS}" \
+ && install -D -m 0755 \
+      /opt/r7-src/spark_transport-build/libspark_transport_capi.so \
+      /opt/sparkring/spark_transport/libspark_transport_capi.so \
+ && /opt/venv/bin/python /opt/r7-src/build-public-overlay.py \
+      --repo /opt/r7-src \
+      --spec /opt/r7-src/public-overlay-files.json \
+      --output /opt/spark-vllm-public \
+ && rm -rf /opt/spark-vllm \
+ && mv /opt/spark-vllm-public /opt/spark-vllm
 
 # ExLlamaV3's native CPU collective sources are x86-only. The inherited
 # SparkRing patch supplies ARM64 stubs because distributed collectives are

--- a/runtime/exl3-r7/README.md
+++ b/runtime/exl3-r7/README.md
@@ -12,6 +12,13 @@ live-validated, but an image built from this clean-checkout builder has not yet
 passed that live gate. It is not the repository default, not an accepted
 public-functional matrix, and not registry-available.
 
+The builder compiles `spark_transport_capi` from the same SparkRing revision
+and installs the manifest-bounded public vLLM adapter overlay. It therefore
+does not depend on an inherited, operator-held SIRCL binary. The exact-Q40
+EXL3 and model-runner overlays remain a separate publication layer because
+they require their own source-input hashes and pre-graph numerical parity
+receipt.
+
 ## Platform
 
 | Property | Value |
@@ -29,7 +36,8 @@ public-functional matrix, and not registry-available.
   receipt-gated inventory verification.
 - `Containerfile` — multi-stage build that clones ExLlamaV3 and InstantTensor
   at pinned commits, applies the ARM64 external-collectives patch, builds
-  vLLM and B12X from the prepared source bundle, and runs `verify_runtime.py`.
+  vLLM and B12X from the prepared source bundle, compiles SIRCL for SM121,
+  installs the public adapter overlay, and runs `verify_runtime.py`.
 - `PREPARED_SOURCES` environment variable (optional) — a pre-verified source
   directory whose receipt is checked by `prepare_context.py --verify`.
 

--- a/runtime/exl3-r7/build-image.sh
+++ b/runtime/exl3-r7/build-image.sh
@@ -39,11 +39,19 @@ repo_root="$(git -C "${here}" rev-parse --show-toplevel 2>/dev/null)" ||
   fatal "builder must run from a Git checkout"
 sparkring_revision="$(git -C "${repo_root}" rev-parse HEAD)"
 if ! git -C "${repo_root}" diff --quiet HEAD -- \
-  runtime/exl3-r7 runtime/exl3/patches/exllamav3-arm64-external-collectives.patch; then
+  runtime/exl3-r7 \
+  runtime/build-public-overlay.py \
+  runtime/public-overlay-files.json \
+  runtime/exl3/patches/exllamav3-arm64-external-collectives.patch \
+  spark_transport; then
   fatal "builder inputs differ from SparkRing revision ${sparkring_revision}"
 fi
 untracked_inputs="$(git -C "${repo_root}" ls-files --others --exclude-standard -- \
-  runtime/exl3-r7 runtime/exl3/patches/exllamav3-arm64-external-collectives.patch)"
+  runtime/exl3-r7 \
+  runtime/build-public-overlay.py \
+  runtime/public-overlay-files.json \
+  runtime/exl3/patches/exllamav3-arm64-external-collectives.patch \
+  spark_transport)"
 if [[ -n "${untracked_inputs}" ]]; then
   fatal "builder inputs include untracked files: ${untracked_inputs%%$'\n'*}"
 fi
@@ -68,6 +76,11 @@ cp -a "${deps_cache}/triton_kernels" "${context}/bundle/deps/triton_kernels"
 cp "${here}/verify_runtime.py" "${context}/bundle/runtime/verify_runtime.py"
 cp "${here}/entrypoint.sh" "${context}/bundle/runtime/entrypoint.sh"
 cp "${here}/patch_sm121_cmake.py" "${context}/bundle/patch_sm121_cmake.py"
+cp "${here}/../build-public-overlay.py" \
+  "${context}/bundle/build-public-overlay.py"
+cp "${here}/../public-overlay-files.json" \
+  "${context}/bundle/public-overlay-files.json"
+cp -a "${repo_root}/spark_transport" "${context}/bundle/spark_transport"
 cp "${here}/../exl3/patches/exllamav3-arm64-external-collectives.patch" \
   "${context}/bundle/exllamav3-arm64-external-collectives.patch"
 mv "${context}/sources/vllm" "${context}/bundle/vllm"

--- a/runtime/exl3-r7/test_build_image_hardening.py
+++ b/runtime/exl3-r7/test_build_image_hardening.py
@@ -179,6 +179,26 @@ def test_containerfile_labels_cutlass_and_triton() -> None:
     assert "0add68262ab0a2e33b84524346cb27cbb2787356" in build_deps  # Triton
 
 
+def test_builder_compiles_and_installs_sircl_from_the_same_checkout() -> None:
+    """The R7 image must not inherit an unpinned SIRCL binary or adapter."""
+
+    containerfile = (HERE / "Containerfile").read_text(encoding="utf-8")
+    assert "COPY bundle /opt/r7-src" in containerfile
+    assert "cmake -S /opt/r7-src/spark_transport" in containerfile
+    assert "--target spark_transport_capi" in containerfile
+    assert "/opt/sparkring/spark_transport/libspark_transport_capi.so" in containerfile
+    assert "build-public-overlay.py" in containerfile
+    assert "public-overlay-files.json" in containerfile
+    assert "--output /opt/spark-vllm-public" in containerfile
+
+    for path in (
+        "runtime/build-public-overlay.py",
+        "runtime/public-overlay-files.json",
+        "spark_transport",
+    ):
+        assert path in BUILD_SCRIPT
+
+
 # ---------------------------------------------------------------------------
 # 5. Receipt verification with prepare_context verifier
 # ---------------------------------------------------------------------------

--- a/runtime/public-overlay-files.json
+++ b/runtime/public-overlay-files.json
@@ -19,6 +19,8 @@
     "spark_transport/integrations/vllm/spark_tp4_backend.py",
     "spark_transport/integrations/vllm/spark_tp4_dcp_backend.py",
     "spark_transport/integrations/vllm/spark_tp4_flight_recorder.py",
+    "spark_transport/integrations/vllm/spark_tp4_port_namespace.py",
+    "spark_transport/integrations/vllm/spark_tp4_prefill_capacity_pool.py",
     "spark_transport/integrations/vllm/spark_tp4_query_contract.py",
     "spark_transport/integrations/vllm/spark_tp4_stock_timing.py",
     "spark_transport/integrations/vllm/spark_tp4_vocab_allgather_backend.py",

--- a/runtime/runtime-lock.json
+++ b/runtime/runtime-lock.json
@@ -380,7 +380,7 @@
   "public_runtime_inputs": [
     {
       "path": "runtime/public-overlay-files.json",
-      "sha256": "2a79a0790a40742a04bdfedb56e95a00369e22eab73c50ab7ccf2be1873f424f"
+      "sha256": "8de0debc8ddc3cdb4aee5951d7aa2adccc81b15199ea8ba3cda6e878e69f6006"
     },
     {
       "path": "runtime/build-public-overlay.py",

--- a/runtime/test_public_overlay.py
+++ b/runtime/test_public_overlay.py
@@ -49,7 +49,7 @@ def test_overlay_spec_covers_every_public_runtime_python_module():
 def test_overlay_build_is_content_addressed(tmp_path):
     output = tmp_path / "bundle"
     manifest = overlay.build(REPO, SPEC, output)
-    assert len(manifest["files"]) == 32
+    assert len(manifest["files"]) == 34
     assert (output / overlay.MANIFEST).is_file()
     for record in manifest["files"]:
         path = output / record["path"]

--- a/spark_transport/CMakeLists.txt
+++ b/spark_transport/CMakeLists.txt
@@ -124,6 +124,14 @@ if(BUILD_TESTING)
     target_link_libraries(wire_protocol_test PRIVATE spark_transport)
     add_test(NAME wire_protocol_test COMMAND wire_protocol_test)
 
+    add_executable(verbs_completion_test
+        tests/verbs_completion_test.cpp)
+    target_include_directories(verbs_completion_test PRIVATE
+        tests/syntax_stubs include)
+    target_compile_options(verbs_completion_test PRIVATE
+        -Wall -Wextra -Wpedantic -Werror)
+    add_test(NAME verbs_completion_test COMMAND verbs_completion_test)
+
     add_executable(topology_test tests/topology_test.cpp)
     target_link_libraries(topology_test PRIVATE spark_transport)
     add_test(NAME topology_test COMMAND topology_test)
@@ -145,6 +153,46 @@ if(BUILD_TESTING)
     add_executable(tp4_schedule_test tests/tp4_schedule_test.cpp)
     target_link_libraries(tp4_schedule_test PRIVATE spark_transport)
     add_test(NAME tp4_schedule_test COMMAND tp4_schedule_test)
+
+    add_executable(tp4_allreduce_protocol_test
+        tests/tp4_allreduce_protocol_test.cpp)
+    target_include_directories(tp4_allreduce_protocol_test PRIVATE include)
+    target_compile_options(tp4_allreduce_protocol_test PRIVATE
+        -Wall -Wextra -Wpedantic -Werror)
+    add_test(NAME tp4_allreduce_protocol_test
+        COMMAND tp4_allreduce_protocol_test)
+
+    add_executable(tp4_graph_kernel_strategy_test
+        tests/tp4_graph_kernel_strategy_test.cpp)
+    target_include_directories(tp4_graph_kernel_strategy_test PRIVATE include)
+    target_compile_options(tp4_graph_kernel_strategy_test PRIVATE
+        -Wall -Wextra -Wpedantic -Werror)
+    add_test(NAME tp4_graph_kernel_strategy_test
+        COMMAND tp4_graph_kernel_strategy_test)
+
+    add_executable(tp4_dual_port_striped_allreduce_test
+        tests/tp4_dual_port_striped_allreduce_test.cpp)
+    target_include_directories(tp4_dual_port_striped_allreduce_test
+        PRIVATE include)
+    target_compile_options(tp4_dual_port_striped_allreduce_test PRIVATE
+        -Wall -Wextra -Wpedantic -Werror)
+    add_test(NAME tp4_dual_port_striped_allreduce_test
+        COMMAND tp4_dual_port_striped_allreduce_test)
+
+    add_executable(tp4_dual_port_striped_host_test
+        tests/tp4_dual_port_striped_host_test.cpp)
+    target_include_directories(tp4_dual_port_striped_host_test
+        PRIVATE include src)
+    target_compile_options(tp4_dual_port_striped_host_test PRIVATE
+        -Wall -Wextra -Wpedantic -Werror)
+    add_test(NAME tp4_dual_port_striped_host_test
+        COMMAND tp4_dual_port_striped_host_test)
+
+    add_executable(tp4_c_api_layout_test tests/tp4_c_api_layout_test.cpp)
+    target_include_directories(tp4_c_api_layout_test PRIVATE include)
+    target_compile_options(tp4_c_api_layout_test PRIVATE
+        -Wall -Wextra -Wpedantic -Werror)
+    add_test(NAME tp4_c_api_layout_test COMMAND tp4_c_api_layout_test)
 
     add_executable(tp4_graph_command_test
         tests/tp4_graph_command_test.cpp

--- a/spark_transport/README.md
+++ b/spark_transport/README.md
@@ -59,6 +59,13 @@ ctest --test-dir /build --output-on-failure
 The gate is the full CTest suite: all 20 test executables declared in
 `CMakeLists.txt` must pass.
 
+The operator-accepted four-rank graph all-reduce uses the additive tiered
+kernel and deferred-credit ABI published in this directory. See
+[TIERED_DEFERRED_GRAPH.md](TIERED_DEFERRED_GRAPH.md) for its build, adapter,
+attestation, qualification, and rollback contract. The exact-Q40 routed-MoE
+optimization is a separate EXL3 overlay; compiling the transport library does
+not install it.
+
 ## Pair probe
 
 Server on `spark1`:

--- a/spark_transport/TIERED_DEFERRED_GRAPH.md
+++ b/spark_transport/TIERED_DEFERRED_GRAPH.md
@@ -1,0 +1,136 @@
+# Tiered graph all-reduce with deferred credits
+
+## Status and scope
+
+The sequential two-slot deferred-credit protocol plus the tiered 64-KiB graph
+kernel is **live-validated** in the operator's accepted four-Spark EXL3 R7
+profile. It serves TP4 BF16 all-reduce shapes from Q1 through Q40. The public
+source is hardware-specific: it assumes four ranks, two directly attached
+ConnectX-7 edges per rank, CUDA architecture SM121, and the GLM hidden width
+6,144.
+
+The dual-port striped schedule and the prefill-capacity pool are
+**research-only** and default off. They are included because the vLLM adapter
+shares the same versioned ABI and port-namespace validator; they are not part
+of the accepted operator profile.
+
+This transport does not implement the measured exact-Q40 routed-MoE speedup.
+That optimization is a separate target-only EXL3 source overlay. A complete
+operator-profile reproduction needs both layers.
+
+## Build the native library
+
+Build on an ARM64 Spark host or in an ARM64 CUDA development container that
+has CUDA 13, CMake, a C++17 compiler, and libibverbs development headers:
+
+```bash
+cmake -S spark_transport -B build/sircl-tiered \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_CUDA_ARCHITECTURES=121
+cmake --build build/sircl-tiered \
+  --target spark_transport_capi \
+  --parallel
+ctest --test-dir build/sircl-tiered --output-on-failure
+```
+
+The serving artifact is:
+
+```text
+build/sircl-tiered/libspark_transport_capi.so
+```
+
+Record the library hash before distribution and verify the same bytes on all
+four ranks:
+
+```bash
+sha256sum build/sircl-tiered/libspark_transport_capi.so
+```
+
+The build keeps the original unversioned `spark_tp4_create` ABI. The accepted
+path uses the additive
+`spark_tp4_create_with_protocol_and_graph_kernel` entry point, allowing an
+old or mismatched native library to fail before graph capture instead of
+silently selecting another protocol.
+
+## Install the vLLM adapter files
+
+Stage the following files together with the native library and verify their
+hashes on every rank:
+
+```text
+spark_transport/integrations/vllm/spark_tp4_backend.py
+spark_transport/integrations/vllm/spark_tp4_port_namespace.py
+spark_transport/integrations/vllm/spark_tp4_prefill_capacity_pool.py
+build/sircl-tiered/libspark_transport_capi.so
+```
+
+Mount the three Python files into a read-only adapter directory on
+`PYTHONPATH`. Mount the native library read-only and point
+`SPARK_TP4_LIBRARY` at its container path. The generic launcher can express
+these as `extra_volumes`; its attestation hook should validate all four
+SHA-256 values before vLLM starts.
+
+## Accepted selector settings
+
+The operator-accepted transport settings are:
+
+```text
+VLLM_SPARK_TP4_MODE=custom
+VLLM_SPARK_TP4_GRAPH_Q1=1
+VLLM_SPARK_TP4_GRAPH_ALLREDUCE_PROTOCOL=two_slot_deferred_ack
+VLLM_SPARK_TP4_GRAPH_KERNEL_STRATEGY=tiered_64k
+VLLM_SPARK_TP4_PREFILL_Q512=0
+SPARK_TP4_MAX_INFLIGHT=64
+SPARK_TP4_GRAPH_SUBMIT_CPU=10
+SPARK_TP4_GRAPH_PROGRESS_CPU=11
+```
+
+The graph control ports must be a distinct validated pair for every active
+session. The accepted profile also uses separate port pairs and progress CPUs
+for vocabulary transport. Site-specific peer addresses, devices, GIDs, CPU
+sets, and ports belong in the ignored site configuration; do not copy values
+from another appliance without validating its topology.
+
+`tiered_64k` selects the fused graph kernel for small Q and the split 64-KiB
+kernel for larger captured Q. The choice is fixed for each captured node.
+`two_slot_deferred_ack` gives each physical edge two generation-tagged payload
+slots. A slot cannot be reused until its peer returns the exact prior
+generation credit. Shutdown drains both slots before releasing registered
+memory.
+
+## Fail-closed qualification
+
+Before selecting `custom` in serving, run the CPU/offline adapter contracts:
+
+```bash
+python -m pytest \
+  spark_transport/integrations/vllm/test_spark_tp4_backend_dispatch.py \
+  spark_transport/integrations/vllm/test_spark_tp4_port_namespace.py \
+  spark_transport/tests/test_tp4_deferred_ack_source_contract.py \
+  spark_transport/tests/test_tp4_split_graph_source_contract.py \
+  -q
+```
+
+On four Sparks, require all of the following before accepting the process:
+
+- the startup hook hashes the exact native library and adapter files;
+- every rank reports the requested deferred-credit and tiered-kernel flags;
+- every required Q1-Q40 graph node is captured;
+- a real request advances published, consumed, and completed sequences;
+- all ranks converge on the same sequence count;
+- fatal, overflow, and cold-fallback counters remain zero;
+- fixed-seed outputs and finite log probabilities match the control;
+- the service returns healthy and idle after the bounded workload.
+
+Captured-node count alone proves only graph definition. Sequence advancement
+and convergence prove replay transport. The exact-Q40 EXL3 overlay adds its
+own pre-graph all-layer numerical parity receipt and must be qualified
+separately.
+
+## Rollback
+
+Keep the prior hash-pinned launch profile intact. A safe rollback stops the
+candidate, removes only the candidate containers, starts the preserved
+profile, waits for graph capture and HTTP health, and confirms the original KV
+capacity. Never change protocol or kernel settings inside an already captured
+process.

--- a/spark_transport/app/tp4_graph_q1_probe.cu
+++ b/spark_transport/app/tp4_graph_q1_probe.cu
@@ -31,6 +31,29 @@ constexpr std::size_t kMaximumPayloadBytes =
     kMaximumElements * sizeof(__nv_bfloat16);
 static_assert(kMaximumPayloadBytes == 6U * 1024U * 1024U);
 
+// A physical deferred-ACK slot is reused every two logical sequences. An odd
+// input-epoch period prevents sequence S from having the same payload as S-2.
+// BF16 represents every integer through 256 exactly. Each rank contributes an
+// integer no larger than 32, so both two-rank partials (<=64) and the final
+// four-rank sum (<=128) remain exact under the transport's BF16 additions.
+constexpr unsigned long long kInputEpochPeriod = 7;
+constexpr unsigned int kInputEpochStep = 4;
+constexpr unsigned int kMaximumInputBase = 8;
+constexpr unsigned int kMaximumInputValue =
+    kMaximumInputBase +
+    static_cast<unsigned int>(kInputEpochPeriod - 1) * kInputEpochStep;
+constexpr unsigned int kMaximumReducedValue = 4 * kMaximumInputValue;
+constexpr unsigned int kBfloat16ConsecutiveIntegerLimit = 256;
+static_assert(kInputEpochPeriod % 2 != 0);
+static_assert(kMaximumInputValue == 32);
+static_assert(kMaximumReducedValue == 128);
+static_assert(kMaximumReducedValue <= kBfloat16ConsecutiveIntegerLimit);
+
+enum class TimingMode {
+  kBurst,
+  kIsolated,
+};
+
 struct Options {
   spark_transport::Tp4AllreduceOptions transport;
   int warmup{10};
@@ -38,9 +61,11 @@ struct Options {
   int operations_per_graph{1};
   bool multi_graph_validation{};
   bool mixed_q_validation{};
+  std::uint32_t fixed_q{1};
   std::uint32_t maximum_q{6};
   int graph_a_operations{3};
   int graph_b_operations{128};
+  TimingMode timing_mode{TimingMode::kBurst};
   double max_graph_submit_us{};
   double max_device_us{};
 };
@@ -61,13 +86,18 @@ struct Options {
       << "  --operations-per-graph COUNT\n"
       << "  --multi-graph-validation\n"
       << "  --mixed-q-validation\n"
+      << "  --fixed-q Q\n"
       << "  --maximum-q Q\n"
       << "  --graph-a-operations COUNT\n"
       << "  --graph-b-operations COUNT\n"
       << "  --graph-submit-cpu CPU\n"
       << "  --graph-progress-cpu CPU\n"
+      << "  --allreduce-protocol serial_ack|two_slot_deferred_ack\n"
+      << "  --graph-kernel fused|split_64k|tiered_64k\n"
+      << "  --wire-schedule sequential|dual_port_striped\n"
+      << "  --timing-mode burst|isolated\n"
       << "  --max-graph-submit-us MICROSECONDS\n"
-      << "  --max-device-us MICROSECONDS\n";
+      << "  --max-device-us OUTPUT_READY_MICROSECONDS\n";
   std::exit(2);
 }
 
@@ -139,6 +169,13 @@ Options parse_options(int argc, char** argv) {
       options.multi_graph_validation = true;
     } else if (argument == "--mixed-q-validation") {
       options.mixed_q_validation = true;
+    } else if (argument == "--fixed-q") {
+      const std::uint64_t fixed_q =
+          unsigned_value(take_value(), "fixed Q");
+      if (fixed_q == 0 || fixed_q > kMaximumQ) {
+        throw std::invalid_argument("fixed Q must be in [1, 512]");
+      }
+      options.fixed_q = static_cast<std::uint32_t>(fixed_q);
     } else if (argument == "--maximum-q") {
       const std::uint64_t maximum_q =
           unsigned_value(take_value(), "maximum Q");
@@ -158,6 +195,46 @@ Options parse_options(int argc, char** argv) {
     } else if (argument == "--graph-progress-cpu") {
       options.transport.graph_progress_cpu = static_cast<std::uint32_t>(
           unsigned_value(take_value(), "graph progress CPU"));
+    } else if (argument == "--allreduce-protocol") {
+      options.transport.protocol =
+          spark_transport::parse_tp4_allreduce_protocol(take_value());
+    } else if (argument == "--graph-kernel") {
+      const std::string_view graph_kernel(take_value());
+      if (graph_kernel == "fused") {
+        options.transport.graph_kernel_strategy =
+            spark_transport::Tp4GraphKernelStrategy::kFused;
+      } else if (graph_kernel == "split_64k") {
+        options.transport.graph_kernel_strategy =
+            spark_transport::Tp4GraphKernelStrategy::kSplit64KiB;
+      } else if (graph_kernel == "tiered_64k") {
+        options.transport.graph_kernel_strategy =
+            spark_transport::Tp4GraphKernelStrategy::kTiered64KiB;
+      } else {
+        throw std::invalid_argument(
+            "graph kernel must be fused, split_64k, or tiered_64k");
+      }
+    } else if (argument == "--wire-schedule") {
+      const std::string_view wire_schedule(take_value());
+      if (wire_schedule == "sequential") {
+        options.transport.schedule =
+            spark_transport::Tp4AllreduceSchedule::kSequential;
+      } else if (wire_schedule == "dual_port_striped") {
+        options.transport.schedule =
+            spark_transport::Tp4AllreduceSchedule::kDualPortStriped;
+      } else {
+        throw std::invalid_argument(
+            "wire schedule must be sequential or dual_port_striped");
+      }
+    } else if (argument == "--timing-mode") {
+      const std::string_view timing_mode(take_value());
+      if (timing_mode == "burst") {
+        options.timing_mode = TimingMode::kBurst;
+      } else if (timing_mode == "isolated") {
+        options.timing_mode = TimingMode::kIsolated;
+      } else {
+        throw std::invalid_argument(
+            "timing mode must be burst or isolated");
+      }
     } else if (argument == "--max-graph-submit-us") {
       options.max_graph_submit_us =
           positive_double(take_value(), "graph submit threshold");
@@ -194,12 +271,55 @@ Options parse_options(int argc, char** argv) {
     throw std::invalid_argument(
         "mixed-Q validation requires multi-graph validation");
   }
+  if (options.timing_mode == TimingMode::kIsolated &&
+      (options.multi_graph_validation ||
+       options.mixed_q_validation ||
+       options.operations_per_graph != 1)) {
+    throw std::invalid_argument(
+        "isolated timing requires one single-graph collective");
+  }
+  if (options.fixed_q != 1 &&
+      (options.multi_graph_validation ||
+       options.mixed_q_validation ||
+       options.operations_per_graph != 1)) {
+    throw std::invalid_argument(
+        "fixed Q above one requires one single-graph collective");
+  }
+  if (options.transport.graph_kernel_strategy ==
+      spark_transport::Tp4GraphKernelStrategy::kSplit64KiB) {
+    if (options.multi_graph_validation ||
+        options.mixed_q_validation ||
+        options.operations_per_graph != 1) {
+      throw std::invalid_argument(
+          "split_64k graph kernel requires fixed Q1 through Q512, "
+          "and one collective per graph");
+    }
+  }
+  if (options.transport.schedule ==
+      spark_transport::Tp4AllreduceSchedule::kDualPortStriped) {
+    if ((options.fixed_q != 40 && options.fixed_q != 512) ||
+        options.multi_graph_validation ||
+        options.mixed_q_validation ||
+        options.operations_per_graph != 1 ||
+        options.transport.protocol !=
+            spark_transport::Tp4AllreduceProtocol::kTwoSlotDeferredAck ||
+        options.transport.graph_kernel_strategy !=
+            spark_transport::Tp4GraphKernelStrategy::kFused) {
+      throw std::invalid_argument(
+          "dual_port_striped wire schedule requires fixed Q40 or Q512, "
+          "two_slot_deferred_ack, fused graph kernel, and one "
+          "single-graph collective");
+    }
+  }
   if (options.maximum_q < 6 || options.maximum_q > kMaximumQ) {
     throw std::invalid_argument("maximum Q must be in [6, 512]");
   }
   if (options.mixed_q_validation) {
     options.transport.payload_bytes =
         spark_transport::tp4_graph_payload_bytes(options.maximum_q);
+  } else {
+    options.transport.payload_bytes =
+        spark_transport::tp4_graph_payload_bytes(options.fixed_q);
   }
   return options;
 }
@@ -231,13 +351,24 @@ spark_transport::Tp4GraphReplayStatus wait_for_graph_completion(
 }
 
 __device__ float tp4_input_value(std::uint32_t rank, std::size_t element,
-                                 unsigned long long replay) {
-  // Every adjacent replay has different, exactly representable BF16 inputs.
-  // The alternating offset catches stale replay data without introducing
-  // floating-point comparison tolerance into the correctness gate.
-  const unsigned int replay_offset = (replay & 1ULL) == 0 ? 0U : 16U;
+                                 unsigned long long input_epoch) {
+  const unsigned int epoch_offset =
+      static_cast<unsigned int>(input_epoch % kInputEpochPeriod) *
+      kInputEpochStep;
   return static_cast<float>(
-      ((element * 3U + rank * 5U) & 7U) + 1U + replay_offset);
+      ((element * 3U + rank * 5U) & 7U) + 1U + epoch_offset);
+}
+
+__device__ unsigned long long mixed_node_input_epoch(
+    unsigned long long replay, std::size_t node_epoch_offset,
+    std::size_t operations_per_cycle) {
+  // The probe always launches graph A then graph B. Two adjacent replay IDs
+  // therefore form one graph cycle. node_epoch_offset is the node's ordinal
+  // across A+B, making this epoch equal to its one-based logical collective
+  // sequence. In particular, every slot occupant S differs from S-2.
+  const unsigned long long cycle = (replay - 1ULL) / 2ULL;
+  return cycle * static_cast<unsigned long long>(operations_per_cycle) +
+         static_cast<unsigned long long>(node_epoch_offset) + 1ULL;
 }
 
 __global__ void prepare_replay(__nv_bfloat16* input, std::uint32_t rank,
@@ -253,6 +384,21 @@ __global__ void prepare_replay(__nv_bfloat16* input, std::uint32_t rank,
   if (index == 0) {
     *replay_marker = replay;
   }
+}
+
+__global__ void prepare_mixed_node_input(
+    __nv_bfloat16* input, std::uint32_t rank,
+    const unsigned long long* replay_marker, std::size_t input_elements,
+    std::size_t node_epoch_offset, std::size_t operations_per_cycle) {
+  const std::size_t index =
+      blockIdx.x * static_cast<std::size_t>(blockDim.x) + threadIdx.x;
+  if (index >= input_elements) {
+    return;
+  }
+  const unsigned long long input_epoch = mixed_node_input_epoch(
+      *replay_marker, node_epoch_offset, operations_per_cycle);
+  input[index] =
+      __float2bfloat16(tp4_input_value(rank, index, input_epoch));
 }
 
 __global__ void validate_q1_output(const __nv_bfloat16* output,
@@ -294,6 +440,27 @@ __global__ void validate_active_output(
   }
 }
 
+__global__ void validate_mixed_node_output(
+    const __nv_bfloat16* output, std::size_t active_elements,
+    const unsigned long long* replay_marker,
+    unsigned long long* mismatches, std::size_t node_epoch_offset,
+    std::size_t operations_per_cycle) {
+  const std::size_t index =
+      blockIdx.x * static_cast<std::size_t>(blockDim.x) + threadIdx.x;
+  if (index >= active_elements) {
+    return;
+  }
+  const unsigned long long input_epoch = mixed_node_input_epoch(
+      *replay_marker, node_epoch_offset, operations_per_cycle);
+  float expected = 0.0F;
+  for (std::uint32_t rank = 0; rank < 4; ++rank) {
+    expected += tp4_input_value(rank, index, input_epoch);
+  }
+  if (__bfloat162float(output[index]) != expected) {
+    atomicAdd(mismatches, 1ULL);
+  }
+}
+
 struct CapturedGraph {
   int operations{};
   std::size_t output_offset{};
@@ -304,7 +471,8 @@ CapturedGraph capture_graph(
     spark_transport::Tp4AllreduceSession& session,
     const __nv_bfloat16* input, __nv_bfloat16* output,
     unsigned long long* replay_marker, unsigned long long* mismatches,
-    cudaStream_t stream, int operations, std::size_t output_offset) {
+    cudaStream_t stream, int operations, std::size_t output_offset,
+    bool capture_validation) {
   constexpr int threads = 256;
   const std::size_t output_elements =
       kElements * static_cast<std::size_t>(operations);
@@ -321,9 +489,11 @@ CapturedGraph capture_graph(
             static_cast<std::size_t>(operation) * kElements,
         stream);
   }
-  validate_q1_output<<<validation_blocks, threads, 0, stream>>>(
-      output + output_offset, output_elements, replay_marker, mismatches);
-  check_cuda(cudaGetLastError(), "validate_q1_output capture launch");
+  if (capture_validation) {
+    validate_q1_output<<<validation_blocks, threads, 0, stream>>>(
+        output + output_offset, output_elements, replay_marker, mismatches);
+    check_cuda(cudaGetLastError(), "validate_q1_output capture launch");
+  }
   check_cuda(cudaStreamEndCapture(stream, &graph), "cudaStreamEndCapture");
 
   CapturedGraph captured{operations, output_offset, nullptr};
@@ -338,11 +508,49 @@ CapturedGraph capture_graph(
   return captured;
 }
 
-CapturedGraph capture_mixed_q_graph(
+CapturedGraph capture_fixed_q_graph(
     spark_transport::Tp4AllreduceSession& session,
     const __nv_bfloat16* input, __nv_bfloat16* output,
     unsigned long long* replay_marker, unsigned long long* mismatches,
-    cudaStream_t stream, const std::vector<std::uint32_t>& q_values) {
+    cudaStream_t stream, std::uint32_t q, bool capture_validation) {
+  constexpr int threads = 256;
+  const std::size_t active_elements =
+      static_cast<std::size_t>(q) * kElements;
+  const int validation_blocks = static_cast<int>(
+      (active_elements + threads - 1) / threads);
+
+  cudaGraph_t graph{};
+  check_cuda(cudaStreamBeginCapture(stream, cudaStreamCaptureModeGlobal),
+             "cudaStreamBeginCapture fixed Q");
+  session.capture_all_reduce(input, output, q, stream);
+  if (capture_validation) {
+    validate_active_output<<<validation_blocks, threads, 0, stream>>>(
+        output, active_elements, replay_marker, mismatches);
+    check_cuda(cudaGetLastError(),
+               "validate_active_output fixed-Q capture launch");
+  }
+  check_cuda(cudaStreamEndCapture(stream, &graph),
+             "cudaStreamEndCapture fixed Q");
+
+  CapturedGraph captured{1, 0, nullptr};
+  try {
+    check_cuda(cudaGraphInstantiate(&captured.executable, graph, 0),
+               "cudaGraphInstantiate fixed Q");
+  } catch (...) {
+    cudaGraphDestroy(graph);
+    throw;
+  }
+  check_cuda(cudaGraphDestroy(graph), "cudaGraphDestroy fixed Q");
+  return captured;
+}
+
+CapturedGraph capture_mixed_q_graph(
+    spark_transport::Tp4AllreduceSession& session,
+    __nv_bfloat16* input, __nv_bfloat16* output,
+    unsigned long long* replay_marker, unsigned long long* mismatches,
+    cudaStream_t stream, std::uint32_t rank,
+    const std::vector<std::uint32_t>& q_values,
+    std::size_t graph_epoch_offset, std::size_t operations_per_cycle) {
   constexpr int threads = 256;
   cudaGraph_t graph{};
   check_cuda(cudaStreamBeginCapture(stream, cudaStreamCaptureModeGlobal),
@@ -354,15 +562,22 @@ CapturedGraph capture_mixed_q_graph(
     // graph, so every node can reuse one stable maximum-capacity output
     // arena instead of reserving hundreds of MiB for distinct node outputs.
     __nv_bfloat16* operation_output = output;
-    session.capture_all_reduce(input, operation_output, q, stream);
     const std::size_t active_elements =
         static_cast<std::size_t>(q) * kElements;
     const int validation_blocks = static_cast<int>(
         (active_elements + threads - 1) / threads);
-    validate_active_output<<<validation_blocks, threads, 0, stream>>>(
-        operation_output, active_elements, replay_marker, mismatches);
+    const std::size_t node_epoch_offset = graph_epoch_offset + operation;
+    prepare_mixed_node_input<<<validation_blocks, threads, 0, stream>>>(
+        input, rank, replay_marker, active_elements, node_epoch_offset,
+        operations_per_cycle);
     check_cuda(cudaGetLastError(),
-               "validate_active_output capture launch");
+               "prepare_mixed_node_input capture launch");
+    session.capture_all_reduce(input, operation_output, q, stream);
+    validate_mixed_node_output<<<validation_blocks, threads, 0, stream>>>(
+        operation_output, active_elements, replay_marker, mismatches,
+        node_epoch_offset, operations_per_cycle);
+    check_cuda(cudaGetLastError(),
+               "validate_mixed_node_output capture launch");
   }
   check_cuda(cudaStreamEndCapture(stream, &graph),
              "cudaStreamEndCapture mixed Q");
@@ -437,13 +652,13 @@ int main(int argc, char** argv) {
     const std::size_t input_elements =
         options.mixed_q_validation
             ? static_cast<std::size_t>(options.maximum_q) * kElements
-            : kElements;
+            : static_cast<std::size_t>(options.fixed_q) * kElements;
     const int input_blocks = static_cast<int>(
         (input_elements + threads - 1) / threads);
     const std::size_t output_stride_elements =
         options.mixed_q_validation
             ? static_cast<std::size_t>(options.maximum_q) * kElements
-            : kElements;
+            : static_cast<std::size_t>(options.fixed_q) * kElements;
     const std::size_t output_elements =
         options.mixed_q_validation
             ? output_stride_elements
@@ -500,10 +715,22 @@ int main(int argc, char** argv) {
         account_q(q);
       }
     } else {
-      q_histogram[0] = total_output_operations;
+      q_histogram[options.fixed_q - 1] = total_output_operations;
       active_bytes_per_graph_cycle =
-          total_output_operations * kPayloadBytes;
+          total_output_operations *
+          spark_transport::tp4_graph_payload_bytes(options.fixed_q);
     }
+    std::uint64_t kernel_split_nodes{};
+    for (std::size_t index = 0; index < q_histogram.size(); ++index) {
+      if (spark_transport::tp4_graph_kernel_uses_split(
+              options.transport.graph_kernel_strategy,
+              static_cast<std::uint32_t>(index + 1))) {
+        kernel_split_nodes += q_histogram[index];
+      }
+    }
+    const std::uint64_t kernel_fused_nodes =
+        static_cast<std::uint64_t>(total_output_operations) -
+        kernel_split_nodes;
 
     __nv_bfloat16* input{};
     __nv_bfloat16* output{};
@@ -536,25 +763,36 @@ int main(int argc, char** argv) {
       spark_transport::Tp4AllreduceSession session(options.transport);
       std::vector<CapturedGraph> graphs;
       if (options.mixed_q_validation) {
+        const std::size_t operations_per_cycle =
+            graph_a_q.size() + graph_b_q.size();
         graphs.push_back(capture_mixed_q_graph(
             session, input, output, replay_marker, mismatches, stream,
-            graph_a_q));
+            options.transport.rank, graph_a_q, 0,
+            operations_per_cycle));
         graphs.push_back(capture_mixed_q_graph(
             session, input, output, replay_marker, mismatches, stream,
-            graph_b_q));
+            options.transport.rank, graph_b_q, graph_a_q.size(),
+            operations_per_cycle));
       } else if (options.multi_graph_validation) {
         graphs.push_back(capture_graph(
             session, input, output, replay_marker, mismatches, stream,
-            options.graph_a_operations, 0));
+            options.graph_a_operations, 0, true));
         graphs.push_back(capture_graph(
             session, input, output, replay_marker, mismatches, stream,
             options.graph_b_operations,
             static_cast<std::size_t>(options.graph_a_operations) *
-                kElements));
-      } else {
+                kElements,
+            true));
+      } else if (options.fixed_q == 1) {
         graphs.push_back(capture_graph(
             session, input, output, replay_marker, mismatches, stream,
-            options.operations_per_graph, 0));
+            options.operations_per_graph, 0,
+            options.timing_mode == TimingMode::kBurst));
+      } else {
+        graphs.push_back(capture_fixed_q_graph(
+            session, input, output, replay_marker, mismatches, stream,
+            options.fixed_q,
+            options.timing_mode == TimingMode::kBurst));
       }
 
       const std::uint64_t expected_captured_nodes =
@@ -580,8 +818,11 @@ int main(int argc, char** argv) {
       bool monotonic_sequences = true;
       bool post_replay_capture_rejected{};
 
+      const bool isolated_timing =
+          options.timing_mode == TimingMode::kIsolated;
       const auto launch_graph = [&](const CapturedGraph& graph,
-                                    const char* phase) {
+                                    const char* phase,
+                                    bool collect_isolated_sample) {
         if (replay == std::numeric_limits<std::uint64_t>::max()) {
           throw std::overflow_error("graph replay marker exhausted");
         }
@@ -590,9 +831,31 @@ int main(int argc, char** argv) {
             input, options.transport.rank, replay, replay_marker,
             input_elements);
         check_cuda(cudaGetLastError(), "prepare_replay launch");
+        if (collect_isolated_sample) {
+          check_cuda(cudaEventRecord(start, stream),
+                     "cudaEventRecord isolated start");
+        }
+        const auto submit_start = std::chrono::steady_clock::now();
         check_cuda(cudaGraphLaunch(graph.executable, stream), phase);
+        const auto submit_stop = std::chrono::steady_clock::now();
+        if (collect_isolated_sample) {
+          check_cuda(cudaEventRecord(stop, stream),
+                     "cudaEventRecord isolated stop");
+        }
         expected_sequence +=
             static_cast<std::uint64_t>(graph.operations);
+
+        if (isolated_timing) {
+          const std::size_t validation_elements =
+              static_cast<std::size_t>(options.fixed_q) * kElements;
+          const int validation_blocks = static_cast<int>(
+              (validation_elements + threads - 1) / threads);
+          validate_active_output<<<validation_blocks, threads, 0, stream>>>(
+              output + graph.output_offset, validation_elements,
+              replay_marker, mismatches);
+          check_cuda(cudaGetLastError(),
+                     "validate_q1_output isolated launch");
+        }
 
         if (options.multi_graph_validation) {
           check_cuda(cudaStreamSynchronize(stream),
@@ -619,29 +882,93 @@ int main(int argc, char** argv) {
                         : 1U);
           }
         }
+        return std::chrono::duration<double, std::micro>(
+                   submit_stop - submit_start)
+            .count();
       };
 
       for (int iteration = 0; iteration < options.warmup; ++iteration) {
         for (const auto& graph : graphs) {
-          launch_graph(graph, "cudaGraphLaunch warmup");
+          (void)launch_graph(graph, "cudaGraphLaunch warmup", false);
+        }
+        if (isolated_timing) {
+          check_cuda(cudaStreamSynchronize(stream),
+                     "isolated warmup synchronize");
+          (void)wait_for_graph_completion(session, expected_sequence);
         }
       }
       check_cuda(cudaStreamSynchronize(stream), "warmup synchronize");
 
-      check_cuda(cudaEventRecord(start, stream), "cudaEventRecord start");
-      const auto host_start = std::chrono::steady_clock::now();
-      for (int iteration = 0; iteration < options.iterations; ++iteration) {
-        for (const auto& graph : graphs) {
-          launch_graph(graph, "cudaGraphLaunch measured");
+      double host_submit_us{};
+      double device_us{};
+      double device_us_per_collective{};
+      double device_us_min{};
+      double device_us_p50{};
+      double device_us_p95{};
+      if (isolated_timing) {
+        std::vector<double> samples;
+        samples.reserve(static_cast<std::size_t>(options.iterations));
+        double submit_us_total{};
+        for (int iteration = 0; iteration < options.iterations;
+             ++iteration) {
+          submit_us_total += launch_graph(
+              graphs.front(), "cudaGraphLaunch isolated", true);
+          check_cuda(cudaEventSynchronize(stop),
+                     "cudaEventSynchronize isolated stop");
+          float sample_ms{};
+          check_cuda(cudaEventElapsedTime(&sample_ms, start, stop),
+                     "cudaEventElapsedTime isolated");
+          samples.push_back(static_cast<double>(sample_ms) * 1000.0);
+          check_cuda(cudaStreamSynchronize(stream),
+                     "isolated validation synchronize");
         }
+        std::sort(samples.begin(), samples.end());
+        const auto nearest_rank = [&](double quantile) {
+          const std::size_t rank = static_cast<std::size_t>(
+              std::ceil(quantile * static_cast<double>(samples.size())));
+          return samples.at(std::max<std::size_t>(1, rank) - 1);
+        };
+        host_submit_us = submit_us_total / options.iterations;
+        device_us_min = samples.front();
+        device_us_p50 = nearest_rank(0.50);
+        device_us_p95 = nearest_rank(0.95);
+        device_us = device_us_p50;
+        device_us_per_collective = device_us_p50;
+      } else {
+        check_cuda(cudaEventRecord(start, stream),
+                   "cudaEventRecord start");
+        const auto host_start = std::chrono::steady_clock::now();
+        for (int iteration = 0; iteration < options.iterations;
+             ++iteration) {
+          for (const auto& graph : graphs) {
+            (void)launch_graph(
+                graph, "cudaGraphLaunch measured", false);
+          }
+        }
+        const auto host_stop = std::chrono::steady_clock::now();
+        check_cuda(cudaEventRecord(stop, stream),
+                   "cudaEventRecord stop");
+        check_cuda(cudaEventSynchronize(stop),
+                   "cudaEventSynchronize stop");
+        float elapsed_ms{};
+        check_cuda(cudaEventElapsedTime(&elapsed_ms, start, stop),
+                   "cudaEventElapsedTime");
+        host_submit_us =
+            std::chrono::duration<double, std::micro>(
+                host_stop - host_start)
+                .count() /
+            options.iterations;
+        device_us =
+            static_cast<double>(elapsed_ms) * 1000.0 /
+            options.iterations;
+        const int operations_per_iteration =
+            options.multi_graph_validation
+                ? options.graph_a_operations +
+                      options.graph_b_operations
+                : options.operations_per_graph;
+        device_us_per_collective =
+            device_us / operations_per_iteration;
       }
-      const auto host_stop = std::chrono::steady_clock::now();
-      check_cuda(cudaEventRecord(stop, stream), "cudaEventRecord stop");
-      check_cuda(cudaEventSynchronize(stop), "cudaEventSynchronize stop");
-
-      float elapsed_ms{};
-      check_cuda(cudaEventElapsedTime(&elapsed_ms, start, stop),
-                 "cudaEventElapsedTime");
       check_cuda(cudaMemcpy(&host_mismatches, mismatches,
                             sizeof(host_mismatches),
                             cudaMemcpyDeviceToHost),
@@ -649,33 +976,35 @@ int main(int argc, char** argv) {
 
       const auto status =
           wait_for_graph_completion(session, expected_sequence);
-      const double host_submit_us =
-          std::chrono::duration<double, std::micro>(host_stop - host_start)
-              .count() /
-          options.iterations;
-      const double device_us =
-          static_cast<double>(elapsed_ms) * 1000.0 / options.iterations;
-      const int operations_per_iteration =
-          options.multi_graph_validation
-              ? options.graph_a_operations + options.graph_b_operations
-              : options.operations_per_graph;
-      const double device_us_per_collective =
-          device_us / operations_per_iteration;
       const bool sequences_match =
           status.captured_nodes == expected_captured_nodes &&
           status.published_sequence == expected_sequence &&
           status.consumed_sequence == expected_sequence &&
           status.completed_sequence == expected_sequence &&
           status.overflow_sequence == 0;
+      const bool protocol_status_match =
+          status.two_slot_deferred_ack ==
+          spark_transport::tp4_protocol_uses_deferred_ack(
+              options.transport.protocol);
+      const std::size_t payload_slots =
+          spark_transport::tp4_payload_slot_count(
+              options.transport.protocol);
+      const bool slot_reuse_exercised =
+          spark_transport::tp4_protocol_uses_deferred_ack(
+              options.transport.protocol) &&
+          status.completed_sequence >= 3;
       const bool submit_fast_enough =
           options.max_graph_submit_us == 0.0 ||
           host_submit_us <= options.max_graph_submit_us;
       const bool device_fast_enough =
           options.max_device_us == 0.0 ||
-          device_us_per_collective <= options.max_device_us;
+          (isolated_timing ? device_us_p95
+                           : device_us_per_collective) <=
+              options.max_device_us;
       const bool correct =
           host_mismatches == 0 && sequences_match &&
-          pre_replay_capture_valid && monotonic_sequences &&
+          protocol_status_match && pre_replay_capture_valid &&
+          monotonic_sequences &&
           (!options.multi_graph_validation ||
            post_replay_capture_rejected);
       const bool passed =
@@ -685,6 +1014,18 @@ int main(int argc, char** argv) {
           static_cast<std::uint64_t>(options.iterations);
       const std::uint64_t validated_active_bytes_total =
           active_bytes_per_graph_cycle * graph_cycles;
+      const char* const transport_kernel_path =
+          options.transport.schedule ==
+                  spark_transport::Tp4AllreduceSchedule::kDualPortStriped
+              ? "dual_port_striped_dag"
+              : options.transport.graph_kernel_strategy ==
+                        spark_transport::Tp4GraphKernelStrategy::kFused
+                    ? "sequential_fused"
+                    : options.transport.graph_kernel_strategy ==
+                              spark_transport::
+                                  Tp4GraphKernelStrategy::kSplit64KiB
+                          ? "sequential_split_64k"
+                          : "sequential_tiered_64k";
 
       std::cout << "TP4_GRAPH_Q1"
                 << " rank=" << options.transport.rank
@@ -695,9 +1036,27 @@ int main(int argc, char** argv) {
                 << (options.multi_graph_validation ? "multi" : "single")
                 << " mixed_q="
                 << (options.mixed_q_validation ? "true" : "false")
+                << " fixed_q=" << options.fixed_q
                 << " maximum_q=" << options.maximum_q
                 << " session_capacity_bytes="
                 << options.transport.payload_bytes
+                << " allreduce_protocol="
+                << spark_transport::tp4_allreduce_protocol_name(
+                       options.transport.protocol)
+                << " wire_schedule="
+                << spark_transport::tp4_allreduce_schedule_name(
+                       options.transport.schedule)
+                << " transport_kernel_path=" << transport_kernel_path
+                << " graph_kernel="
+                << spark_transport::tp4_graph_kernel_strategy_name(
+                       options.transport.graph_kernel_strategy)
+                << " kernel_fused_nodes=" << kernel_fused_nodes
+                << " kernel_split_64k_nodes=" << kernel_split_nodes
+                << " payload_slots=" << payload_slots
+                << " slot_reuse_exercised="
+                << (slot_reuse_exercised ? "true" : "false")
+                << " timing_mode="
+                << (isolated_timing ? "isolated" : "burst")
                 << " iterations=" << options.iterations
                 << " operations_per_graph="
                 << options.operations_per_graph
@@ -715,6 +1074,7 @@ int main(int argc, char** argv) {
                 << " q4_nodes=" << q_histogram[3]
                 << " q5_nodes=" << q_histogram[4]
                 << " q6_nodes=" << q_histogram[5]
+                << " q40_nodes=" << q_histogram[39]
                 << " q48_nodes=" << q_histogram[47]
                 << " q72_nodes=" << q_histogram[71]
                 << " q144_nodes=" << q_histogram[143]
@@ -730,14 +1090,35 @@ int main(int argc, char** argv) {
                 << (status.submit_affinity_verified ? "true" : "false")
                 << " progress_affinity_verified="
                 << (status.progress_affinity_verified ? "true" : "false")
+                << " protocol_status_match="
+                << (protocol_status_match ? "true" : "false")
                 << " graph_submit_cpu=" << status.graph_submit_cpu
                 << " graph_progress_cpu=" << status.graph_progress_cpu
                 << " pre_replay_capture_valid="
                 << (pre_replay_capture_valid ? "true" : "false")
-                << " graph_submit_us_per_call=" << host_submit_us
-                << " device_us_per_graph=" << device_us
-                << " device_us_per_call=" << device_us_per_collective
-                << " published=" << status.published_sequence
+                << " graph_submit_us_per_call=" << host_submit_us;
+      if (isolated_timing) {
+        std::cout
+            << " timing_scope=device_output_ready_single_replay"
+            << " timing_samples=" << options.iterations
+            << " device_output_ready_us_per_graph_min="
+            << device_us_min
+            << " device_output_ready_us_per_graph_p50="
+            << device_us_p50
+            << " device_output_ready_us_per_graph_p95="
+            << device_us_p95
+            << " device_gate_metric="
+               "p95_device_output_ready_us_per_graph";
+      } else {
+        std::cout
+            << " timing_scope=device_output_ready_replay_throughput"
+            << " device_output_ready_us_per_graph=" << device_us
+            << " device_output_ready_us_per_collective="
+            << device_us_per_collective
+            << " device_gate_metric="
+               "mean_device_output_ready_us_per_collective";
+      }
+      std::cout << " published=" << status.published_sequence
                 << " consumed=" << status.consumed_sequence
                 << " completed=" << status.completed_sequence
                 << " overflow=" << status.overflow_sequence

--- a/spark_transport/include/spark_transport/gpu_doorbell.hpp
+++ b/spark_transport/include/spark_transport/gpu_doorbell.hpp
@@ -13,6 +13,8 @@ struct alignas(64) DoorbellControl {
   std::uint64_t acknowledgement_sequence{};
   std::uint64_t observed_sequence{};
   std::uint64_t mismatch_count{};
+  // The graph-only two-slot all-reduce stages its raw logical credit here
+  // before an inline RDMA write. Other doorbell protocols leave it unused.
   std::uint64_t reserved{};
 };
 

--- a/spark_transport/include/spark_transport/gpu_tp4_tensor.hpp
+++ b/spark_transport/include/spark_transport/gpu_tp4_tensor.hpp
@@ -4,7 +4,10 @@
 #include <cstdint>
 
 #include "spark_transport/gpu_tp2.hpp"
+#include "spark_transport/tp4_allreduce_protocol.hpp"
+#include "spark_transport/tp4_dual_port_striped_allreduce.hpp"
 #include "spark_transport/tp4_graph_command.hpp"
+#include "spark_transport/tp4_graph_kernel_strategy.hpp"
 
 namespace spark_transport {
 
@@ -17,8 +20,11 @@ class GpuTp4TensorWorker {
                      void* round0_mapped_device_buffer,
                      const Tp2BufferLayout& round0_layout,
                      void* round1_mapped_device_buffer,
-                     const Tp2BufferLayout& round1_layout);
-  ~GpuTp4TensorWorker() = default;
+                     const Tp2BufferLayout& round1_layout,
+                     Tp4AllreduceProtocol protocol,
+                     Tp4GraphKernelStrategy graph_kernel_strategy,
+                     Tp4AllreduceSchedule schedule);
+  ~GpuTp4TensorWorker();
 
   // Enqueues one fused all-reduce kernel on the caller stream. The kernel
   // publishes GPU/CPU doorbells while a dedicated host thread drives RDMA.
@@ -27,7 +33,10 @@ class GpuTp4TensorWorker {
 
   // Enqueues the graph-replay kernel. The kernel atomically claims and
   // publishes a fresh replay sequence through command_ring before using that
-  // same sequence for its transport doorbells.
+  // same sequence for its transport doorbells. Research graph strategies may
+  // expand the logical operation into an ordered graph-node chain without
+  // changing the host progress protocol. The tiered strategy makes that
+  // choice independently for every captured q.
   void enqueue_graph(const void* external_input, void* external_output,
                      std::uint32_t q, void* cuda_stream,
                      Tp4GraphCommandRing* command_ring, bool trace);
@@ -38,6 +47,12 @@ class GpuTp4TensorWorker {
   Tp2BufferLayout round0_layout_{};
   Tp2BufferLayout round1_layout_{};
   std::size_t payload_bytes_{};
+  Tp4AllreduceProtocol protocol_{Tp4AllreduceProtocol::kSerialAck};
+  Tp4GraphKernelStrategy graph_kernel_strategy_{
+      Tp4GraphKernelStrategy::kFused};
+  Tp4AllreduceSchedule schedule_{Tp4AllreduceSchedule::kSequential};
+  void* split_graph_state_{};
+  void* striped_graph_state_{};
 };
 
 }  // namespace spark_transport

--- a/spark_transport/include/spark_transport/tp4_allreduce_protocol.hpp
+++ b/spark_transport/include/spark_transport/tp4_allreduce_protocol.hpp
@@ -1,0 +1,127 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+
+namespace spark_transport {
+
+enum class Tp4AllreduceProtocol : std::uint32_t {
+  kSerialAck = 0,
+  kTwoSlotDeferredAck = 1,
+};
+
+enum class Tp4CreditReuseState : std::uint8_t {
+  kReady,
+  kWaiting,
+  kFutureGeneration,
+};
+
+constexpr std::uint16_t kTp4TwoSlotEndpointTag = 0xc202;
+
+constexpr bool tp4_protocol_uses_deferred_ack(
+    Tp4AllreduceProtocol protocol) noexcept {
+  return protocol == Tp4AllreduceProtocol::kTwoSlotDeferredAck;
+}
+
+constexpr std::size_t tp4_payload_slot_count(
+    Tp4AllreduceProtocol protocol) noexcept {
+  return tp4_protocol_uses_deferred_ack(protocol) ? 2U : 1U;
+}
+
+constexpr std::uint16_t tp4_endpoint_protocol_tag(
+    Tp4AllreduceProtocol protocol) noexcept {
+  return tp4_protocol_uses_deferred_ack(protocol)
+             ? kTp4TwoSlotEndpointTag
+             : 0U;
+}
+
+constexpr std::size_t tp4_payload_slot_index(
+    std::uint64_t sequence, Tp4AllreduceProtocol protocol) noexcept {
+  if (sequence == 0) {
+    return 0;
+  }
+  return static_cast<std::size_t>(
+      (sequence - 1) % tp4_payload_slot_count(protocol));
+}
+
+constexpr std::uint64_t tp4_expected_reuse_credit(
+    std::uint64_t sequence, Tp4AllreduceProtocol protocol) noexcept {
+  const std::uint64_t slots = tp4_payload_slot_count(protocol);
+  return tp4_protocol_uses_deferred_ack(protocol) && sequence > slots
+             ? sequence - slots
+             : 0;
+}
+
+constexpr Tp4CreditReuseState tp4_credit_reuse_state(
+    std::uint64_t sequence, std::uint64_t observed_credit,
+    Tp4AllreduceProtocol protocol) noexcept {
+  const std::uint64_t expected =
+      tp4_expected_reuse_credit(sequence, protocol);
+  if (observed_credit == expected) {
+    return Tp4CreditReuseState::kReady;
+  }
+  return observed_credit < expected
+             ? Tp4CreditReuseState::kWaiting
+             : Tp4CreditReuseState::kFutureGeneration;
+}
+
+constexpr std::uint64_t tp4_latest_slot_sequence(
+    std::uint64_t final_sequence, std::size_t slot,
+    Tp4AllreduceProtocol protocol) noexcept {
+  const std::size_t slots = tp4_payload_slot_count(protocol);
+  if (final_sequence == 0 || slot >= slots || final_sequence <= slot) {
+    return 0;
+  }
+  const std::uint64_t distance =
+      (final_sequence - 1 - slot) % slots;
+  return final_sequence - distance;
+}
+
+inline std::size_t tp4_payload_arena_bytes(
+    std::size_t slot_bytes, Tp4AllreduceProtocol protocol) {
+  const std::size_t slots = tp4_payload_slot_count(protocol);
+  if (slot_bytes == 0 ||
+      slot_bytes > std::numeric_limits<std::size_t>::max() / slots) {
+    throw std::overflow_error("TP4 payload-slot arena size overflow");
+  }
+  return slot_bytes * slots;
+}
+
+inline Tp4AllreduceProtocol tp4_allreduce_protocol_from_wire(
+    std::uint32_t value) {
+  switch (value) {
+    case static_cast<std::uint32_t>(Tp4AllreduceProtocol::kSerialAck):
+      return Tp4AllreduceProtocol::kSerialAck;
+    case static_cast<std::uint32_t>(
+        Tp4AllreduceProtocol::kTwoSlotDeferredAck):
+      return Tp4AllreduceProtocol::kTwoSlotDeferredAck;
+    default:
+      throw std::invalid_argument("invalid TP4 all-reduce protocol");
+  }
+}
+
+inline Tp4AllreduceProtocol parse_tp4_allreduce_protocol(
+    std::string_view value) {
+  if (value == "serial_ack") {
+    return Tp4AllreduceProtocol::kSerialAck;
+  }
+  if (value == "two_slot_deferred_ack") {
+    return Tp4AllreduceProtocol::kTwoSlotDeferredAck;
+  }
+  throw std::invalid_argument(
+      "TP4 all-reduce protocol must be serial_ack or "
+      "two_slot_deferred_ack");
+}
+
+inline const char* tp4_allreduce_protocol_name(
+    Tp4AllreduceProtocol protocol) noexcept {
+  return tp4_protocol_uses_deferred_ack(protocol)
+             ? "two_slot_deferred_ack"
+             : "serial_ack";
+}
+
+}  // namespace spark_transport

--- a/spark_transport/include/spark_transport/tp4_c_api.h
+++ b/spark_transport/include/spark_transport/tp4_c_api.h
@@ -45,6 +45,30 @@ enum {
    * This is valid only with an exclusively affined progress CPU.
    */
   SPARK_TP4_GRAPH_STATUS_DEDICATED_SPIN = 1U << 6,
+  /* The graph session uses two generation-tagged payload slots per edge. */
+  SPARK_TP4_GRAPH_STATUS_TWO_SLOT_DEFERRED_ACK = 1U << 7,
+  /* Every captured node uses the fixed 64 KiB split-kernel graph. */
+  SPARK_TP4_GRAPH_STATUS_SPLIT_64K = 1U << 8,
+  /* Captured nodes select fused or split kernels from their active Q. */
+  SPARK_TP4_GRAPH_STATUS_TIERED_64K = 1U << 9,
+  /* The session counter-rotates tensor halves across both physical links. */
+  SPARK_TP4_GRAPH_STATUS_DUAL_PORT_STRIPED = 1U << 10,
+};
+
+enum {
+  SPARK_TP4_ALLREDUCE_PROTOCOL_SERIAL_ACK = 0,
+  SPARK_TP4_ALLREDUCE_PROTOCOL_TWO_SLOT_DEFERRED_ACK = 1,
+};
+
+enum {
+  SPARK_TP4_GRAPH_KERNEL_FUSED = 0,
+  SPARK_TP4_GRAPH_KERNEL_SPLIT_64K = 1,
+  SPARK_TP4_GRAPH_KERNEL_TIERED_64K = 2,
+};
+
+enum {
+  SPARK_TP4_WIRE_SCHEDULE_SEQUENTIAL = 0,
+  SPARK_TP4_WIRE_SCHEDULE_DUAL_PORT_STRIPED = 1,
 };
 
 typedef struct spark_tp4_graph_status {
@@ -61,6 +85,39 @@ typedef struct spark_tp4_graph_status {
 
 spark_tp4_handle spark_tp4_create(const spark_tp4_config* config,
                                   char* error, size_t error_bytes);
+
+/*
+ * Selects a protocol without extending the unversioned spark_tp4_config ABI.
+ * The graph kernel remains FUSED. spark_tp4_create remains equivalent to
+ * SERIAL_ACK plus FUSED. The two-slot protocol is experimental and accepted
+ * only for graph-only sessions.
+ */
+spark_tp4_handle spark_tp4_create_with_protocol(
+    const spark_tp4_config* config, uint32_t protocol, char* error,
+    size_t error_bytes);
+
+/*
+ * Selects protocol and graph-kernel strategy without changing
+ * spark_tp4_config. Invalid scalar values fail before session construction.
+ * SPLIT_64K and TIERED_64K are graph-only research strategies. Their selected
+ * strategy is attested by the corresponding mutually exclusive graph-status
+ * flag; FUSED sets neither strategy flag.
+ */
+spark_tp4_handle spark_tp4_create_with_protocol_and_graph_kernel(
+    const spark_tp4_config* config, uint32_t protocol,
+    uint32_t graph_kernel, char* error, size_t error_bytes);
+
+/*
+ * Additive constructor for a versioned wire schedule. Existing constructors
+ * remain equivalent to SEQUENTIAL. DUAL_PORT_STRIPED is graph-only and the
+ * native session rejects any incompatible protocol, graph kernel, affinity,
+ * or payload capacity before endpoint setup.
+ */
+spark_tp4_handle
+spark_tp4_create_with_protocol_graph_kernel_and_schedule(
+    const spark_tp4_config* config, uint32_t protocol,
+    uint32_t graph_kernel, uint32_t wire_schedule, char* error,
+    size_t error_bytes);
 
 int spark_tp4_all_reduce(spark_tp4_handle handle, const void* input,
                          void* output, void* cuda_stream, char* error,
@@ -95,7 +152,10 @@ int spark_tp4_capture_q1_all_reduce(
  * Counters may advance while they are copied, so callers that require a
  * quiescent equality gate should sample after request synchronization. A
  * completed_sequence increase proves actual graph replay transport progress;
- * captured_nodes alone proves only graph definition.
+ * captured_nodes alone proves only graph definition. When
+ * TWO_SLOT_DEFERRED_ACK is set, completed_sequence means the progress worker
+ * observed output consumption and posted both credits. Device output can be
+ * ready earlier; physical payload-slot retirement remains credit-gated.
  */
 int spark_tp4_get_graph_status(
     spark_tp4_handle handle, spark_tp4_graph_status* status,

--- a/spark_transport/include/spark_transport/tp4_dual_port_striped_allreduce.hpp
+++ b/spark_transport/include/spark_transport/tp4_dual_port_striped_allreduce.hpp
@@ -1,0 +1,296 @@
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <stdexcept>
+
+namespace spark_transport {
+
+constexpr std::size_t kTp4StripedRankCount = 4;
+constexpr std::size_t kTp4StripedPhaseCount = 2;
+constexpr std::size_t kTp4StripedEndpointCount = 2;
+constexpr std::size_t kTp4StripedLaneCount = 2;
+constexpr std::size_t kTp4StripedGenerationCount = 2;
+constexpr std::size_t kTp4StripedControlAlignment = 64;
+constexpr std::size_t kTp4StripedControlBytes = 64;
+
+// Internal C++ selector. The public C ABI and vLLM adapter remain on the
+// sequential schedule unless a research-only native caller opts in.
+enum class Tp4AllreduceSchedule : std::uint8_t {
+  kSequential = 0,
+  kDualPortStriped = 1,
+};
+
+constexpr bool tp4_allreduce_schedule_valid(
+    Tp4AllreduceSchedule schedule) noexcept {
+  return schedule == Tp4AllreduceSchedule::kSequential ||
+         schedule == Tp4AllreduceSchedule::kDualPortStriped;
+}
+
+constexpr const char* tp4_allreduce_schedule_name(
+    Tp4AllreduceSchedule schedule) noexcept {
+  switch (schedule) {
+    case Tp4AllreduceSchedule::kSequential:
+      return "sequential";
+    case Tp4AllreduceSchedule::kDualPortStriped:
+      return "dual_port_striped";
+  }
+  return "invalid";
+}
+
+enum class Tp4TensorStripe : std::uint8_t {
+  kLowerHalf = 0,
+  kUpperHalf = 1,
+};
+
+enum class Tp4DirectMatching : std::uint8_t {
+  kXor1 = 1,
+  kXor3 = 3,
+};
+
+struct Tp4StripedPhaseStrategy {
+  Tp4TensorStripe endpoint0_stripe{};
+  Tp4TensorStripe endpoint1_stripe{};
+};
+
+// Research-only schedule description. It is intentionally independent of the
+// implemented transport protocol and does not identify a compatible wire
+// layout. A transport implementation must use a distinct endpoint identity.
+struct Tp4DualPortStripedAllreduceStrategy {
+  std::array<Tp4StripedPhaseStrategy, kTp4StripedPhaseCount> phases{};
+};
+
+inline constexpr Tp4DualPortStripedAllreduceStrategy
+    kTp4DualPortOppositeOrderStrategy{
+        std::array<Tp4StripedPhaseStrategy, kTp4StripedPhaseCount>{
+            Tp4StripedPhaseStrategy{Tp4TensorStripe::kLowerHalf,
+                                    Tp4TensorStripe::kUpperHalf},
+            Tp4StripedPhaseStrategy{Tp4TensorStripe::kUpperHalf,
+                                    Tp4TensorStripe::kLowerHalf},
+        }};
+
+struct Tp4StripedPhaseTransfer {
+  std::uint32_t rank{};
+  std::uint32_t peer_rank{};
+  std::uint32_t phase{};
+  std::uint32_t endpoint{};
+  Tp4DirectMatching matching{};
+  Tp4TensorStripe stripe{};
+};
+
+constexpr Tp4DirectMatching tp4_striped_endpoint_matching(
+    std::uint32_t endpoint) {
+  if (endpoint >= kTp4StripedEndpointCount) {
+    throw std::out_of_range("TP4 striped endpoint must be zero or one");
+  }
+  return endpoint == 0 ? Tp4DirectMatching::kXor1
+                       : Tp4DirectMatching::kXor3;
+}
+
+constexpr std::uint32_t tp4_striped_matching_mask(
+    Tp4DirectMatching matching) noexcept {
+  return static_cast<std::uint32_t>(matching);
+}
+
+constexpr Tp4StripedPhaseTransfer tp4_striped_phase_transfer(
+    const Tp4DualPortStripedAllreduceStrategy& strategy,
+    std::uint32_t rank, std::uint32_t phase, std::uint32_t endpoint) {
+  if (rank >= kTp4StripedRankCount) {
+    throw std::out_of_range("TP4 striped rank must be in [0, 3]");
+  }
+  if (phase >= kTp4StripedPhaseCount) {
+    throw std::out_of_range("TP4 striped phase must be zero or one");
+  }
+  const Tp4DirectMatching matching =
+      tp4_striped_endpoint_matching(endpoint);
+  const auto& phase_strategy = strategy.phases[phase];
+  const Tp4TensorStripe stripe =
+      endpoint == 0 ? phase_strategy.endpoint0_stripe
+                    : phase_strategy.endpoint1_stripe;
+  return {rank, rank ^ tp4_striped_matching_mask(matching), phase,
+          endpoint, matching, stripe};
+}
+
+struct Tp4StripedScheduleVerification {
+  bool valid{};
+  std::array<std::uint8_t, kTp4StripedRankCount>
+      lower_half_contributors{};
+  std::array<std::uint8_t, kTp4StripedRankCount>
+      upper_half_contributors{};
+
+  constexpr bool complete() const noexcept {
+    if (!valid) {
+      return false;
+    }
+    for (std::size_t rank = 0; rank < kTp4StripedRankCount; ++rank) {
+      if (lower_half_contributors[rank] != 0x0fU ||
+          upper_half_contributors[rank] != 0x0fU) {
+        return false;
+      }
+    }
+    return true;
+  }
+};
+
+constexpr bool tp4_tensor_stripe_valid(Tp4TensorStripe stripe) noexcept {
+  return stripe == Tp4TensorStripe::kLowerHalf ||
+         stripe == Tp4TensorStripe::kUpperHalf;
+}
+
+constexpr std::array<std::uint8_t, kTp4StripedRankCount>
+tp4_exchange_symbolic_contributors(
+    const std::array<std::uint8_t, kTp4StripedRankCount>& contributors,
+    std::uint32_t matching_mask) noexcept {
+  std::array<std::uint8_t, kTp4StripedRankCount> exchanged{};
+  for (std::uint32_t rank = 0; rank < kTp4StripedRankCount; ++rank) {
+    exchanged[rank] = static_cast<std::uint8_t>(
+        contributors[rank] | contributors[rank ^ matching_mask]);
+  }
+  return exchanged;
+}
+
+constexpr Tp4StripedScheduleVerification verify_tp4_striped_allreduce(
+    const Tp4DualPortStripedAllreduceStrategy& strategy) noexcept {
+  Tp4StripedScheduleVerification result{};
+  for (std::uint32_t rank = 0; rank < kTp4StripedRankCount; ++rank) {
+    const auto contributor = static_cast<std::uint8_t>(1U << rank);
+    result.lower_half_contributors[rank] = contributor;
+    result.upper_half_contributors[rank] = contributor;
+  }
+
+  for (const auto& phase : strategy.phases) {
+    if (!tp4_tensor_stripe_valid(phase.endpoint0_stripe) ||
+        !tp4_tensor_stripe_valid(phase.endpoint1_stripe) ||
+        phase.endpoint0_stripe == phase.endpoint1_stripe) {
+      return result;
+    }
+    if (phase.endpoint0_stripe == Tp4TensorStripe::kLowerHalf) {
+      result.lower_half_contributors =
+          tp4_exchange_symbolic_contributors(
+              result.lower_half_contributors, 1U);
+      result.upper_half_contributors =
+          tp4_exchange_symbolic_contributors(
+              result.upper_half_contributors, 3U);
+    } else {
+      result.upper_half_contributors =
+          tp4_exchange_symbolic_contributors(
+              result.upper_half_contributors, 1U);
+      result.lower_half_contributors =
+          tp4_exchange_symbolic_contributors(
+              result.lower_half_contributors, 3U);
+    }
+  }
+  result.valid = true;
+  return result;
+}
+
+struct Tp4StripedEndpointLayout {
+  std::size_t payload_bytes{};
+  std::size_t stripe_bytes{};
+  std::size_t lane_receive_offset{};
+  std::size_t lane_control_offset{};
+  std::size_t lane_stride{};
+  std::size_t generation_stride{};
+  std::size_t total_bytes{};
+};
+
+struct Tp4StripedLaneRegion {
+  std::size_t send_offset{};
+  std::size_t receive_offset{};
+  std::size_t control_offset{};
+  std::size_t end_offset{};
+};
+
+constexpr std::size_t tp4_striped_generation_slot(
+    std::uint64_t sequence) {
+  if (sequence == 0) {
+    throw std::out_of_range("TP4 striped sequence must be positive");
+  }
+  return static_cast<std::size_t>(
+      (sequence - 1U) % kTp4StripedGenerationCount);
+}
+
+namespace detail {
+
+constexpr std::size_t tp4_striped_checked_add(std::size_t left,
+                                              std::size_t right) {
+  if (left > std::numeric_limits<std::size_t>::max() - right) {
+    throw std::overflow_error("TP4 striped layout size overflow");
+  }
+  return left + right;
+}
+
+constexpr std::size_t tp4_striped_checked_multiply(std::size_t left,
+                                                   std::size_t right) {
+  if (left != 0 &&
+      right > std::numeric_limits<std::size_t>::max() / left) {
+    throw std::overflow_error("TP4 striped layout size overflow");
+  }
+  return left * right;
+}
+
+}  // namespace detail
+
+constexpr std::size_t tp4_striped_align_control(
+    std::size_t bytes) {
+  const std::size_t remainder = bytes % kTp4StripedControlAlignment;
+  const std::size_t padding =
+      remainder == 0 ? 0 : kTp4StripedControlAlignment - remainder;
+  return detail::tp4_striped_checked_add(bytes, padding);
+}
+
+constexpr Tp4StripedEndpointLayout make_tp4_striped_endpoint_layout(
+    std::size_t payload_bytes) {
+  constexpr std::size_t bytes_per_bf16 = 2;
+  constexpr std::size_t stripe_count = 2;
+  if (payload_bytes == 0 ||
+      payload_bytes % (bytes_per_bf16 * stripe_count) != 0) {
+    throw std::invalid_argument(
+        "TP4 striped payload must split into two nonempty BF16 halves");
+  }
+  const std::size_t stripe_bytes = payload_bytes / 2U;
+  const std::size_t receive_offset =
+      tp4_striped_align_control(stripe_bytes);
+  const std::size_t control_offset =
+      tp4_striped_align_control(
+          detail::tp4_striped_checked_add(receive_offset, stripe_bytes));
+  const std::size_t lane_stride =
+      detail::tp4_striped_checked_add(control_offset,
+                                      kTp4StripedControlBytes);
+  const std::size_t generation_stride =
+      detail::tp4_striped_checked_multiply(lane_stride,
+                                          kTp4StripedLaneCount);
+  return {payload_bytes,
+          stripe_bytes,
+          receive_offset,
+          control_offset,
+          lane_stride,
+          generation_stride,
+          detail::tp4_striped_checked_multiply(
+              generation_stride, kTp4StripedGenerationCount)};
+}
+
+constexpr Tp4StripedLaneRegion tp4_striped_lane_region(
+    const Tp4StripedEndpointLayout& layout, std::size_t generation,
+    Tp4TensorStripe stripe) {
+  if (generation >= kTp4StripedGenerationCount) {
+    throw std::out_of_range(
+        "TP4 striped generation must be zero or one");
+  }
+  if (!tp4_tensor_stripe_valid(stripe)) {
+    throw std::out_of_range("invalid TP4 tensor stripe");
+  }
+  const std::size_t stripe_index =
+      static_cast<std::size_t>(stripe);
+  const std::size_t send_offset =
+      generation * layout.generation_stride +
+      stripe_index * layout.lane_stride;
+  return {send_offset,
+          send_offset + layout.lane_receive_offset,
+          send_offset + layout.lane_control_offset,
+          send_offset + layout.lane_stride};
+}
+
+}  // namespace spark_transport

--- a/spark_transport/include/spark_transport/tp4_graph_kernel_strategy.hpp
+++ b/spark_transport/include/spark_transport/tp4_graph_kernel_strategy.hpp
@@ -1,0 +1,64 @@
+#pragma once
+
+#include <cstdint>
+
+namespace spark_transport {
+
+// Research-only CUDA kernel selection for graph TP4 all-reduce. The public C
+// ABI and vLLM adapter do not expose this selector; their default-constructed
+// C++ options remain on the fused kernel.
+enum class Tp4GraphKernelStrategy : std::uint8_t {
+  kFused = 0,
+  kSplit64KiB = 1,
+  // Research-only per-node selector. One graph session retains the fused
+  // latency path for decode-sized nodes and selects the split grid for larger
+  // nodes without changing transport sequence or payload-slot ownership.
+  kTiered64KiB = 2,
+};
+
+constexpr std::uint32_t kTp4TieredSplitMinimumQ = 7;
+
+constexpr bool tp4_graph_kernel_strategy_valid(
+    Tp4GraphKernelStrategy strategy) noexcept {
+  switch (strategy) {
+    case Tp4GraphKernelStrategy::kFused:
+    case Tp4GraphKernelStrategy::kSplit64KiB:
+    case Tp4GraphKernelStrategy::kTiered64KiB:
+      return true;
+  }
+  return false;
+}
+
+constexpr bool tp4_graph_kernel_strategy_is_graph_only(
+    Tp4GraphKernelStrategy strategy) noexcept {
+  return strategy == Tp4GraphKernelStrategy::kSplit64KiB ||
+         strategy == Tp4GraphKernelStrategy::kTiered64KiB;
+}
+
+constexpr bool tp4_graph_kernel_uses_split(
+    Tp4GraphKernelStrategy strategy, std::uint32_t q) noexcept {
+  switch (strategy) {
+    case Tp4GraphKernelStrategy::kFused:
+      return false;
+    case Tp4GraphKernelStrategy::kSplit64KiB:
+      return true;
+    case Tp4GraphKernelStrategy::kTiered64KiB:
+      return q >= kTp4TieredSplitMinimumQ;
+  }
+  return false;
+}
+
+constexpr const char* tp4_graph_kernel_strategy_name(
+    Tp4GraphKernelStrategy strategy) noexcept {
+  switch (strategy) {
+    case Tp4GraphKernelStrategy::kFused:
+      return "fused";
+    case Tp4GraphKernelStrategy::kSplit64KiB:
+      return "split_64k";
+    case Tp4GraphKernelStrategy::kTiered64KiB:
+      return "tiered_64k";
+  }
+  return "invalid";
+}
+
+}  // namespace spark_transport

--- a/spark_transport/include/spark_transport/tp4_session.hpp
+++ b/spark_transport/include/spark_transport/tp4_session.hpp
@@ -6,6 +6,10 @@
 #include <optional>
 #include <string>
 
+#include "spark_transport/tp4_allreduce_protocol.hpp"
+#include "spark_transport/tp4_dual_port_striped_allreduce.hpp"
+#include "spark_transport/tp4_graph_kernel_strategy.hpp"
+
 namespace spark_transport {
 
 struct Tp4AllreduceOptions {
@@ -19,6 +23,10 @@ struct Tp4AllreduceOptions {
   std::uint16_t control_port0{9470};
   std::uint16_t control_port1{9471};
   std::size_t payload_bytes{12288};
+  Tp4AllreduceProtocol protocol{Tp4AllreduceProtocol::kSerialAck};
+  Tp4GraphKernelStrategy graph_kernel_strategy{
+      Tp4GraphKernelStrategy::kFused};
+  Tp4AllreduceSchedule schedule{Tp4AllreduceSchedule::kSequential};
   // When both are set, graph-only deployment pins the calling/submission
   // thread exclusively to graph_submit_cpu and pins the persistent verbs
   // progress thread exclusively to graph_progress_cpu. They must be distinct.
@@ -37,6 +45,7 @@ struct Tp4GraphReplayStatus {
   bool host_native_atomics_supported{};
   bool submit_affinity_verified{};
   bool progress_affinity_verified{};
+  bool two_slot_deferred_ack{};
   int graph_submit_cpu{-1};
   int graph_progress_cpu{-1};
 };

--- a/spark_transport/include/spark_transport/tp4_tiled_session.hpp
+++ b/spark_transport/include/spark_transport/tp4_tiled_session.hpp
@@ -1,0 +1,550 @@
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <stdexcept>
+
+#include "spark_transport/gpu_doorbell.hpp"
+
+namespace spark_transport {
+
+// Status: offline-validated, research-only. These types define a bounded
+// native integration seam but no production session, CUDA kernel, verbs
+// endpoint, public C function, or vLLM adapter consumes them.
+
+constexpr std::uint32_t kTp4TiledLatencyMaximumQ = 40;
+constexpr std::uint32_t kTp4TiledMediumMaximumQ = 512;
+constexpr std::uint32_t kTp4TiledLargeMaximumQ = 1024;
+constexpr std::uint32_t kTp4TiledStreamingMaximumQ = 4096;
+constexpr std::uint32_t kTp4TiledBf16ElementsPerQueryRow = 6144;
+constexpr std::size_t kTp4TiledBytesPerBf16 = 2;
+constexpr std::size_t kTp4TiledBytesPerQueryRow =
+    kTp4TiledBf16ElementsPerQueryRow * kTp4TiledBytesPerBf16;
+constexpr std::size_t kTp4TiledDefaultTilePayloadBytes = 512U * 1024U;
+constexpr std::uint32_t kTp4TiledDefaultSlotsPerEdge = 8;
+constexpr std::uint32_t kTp4TiledDefaultLanesPerEdge = 2;
+constexpr std::size_t kTp4TiledEdgeCount = 2;
+constexpr std::size_t kTp4TiledControlAlignment = alignof(DoorbellControl);
+constexpr std::size_t kTp4TiledControlBytes = sizeof(DoorbellControl);
+
+static_assert(kTp4TiledControlAlignment == 64);
+static_assert(kTp4TiledControlBytes == 64);
+
+// This source-level selector is not consumed by Tp4AllreduceSession or the C
+// ABI. Keeping the default exact-payload state in a separate options object
+// lets a later explicit factory opt into tiled storage without changing the
+// layout or behavior of the existing session options.
+enum class Tp4SessionStorageSelector : std::uint8_t {
+  kExactPayload = 0,
+  kCapacityTieredTiles = 1,
+};
+
+enum class Tp4TiledCapacityClass : std::uint8_t {
+  kUnspecified = 0,
+  kLatencyQ40 = 1,
+  kMediumQ512 = 2,
+  kLargeQ1024 = 3,
+  kStreamingQ4096 = 4,
+};
+
+struct Tp4SessionStorageOptions {
+  Tp4SessionStorageSelector selector{
+      Tp4SessionStorageSelector::kExactPayload};
+  Tp4TiledCapacityClass capacity_class{
+      Tp4TiledCapacityClass::kUnspecified};
+  std::uint32_t maximum_query_rows{};
+  std::size_t tile_payload_bytes{};
+  std::uint32_t slots_per_edge{};
+  std::uint32_t lanes_per_edge{};
+};
+
+constexpr bool operator==(const Tp4SessionStorageOptions& left,
+                          const Tp4SessionStorageOptions& right) noexcept {
+  return left.selector == right.selector &&
+         left.capacity_class == right.capacity_class &&
+         left.maximum_query_rows == right.maximum_query_rows &&
+         left.tile_payload_bytes == right.tile_payload_bytes &&
+         left.slots_per_edge == right.slots_per_edge &&
+         left.lanes_per_edge == right.lanes_per_edge;
+}
+
+constexpr bool operator!=(const Tp4SessionStorageOptions& left,
+                          const Tp4SessionStorageOptions& right) noexcept {
+  return !(left == right);
+}
+
+constexpr std::uint32_t tp4_tiled_capacity_maximum_query_rows(
+    Tp4TiledCapacityClass capacity_class) noexcept {
+  switch (capacity_class) {
+    case Tp4TiledCapacityClass::kLatencyQ40:
+      return kTp4TiledLatencyMaximumQ;
+    case Tp4TiledCapacityClass::kMediumQ512:
+      return kTp4TiledMediumMaximumQ;
+    case Tp4TiledCapacityClass::kLargeQ1024:
+      return kTp4TiledLargeMaximumQ;
+    case Tp4TiledCapacityClass::kStreamingQ4096:
+      return kTp4TiledStreamingMaximumQ;
+    case Tp4TiledCapacityClass::kUnspecified:
+      return 0;
+  }
+  return 0;
+}
+
+constexpr Tp4TiledCapacityClass tp4_select_tiled_capacity_class(
+    std::uint32_t query_rows) {
+  if (query_rows == 0 || query_rows > kTp4TiledStreamingMaximumQ) {
+    throw std::out_of_range("tiled TP4 query rows must be in [1, 4096]");
+  }
+  if (query_rows <= kTp4TiledLatencyMaximumQ) {
+    return Tp4TiledCapacityClass::kLatencyQ40;
+  }
+  if (query_rows <= kTp4TiledMediumMaximumQ) {
+    return Tp4TiledCapacityClass::kMediumQ512;
+  }
+  if (query_rows <= kTp4TiledLargeMaximumQ) {
+    return Tp4TiledCapacityClass::kLargeQ1024;
+  }
+  if (query_rows <= kTp4TiledStreamingMaximumQ) {
+    return Tp4TiledCapacityClass::kStreamingQ4096;
+  }
+  throw std::out_of_range("tiled TP4 capacity selector is inconsistent");
+}
+
+constexpr Tp4SessionStorageOptions
+make_tp4_tiled_session_storage_options(std::uint32_t query_rows) {
+  const auto capacity_class =
+      tp4_select_tiled_capacity_class(query_rows);
+  return {Tp4SessionStorageSelector::kCapacityTieredTiles,
+          capacity_class,
+          tp4_tiled_capacity_maximum_query_rows(capacity_class),
+          kTp4TiledDefaultTilePayloadBytes,
+          kTp4TiledDefaultSlotsPerEdge,
+          kTp4TiledDefaultLanesPerEdge};
+}
+
+constexpr bool tp4_session_storage_options_valid(
+    const Tp4SessionStorageOptions& options) noexcept {
+  if (options.selector == Tp4SessionStorageSelector::kExactPayload) {
+    return options.capacity_class ==
+               Tp4TiledCapacityClass::kUnspecified &&
+           options.maximum_query_rows == 0 &&
+           options.tile_payload_bytes == 0 &&
+           options.slots_per_edge == 0 && options.lanes_per_edge == 0;
+  }
+  if (options.selector !=
+      Tp4SessionStorageSelector::kCapacityTieredTiles) {
+    return false;
+  }
+  const auto maximum = tp4_tiled_capacity_maximum_query_rows(
+      options.capacity_class);
+  return maximum != 0 && options.maximum_query_rows == maximum &&
+         options.tile_payload_bytes ==
+             kTp4TiledDefaultTilePayloadBytes &&
+         options.slots_per_edge == kTp4TiledDefaultSlotsPerEdge &&
+         options.lanes_per_edge == kTp4TiledDefaultLanesPerEdge;
+}
+
+struct Tp4TiledPoolLayout {
+  std::size_t tile_payload_bytes{};
+  std::uint32_t slots_per_edge{};
+  std::uint32_t lanes_per_edge{};
+  std::size_t lane_payload_bytes{};
+  std::size_t lane_receive_offset{};
+  std::size_t lane_control_offset{};
+  std::size_t lane_stride{};
+  std::size_t slot_stride{};
+  std::size_t total_bytes{};
+};
+
+struct Tp4TiledSlotRegion {
+  std::size_t send_offset{};
+  std::size_t receive_offset{};
+  std::size_t control_offset{};
+  std::size_t end_offset{};
+};
+
+namespace detail {
+
+constexpr std::size_t tp4_tiled_checked_add(std::size_t left,
+                                            std::size_t right) {
+  if (left > std::numeric_limits<std::size_t>::max() - right) {
+    throw std::overflow_error("tiled TP4 layout size overflow");
+  }
+  return left + right;
+}
+
+constexpr std::size_t tp4_tiled_checked_multiply(std::size_t left,
+                                                 std::size_t right) {
+  if (left != 0 &&
+      right > std::numeric_limits<std::size_t>::max() / left) {
+    throw std::overflow_error("tiled TP4 layout size overflow");
+  }
+  return left * right;
+}
+
+constexpr std::uint64_t tp4_tiled_checked_add_u64(
+    std::uint64_t left, std::uint64_t right) {
+  if (left > std::numeric_limits<std::uint64_t>::max() - right) {
+    throw std::overflow_error("tiled TP4 tile ordinal overflow");
+  }
+  return left + right;
+}
+
+constexpr std::uint64_t tp4_tiled_checked_multiply_u64(
+    std::uint64_t left, std::uint64_t right) {
+  if (left != 0 &&
+      right > std::numeric_limits<std::uint64_t>::max() / left) {
+    throw std::overflow_error("tiled TP4 tile ordinal overflow");
+  }
+  return left * right;
+}
+
+}  // namespace detail
+
+constexpr std::size_t tp4_tiled_align_control(std::size_t bytes) {
+  const std::size_t remainder = bytes % kTp4TiledControlAlignment;
+  const std::size_t padding =
+      remainder == 0 ? 0 : kTp4TiledControlAlignment - remainder;
+  return detail::tp4_tiled_checked_add(bytes, padding);
+}
+
+constexpr Tp4TiledPoolLayout make_tp4_tiled_pool_layout(
+    std::size_t tile_payload_bytes, std::uint32_t slots_per_edge,
+    std::uint32_t lanes_per_edge) {
+  if (tile_payload_bytes == 0 ||
+      tile_payload_bytes % kTp4TiledBytesPerBf16 != 0) {
+    throw std::invalid_argument(
+        "tiled TP4 payload must contain whole BF16 elements");
+  }
+  if (slots_per_edge == 0) {
+    throw std::invalid_argument(
+        "tiled TP4 pool requires at least one slot per edge");
+  }
+  if (lanes_per_edge == 0 ||
+      tile_payload_bytes % lanes_per_edge != 0) {
+    throw std::invalid_argument(
+        "tiled TP4 payload must split exactly across nonempty lanes");
+  }
+  const std::size_t lane_payload_bytes =
+      tile_payload_bytes / lanes_per_edge;
+  if (lane_payload_bytes % kTp4TiledBytesPerBf16 != 0) {
+    throw std::invalid_argument(
+        "tiled TP4 lane must contain whole BF16 elements");
+  }
+  const std::size_t receive_offset =
+      tp4_tiled_align_control(lane_payload_bytes);
+  const std::size_t control_offset = tp4_tiled_align_control(
+      detail::tp4_tiled_checked_add(receive_offset,
+                                    lane_payload_bytes));
+  const std::size_t lane_stride = tp4_tiled_align_control(
+      detail::tp4_tiled_checked_add(control_offset,
+                                    kTp4TiledControlBytes));
+  const std::size_t slot_stride =
+      detail::tp4_tiled_checked_multiply(lane_stride,
+                                         lanes_per_edge);
+  return {tile_payload_bytes,
+          slots_per_edge,
+          lanes_per_edge,
+          lane_payload_bytes,
+          receive_offset,
+          control_offset,
+          lane_stride,
+          slot_stride,
+          detail::tp4_tiled_checked_multiply(slot_stride,
+                                             slots_per_edge)};
+}
+
+constexpr Tp4TiledPoolLayout make_tp4_tiled_pool_layout(
+    const Tp4SessionStorageOptions& options) {
+  if (options.selector !=
+          Tp4SessionStorageSelector::kCapacityTieredTiles ||
+      !tp4_session_storage_options_valid(options)) {
+    throw std::invalid_argument(
+        "tiled TP4 pool requires valid capacity-tiered storage options");
+  }
+  return make_tp4_tiled_pool_layout(options.tile_payload_bytes,
+                                    options.slots_per_edge,
+                                    options.lanes_per_edge);
+}
+
+constexpr Tp4TiledSlotRegion tp4_tiled_slot_region(
+    const Tp4TiledPoolLayout& layout, std::uint32_t slot,
+    std::uint32_t lane) {
+  if (slot >= layout.slots_per_edge) {
+    throw std::out_of_range("tiled TP4 slot is outside the pool");
+  }
+  if (lane >= layout.lanes_per_edge) {
+    throw std::out_of_range("tiled TP4 lane is outside the slot");
+  }
+  const std::size_t slot_offset =
+      detail::tp4_tiled_checked_multiply(layout.slot_stride, slot);
+  const std::size_t lane_offset =
+      detail::tp4_tiled_checked_multiply(layout.lane_stride, lane);
+  const std::size_t send_offset =
+      detail::tp4_tiled_checked_add(slot_offset, lane_offset);
+  return {send_offset,
+          detail::tp4_tiled_checked_add(send_offset,
+                                        layout.lane_receive_offset),
+          detail::tp4_tiled_checked_add(send_offset,
+                                        layout.lane_control_offset),
+          detail::tp4_tiled_checked_add(send_offset,
+                                        layout.lane_stride)};
+}
+
+struct Tp4TileTicket {
+  std::uint64_t generation{};
+  std::uint32_t slot{};
+};
+
+constexpr bool operator==(const Tp4TileTicket& left,
+                          const Tp4TileTicket& right) noexcept {
+  return left.generation == right.generation && left.slot == right.slot;
+}
+
+constexpr bool operator!=(const Tp4TileTicket& left,
+                          const Tp4TileTicket& right) noexcept {
+  return !(left == right);
+}
+
+constexpr Tp4TileTicket tp4_tiled_ticket_from_ordinal(
+    std::uint64_t ordinal, std::uint32_t slots_per_edge) {
+  if (slots_per_edge == 0) {
+    throw std::invalid_argument(
+        "tiled TP4 ticket requires at least one slot per edge");
+  }
+  const std::uint64_t generation_index = ordinal / slots_per_edge;
+  if (generation_index ==
+      std::numeric_limits<std::uint64_t>::max()) {
+    throw std::overflow_error("tiled TP4 ticket generation exhausted");
+  }
+  return {generation_index + 1,
+          static_cast<std::uint32_t>(ordinal % slots_per_edge)};
+}
+
+constexpr std::uint64_t tp4_tiled_ticket_ordinal(
+    Tp4TileTicket ticket, std::uint32_t slots_per_edge) {
+  if (slots_per_edge == 0 || ticket.generation == 0 ||
+      ticket.slot >= slots_per_edge) {
+    throw std::invalid_argument("invalid tiled TP4 ticket");
+  }
+  const auto generation_offset =
+      detail::tp4_tiled_checked_multiply_u64(
+          ticket.generation - 1, slots_per_edge);
+  return detail::tp4_tiled_checked_add_u64(generation_offset,
+                                           ticket.slot);
+}
+
+struct Tp4TiledOperationDescriptor {
+  Tp4TiledCapacityClass capacity_class{
+      Tp4TiledCapacityClass::kUnspecified};
+  std::uint32_t query_rows{};
+  std::uint32_t tile_count{};
+  std::uint64_t active_bytes{};
+};
+
+struct Tp4TiledTileDescriptor {
+  Tp4TileTicket ticket{};
+  std::uint64_t operation_offset_bytes{};
+  std::uint32_t active_bytes{};
+};
+
+constexpr Tp4TiledOperationDescriptor
+make_tp4_tiled_bf16_allreduce_operation(std::uint32_t query_rows) {
+  const auto capacity_class =
+      tp4_select_tiled_capacity_class(query_rows);
+  const std::uint64_t active_bytes =
+      static_cast<std::uint64_t>(query_rows) * kTp4TiledBytesPerQueryRow;
+  const std::uint64_t tile_count =
+      (active_bytes + kTp4TiledDefaultTilePayloadBytes - 1U) /
+      kTp4TiledDefaultTilePayloadBytes;
+  return {capacity_class,
+          query_rows,
+          static_cast<std::uint32_t>(tile_count),
+          active_bytes};
+}
+
+constexpr bool tp4_tiled_operation_descriptor_valid(
+    const Tp4TiledOperationDescriptor& operation) noexcept {
+  if (operation.query_rows == 0 ||
+      operation.query_rows > kTp4TiledStreamingMaximumQ) {
+    return false;
+  }
+  const Tp4TiledCapacityClass expected_capacity =
+      operation.query_rows <= kTp4TiledLatencyMaximumQ
+          ? Tp4TiledCapacityClass::kLatencyQ40
+          : operation.query_rows <= kTp4TiledMediumMaximumQ
+                ? Tp4TiledCapacityClass::kMediumQ512
+                : operation.query_rows <= kTp4TiledLargeMaximumQ
+                      ? Tp4TiledCapacityClass::kLargeQ1024
+                      : Tp4TiledCapacityClass::kStreamingQ4096;
+  const std::uint64_t expected_active_bytes =
+      static_cast<std::uint64_t>(operation.query_rows) *
+      kTp4TiledBytesPerQueryRow;
+  const std::uint64_t expected_tile_count =
+      (expected_active_bytes + kTp4TiledDefaultTilePayloadBytes - 1U) /
+      kTp4TiledDefaultTilePayloadBytes;
+  return operation.capacity_class == expected_capacity &&
+         operation.active_bytes == expected_active_bytes &&
+         operation.tile_count == expected_tile_count;
+}
+
+constexpr Tp4TiledTileDescriptor make_tp4_tiled_tile_descriptor(
+    const Tp4TiledOperationDescriptor& operation,
+    std::uint32_t tile_index, std::uint64_t first_tile_ordinal = 0) {
+  if (!tp4_tiled_operation_descriptor_valid(operation)) {
+    throw std::invalid_argument(
+        "invalid tiled TP4 operation descriptor");
+  }
+  if (tile_index >= operation.tile_count) {
+    throw std::out_of_range(
+        "tiled TP4 tile index is outside the operation");
+  }
+  const std::uint64_t operation_offset =
+      static_cast<std::uint64_t>(tile_index) *
+      kTp4TiledDefaultTilePayloadBytes;
+  const std::uint64_t remaining =
+      operation.active_bytes - operation_offset;
+  const std::uint64_t active_bytes =
+      remaining < kTp4TiledDefaultTilePayloadBytes
+          ? remaining
+          : kTp4TiledDefaultTilePayloadBytes;
+  const std::uint64_t ordinal = detail::tp4_tiled_checked_add_u64(
+      first_tile_ordinal, tile_index);
+  return {tp4_tiled_ticket_from_ordinal(
+              ordinal, kTp4TiledDefaultSlotsPerEdge),
+          operation_offset,
+          static_cast<std::uint32_t>(active_bytes)};
+}
+
+enum class Tp4TiledAcquireState : std::uint8_t {
+  kReady,
+  kWaitingForCredit,
+  kUnexpectedTicket,
+  kPoisoned,
+  kExhausted,
+};
+
+enum class Tp4TiledCreditUpdateState : std::uint8_t {
+  kAdvanced,
+  kDuplicate,
+  kPoisoned,
+};
+
+// Plain host state for one logical tile sequence spanning both TP4 edges.
+// Credits are inclusive cumulative tile ordinals. Slot reuse requires both
+// edges to have consumed that slot's prior generation. A stale ticket,
+// regressing watermark, credit for unissued work, or invalid edge poisons the
+// state permanently; production integration must translate that condition
+// into the transport's process-fatal protocol path. The object has one host
+// owner; concurrent edge engines must synchronize updates before calling it.
+class Tp4TiledCreditWindow {
+ public:
+  explicit Tp4TiledCreditWindow(std::uint32_t slots_per_edge)
+      : slots_per_edge_(slots_per_edge) {
+    if (slots_per_edge_ == 0) {
+      throw std::invalid_argument(
+          "tiled TP4 credit window requires at least one slot");
+    }
+  }
+
+  Tp4TiledAcquireState try_acquire(Tp4TileTicket ticket) noexcept {
+    if (poisoned_) {
+      return Tp4TiledAcquireState::kPoisoned;
+    }
+    if (exhausted_) {
+      return Tp4TiledAcquireState::kExhausted;
+    }
+
+    const std::uint64_t generation_index =
+        next_ordinal_ / slots_per_edge_;
+    if (generation_index ==
+        std::numeric_limits<std::uint64_t>::max()) {
+      exhausted_ = true;
+      return Tp4TiledAcquireState::kExhausted;
+    }
+    const Tp4TileTicket expected{
+        generation_index + 1,
+        static_cast<std::uint32_t>(next_ordinal_ % slots_per_edge_)};
+    if (ticket != expected) {
+      poisoned_ = true;
+      return Tp4TiledAcquireState::kUnexpectedTicket;
+    }
+
+    if (next_ordinal_ >= slots_per_edge_) {
+      const std::uint64_t required_consumed_ordinal =
+          next_ordinal_ - slots_per_edge_;
+      for (std::size_t edge = 0; edge < kTp4TiledEdgeCount; ++edge) {
+        if (!credit_observed_[edge] ||
+            consumed_through_[edge] < required_consumed_ordinal) {
+          return Tp4TiledAcquireState::kWaitingForCredit;
+        }
+      }
+    }
+
+    has_issued_ = true;
+    highest_issued_ = next_ordinal_;
+    if (next_ordinal_ ==
+        std::numeric_limits<std::uint64_t>::max()) {
+      exhausted_ = true;
+    } else {
+      ++next_ordinal_;
+    }
+    return Tp4TiledAcquireState::kReady;
+  }
+
+  Tp4TiledCreditUpdateState observe_consumed_through(
+      std::uint32_t edge, std::uint64_t consumed_ordinal) noexcept {
+    if (poisoned_) {
+      return Tp4TiledCreditUpdateState::kPoisoned;
+    }
+    if (edge >= kTp4TiledEdgeCount || !has_issued_ ||
+        consumed_ordinal > highest_issued_) {
+      poisoned_ = true;
+      return Tp4TiledCreditUpdateState::kPoisoned;
+    }
+    if (credit_observed_[edge]) {
+      if (consumed_ordinal < consumed_through_[edge]) {
+        poisoned_ = true;
+        return Tp4TiledCreditUpdateState::kPoisoned;
+      }
+      if (consumed_ordinal == consumed_through_[edge]) {
+        return Tp4TiledCreditUpdateState::kDuplicate;
+      }
+    }
+    consumed_through_[edge] = consumed_ordinal;
+    credit_observed_[edge] = true;
+    return Tp4TiledCreditUpdateState::kAdvanced;
+  }
+
+  constexpr std::uint32_t slots_per_edge() const noexcept {
+    return slots_per_edge_;
+  }
+
+  constexpr std::uint64_t next_ordinal() const noexcept {
+    return next_ordinal_;
+  }
+
+  constexpr bool has_issued() const noexcept { return has_issued_; }
+
+  constexpr std::uint64_t highest_issued() const noexcept {
+    return highest_issued_;
+  }
+
+  constexpr bool poisoned() const noexcept { return poisoned_; }
+
+  constexpr bool exhausted() const noexcept { return exhausted_; }
+
+ private:
+  std::uint32_t slots_per_edge_{};
+  std::uint64_t next_ordinal_{};
+  std::uint64_t highest_issued_{};
+  std::array<std::uint64_t, kTp4TiledEdgeCount> consumed_through_{};
+  std::array<bool, kTp4TiledEdgeCount> credit_observed_{};
+  bool has_issued_{};
+  bool poisoned_{};
+  bool exhausted_{};
+};
+
+}  // namespace spark_transport

--- a/spark_transport/include/spark_transport/verbs_endpoint.hpp
+++ b/spark_transport/include/spark_transport/verbs_endpoint.hpp
@@ -18,6 +18,8 @@ constexpr std::uint16_t kEndpointVersion = 1;
 struct EndpointInfo {
   std::uint32_t magic{kEndpointMagic};
   std::uint16_t version{kEndpointVersion};
+  // A session family may carry a setup-only compatibility tag here. The
+  // generic endpoint validates magic/version and otherwise leaves it opaque.
   std::uint16_t reserved{};
   std::uint32_t qp_number{};
   std::uint32_t rkey{};
@@ -29,6 +31,36 @@ struct EndpointInfo {
 
 static_assert(std::is_trivially_copyable_v<EndpointInfo>);
 
+enum class SendCompletionPollState : std::uint8_t {
+  kPending,
+  kComplete,
+};
+
+namespace detail {
+
+enum class SendCompletionDisposition : std::uint8_t {
+  kRetire,
+  kComplete,
+  kUnexpected,
+};
+
+// Through polling uses ordinary unsigned order. Callers that permit older
+// completions must assign monotonic work IDs and must not wrap while a
+// completion remains outstanding on the endpoint.
+constexpr SendCompletionDisposition classify_send_completion(
+    std::uint64_t expected_work_id, std::uint64_t completed_work_id,
+    bool allow_older) noexcept {
+  if (completed_work_id == expected_work_id) {
+    return SendCompletionDisposition::kComplete;
+  }
+  if (allow_older && completed_work_id < expected_work_id) {
+    return SendCompletionDisposition::kRetire;
+  }
+  return SendCompletionDisposition::kUnexpected;
+}
+
+}  // namespace detail
+
 class VerbsEndpoint {
  public:
   VerbsEndpoint(const VerbsEndpoint&) = delete;
@@ -39,15 +71,32 @@ class VerbsEndpoint {
                 std::uint8_t gid_index, MemoryBuffer& buffer);
 
   EndpointInfo local_info() const;
-  void connect(const EndpointInfo& remote);
+  void connect(const EndpointInfo& remote,
+               std::uint16_t expected_version = kEndpointVersion);
 
   void write(std::size_t local_offset, std::size_t remote_offset,
              std::size_t bytes, std::uint64_t work_id,
              bool signaled = true);
   void wait_for_send(std::uint64_t expected_work_id);
+  // Waits for expected_work_id while retiring successful older completions.
+  // Deferred-credit TP4 uses this to reap the preceding signaled credit WR
+  // without putting that credit on the operation's output-ready path.
+  void wait_for_send_through(std::uint64_t expected_work_id);
+  // Performs a nonblocking form of wait_for_send_through for a signaled write.
+  // Successful older CQEs are retired; kPending means the CQ was empty after
+  // any available older CQEs were retired; and kComplete consumes
+  // expected_work_id. Poll failures, failed CQEs, and newer work IDs throw.
+  // The caller must serialize all completion methods and must not poll an ID
+  // again after kComplete.
+  SendCompletionPollState poll_send_through(
+      std::uint64_t expected_work_id);
 
  private:
   void cleanup() noexcept;
+  SendCompletionPollState poll_send_completion(
+      std::uint64_t expected_work_id, bool allow_older);
+  void wait_for_send_completion(std::uint64_t expected_work_id,
+                                bool allow_older);
 
   std::uint8_t port_{};
   std::uint8_t gid_index_{};

--- a/spark_transport/integrations/vllm/TP4_PREFILL_CAPACITY_POOL.md
+++ b/spark_transport/integrations/vllm/TP4_PREFILL_CAPACITY_POOL.md
@@ -1,0 +1,156 @@
+# TP4 shared tiled-prefill engine research contract
+
+## Status
+
+The capacity selector in `spark_tp4_prefill_capacity_pool.py` is
+**implemented** and **offline-validated**. Native dispatch is **unsupported**.
+The serving adapter defaults `VLLM_SPARK_TP4_PREFILL_CAPACITY_POOL` to `0` and
+fails before loading native code when an operator sets it to `1`.
+
+This contract does not claim a live result. It defines the adapter surface and
+evidence gates needed to replace exact-payload eager sessions with one physical
+transport engine, one QP pair per edge, and one generation-tagged tile pool per
+edge. Four logical capacity plans share that physical engine.
+
+## Exact-payload scaling in the executable adapter
+
+`_Backend.native_sessions` is indexed by payload bytes. Every newly observed
+`[Q, 6144]` BF16 payload therefore creates a distinct native session. A native
+session owns the transport resources behind the current C API, while
+`active_port_reservations()` reserves one control-port pair for every Q that
+the selected configuration could instantiate, including sessions that have
+not yet been created lazily.
+
+The stride-two port formula projects as follows with the default base pair
+`11000/11001`:
+
+| Maximum Q | Possible exact sessions/rank | Reserved or projected ports/rank | Last pair | Executable status |
+|---:|---:|---:|---:|---|
+| 40 | 40 | 80 | 11078/11079 | Admitted when the decode contract is configured through Q40 |
+| 512 | 512 | 1,024 | 12022/12023 | Admitted only with `VLLM_SPARK_TP4_PREFILL_Q512=1` |
+| 1,024 | 1,024 | 2,048 | 13046/13047 | Unsupported projection |
+| 4,096 | 4,096 | 8,192 | 19190/19191 | Unsupported projection |
+
+Q1024 and Q4096 are not eligible for the current adapter. Their rows quantify
+what extending the exact-Q formula would cost; they are not executable claims.
+
+## One transport engine with four logical capacity plans
+
+The selector maps each operation to the smallest logical plan that contains
+its active rows. Every plan returns the same durable transport key,
+`prefill-tile-engine`, and the same proposed pair `12500/12501`:
+
+| Active Q interval | Plan maximum Q | Maximum logical payload | Shared pair | 512-KiB payload tiles at the maximum |
+|---:|---:|---:|---:|---:|
+| 1-40 | 40 | 480 KiB | 12500/12501 | 1 |
+| 41-512 | 512 | 6 MiB | 12500/12501 | 12 |
+| 513-1,024 | 1,024 | 12 MiB | 12500/12501 | 24 |
+| 1,025-4,096 | 4,096 | 48 MiB | 12500/12501 | 96 |
+
+The plan maximum is not a registered-arena allocation. Eight 512-KiB tiles
+provide 4 MiB of logical one-plane payload capacity per edge. That 4-MiB
+number is not the registered footprint. Each slot contains two 256-KiB lanes;
+each lane has distinct send and receive storage plus one 64-byte control. The
+conservative registered storage is therefore:
+
+```text
+8 slots * 2 lanes * (256 KiB send + 256 KiB receive + 64 B control)
+  = 8,389,632 bytes per edge
+```
+
+The figure excludes descriptor-ring storage and matches the source contract
+in `tp4_tiled_session.hpp`. Larger operations stream through this bounded
+pool. Q4096 is a 96-tile logical payload and therefore requires at least
+twelve waves through an eight-tile pool.
+
+The four plan maxima do not identify sessions, QPs, registered arenas, or port
+pairs. They select descriptor bounds and kernel plans within the same physical
+engine. A transitional four-session implementation is not the target.
+
+## Required operation descriptor
+
+A variable-size operation needs a descriptor equivalent to:
+
+```text
+OperationTicket {
+    capacity_plan
+    active_bytes
+    first_tile_slot
+    tile_count
+    generation
+}
+```
+
+Each edge maintains a monotonic `consumed_through_generation` watermark.
+Acquisition can reuse a slot only after its prior generation is covered by the
+watermark. Output readiness is separate from slot retirement. An unexpected
+generation, invalid active byte count, or poisoned slot remains process-fatal.
+
+The current eager all-reduce call carries no per-operation active byte count.
+Its session configuration fixes `payload_bytes`, while the call receives only
+the handle, input, output, and CUDA stream. Capacity dispatch cannot be
+implemented safely by padding a smaller tensor or calling an invented symbol.
+The Python adapter intentionally contains no tiled-engine native symbol lookup.
+
+## Port coexistence
+
+The proposed shared pair is disjoint from exact decode Q1-Q40 under both the
+default exact base `11000/11001` and the canary base `11100/11101`. It cannot
+coexist with an arbitrarily extended exact-Q prefill family:
+
+- default exact base: the first projected collision is Q751;
+- canary exact base: the first projected collision is Q701.
+
+Capacity mode must replace exact-Q reservations above Q40. Before live use,
+the shared namespace validator must reserve the one tiled-engine pair and prove
+that it is free and globally unique on all four ranks. The Python selector only
+proposes the pair; it does not bind or reserve it.
+
+## Live prerequisites
+
+All seven gates below are blocking:
+
+1. **Native active-byte submission:** one engine submits any row-aligned
+   `active_bytes` not greater than its plan maximum without recreation. Zero,
+   misaligned, and oversized values fail before touching CUDA.
+2. **Generation-tagged tile pool:** every edge uses fixed `(generation, slot)`
+   tickets and operation descriptors carry `active_bytes`. Unexpected
+   generations and poisoned slots terminate the worker.
+3. **Cumulative credit retirement:** each edge publishes a monotonic
+   consumed-through watermark; reciprocal slot retirement is not on the
+   output-ready critical path.
+4. **Capacity port namespace:** exactly one pair is reserved for the tiled
+   engine, exact-Q prefill reservations above Q40 disappear, and global
+   collision validation passes.
+5. **Q4096 kernel capacity:** staging, reduction, and output kernels tile
+   through Q4096 without a single-CTA whole-payload dependency or a 48-MiB
+   registered arena per exact shape.
+6. **Four-rank fixed-Q probe:** the bounded probe accepts Q40, Q512, Q1024, and
+   Q4096 and reports plan, engine, tile, generation, credit, overflow, and
+   poison counters on every rank.
+7. **Serving engine receipt:** model evidence proves exactly one tiled engine
+   per rank, zero exact-Q prefill sessions, the logical plan and active bytes
+   selected for every observed shape, and zero overflow or poison. The receipt
+   separately records 4,194,304 logical one-plane payload bytes and 8,389,632
+   registered tile-storage bytes per edge; descriptor storage is accounted for
+   separately.
+
+## Qualification sequence
+
+Print the offline plan without contacting a host:
+
+```powershell
+python spark_transport/scripts/plan_tp4_prefill_capacity_pool.py
+```
+
+After all prerequisites are implemented, the live harness must run bracketed
+baseline/candidate arms for Q40, Q512, Q1024, and Q4096. It must also exercise
+Q1, Q39, Q40, Q41, Q511, Q512, Q513, Q1023, Q1024, Q1025, Q4095, and Q4096 to
+prove boundary reuse rather than four exact-size special cases.
+
+Acceptance requires all-rank exit zero, exact integer-valued oracle equality,
+the declared random-BF16 association gate, fixed-seed token equality, matching
+engine/tile/credit counters, and separate p50/p95 results for every fixed-Q
+arm. Serving evidence must use shape tracing to prove which Q values actually
+occur; prompt length alone is not evidence that a particular collective shape
+was dispatched.

--- a/spark_transport/integrations/vllm/spark_tp4_allgather_backend.py
+++ b/spark_transport/integrations/vllm/spark_tp4_allgather_backend.py
@@ -13,6 +13,14 @@ from collections import defaultdict
 from pathlib import Path
 from typing import Any
 
+from spark_tp4_port_namespace import (
+    EAGER_ALLGATHER_PORT_SLOTS,
+    eager_allgather_control_ports,
+    graph_indexer_control_ports,
+    validate_active_port_namespace,
+    validate_control_port_pair,
+)
+
 logger = logging.getLogger(__name__)
 
 _installed = False
@@ -60,6 +68,14 @@ _SUPPORTED_SIGNATURES = {
     ((5, 2, 2048), "torch.int32"): (81920, 6, "indexer-k4"),
     ((23552,), "torch.uint8"): (23552, 7, "ckv-prefill"),
 }
+_CONFIGURED_PORT_SLOTS = tuple(
+    sorted(signature[1] for signature in _SUPPORTED_SIGNATURES.values())
+)
+if _CONFIGURED_PORT_SLOTS != EAGER_ALLGATHER_PORT_SLOTS:
+    raise RuntimeError(
+        "Spark TP4 exact all-gather signatures and the shared port "
+        "namespace disagree"
+    )
 
 
 def _abort_after_native_failure() -> None:
@@ -185,82 +201,18 @@ def _indexer_graph_custom_enabled(mode: str) -> bool:
 
 
 def _validate_control_ports(ports: tuple[int, int]) -> None:
-    port0, port1 = ports
-    if not (0 < port0 <= 65535 and 0 < port1 <= 65535):
-        raise ValueError(
-            "Spark TP4 indexer graph control ports must be in [1,65535]"
-        )
-    if port0 == port1:
-        raise ValueError(
-            "Spark TP4 indexer graph control ports must be distinct"
-        )
+    validate_control_port_pair(
+        ports, owner="graph indexer all-gather"
+    )
+    validate_active_port_namespace()
 
 
 def _indexer_graph_control_ports() -> tuple[int, int]:
-    ports = (
-        int(
-            os.getenv(
-                "SPARK_TP4_GRAPH_INDEXER_CONTROL_PORT0", "9462"
-            )
-        ),
-        int(
-            os.getenv(
-                "SPARK_TP4_GRAPH_INDEXER_CONTROL_PORT1", "9463"
-            )
-        ),
-    )
-    _validate_control_ports(ports)
+    return graph_indexer_control_ports()
 
-    # Exact eager signatures retain their existing namespace. The graph
-    # family gets one audited pair, never one pair per Q.
-    base = int(os.getenv("SPARK_TP4_ALLGATHER_BASE_PORT", "9490"))
-    exact_ports = {
-        port
-        for _, slot, _ in _SUPPORTED_SIGNATURES.values()
-        for port in (base + slot * 10, base + slot * 10 + 1)
-    }
-    allreduce_base0 = int(
-        os.getenv("SPARK_TP4_CONTROL_PORT0", "9480")
-    )
-    allreduce_base1 = int(
-        os.getenv("SPARK_TP4_CONTROL_PORT1", "9481")
-    )
-    allreduce_ports = {
-        port
-        for slot in range(512)
-        for port in (
-            allreduce_base0 + slot * 10,
-            allreduce_base1 + slot * 10,
-        )
-        if port <= 65535
-    }
-    static_ports = {
-        int(os.getenv("SPARK_TP4_GRAPH_CONTROL_PORT0", "9970")),
-        int(os.getenv("SPARK_TP4_GRAPH_CONTROL_PORT1", "9971")),
-        int(os.getenv("SPARK_TP4_DCP_CONTROL_PORT0", "9890")),
-        int(os.getenv("SPARK_TP4_DCP_CONTROL_PORT1", "9891")),
-        int(os.getenv("SPARK_TP4_GRAPH_DCP_CONTROL_PORT0", "9892")),
-        int(os.getenv("SPARK_TP4_GRAPH_DCP_CONTROL_PORT1", "9893")),
-        int(os.getenv("SPARK_TP4_VOCAB_CONTROL_PORT0", "9990")),
-        int(os.getenv("SPARK_TP4_VOCAB_CONTROL_PORT1", "9991")),
-        int(
-            os.getenv(
-                "SPARK_TP4_GRAPH_VOCAB_CONTROL_PORT0", "10110"
-            )
-        ),
-        int(
-            os.getenv(
-                "SPARK_TP4_GRAPH_VOCAB_CONTROL_PORT1", "10111"
-            )
-        ),
-    }
-    reserved_ports = exact_ports | allreduce_ports | static_ports
-    if set(ports) & reserved_ports:
-        raise ValueError(
-            "Spark TP4 indexer graph ports collide with a reserved "
-            "transport namespace"
-        )
-    return ports
+
+def _allgather_control_ports(port_slot: int) -> tuple[int, int]:
+    return eager_allgather_control_ports(port_slot)
 
 
 def _indexer_graph_preflight() -> tuple[int, int]:
@@ -555,6 +507,53 @@ def _record_stock_path(
     )
 
 
+def _is_indexer_communicator(communicator: Any) -> bool:
+    """Return whether this is the exact sparse-indexer shard communicator.
+
+    ``PyNcclCommunicator`` does not carry ``GroupCoordinator.unique_name``.
+    Resolve the indexer's configured shard group and require object identity
+    with its owned PyNCCL communicator.  Any unavailable or mismatched group
+    state fails closed to the stock collective.
+    """
+
+    try:
+        from vllm.distributed.parallel_state import (
+            get_indexer_dcp_group,
+        )
+
+        world_size = int(getattr(communicator, "world_size", 0))
+        communicator_rank = int(getattr(communicator, "rank", -2))
+        indexer_group = get_indexer_dcp_group(world_size)
+        indexer_world_size = int(
+            getattr(indexer_group, "world_size", 0)
+        )
+        indexer_rank = int(
+            getattr(indexer_group, "rank_in_group", -1)
+        )
+    except (AssertionError, ImportError, RuntimeError, TypeError, ValueError):
+        return False
+    if (
+        world_size != 4
+        or getattr(indexer_group, "unique_name", "") != "dcp:0"
+        or indexer_world_size != 4
+        or indexer_rank != communicator_rank
+    ):
+        return False
+    expected_cpu_group = getattr(indexer_group, "cpu_group", None)
+    device_communicator = getattr(
+        indexer_group, "device_communicator", None
+    )
+    expected_pynccl = getattr(
+        device_communicator, "pynccl_comm", None
+    )
+    return (
+        expected_cpu_group is not None
+        and getattr(communicator, "group", None)
+        is expected_cpu_group
+        and expected_pynccl is communicator
+    )
+
+
 def _signature(
     communicator: Any, input_tensor: Any, output_tensor: Any, mode: str
 ) -> _Signature | None:
@@ -596,7 +595,7 @@ def _indexer_graph_q(
     if (
         mode not in _VALID_MODES
         or getattr(communicator, "world_size", None) != 4
-        or getattr(communicator, "unique_name", "") != "tp:0"
+        or not _is_indexer_communicator(communicator)
         or bool(getattr(communicator, "disabled", False))
         or len(shape) != 3
         or shape[0] not in range(1, _INDEXER_MAX_Q + 1)
@@ -642,8 +641,7 @@ class _NativeAllgatherSession:
         self._protocol_trace_calls = 0
 
         default_peer0, default_peer1 = _DEFAULT_PEERS[rank]
-        base_port = int(os.getenv("SPARK_TP4_ALLGATHER_BASE_PORT", "9490"))
-        port0 = base_port + port_slot * 10
+        port0, port1 = _allgather_control_ports(port_slot)
         config = _NativeAllgatherConfig(
             rank=rank,
             peer0=os.getenv("SPARK_TP4_PEER0", default_peer0).encode(),
@@ -653,7 +651,7 @@ class _NativeAllgatherSession:
             gid0=int(os.getenv("SPARK_TP4_GID0", "3")),
             gid1=int(os.getenv("SPARK_TP4_GID1", "3")),
             control_port0=port0,
-            control_port1=port0 + 1,
+            control_port1=port1,
             input_bytes=input_bytes,
         )
         error = ctypes.create_string_buffer(512)
@@ -670,7 +668,7 @@ class _NativeAllgatherSession:
             rank,
             input_bytes,
             port0,
-            port0 + 1,
+            port1,
         )
 
     def all_gather(
@@ -1022,6 +1020,7 @@ def install() -> None:
     if _installed or not mode:
         return
     _indexer_graph_custom_enabled(mode)
+    validate_active_port_namespace()
 
     from vllm.distributed.device_communicators.pynccl import (
         PyNcclCommunicator,

--- a/spark_transport/integrations/vllm/spark_tp4_backend.py
+++ b/spark_transport/integrations/vllm/spark_tp4_backend.py
@@ -10,14 +10,23 @@ from dataclasses import asdict, dataclass
 from typing import Any
 
 from spark_persistent_output_ring import PersistentOutputRing
+from spark_tp4_port_namespace import (
+    eager_allreduce_control_ports,
+    graph_allreduce_control_ports,
+    graph_dual_port_q40_control_ports,
+    validate_active_port_namespace,
+    validate_control_port_pair,
+)
+from spark_tp4_prefill_capacity_pool import capacity_pool_requested
 from spark_tp4_query_contract import (
+    ABSOLUTE_MAX_QUERY_ROWS,
     MAX_QUERY_ROWS,
 )
 
 logger = logging.getLogger(__name__)
 
 _installed = False
-_VALID_MODES = {"shadow", "custom"}
+_VALID_MODES = {"shadow", "custom", "disabled"}
 _TARGET_WIDTH = 6144
 _BF16_BYTES = 2
 _BYTES_PER_ROW = _TARGET_WIDTH * _BF16_BYTES
@@ -25,19 +34,44 @@ _ALLREDUCE_PREFILL_MAX_QUERY_ROWS = 512
 _ALLREDUCE_PREFILL_CAPACITY_BYTES = (
     _ALLREDUCE_PREFILL_MAX_QUERY_ROWS * _BYTES_PER_ROW
 )
+_DUAL_PORT_Q40_CAPACITY_BYTES = ABSOLUTE_MAX_QUERY_ROWS * _BYTES_PER_ROW
 _TARGET_SHAPES = frozenset(
     (rows, _TARGET_WIDTH) for rows in range(1, MAX_QUERY_ROWS + 1)
 )
 _GRAPH_CAPACITY_BYTES = MAX_QUERY_ROWS * _BYTES_PER_ROW
-_CONTROL_PORT_STRIDE = 2
 _GRAPH_STATUS_CAPTURE_CONFIGURED = 1 << 0
 _GRAPH_STATUS_POLLING_ENABLED = 1 << 1
 _GRAPH_STATUS_HOST_NATIVE_ATOMICS = 1 << 2
 _GRAPH_STATUS_SUBMIT_AFFINITY_VERIFIED = 1 << 3
 _GRAPH_STATUS_PROGRESS_AFFINITY_VERIFIED = 1 << 4
 _GRAPH_STATUS_OVERFLOW_FATAL = 1 << 5
+_GRAPH_STATUS_TWO_SLOT_DEFERRED_ACK = 1 << 7
+_GRAPH_STATUS_SPLIT_64K = 1 << 8
+_GRAPH_STATUS_TIERED_64K = 1 << 9
+_GRAPH_STATUS_DUAL_PORT_STRIPED = 1 << 10
+_SERIAL_ACK_PROTOCOL = "serial_ack"
+_TWO_SLOT_DEFERRED_ACK_PROTOCOL = "two_slot_deferred_ack"
+_ALLREDUCE_PROTOCOL_WIRE = {
+    _SERIAL_ACK_PROTOCOL: 0,
+    _TWO_SLOT_DEFERRED_ACK_PROTOCOL: 1,
+}
+_FUSED_GRAPH_KERNEL = "fused"
+_SPLIT_64K_GRAPH_KERNEL = "split_64k"
+_TIERED_64K_GRAPH_KERNEL = "tiered_64k"
+_GRAPH_KERNEL_WIRE = {
+    _FUSED_GRAPH_KERNEL: 0,
+    _SPLIT_64K_GRAPH_KERNEL: 1,
+    _TIERED_64K_GRAPH_KERNEL: 2,
+}
+_SEQUENTIAL_WIRE_SCHEDULE = "sequential"
+_DUAL_PORT_STRIPED_WIRE_SCHEDULE = "dual_port_striped"
+_WIRE_SCHEDULE_WIRE = {
+    _SEQUENTIAL_WIRE_SCHEDULE: 0,
+    _DUAL_PORT_STRIPED_WIRE_SCHEDULE: 1,
+}
 _MAX_PERSISTENT_OUTPUT_SLOTS = 4096
 _graph_q1_sessions: dict[int, "_NativeSession"] = {}
+_graph_dual_port_q40_sessions: dict[int, "_NativeSession"] = {}
 _graph_event_counts: dict[str, int] = {}
 # PLACEHOLDER ring peers (RFC 5737 TEST-NET-1): 192.0.2.N stands in for
 # rank N-1's direct-cable address. These are NOT routable and MUST be
@@ -101,6 +135,9 @@ class GraphReplayStatus:
     progress_affinity_verified: bool
     submit_cpu: int | None
     progress_cpu: int | None
+    two_slot_deferred_ack: bool = False
+    graph_kernel_strategy: str = _FUSED_GRAPH_KERNEL
+    wire_schedule: str = _SEQUENTIAL_WIRE_SCHEDULE
 
     @property
     def replay_advanced(self) -> bool:
@@ -108,7 +145,7 @@ class GraphReplayStatus:
         return self.published_sequence > 0
 
     @property
-    def replay_caught_up(self) -> bool:
+    def command_caught_up(self) -> bool:
         return (
             self.replay_advanced
             and self.published_sequence == self.consumed_sequence
@@ -116,13 +153,31 @@ class GraphReplayStatus:
         )
 
     @property
+    def replay_caught_up(self) -> bool:
+        """Compatibility alias for command-ring completion.
+
+        In two-slot mode this proves both outgoing credits were posted, not
+        that reciprocal credits retired both physical payload slots.
+        """
+        return self.command_caught_up
+
+    @property
+    def payload_slots_retired(self) -> bool | None:
+        """Return retirement proof when the selected protocol exposes it."""
+        if self.two_slot_deferred_ack:
+            return None
+        return self.command_caught_up
+
+    @property
     def fatal(self) -> bool:
         return self.overflow_sequence != 0
 
     def to_dict(self) -> dict[str, object]:
         snapshot = asdict(self)
+        snapshot["command_caught_up"] = self.command_caught_up
         snapshot["replay_advanced"] = self.replay_advanced
         snapshot["replay_caught_up"] = self.replay_caught_up
+        snapshot["payload_slots_retired"] = self.payload_slots_retired
         snapshot["fatal"] = self.fatal
         return snapshot
 
@@ -130,8 +185,34 @@ class GraphReplayStatus:
 def _mode() -> str:
     mode = os.getenv("VLLM_SPARK_TP4_MODE", "").lower()
     if mode and mode not in _VALID_MODES:
-        raise ValueError("VLLM_SPARK_TP4_MODE must be 'shadow', 'custom', or unset")
+        raise ValueError("VLLM_SPARK_TP4_MODE must be 'shadow', 'custom', 'disabled', or unset")
     return mode
+
+
+def _graph_allreduce_protocol() -> str:
+    value = os.getenv(
+        "VLLM_SPARK_TP4_GRAPH_ALLREDUCE_PROTOCOL",
+        _SERIAL_ACK_PROTOCOL,
+    )
+    if value not in _ALLREDUCE_PROTOCOL_WIRE:
+        raise ValueError(
+            "VLLM_SPARK_TP4_GRAPH_ALLREDUCE_PROTOCOL must be "
+            "'serial_ack', 'two_slot_deferred_ack', or unset"
+        )
+    return value
+
+
+def _graph_kernel_strategy() -> str:
+    value = os.getenv(
+        "VLLM_SPARK_TP4_GRAPH_KERNEL_STRATEGY",
+        _FUSED_GRAPH_KERNEL,
+    )
+    if value not in _GRAPH_KERNEL_WIRE:
+        raise ValueError(
+            "VLLM_SPARK_TP4_GRAPH_KERNEL_STRATEGY must be "
+            "'fused', 'split_64k', 'tiered_64k', or unset"
+        )
+    return value
 
 
 def _prefill_q512_enabled() -> bool:
@@ -258,25 +339,23 @@ def _control_ports(payload_bytes: int) -> tuple[int, int]:
         raise ValueError(
             f"unsupported Spark TP4 payload size: {payload_bytes} bytes"
         )
-    slot = payload_bytes // _BYTES_PER_ROW - 1
-
-    offset = slot * _CONTROL_PORT_STRIDE
-    ports = (
-        int(os.getenv("SPARK_TP4_CONTROL_PORT0", "9480")) + offset,
-        int(os.getenv("SPARK_TP4_CONTROL_PORT1", "9481")) + offset,
-    )
-    if any(port < 0 or port > 65535 for port in ports):
-        raise ValueError(
-            "Spark TP4 control port must be in [0, 65535] after applying "
-            f"payload slot {slot}: {ports}"
-        )
-    return ports
+    query_rows = payload_bytes // _BYTES_PER_ROW
+    return eager_allreduce_control_ports(query_rows)
 
 
 def _graph_q1_enabled() -> bool:
     value = os.getenv("VLLM_SPARK_TP4_GRAPH_Q1", "0")
     if value not in {"0", "1"}:
         raise ValueError("VLLM_SPARK_TP4_GRAPH_Q1 must be '0' or '1'")
+    return value == "1"
+
+
+def _graph_dual_port_q40_enabled() -> bool:
+    value = os.getenv("VLLM_SPARK_TP4_GRAPH_DUAL_PORT_Q40", "0")
+    if value not in {"0", "1"}:
+        raise ValueError(
+            "VLLM_SPARK_TP4_GRAPH_DUAL_PORT_Q40 must be '0' or '1'"
+        )
     return value == "1"
 
 
@@ -297,13 +376,11 @@ def _persistent_output_slots() -> int:
 
 
 def _graph_control_ports() -> tuple[int, int]:
-    ports = (
-        int(os.getenv("SPARK_TP4_GRAPH_CONTROL_PORT0", "9970")),
-        int(os.getenv("SPARK_TP4_GRAPH_CONTROL_PORT1", "9971")),
-    )
-    if any(port < 0 or port > 65535 for port in ports):
-        raise ValueError(f"Spark TP4 graph control port must be in [0, 65535]: {ports}")
-    return ports
+    return graph_allreduce_control_ports()
+
+
+def _graph_dual_port_q40_control_ports() -> tuple[int, int]:
+    return graph_dual_port_q40_control_ports()
 
 
 def _fixed_kv_cache_bytes(argv: list[str] | None = None) -> int:
@@ -378,6 +455,50 @@ def _graph_preflight(argv: list[str] | None = None) -> tuple[int, int]:
     return _graph_cpu_affinity()
 
 
+def _graph_dual_port_q40_cpu_affinity(
+    argv: list[str] | None = None,
+) -> tuple[int, int]:
+    submit_cpu, tp_progress_cpu = _graph_preflight(argv)
+    name = "SPARK_TP4_GRAPH_DUAL_PORT_Q40_PROGRESS_CPU"
+    text = os.getenv(name)
+    if text is None:
+        raise RuntimeError(
+            f"exact-Q40 dual-port graph TP4 requires explicit {name}"
+        )
+    try:
+        progress_cpu = int(text)
+    except ValueError as error:
+        raise RuntimeError(f"{name} must be a nonnegative integer") from error
+    if progress_cpu < 0:
+        raise RuntimeError(f"{name} must be a nonnegative integer")
+
+    occupied = {
+        submit_cpu: "shared graph submit",
+        tp_progress_cpu: "sequential TP graph progress",
+    }
+    if os.getenv("VLLM_SPARK_TP4_VOCAB_MODE", "") == "custom":
+        occupied[
+            int(os.getenv("SPARK_TP4_GRAPH_VOCAB_PROGRESS_CPU", "12"))
+        ] = "vocabulary graph progress"
+    if (
+        os.getenv("VLLM_SPARK_TP4_DCP_GRAPH_CUSTOM", "0") == "1"
+        or os.getenv("VLLM_SPARK_TP4_DCP_GRAPH_SHADOW", "0") == "1"
+    ):
+        occupied[
+            int(os.getenv("SPARK_TP4_GRAPH_DCP_PROGRESS_CPU", "13"))
+        ] = "DCP graph progress"
+    if os.getenv("VLLM_SPARK_TP4_INDEXER_GRAPH_CUSTOM", "0") == "1":
+        occupied[
+            int(os.getenv("SPARK_TP4_GRAPH_INDEXER_PROGRESS_CPU", "14"))
+        ] = "indexer graph progress"
+    if progress_cpu in occupied:
+        raise RuntimeError(
+            f"{name}={progress_cpu} collides with "
+            f"{occupied[progress_cpu]} CPU ownership"
+        )
+    return submit_cpu, progress_cpu
+
+
 def _record_graph_event(communicator: Any, event: str) -> int:
     attribute = f"_spark_tp4_graph_q1_{event}"
     count = int(getattr(communicator, attribute, 0)) + 1
@@ -402,23 +523,74 @@ class _NativeSession:
         control_ports: tuple[int, int] | None = None,
         graph_only: bool = False,
         graph_cpu_affinity: tuple[int, int] | None = None,
+        allreduce_protocol: str = _SERIAL_ACK_PROTOCOL,
+        graph_kernel_strategy: str = _FUSED_GRAPH_KERNEL,
+        wire_schedule: str = _SEQUENTIAL_WIRE_SCHEDULE,
     ) -> None:
         if rank not in _DEFAULT_PEERS:
             raise ValueError(f"TP4 rank must be in [0, 3], got {rank}")
         expected_graph_capacity = _graph_capacity_bytes()
-        if graph_only and payload_bytes != expected_graph_capacity:
+        if (
+            graph_only
+            and wire_schedule == _SEQUENTIAL_WIRE_SCHEDULE
+            and payload_bytes != expected_graph_capacity
+        ):
             raise ValueError(
                 "Spark TP4 graph session requires "
-                f"Q{_maximum_allreduce_query_rows()} capacity"
+                f"Q{expected_graph_capacity // _BYTES_PER_ROW} capacity"
             )
         if graph_only != (graph_cpu_affinity is not None):
             raise ValueError(
                 "Spark TP4 graph session requires an explicit graph CPU "
                 "affinity pair; eager sessions cannot set one"
             )
-        control_port0, control_port1 = (
-            _control_ports(payload_bytes) if control_ports is None else control_ports
-        )
+        if allreduce_protocol not in _ALLREDUCE_PROTOCOL_WIRE:
+            raise ValueError("invalid Spark TP4 all-reduce protocol")
+        if graph_kernel_strategy not in _GRAPH_KERNEL_WIRE:
+            raise ValueError("invalid Spark TP4 graph kernel strategy")
+        if wire_schedule not in _WIRE_SCHEDULE_WIRE:
+            raise ValueError("invalid Spark TP4 wire schedule")
+        if graph_kernel_strategy != _FUSED_GRAPH_KERNEL and not graph_only:
+            raise ValueError(
+                "research graph kernel strategies require a graph-only session"
+            )
+        if (
+            allreduce_protocol == _TWO_SLOT_DEFERRED_ACK_PROTOCOL
+            and not graph_only
+        ):
+            raise ValueError(
+                "two_slot_deferred_ack requires a graph-only session"
+            )
+        if wire_schedule == _DUAL_PORT_STRIPED_WIRE_SCHEDULE:
+            if not graph_only:
+                raise ValueError(
+                    "dual_port_striped requires a graph-only session"
+                )
+            if allreduce_protocol != _TWO_SLOT_DEFERRED_ACK_PROTOCOL:
+                raise ValueError(
+                    "dual_port_striped requires two_slot_deferred_ack"
+                )
+            if graph_kernel_strategy != _FUSED_GRAPH_KERNEL:
+                raise ValueError(
+                    "dual_port_striped requires the fused graph kernel"
+                )
+            if payload_bytes not in {
+                _DUAL_PORT_Q40_CAPACITY_BYTES,
+                _ALLREDUCE_PREFILL_CAPACITY_BYTES,
+            }:
+                raise ValueError(
+                    "dual_port_striped requires Q40 or Q512 capacity"
+                )
+        if control_ports is None:
+            control_port0, control_port1 = _control_ports(payload_bytes)
+        else:
+            control_port0, control_port1 = validate_control_port_pair(
+                control_ports,
+                owner=(
+                    "graph all-reduce" if graph_only else "eager all-reduce"
+                ),
+            )
+            validate_active_port_namespace()
         library_path = os.environ["SPARK_TP4_LIBRARY"]
         self._library = ctypes.CDLL(library_path)
         self._library.spark_tp4_create.argtypes = [
@@ -427,6 +599,62 @@ class _NativeSession:
             ctypes.c_size_t,
         ]
         self._library.spark_tp4_create.restype = ctypes.c_void_p
+        create_session = self._library.spark_tp4_create
+        if wire_schedule != _SEQUENTIAL_WIRE_SCHEDULE:
+            try:
+                create_session = (
+                    self._library
+                    .spark_tp4_create_with_protocol_graph_kernel_and_schedule
+                )
+            except AttributeError as error:
+                raise RuntimeError(
+                    "Spark TP4 native library lacks the wire-schedule ABI; "
+                    "rebuild and deploy a matching library"
+                ) from error
+            create_session.argtypes = [
+                ctypes.POINTER(_NativeConfig),
+                ctypes.c_uint32,
+                ctypes.c_uint32,
+                ctypes.c_uint32,
+                ctypes.c_char_p,
+                ctypes.c_size_t,
+            ]
+            create_session.restype = ctypes.c_void_p
+        elif graph_kernel_strategy != _FUSED_GRAPH_KERNEL:
+            try:
+                create_session = (
+                    self._library.spark_tp4_create_with_protocol_and_graph_kernel
+                )
+            except AttributeError as error:
+                raise RuntimeError(
+                    "Spark TP4 native library lacks the graph-kernel ABI; "
+                    "rebuild and deploy a matching library"
+                ) from error
+            create_session.argtypes = [
+                ctypes.POINTER(_NativeConfig),
+                ctypes.c_uint32,
+                ctypes.c_uint32,
+                ctypes.c_char_p,
+                ctypes.c_size_t,
+            ]
+            create_session.restype = ctypes.c_void_p
+        elif allreduce_protocol == _TWO_SLOT_DEFERRED_ACK_PROTOCOL:
+            try:
+                create_session = (
+                    self._library.spark_tp4_create_with_protocol
+                )
+            except AttributeError as error:
+                raise RuntimeError(
+                    "Spark TP4 native library lacks the deferred-ACK ABI; "
+                    "rebuild and deploy a matching library"
+                ) from error
+            create_session.argtypes = [
+                ctypes.POINTER(_NativeConfig),
+                ctypes.c_uint32,
+                ctypes.c_char_p,
+                ctypes.c_size_t,
+            ]
+            create_session.restype = ctypes.c_void_p
         self._library.spark_tp4_all_reduce.argtypes = [
             ctypes.c_void_p,
             ctypes.c_void_p,
@@ -458,6 +686,9 @@ class _NativeSession:
         self._library.spark_tp4_destroy.argtypes = [ctypes.c_void_p]
         self._library.spark_tp4_destroy.restype = None
         self._graph_only = graph_only
+        self._allreduce_protocol = allreduce_protocol
+        self._graph_kernel_strategy = graph_kernel_strategy
+        self._wire_schedule = wire_schedule
         self._graph_max_query_rows = (
             payload_bytes // _BYTES_PER_ROW if graph_only else 0
         )
@@ -493,20 +724,49 @@ class _NativeSession:
             graph_progress_cpu_plus_one=progress_cpu + 1,
         )
         error = ctypes.create_string_buffer(512)
-        self._handle = self._library.spark_tp4_create(
-            ctypes.byref(config), error, len(error)
-        )
+        if wire_schedule != _SEQUENTIAL_WIRE_SCHEDULE:
+            self._handle = create_session(
+                ctypes.byref(config),
+                _ALLREDUCE_PROTOCOL_WIRE[allreduce_protocol],
+                _GRAPH_KERNEL_WIRE[graph_kernel_strategy],
+                _WIRE_SCHEDULE_WIRE[wire_schedule],
+                error,
+                len(error),
+            )
+        elif graph_kernel_strategy != _FUSED_GRAPH_KERNEL:
+            self._handle = create_session(
+                ctypes.byref(config),
+                _ALLREDUCE_PROTOCOL_WIRE[allreduce_protocol],
+                _GRAPH_KERNEL_WIRE[graph_kernel_strategy],
+                error,
+                len(error),
+            )
+        elif allreduce_protocol == _SERIAL_ACK_PROTOCOL:
+            self._handle = create_session(
+                ctypes.byref(config), error, len(error)
+            )
+        else:
+            self._handle = create_session(
+                ctypes.byref(config),
+                _ALLREDUCE_PROTOCOL_WIRE[allreduce_protocol],
+                error,
+                len(error),
+            )
         if not self._handle:
             message = error.value.decode(errors="replace")
             raise RuntimeError(f"failed to create Spark TP4 session: {message}")
         logger.warning(
             "Spark TP4 %s session ready on rank %d for %d bytes "
-            "(control ports %d/%d)",
+            "(control ports %d/%d, protocol %s, graph kernel %s, "
+            "wire schedule %s)",
             "graph-only" if graph_only else "eager",
             rank,
             payload_bytes,
             control_port0,
             control_port1,
+            allreduce_protocol,
+            graph_kernel_strategy,
+            wire_schedule,
         )
 
     def all_reduce(self, tensor: Any) -> Any:
@@ -556,6 +816,48 @@ class _NativeSession:
                 f"{ctypes.sizeof(_NativeGraphStatus)}"
             )
         flags = int(native.flags)
+        native_deferred = bool(
+            flags & _GRAPH_STATUS_TWO_SLOT_DEFERRED_ACK
+        )
+        requested_deferred = (
+            self._allreduce_protocol == _TWO_SLOT_DEFERRED_ACK_PROTOCOL
+        )
+        if native_deferred != requested_deferred:
+            raise RuntimeError(
+                "Spark TP4 graph protocol attestation mismatch: "
+                f"requested={self._allreduce_protocol} "
+                f"native_deferred={native_deferred}"
+            )
+        native_split = bool(flags & _GRAPH_STATUS_SPLIT_64K)
+        native_tiered = bool(flags & _GRAPH_STATUS_TIERED_64K)
+        if native_split and native_tiered:
+            raise RuntimeError(
+                "Spark TP4 graph kernel attestation is contradictory"
+            )
+        native_graph_kernel = (
+            _TIERED_64K_GRAPH_KERNEL
+            if native_tiered
+            else _SPLIT_64K_GRAPH_KERNEL
+            if native_split
+            else _FUSED_GRAPH_KERNEL
+        )
+        if native_graph_kernel != self._graph_kernel_strategy:
+            raise RuntimeError(
+                "Spark TP4 graph kernel attestation mismatch: "
+                f"requested={self._graph_kernel_strategy} "
+                f"native={native_graph_kernel}"
+            )
+        native_wire_schedule = (
+            _DUAL_PORT_STRIPED_WIRE_SCHEDULE
+            if flags & _GRAPH_STATUS_DUAL_PORT_STRIPED
+            else _SEQUENTIAL_WIRE_SCHEDULE
+        )
+        if native_wire_schedule != self._wire_schedule:
+            raise RuntimeError(
+                "Spark TP4 wire schedule attestation mismatch: "
+                f"requested={self._wire_schedule} "
+                f"native={native_wire_schedule}"
+            )
         return GraphReplayStatus(
             captured_nodes=int(native.captured_nodes),
             published_sequence=int(native.published_sequence),
@@ -585,23 +887,39 @@ class _NativeSession:
                 if native.graph_progress_cpu_plus_one
                 else None
             ),
+            two_slot_deferred_ack=native_deferred,
+            graph_kernel_strategy=native_graph_kernel,
+            wire_schedule=native_wire_schedule,
         )
 
     def capture(self, tensor: Any) -> Any:
         if not self._graph_only:
             raise RuntimeError("Spark TP4 eager session cannot define graph nodes")
         shape = _tensor_shape(tensor)
+        dual_port_session = (
+            self._wire_schedule == _DUAL_PORT_STRIPED_WIRE_SCHEDULE
+        )
+        exact_dual_port_shape = (
+            not dual_port_session
+            or shape == (self._graph_max_query_rows, _TARGET_WIDTH)
+        )
         if (
             not _target_shape_eligible(shape)
             or shape[0] > self._graph_max_query_rows
+            or not exact_dual_port_shape
             or str(tensor.dtype) != "torch.bfloat16"
             or not bool(tensor.is_cuda)
             or not bool(tensor.is_contiguous())
         ):
+            query_requirement = (
+                f"Q={self._graph_max_query_rows}"
+                if dual_port_session
+                else f"Q in [1, {self._graph_max_query_rows}]"
+            )
             raise ValueError(
                 "Spark TP4 graph capture requires contiguous CUDA BF16 "
-                "[Q, 6144] with Q in [1, "
-                f"{self._graph_max_query_rows}]"
+                f"[Q, 6144] with {query_requirement}; dual-port striped "
+                "sessions require their exact fixed Q"
             )
         q = shape[0]
 
@@ -728,6 +1046,7 @@ class _Backend:
         self.rank = rank
         self.native_sessions: dict[int, _NativeSession] = {}
         self.graph_q1_session: _NativeSession | None = None
+        self.graph_dual_port_q40_session: _NativeSession | None = None
         self.shadow_stats: dict[tuple[int, tuple[int, ...], str], _ShadowStats] = {}
 
     def native_for(self, payload_bytes: int) -> _NativeSession:
@@ -747,6 +1066,8 @@ class _Backend:
                 control_ports=_graph_control_ports(),
                 graph_only=True,
                 graph_cpu_affinity=graph_cpu_affinity,
+                allreduce_protocol=_graph_allreduce_protocol(),
+                graph_kernel_strategy=_graph_kernel_strategy(),
             )
             self.graph_q1_session = session
             _graph_q1_sessions[self.rank] = session
@@ -755,7 +1076,33 @@ class _Backend:
             )
 
             ensure_status_reporter(rank=self.rank)
+        if (
+            _graph_dual_port_q40_enabled()
+            and self.graph_dual_port_q40_session is None
+        ):
+            dual_port_session = _NativeSession(
+                self.rank,
+                _DUAL_PORT_Q40_CAPACITY_BYTES,
+                control_ports=_graph_dual_port_q40_control_ports(),
+                graph_only=True,
+                graph_cpu_affinity=_graph_dual_port_q40_cpu_affinity(),
+                allreduce_protocol=_TWO_SLOT_DEFERRED_ACK_PROTOCOL,
+                graph_kernel_strategy=_FUSED_GRAPH_KERNEL,
+                wire_schedule=_DUAL_PORT_STRIPED_WIRE_SCHEDULE,
+            )
+            self.graph_dual_port_q40_session = dual_port_session
+            _graph_dual_port_q40_sessions[self.rank] = dual_port_session
         return session
+
+    def graph_session_for_capture(
+        self, tensor: Any
+    ) -> _NativeSession | None:
+        if (
+            _tensor_shape(tensor) == (ABSOLUTE_MAX_QUERY_ROWS, _TARGET_WIDTH)
+            and self.graph_dual_port_q40_session is not None
+        ):
+            return self.graph_dual_port_q40_session
+        return self.graph_q1_session
 
     def shadow_for(self, signature: tuple[int, tuple[int, ...], str]) -> _ShadowStats:
         stats = self.shadow_stats.get(signature)
@@ -773,9 +1120,18 @@ def graph_q1_status_snapshot() -> dict[int, dict[str, object]]:
     }
 
 
+def graph_dual_port_q40_status_snapshot() -> dict[int, dict[str, object]]:
+    """Return exact-Q40 striped graph progress for process-local TP ranks."""
+    return {
+        rank: session.graph_status().to_dict()
+        for rank, session in sorted(_graph_dual_port_q40_sessions.items())
+    }
+
+
 def graph_q1_diagnostic_snapshot() -> dict[str, object]:
     return {
         "sessions": graph_q1_status_snapshot(),
+        "dual_port_q40_sessions": graph_dual_port_q40_status_snapshot(),
         "events": dict(sorted(_graph_event_counts.items())),
     }
 
@@ -783,9 +1139,40 @@ def graph_q1_diagnostic_snapshot() -> dict[str, object]:
 def install() -> None:
     global _installed
     mode = _mode()
-    if _installed or not mode:
+    graph_protocol = _graph_allreduce_protocol()
+    graph_kernel = _graph_kernel_strategy()
+    graph_dual_port_q40 = _graph_dual_port_q40_enabled()
+    if capacity_pool_requested():
+        raise RuntimeError(
+            "VLLM_SPARK_TP4_PREFILL_CAPACITY_POOL is research-only: "
+            "the active-bytes native ABI is unavailable, so the shared "
+            "tiled engine cannot be dispatched safely"
+        )
+    if graph_protocol == _TWO_SLOT_DEFERRED_ACK_PROTOCOL and (
+        mode != "custom" or not _graph_q1_enabled()
+    ):
+        raise ValueError(
+            "two_slot_deferred_ack requires custom graph all-reduce"
+        )
+    if graph_kernel != _FUSED_GRAPH_KERNEL and (
+        mode != "custom" or not _graph_q1_enabled()
+    ):
+        raise ValueError(
+            "research graph kernel strategies require custom graph all-reduce"
+        )
+    if graph_dual_port_q40 and (
+        mode != "custom"
+        or not _graph_q1_enabled()
+        or MAX_QUERY_ROWS != ABSOLUTE_MAX_QUERY_ROWS
+    ):
+        raise ValueError(
+            "exact-Q40 dual-port graph TP4 requires custom graph all-reduce "
+            f"with VLLM_SPARK_MAX_QUERY_ROWS={ABSOLUTE_MAX_QUERY_ROWS}"
+        )
+    if _installed or not mode or mode == "disabled":
         return
     _prefill_q512_enabled()
+    validate_active_port_namespace()
 
     from vllm.distributed.device_communicators.cuda_communicator import (
         CudaCommunicator,
@@ -819,7 +1206,9 @@ def install() -> None:
             ):
                 backend = getattr(self, "_spark_tp4_native", None)
                 graph_session = (
-                    None if backend is None else backend.graph_q1_session
+                    None
+                    if backend is None
+                    else backend.graph_session_for_capture(input_)
                 )
                 if graph_session is not None:
                     try:
@@ -866,9 +1255,9 @@ def install() -> None:
             )
 
         try:
-            native_session = backend.native_for(payload_bytes)
             if mode == "custom" and _graph_q1_enabled():
                 backend.prepare_graph_q1()
+            native_session = backend.native_for(payload_bytes)
             if os.getenv("SPARK_TP4_FLIGHT_RECORDER", "0") == "1":
                 import torch
                 from spark_tp4_flight_recorder import record_collective

--- a/spark_transport/integrations/vllm/spark_tp4_dcp_backend.py
+++ b/spark_transport/integrations/vllm/spark_tp4_dcp_backend.py
@@ -12,6 +12,12 @@ import sys
 from types import ModuleType
 from typing import Any
 
+from spark_tp4_port_namespace import (
+    eager_dcp_control_ports,
+    graph_dcp_control_ports,
+    validate_active_port_namespace,
+    validate_control_port_pair,
+)
 from spark_tp4_query_contract import SUPPORTED_QUERY_ROWS
 
 logger = logging.getLogger(__name__)
@@ -125,6 +131,30 @@ def _stride(tensor: Any) -> tuple[int, ...]:
     return tuple(int(value) for value in tensor.stride())
 
 
+def _combine_stride_supported(
+    q: int,
+    head_dimension: int,
+    output_stride: tuple[int, ...],
+) -> bool:
+    token_major = (
+        _OUTPUT_HEADS * head_dimension,
+        head_dimension,
+        1,
+    )
+    if output_stride == token_major:
+        return True
+    if len(output_stride) != 3:
+        return False
+    query_stride, head_stride, dimension_stride = output_stride
+    return (
+        query_stride == head_dimension
+        and dimension_stride == 1
+        and head_stride % head_dimension == 0
+        and q * head_dimension <= head_stride
+        and head_stride <= max(_SUPPORTED_Q) * head_dimension
+    )
+
+
 def _query_signature(
     group: Any, input_tensor: Any, dim: int, mode: str
 ) -> _QuerySignature | None:
@@ -153,6 +183,7 @@ def _combine_signature(
     lse_tensor: Any,
     return_lse: bool,
     is_lse_base_on_e: bool,
+    head_major_output: bool,
     mode: str,
 ) -> _CombineSignature | None:
     output_shape = _shape(output_tensor)
@@ -174,29 +205,20 @@ def _combine_signature(
         or not bool(output_tensor.is_cuda)
         or not bool(lse_tensor.is_cuda)
         or output_tensor.device != lse_tensor.device
-        or output_stride
-        not in (
-            (
-                _OUTPUT_HEADS * output_shape[2],
-                output_shape[2],
-                1,
-            ),
-            (
-                output_shape[2],
-                output_shape[0] * output_shape[2],
-                1,
-            ),
+        or not _combine_stride_supported(
+            output_shape[0], output_shape[2], output_stride
         )
         or type(return_lse) is not bool
         or is_lse_base_on_e is not True
+        or type(head_major_output) is not bool
     ):
         return None
-    return (
-        output_shape[0],
-        output_shape[2],
-        output_stride[0],
-        output_stride[1],
-    )
+    q, head_dimension = output_shape[0], output_shape[2]
+    if output_stride[0] == head_dimension:
+        # The native ABI accepts head-major input only with a tight query
+        # pitch. A bounded wider pitch is compacted on the caller stream.
+        return (q, head_dimension, head_dimension, q * head_dimension)
+    return (q, head_dimension, output_stride[0], output_stride[1])
 
 
 def _is_stream_capturing(torch_module: Any) -> bool:
@@ -204,65 +226,23 @@ def _is_stream_capturing(torch_module: Any) -> bool:
     return bool(checker is not None and checker())
 
 
-def _device_index(torch_module: Any, device: Any) -> int:
-    index = getattr(device, "index", None)
-    if not isinstance(index, int):
-        index = None
-    if index is None:
-        text = str(device)
-        if text.startswith("cuda:"):
-            index = int(text.removeprefix("cuda:"))
-    if index is None:
-        current_device = getattr(torch_module.cuda, "current_device", None)
-        if current_device is None:
-            raise RuntimeError(
-                "Spark shared CUDA graph capture cannot resolve the device index"
-            )
-        index = current_device()
-    return int(index)
-
-
-def _stream_handle(stream: Any) -> int | None:
-    handle = getattr(stream, "cuda_stream", None)
-    return None if handle is None else int(handle)
-
-
 def _is_shared_capture_warmup(torch_module: Any, device: Any) -> bool:
-    """Identify vLLM graph-manager warmup on its retained capture stream."""
+    """Identify graph-manager warmup inside vLLM's public capture scope."""
 
+    del torch_module, device
     if os.getenv("VLLM_SPARK_SHARED_CAPTURE_STREAM", "0") != "1":
         return False
-    parallel_state = sys.modules.get("vllm.distributed.parallel_state")
-    if parallel_state is None:
+    multi_stream_utils = sys.modules.get("vllm.utils.multi_stream_utils")
+    marker = getattr(
+        multi_stream_utils,
+        "is_vllm_cudagraph_capture_active",
+        None,
+    )
+    if not callable(marker):
         raise RuntimeError(
-            "Spark shared CUDA graph capture state is unavailable"
+            "vLLM CUDA graph capture-scope marker API is unavailable"
         )
-    active = getattr(parallel_state, "_SPARK_ACTIVE_CAPTURE_STREAMS", None)
-    streams = getattr(parallel_state, "_SPARK_SHARED_CAPTURE_STREAMS", None)
-    if active is None or streams is None:
-        raise RuntimeError(
-            "Spark shared CUDA graph capture markers are unavailable"
-        )
-    key = (os.getpid(), _device_index(torch_module, device))
-    if key not in active:
-        return False
-    expected = streams.get(key)
-    if expected is None:
-        raise RuntimeError(
-            "Spark shared CUDA graph capture is active without a retained stream"
-        )
-    current = torch_module.cuda.current_stream(device=device)
-    expected_handle = _stream_handle(expected)
-    current_handle = _stream_handle(current)
-    if expected_handle is None or current_handle is None:
-        matches = current is expected
-    else:
-        matches = current_handle == expected_handle
-    if not matches:
-        raise RuntimeError(
-            "Spark shared CUDA graph capture warmup left its retained stream"
-        )
-    return True
+    return bool(marker())
 
 
 def _execution_phase(torch_module: Any, device: Any) -> str:
@@ -300,20 +280,16 @@ def _graph_enabled(mode: str) -> bool:
 
 
 def _validate_control_ports(ports: tuple[int, int]) -> None:
-    port0, port1 = ports
-    if not (0 < port0 <= 65535 and 0 < port1 <= 65535):
-        raise ValueError("Spark TP4 DCP graph control ports must be in [1, 65535]")
-    if port0 == port1:
-        raise ValueError("Spark TP4 DCP graph control ports must be distinct")
+    validate_control_port_pair(ports, owner="DCP")
+    validate_active_port_namespace()
 
 
 def _graph_control_ports() -> tuple[int, int]:
-    ports = (
-        int(os.getenv("SPARK_TP4_GRAPH_DCP_CONTROL_PORT0", "9892")),
-        int(os.getenv("SPARK_TP4_GRAPH_DCP_CONTROL_PORT1", "9893")),
-    )
-    _validate_control_ports(ports)
-    return ports
+    return graph_dcp_control_ports()
+
+
+def _eager_control_ports() -> tuple[int, int]:
+    return eager_dcp_control_ports()
 
 
 def _graph_preflight() -> tuple[int, int]:
@@ -494,9 +470,10 @@ class _NativeDcpSession:
         self._graph_only = graph_only
 
         default_peer0, default_peer1 = _DEFAULT_PEERS[rank]
-        ports = control_ports or (
-            int(os.getenv("SPARK_TP4_DCP_CONTROL_PORT0", "9890")),
-            int(os.getenv("SPARK_TP4_DCP_CONTROL_PORT1", "9891")),
+        ports = (
+            _eager_control_ports()
+            if control_ports is None
+            else control_ports
         )
         _validate_control_ports(ports)
         port0, port1 = ports
@@ -814,10 +791,15 @@ class _CombineShadowState:
         self.count = 0
         self.validated = False
 
-    def observe(self, reference_output: Any, reference_lse: Any) -> None:
+    def observe(
+        self,
+        candidate_output: Any,
+        reference_output: Any,
+        reference_lse: Any,
+    ) -> None:
         output_rtol, output_atol, lse_rtol, lse_atol = self.tolerances
         self.output_stats.observe(
-            self.candidate_output,
+            candidate_output,
             reference_output,
             output_rtol,
             output_atol,
@@ -1325,6 +1307,7 @@ def _call_stock_combine(
     ctx: Any,
     return_lse: bool,
     is_lse_base_on_e: bool,
+    head_major_output: bool,
     *,
     reason: str = "original",
 ) -> Any:
@@ -1341,11 +1324,61 @@ def _call_stock_combine(
         ctx=ctx,
         return_lse=return_lse,
         is_lse_base_on_e=is_lse_base_on_e,
+        head_major_output=head_major_output,
     )
 
 
 def _combine_result(output_tensor: Any, lse_tensor: Any, return_lse: bool) -> Any:
     return (output_tensor, lse_tensor) if return_lse else output_tensor
+
+
+def _combine_input_layout(
+    torch_module: Any,
+    output_tensor: Any,
+    signature: _CombineSignature,
+) -> Any:
+    q, head_dimension, query_stride, head_stride = signature
+    expected_stride = (query_stride, head_stride, 1)
+    if _stride(output_tensor) == expected_stride:
+        return output_tensor
+
+    # The B12X decode workspace exposes the active Q rows from a bounded
+    # head-major allocation, so the view retains the maximum-Q head pitch.
+    # This same-stream clone removes the inactive-row gaps before native eager
+    # enqueue or graph capture. Transposing before the clone guarantees Q=1
+    # cannot be treated as contiguous and returned without a copy.
+    compact = (
+        output_tensor.transpose(0, 1)
+        .clone(memory_format=torch_module.contiguous_format)
+        .transpose(0, 1)
+    )
+    if (
+        _shape(compact) != (q, _OUTPUT_HEADS, head_dimension)
+        or _stride(compact) != expected_stride
+        or compact.dtype != output_tensor.dtype
+        or compact.device != output_tensor.device
+    ):
+        raise RuntimeError(
+            "Spark TP4 DCP combine input compaction returned an invalid layout"
+        )
+    return compact
+
+
+def _combine_output_layout(
+    torch_module: Any,
+    output_tensor: Any,
+    head_major_output: bool,
+) -> Any:
+    if not head_major_output:
+        return output_tensor
+    # The native C ABI writes token-major contiguous storage. This conversion
+    # is enqueued immediately on the same caller stream, so the allocator
+    # cannot reuse the raw staging before the copy, including during capture.
+    return (
+        output_tensor.transpose(0, 1)
+        .clone(memory_format=torch_module.contiguous_format)
+        .transpose(0, 1)
+    )
 
 
 def _patch_combine(module: ModuleType) -> None:
@@ -1364,6 +1397,7 @@ def _patch_combine(module: ModuleType) -> None:
         ctx: Any = None,
         return_lse: bool = False,
         is_lse_base_on_e: bool = True,
+        head_major_output: bool = False,
     ) -> Any:
         mode = _mode()
         signature = _combine_signature(
@@ -1372,6 +1406,7 @@ def _patch_combine(module: ModuleType) -> None:
             cp_attn_lse,
             return_lse,
             is_lse_base_on_e,
+            head_major_output,
             mode,
         )
         if signature is None:
@@ -1383,6 +1418,7 @@ def _patch_combine(module: ModuleType) -> None:
                 ctx,
                 return_lse,
                 is_lse_base_on_e,
+                head_major_output,
             )
 
         import torch
@@ -1405,6 +1441,7 @@ def _patch_combine(module: ModuleType) -> None:
                 ctx,
                 return_lse,
                 is_lse_base_on_e,
+                head_major_output,
                 reason="shared_capture_warmup_reference",
             )
 
@@ -1418,6 +1455,7 @@ def _patch_combine(module: ModuleType) -> None:
                     ctx,
                     return_lse,
                     is_lse_base_on_e,
+                    head_major_output,
                 )
             backend = getattr(cp_group, "_spark_tp4_dcp_native", None)
             graph_session = None if backend is None else backend._graph_session
@@ -1435,8 +1473,11 @@ def _patch_combine(module: ModuleType) -> None:
             )
             stream = torch.cuda.current_stream(device=cp_attn_out.device)
             try:
+                native_attn_out = _combine_input_layout(
+                    torch, cp_attn_out, signature
+                )
                 graph_session.capture_combine(
-                    cp_attn_out,
+                    native_attn_out,
                     contiguous_lse,
                     candidate_output,
                     candidate_lse,
@@ -1444,8 +1485,11 @@ def _patch_combine(module: ModuleType) -> None:
                     stream,
                 )
                 _record_graph_event(cp_group, "captured_combine_nodes")
+                result_output = _combine_output_layout(
+                    torch, candidate_output, head_major_output
+                )
                 if mode == "custom":
-                    return _combine_result(candidate_output, candidate_lse, return_lse)
+                    return _combine_result(result_output, candidate_lse, return_lse)
                 reference_output, reference_lse = _call_stock_combine(
                     original,
                     cp_attn_out,
@@ -1454,6 +1498,7 @@ def _patch_combine(module: ModuleType) -> None:
                     ctx,
                     True,
                     is_lse_base_on_e,
+                    head_major_output,
                 )
                 (
                     output_rtol,
@@ -1469,7 +1514,7 @@ def _patch_combine(module: ModuleType) -> None:
                 record = arena.reserve_combine(signature)
                 record.capture(
                     _numeric_sample(
-                        candidate_output,
+                        result_output,
                         reference_output,
                         output_rtol,
                         output_atol,
@@ -1508,6 +1553,7 @@ def _patch_combine(module: ModuleType) -> None:
                     ctx,
                     return_lse,
                     is_lse_base_on_e,
+                    head_major_output,
                 ),
                 torch,
             )
@@ -1538,6 +1584,7 @@ def _patch_combine(module: ModuleType) -> None:
                 ctx,
                 return_lse,
                 is_lse_base_on_e,
+                head_major_output,
             )
 
         shadow_limit = 0
@@ -1559,6 +1606,7 @@ def _patch_combine(module: ModuleType) -> None:
                         ctx,
                         return_lse,
                         is_lse_base_on_e,
+                        head_major_output,
                     )
 
         contiguous_lse = cp_attn_lse.contiguous()
@@ -1577,8 +1625,11 @@ def _patch_combine(module: ModuleType) -> None:
 
         stream = torch.cuda.current_stream(device=cp_attn_out.device)
         try:
+            native_attn_out = _combine_input_layout(
+                torch, cp_attn_out, signature
+            )
             session.combine(
-                cp_attn_out,
+                native_attn_out,
                 contiguous_lse,
                 candidate_output,
                 candidate_lse,
@@ -1593,8 +1644,11 @@ def _patch_combine(module: ModuleType) -> None:
             _abort_after_native_failure()
             raise AssertionError("unreachable after worker termination")
 
+        result_output = _combine_output_layout(
+            torch, candidate_output, head_major_output
+        )
         if mode == "custom" or promoted:
-            return _combine_result(candidate_output, candidate_lse, return_lse)
+            return _combine_result(result_output, candidate_lse, return_lse)
 
         try:
             # Always request LSE during the finite shadow window so both native
@@ -1608,9 +1662,10 @@ def _patch_combine(module: ModuleType) -> None:
                 ctx,
                 True,
                 is_lse_base_on_e,
+                head_major_output,
             )
             assert shadow is not None
-            shadow.observe(reference_output, reference_lse)
+            shadow.observe(result_output, reference_output, reference_lse)
             report = None
             if shadow.count == shadow_limit:
                 report = (
@@ -1734,6 +1789,7 @@ def install() -> None:
     if _installed or not mode:
         return
     _graph_enabled(mode)
+    validate_active_port_namespace()
     if mode == "shadow":
         _positive_integer("SPARK_TP4_DCP_SHADOW_COLLECTIVES", 8)
         _combine_tolerances()

--- a/spark_transport/integrations/vllm/spark_tp4_port_namespace.py
+++ b/spark_transport/integrations/vllm/spark_tp4_port_namespace.py
@@ -1,0 +1,502 @@
+"""Deterministic control-port namespace for process-local SIRCL sessions.
+
+Every selected TP4 adapter derives this complete plan from the process
+environment before it creates a native session.  Reserving every session that
+the executable configuration can instantiate prevents a later lazy bind from
+colliding with an already-running transport family.
+"""
+
+from __future__ import annotations
+
+import os
+from collections import defaultdict
+from dataclasses import dataclass
+from typing import Mapping
+
+from spark_tp4_query_contract import MAX_QUERY_ROWS
+
+_MIN_CONTROL_PORT = 1
+_MAX_CONTROL_PORT = 65535
+
+_EAGER_ALLREDUCE_DEFAULT_PORTS = (11000, 11001)
+_EAGER_ALLREDUCE_PORT_STRIDE = 2
+_EAGER_ALLREDUCE_PREFILL_MAX_QUERY_ROWS = 512
+
+_EAGER_ALLGATHER_DEFAULT_BASE_PORT = 9490
+_EAGER_ALLGATHER_PORT_STRIDE = 10
+# The exact-signature adapter assigns one durable slot to each admitted
+# signature.  Keep its source-level assertion synchronized with this tuple.
+EAGER_ALLGATHER_PORT_SLOTS = tuple(range(8))
+_EAGER_ALLGATHER_CKV_PORT_SLOTS = frozenset({2, 7})
+
+_GRAPH_INDEXER_DEFAULT_PORTS = (9462, 9463)
+_EAGER_DCP_DEFAULT_PORTS = (9890, 9891)
+_GRAPH_DCP_DEFAULT_PORTS = (9892, 9893)
+_GRAPH_ALLREDUCE_DEFAULT_PORTS = (9970, 9971)
+_GRAPH_DUAL_PORT_Q40_DEFAULT_PORTS = (9972, 9973)
+_EAGER_VOCAB_DEFAULT_PORTS = (9990, 9991)
+_GRAPH_VOCAB_DEFAULT_PORTS = (10110, 10111)
+
+
+@dataclass(frozen=True)
+class PortReservation:
+    """One native session's two process-local TCP control ports."""
+
+    owner: str
+    ports: tuple[int, int]
+
+
+def _environment(environ: Mapping[str, str] | None) -> Mapping[str, str]:
+    return os.environ if environ is None else environ
+
+
+def _integer(
+    environ: Mapping[str, str], name: str, default: int
+) -> int:
+    value = environ.get(name, str(default))
+    try:
+        return int(value)
+    except ValueError as error:
+        raise ValueError(f"{name} must be an integer, got {value!r}") from error
+
+
+def _flag(
+    environ: Mapping[str, str], name: str, default: str = "0"
+) -> bool:
+    value = environ.get(name, default)
+    if value not in {"0", "1"}:
+        raise ValueError(f"{name} must be '0', '1', or unset")
+    return value == "1"
+
+
+def _mode(
+    environ: Mapping[str, str],
+    name: str,
+    allowed: frozenset[str],
+) -> str:
+    value = environ.get(name, "").lower()
+    if value and value not in allowed:
+        choices = ", ".join(repr(choice) for choice in sorted(allowed))
+        raise ValueError(f"{name} must be one of {choices}, or unset")
+    return value
+
+
+def validate_control_port_pair(
+    ports: tuple[int, int], *, owner: str
+) -> tuple[int, int]:
+    """Validate one pair independently of whether its family is selected."""
+
+    if len(ports) != 2:
+        raise ValueError(f"Spark TP4 {owner} requires exactly two control ports")
+    port0, port1 = ports
+    if not all(
+        isinstance(port, int)
+        and not isinstance(port, bool)
+        and _MIN_CONTROL_PORT <= port <= _MAX_CONTROL_PORT
+        for port in ports
+    ):
+        raise ValueError(
+            f"Spark TP4 {owner} control ports must be in "
+            f"[{_MIN_CONTROL_PORT}, {_MAX_CONTROL_PORT}]: {ports}"
+        )
+    if port0 == port1:
+        raise ValueError(
+            f"Spark TP4 {owner} control ports must be distinct: {ports}"
+        )
+    return ports
+
+
+def _configured_pair(
+    environ: Mapping[str, str],
+    *,
+    owner: str,
+    name0: str,
+    name1: str,
+    defaults: tuple[int, int],
+) -> tuple[int, int]:
+    return validate_control_port_pair(
+        (
+            _integer(environ, name0, defaults[0]),
+            _integer(environ, name1, defaults[1]),
+        ),
+        owner=owner,
+    )
+
+
+def _maximum_allreduce_query_rows(environ: Mapping[str, str]) -> int:
+    return (
+        _EAGER_ALLREDUCE_PREFILL_MAX_QUERY_ROWS
+        if _flag(environ, "VLLM_SPARK_TP4_PREFILL_Q512")
+        else MAX_QUERY_ROWS
+    )
+
+
+def _eager_allreduce_pair(
+    query_rows: int, environ: Mapping[str, str]
+) -> tuple[int, int]:
+    maximum = _maximum_allreduce_query_rows(environ)
+    if (
+        not isinstance(query_rows, int)
+        or isinstance(query_rows, bool)
+        or query_rows < 1
+        or query_rows > maximum
+    ):
+        raise ValueError(
+            "Spark TP4 eager all-reduce query rows must be in "
+            f"[1, {maximum}]: {query_rows}"
+        )
+    base0 = _integer(
+        environ,
+        "SPARK_TP4_CONTROL_PORT0",
+        _EAGER_ALLREDUCE_DEFAULT_PORTS[0],
+    )
+    base1 = _integer(
+        environ,
+        "SPARK_TP4_CONTROL_PORT1",
+        _EAGER_ALLREDUCE_DEFAULT_PORTS[1],
+    )
+    offset = (query_rows - 1) * _EAGER_ALLREDUCE_PORT_STRIDE
+    return validate_control_port_pair(
+        (base0 + offset, base1 + offset),
+        owner=f"eager all-reduce Q{query_rows}",
+    )
+
+
+def _eager_allgather_pair(
+    port_slot: int, environ: Mapping[str, str]
+) -> tuple[int, int]:
+    if port_slot not in EAGER_ALLGATHER_PORT_SLOTS:
+        raise ValueError(
+            "Spark TP4 eager all-gather port slot must be one of "
+            f"{EAGER_ALLGATHER_PORT_SLOTS}: {port_slot}"
+        )
+    base = _integer(
+        environ,
+        "SPARK_TP4_ALLGATHER_BASE_PORT",
+        _EAGER_ALLGATHER_DEFAULT_BASE_PORT,
+    )
+    port0 = base + port_slot * _EAGER_ALLGATHER_PORT_STRIDE
+    return validate_control_port_pair(
+        (port0, port0 + 1),
+        owner=f"eager all-gather slot {port_slot}",
+    )
+
+
+def _active_eager_allgather_port_slots(
+    environ: Mapping[str, str],
+) -> tuple[int, ...]:
+    ckv_enabled = _flag(
+        environ, "SPARK_TP4_ALLGATHER_ENABLE_CKV"
+    )
+    return tuple(
+        port_slot
+        for port_slot in EAGER_ALLGATHER_PORT_SLOTS
+        if ckv_enabled
+        or port_slot not in _EAGER_ALLGATHER_CKV_PORT_SLOTS
+    )
+
+
+def _graph_allreduce_pair(environ: Mapping[str, str]) -> tuple[int, int]:
+    return _configured_pair(
+        environ,
+        owner="graph all-reduce",
+        name0="SPARK_TP4_GRAPH_CONTROL_PORT0",
+        name1="SPARK_TP4_GRAPH_CONTROL_PORT1",
+        defaults=_GRAPH_ALLREDUCE_DEFAULT_PORTS,
+    )
+
+
+def _graph_dual_port_q40_pair(
+    environ: Mapping[str, str],
+) -> tuple[int, int]:
+    return _configured_pair(
+        environ,
+        owner="graph exact-Q40 dual-port all-reduce",
+        name0="SPARK_TP4_GRAPH_DUAL_PORT_Q40_CONTROL_PORT0",
+        name1="SPARK_TP4_GRAPH_DUAL_PORT_Q40_CONTROL_PORT1",
+        defaults=_GRAPH_DUAL_PORT_Q40_DEFAULT_PORTS,
+    )
+
+
+def _graph_indexer_pair(environ: Mapping[str, str]) -> tuple[int, int]:
+    return _configured_pair(
+        environ,
+        owner="graph indexer all-gather",
+        name0="SPARK_TP4_GRAPH_INDEXER_CONTROL_PORT0",
+        name1="SPARK_TP4_GRAPH_INDEXER_CONTROL_PORT1",
+        defaults=_GRAPH_INDEXER_DEFAULT_PORTS,
+    )
+
+
+def _eager_dcp_pair(environ: Mapping[str, str]) -> tuple[int, int]:
+    return _configured_pair(
+        environ,
+        owner="eager DCP",
+        name0="SPARK_TP4_DCP_CONTROL_PORT0",
+        name1="SPARK_TP4_DCP_CONTROL_PORT1",
+        defaults=_EAGER_DCP_DEFAULT_PORTS,
+    )
+
+
+def _graph_dcp_pair(environ: Mapping[str, str]) -> tuple[int, int]:
+    return _configured_pair(
+        environ,
+        owner="graph DCP",
+        name0="SPARK_TP4_GRAPH_DCP_CONTROL_PORT0",
+        name1="SPARK_TP4_GRAPH_DCP_CONTROL_PORT1",
+        defaults=_GRAPH_DCP_DEFAULT_PORTS,
+    )
+
+
+def _eager_vocab_pair(environ: Mapping[str, str]) -> tuple[int, int]:
+    return _configured_pair(
+        environ,
+        owner="eager vocabulary all-gather",
+        name0="SPARK_TP4_VOCAB_CONTROL_PORT0",
+        name1="SPARK_TP4_VOCAB_CONTROL_PORT1",
+        defaults=_EAGER_VOCAB_DEFAULT_PORTS,
+    )
+
+
+def _graph_vocab_pair(environ: Mapping[str, str]) -> tuple[int, int]:
+    return _configured_pair(
+        environ,
+        owner="graph vocabulary all-gather",
+        name0="SPARK_TP4_GRAPH_VOCAB_CONTROL_PORT0",
+        name1="SPARK_TP4_GRAPH_VOCAB_CONTROL_PORT1",
+        defaults=_GRAPH_VOCAB_DEFAULT_PORTS,
+    )
+
+
+def active_port_reservations(
+    environ: Mapping[str, str] | None = None,
+) -> tuple[PortReservation, ...]:
+    """Return every control-port pair the selected adapters may bind."""
+
+    environment = _environment(environ)
+    reservations: list[PortReservation] = []
+
+    allreduce_mode = _mode(
+        environment,
+        "VLLM_SPARK_TP4_MODE",
+        frozenset({"custom", "disabled", "shadow"}),
+    )
+    if allreduce_mode in {"custom", "shadow"}:
+        for query_rows in range(
+            1, _maximum_allreduce_query_rows(environment) + 1
+        ):
+            reservations.append(
+                PortReservation(
+                    f"eager_allreduce:q={query_rows}",
+                    _eager_allreduce_pair(query_rows, environment),
+                )
+            )
+        if allreduce_mode == "custom" and _flag(
+            environment, "VLLM_SPARK_TP4_GRAPH_Q1"
+        ):
+            reservations.append(
+                PortReservation(
+                    "graph_allreduce", _graph_allreduce_pair(environment)
+                )
+            )
+            if _flag(
+                environment, "VLLM_SPARK_TP4_GRAPH_DUAL_PORT_Q40"
+            ):
+                reservations.append(
+                    PortReservation(
+                        "graph_dual_port_q40_allreduce",
+                        _graph_dual_port_q40_pair(environment),
+                    )
+                )
+
+    allgather_mode = _mode(
+        environment,
+        "VLLM_SPARK_TP4_ALLGATHER_MODE",
+        frozenset({"custom", "shadow"}),
+    )
+    if allgather_mode:
+        for port_slot in _active_eager_allgather_port_slots(environment):
+            reservations.append(
+                PortReservation(
+                    f"eager_allgather:slot={port_slot}",
+                    _eager_allgather_pair(port_slot, environment),
+                )
+            )
+        if allgather_mode == "custom" and _flag(
+            environment, "VLLM_SPARK_TP4_INDEXER_GRAPH_CUSTOM"
+        ):
+            reservations.append(
+                PortReservation(
+                    "graph_indexer_allgather",
+                    _graph_indexer_pair(environment),
+                )
+            )
+
+    vocab_mode = _mode(
+        environment,
+        "VLLM_SPARK_TP4_VOCAB_MODE",
+        frozenset({"custom", "shadow"}),
+    )
+    if vocab_mode:
+        reservations.append(
+            PortReservation("eager_vocab", _eager_vocab_pair(environment))
+        )
+        if vocab_mode == "custom" and _flag(
+            environment, "VLLM_SPARK_TP4_GRAPH_Q1"
+        ):
+            reservations.append(
+                PortReservation("graph_vocab", _graph_vocab_pair(environment))
+            )
+
+    dcp_mode = _mode(
+        environment,
+        "VLLM_SPARK_TP4_DCP_MODE",
+        frozenset({"custom", "shadow"}),
+    )
+    if dcp_mode:
+        query_enabled = _flag(
+            environment, "VLLM_SPARK_TP4_DCP_QUERY_ENABLED", "1"
+        )
+        combine_enabled = _flag(
+            environment, "VLLM_SPARK_TP4_DCP_COMBINE_ENABLED", "1"
+        )
+        if query_enabled or combine_enabled:
+            reservations.append(
+                PortReservation("eager_dcp", _eager_dcp_pair(environment))
+            )
+            graph_shadow = _flag(
+                environment, "VLLM_SPARK_TP4_DCP_GRAPH_SHADOW"
+            )
+            graph_custom = _flag(
+                environment, "VLLM_SPARK_TP4_DCP_GRAPH_CUSTOM"
+            )
+            if graph_shadow and graph_custom:
+                raise ValueError(
+                    "Spark TP4 DCP graph shadow and custom modes are "
+                    "mutually exclusive"
+                )
+            if graph_shadow and dcp_mode != "shadow":
+                raise ValueError(
+                    "VLLM_SPARK_TP4_DCP_GRAPH_SHADOW requires DCP shadow mode"
+                )
+            if graph_custom and dcp_mode != "custom":
+                raise ValueError(
+                    "VLLM_SPARK_TP4_DCP_GRAPH_CUSTOM requires DCP custom mode"
+                )
+            if graph_shadow or graph_custom:
+                reservations.append(
+                    PortReservation("graph_dcp", _graph_dcp_pair(environment))
+                )
+
+    return tuple(reservations)
+
+
+def validate_active_port_namespace(
+    environ: Mapping[str, str] | None = None,
+) -> tuple[PortReservation, ...]:
+    """Reject out-of-range, internally duplicated, or shared active ports."""
+
+    reservations = active_port_reservations(environ)
+    owners_by_port: dict[int, list[str]] = defaultdict(list)
+    for reservation in reservations:
+        validate_control_port_pair(
+            reservation.ports, owner=reservation.owner
+        )
+        for port in reservation.ports:
+            owners_by_port[port].append(reservation.owner)
+
+    collisions = {
+        port: tuple(owners)
+        for port, owners in sorted(owners_by_port.items())
+        if len(owners) > 1
+    }
+    if collisions:
+        details = "; ".join(
+            f"port {port}: {', '.join(owners)}"
+            for port, owners in collisions.items()
+        )
+        raise ValueError(
+            "Spark TP4 active control-port namespaces collide: " + details
+        )
+    return reservations
+
+
+def eager_allreduce_control_ports(
+    query_rows: int, environ: Mapping[str, str] | None = None
+) -> tuple[int, int]:
+    environment = _environment(environ)
+    ports = _eager_allreduce_pair(query_rows, environment)
+    validate_active_port_namespace(environment)
+    return ports
+
+
+def graph_allreduce_control_ports(
+    environ: Mapping[str, str] | None = None,
+) -> tuple[int, int]:
+    environment = _environment(environ)
+    ports = _graph_allreduce_pair(environment)
+    validate_active_port_namespace(environment)
+    return ports
+
+
+def graph_dual_port_q40_control_ports(
+    environ: Mapping[str, str] | None = None,
+) -> tuple[int, int]:
+    environment = _environment(environ)
+    ports = _graph_dual_port_q40_pair(environment)
+    validate_active_port_namespace(environment)
+    return ports
+
+
+def eager_allgather_control_ports(
+    port_slot: int, environ: Mapping[str, str] | None = None
+) -> tuple[int, int]:
+    environment = _environment(environ)
+    ports = _eager_allgather_pair(port_slot, environment)
+    validate_active_port_namespace(environment)
+    return ports
+
+
+def graph_indexer_control_ports(
+    environ: Mapping[str, str] | None = None,
+) -> tuple[int, int]:
+    environment = _environment(environ)
+    ports = _graph_indexer_pair(environment)
+    validate_active_port_namespace(environment)
+    return ports
+
+
+def eager_dcp_control_ports(
+    environ: Mapping[str, str] | None = None,
+) -> tuple[int, int]:
+    environment = _environment(environ)
+    ports = _eager_dcp_pair(environment)
+    validate_active_port_namespace(environment)
+    return ports
+
+
+def graph_dcp_control_ports(
+    environ: Mapping[str, str] | None = None,
+) -> tuple[int, int]:
+    environment = _environment(environ)
+    ports = _graph_dcp_pair(environment)
+    validate_active_port_namespace(environment)
+    return ports
+
+
+def eager_vocab_control_ports(
+    environ: Mapping[str, str] | None = None,
+) -> tuple[int, int]:
+    environment = _environment(environ)
+    ports = _eager_vocab_pair(environment)
+    validate_active_port_namespace(environment)
+    return ports
+
+
+def graph_vocab_control_ports(
+    environ: Mapping[str, str] | None = None,
+) -> tuple[int, int]:
+    environment = _environment(environ)
+    ports = _graph_vocab_pair(environment)
+    validate_active_port_namespace(environment)
+    return ports

--- a/spark_transport/integrations/vllm/spark_tp4_prefill_capacity_pool.py
+++ b/spark_transport/integrations/vllm/spark_tp4_prefill_capacity_pool.py
@@ -1,0 +1,432 @@
+"""Research-only capacity selector for a future tiled TP4 prefill engine.
+
+The executable TP4 adapter still creates one eager native session per exact
+payload size. This module describes one physical transport engine with four
+logical capacity plans, but does not create an engine or call an unavailable
+ABI. Selecting the feature in a serving process remains fail-closed until the
+native transport accepts an operation-specific active byte count and streams
+it through a fixed generation-tagged tile pool.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Mapping
+
+from spark_tp4_port_namespace import validate_control_port_pair
+
+FEATURE_ENV = "VLLM_SPARK_TP4_PREFILL_CAPACITY_POOL"
+PORT0_ENV = "SPARK_TP4_PREFILL_POOL_CONTROL_PORT0"
+PORT1_ENV = "SPARK_TP4_PREFILL_POOL_CONTROL_PORT1"
+
+TARGET_WIDTH = 6144
+BF16_BYTES = 2
+BYTES_PER_QUERY_ROW = TARGET_WIDTH * BF16_BYTES
+CAPACITY_QUERY_ROWS = (40, 512, 1024, 4096)
+DEFAULT_CONTROL_PORTS = (12500, 12501)
+TILE_BYTES = 512 * 1024
+TILES_PER_EDGE = 8
+LANES_PER_EDGE = 2
+LANE_PAYLOAD_BYTES = TILE_BYTES // LANES_PER_EDGE
+SEND_RECEIVE_REGIONS_PER_LANE = 2
+CONTROL_BYTES_PER_LANE = 64
+REGISTERED_SLOT_BYTES_PER_EDGE = LANES_PER_EDGE * (
+    SEND_RECEIVE_REGIONS_PER_LANE * LANE_PAYLOAD_BYTES
+    + CONTROL_BYTES_PER_LANE
+)
+REGISTERED_BYTES_PER_EDGE = REGISTERED_SLOT_BYTES_PER_EDGE * TILES_PER_EDGE
+LOGICAL_ONE_PLANE_PAYLOAD_BYTES_PER_EDGE = TILE_BYTES * TILES_PER_EDGE
+
+
+@dataclass(frozen=True)
+class SharedTransportKey:
+    """Identity of the one physical tiled-prefill engine per rank."""
+
+    engine_id: str
+    control_ports: tuple[int, int]
+
+
+@dataclass(frozen=True)
+class CapacityPlan:
+    """A logical maximum used to select kernels and descriptor bounds."""
+
+    maximum_query_rows: int
+    maximum_payload_bytes: int
+
+
+@dataclass(frozen=True)
+class CapacitySelection:
+    """One operation routed through the shared engine under a logical plan."""
+
+    query_rows: int
+    active_bytes: int
+    capacity_plan: CapacityPlan
+    transport_key: SharedTransportKey
+
+    @property
+    def requires_active_bytes_submission(self) -> bool:
+        """True when arena capacity alone cannot describe the operation."""
+
+        return self.active_bytes != self.capacity_plan.maximum_payload_bytes
+
+
+def _environment(environ: Mapping[str, str] | None) -> Mapping[str, str]:
+    import os
+
+    return os.environ if environ is None else environ
+
+
+def capacity_pool_requested(
+    environ: Mapping[str, str] | None = None,
+) -> bool:
+    """Return the explicit research request; default is disabled."""
+
+    value = _environment(environ).get(FEATURE_ENV, "0")
+    if value not in {"0", "1"}:
+        raise ValueError(f"{FEATURE_ENV} must be '0', '1', or unset")
+    return value == "1"
+
+
+def _integer(
+    environ: Mapping[str, str], name: str, default: int
+) -> int:
+    value = environ.get(name, str(default))
+    try:
+        return int(value)
+    except ValueError as error:
+        raise ValueError(f"{name} must be an integer, got {value!r}") from error
+
+
+def shared_transport_key(
+    environ: Mapping[str, str] | None = None,
+) -> SharedTransportKey:
+    """Return the proposed shared engine identity without binding its ports."""
+
+    environment = _environment(environ)
+    base0 = _integer(environment, PORT0_ENV, DEFAULT_CONTROL_PORTS[0])
+    base1 = _integer(environment, PORT1_ENV, DEFAULT_CONTROL_PORTS[1])
+    ports = validate_control_port_pair(
+        (base0, base1),
+        owner="research shared tiled-prefill engine",
+    )
+    return SharedTransportKey(
+        engine_id="prefill-tile-engine",
+        control_ports=ports,
+    )
+
+
+def select_capacity_plan(
+    query_rows: int,
+    environ: Mapping[str, str] | None = None,
+) -> CapacitySelection:
+    """Select the smallest logical plan while retaining one transport key."""
+
+    if (
+        not isinstance(query_rows, int)
+        or isinstance(query_rows, bool)
+        or not 1 <= query_rows <= CAPACITY_QUERY_ROWS[-1]
+    ):
+        raise ValueError(
+            "query rows must be an integer in "
+            f"[1, {CAPACITY_QUERY_ROWS[-1]}]: {query_rows!r}"
+        )
+    capacity_rows = next(
+        value for value in CAPACITY_QUERY_ROWS if query_rows <= value
+    )
+    capacity_plan = CapacityPlan(
+        maximum_query_rows=capacity_rows,
+        maximum_payload_bytes=capacity_rows * BYTES_PER_QUERY_ROW,
+    )
+    return CapacitySelection(
+        query_rows=query_rows,
+        active_bytes=query_rows * BYTES_PER_QUERY_ROW,
+        capacity_plan=capacity_plan,
+        transport_key=shared_transport_key(environ),
+    )
+
+
+def _projected_exact_q_ports(
+    query_rows: int, environ: Mapping[str, str]
+) -> tuple[int, int]:
+    base0 = _integer(environ, "SPARK_TP4_CONTROL_PORT0", 11000)
+    base1 = _integer(environ, "SPARK_TP4_CONTROL_PORT1", 11001)
+    offset = (query_rows - 1) * 2
+    return validate_control_port_pair(
+        (base0 + offset, base1 + offset),
+        owner=f"projected exact-Q eager all-reduce Q{query_rows}",
+    )
+
+
+def transport_engine_audit(
+    environ: Mapping[str, str] | None = None,
+) -> dict[str, object]:
+    """Describe exact-Q scaling and the bounded research replacement.
+
+    Q1024 and Q4096 entries are projections of the present stride-two port
+    formula, not claims that the executable adapter admits those shapes.
+    """
+
+    environment = _environment(environ)
+    exact_projection = []
+    for maximum in CAPACITY_QUERY_ROWS:
+        exact_projection.append({
+            "maximum_query_rows": maximum,
+            "session_count_per_rank": maximum,
+            "control_port_count_per_rank": maximum * 2,
+            "first_control_ports": _projected_exact_q_ports(1, environment),
+            "last_control_ports": _projected_exact_q_ports(
+                maximum, environment
+            ),
+            "executable_today": maximum <= 512,
+        })
+
+    transport_key = shared_transport_key(environment)
+    capacity_rows = [
+        {
+            "capacity_query_rows": value,
+            "maximum_payload_bytes": value * BYTES_PER_QUERY_ROW,
+        }
+        for value in CAPACITY_QUERY_ROWS
+    ]
+    pool_ports = set(transport_key.control_ports)
+    exact_decode_ports = {
+        port
+        for query_rows in range(1, CAPACITY_QUERY_ROWS[0] + 1)
+        for port in _projected_exact_q_ports(query_rows, environment)
+    }
+    first_projected_collision = next(
+        (
+            query_rows
+            for query_rows in range(1, CAPACITY_QUERY_ROWS[-1] + 1)
+            if not pool_ports.isdisjoint(
+                _projected_exact_q_ports(query_rows, environment)
+            )
+        ),
+        None,
+    )
+    return {
+        "status": "research-only",
+        "native_dispatch_enabled": False,
+        "exact_q_projection": exact_projection,
+        "capacity_pool": {
+            "transport_key": {
+                "engine_id": transport_key.engine_id,
+                "control_ports": transport_key.control_ports,
+            },
+            "logical_capacity_plans": capacity_rows,
+            "physical_transport_engines_per_rank": 1,
+            "logical_capacity_plan_count": len(CAPACITY_QUERY_ROWS),
+            "control_port_count_per_rank": len(pool_ports),
+            "ports_disjoint_from_exact_decode_q1_q40": pool_ports.isdisjoint(
+                exact_decode_ports
+            ),
+            "coexistence_contract": (
+                "capacity mode must replace exact-Q sessions above Q40 with one "
+                "shared tiled-prefill engine; the namespaces do not coexist"
+            ),
+        },
+        "q4096_physical_engine_reduction_factor": float(
+            CAPACITY_QUERY_ROWS[-1]
+        ),
+        "first_projected_exact_q_collision_with_pool": (
+            first_projected_collision
+        ),
+    }
+
+
+def qualification_plan(
+    environ: Mapping[str, str] | None = None,
+) -> dict[str, object]:
+    """Return the blocked, machine-readable live qualification contract."""
+
+    environment = _environment(environ)
+    iterations = {40: 200, 512: 50, 1024: 25, 4096: 10}
+    fixed_q_arms = []
+    for query_rows in CAPACITY_QUERY_ROWS:
+        selection = select_capacity_plan(query_rows, environment)
+        fixed_q_arms.append({
+            "query_rows": query_rows,
+            "active_bytes": selection.active_bytes,
+            "capacity_query_rows": (
+                selection.capacity_plan.maximum_query_rows
+            ),
+            "maximum_payload_bytes": (
+                selection.capacity_plan.maximum_payload_bytes
+            ),
+            "logical_payload_tiles": (
+                selection.active_bytes + TILE_BYTES - 1
+            )
+            // TILE_BYTES,
+            "transport_engine_id": selection.transport_key.engine_id,
+            "control_ports": selection.transport_key.control_ports,
+            "warmup_iterations": 10,
+            "iterations": iterations[query_rows],
+        })
+
+    live_prerequisites = [
+        {
+            "id": "native-active-bytes-submission",
+            "satisfied": False,
+            "removal_gate": (
+                "one native engine must submit aligned active_bytes not greater "
+                "than its class maximum without recreation; zero, misaligned, "
+                "and oversized submissions must fail before touching CUDA"
+            ),
+        },
+        {
+            "id": "generation-tagged-tile-pool",
+            "satisfied": False,
+            "removal_gate": (
+                "each edge must expose fixed tiles addressed by generation and "
+                "slot, carry active_bytes in the operation descriptor, and make "
+                "unexpected generations or poisoned slots process-fatal"
+            ),
+        },
+        {
+            "id": "cumulative-credit-retirement",
+            "satisfied": False,
+            "removal_gate": (
+                "each edge must publish a monotonic consumed-through watermark; "
+                "output readiness must not wait for reciprocal slot retirement"
+            ),
+        },
+        {
+            "id": "capacity-port-namespace",
+            "satisfied": False,
+            "removal_gate": (
+                "the shared namespace must reserve exactly one pair for the tiled "
+                "engine, replace exact-Q prefill reservations above Q40, reject "
+                "collisions, and confirm the selected pairs are free on all ranks"
+            ),
+        },
+        {
+            "id": "q4096-kernel-capacity",
+            "satisfied": False,
+            "removal_gate": (
+                "staging, reduction, and output kernels must tile through Q4096 "
+                "without a single-CTA whole-payload dependency or an arena-sized "
+                "allocation per exact query width"
+            ),
+        },
+        {
+            "id": "four-rank-fixed-q-probe",
+            "satisfied": False,
+            "removal_gate": (
+                "the standalone four-rank probe must accept Q40/Q512/Q1024/Q4096, "
+                "report capacity-plan/engine/tile counters, and enforce a bounded "
+                "watchdog with all-rank receipts"
+            ),
+        },
+        {
+            "id": "serving-engine-receipt",
+            "satisfied": False,
+            "removal_gate": (
+                "serving evidence must attest one tiled engine per rank, zero "
+                "exact-Q prefill sessions, selected plan and active "
+                "bytes for every observed shape, and zero overflow or poison"
+            ),
+        },
+    ]
+
+    return {
+        "schema": "sparkring-tp4-prefill-capacity-qualification/v1",
+        "status": "research-only",
+        "runnable": False,
+        "adapter_dispatch_enabled": False,
+        "feature_environment": FEATURE_ENV,
+        "tile_pool": {
+            "tile_bytes": TILE_BYTES,
+            "tiles_per_edge": TILES_PER_EDGE,
+            "lanes_per_edge": LANES_PER_EDGE,
+            "lane_payload_bytes": LANE_PAYLOAD_BYTES,
+            "send_receive_regions_per_lane": SEND_RECEIVE_REGIONS_PER_LANE,
+            "control_bytes_per_lane": CONTROL_BYTES_PER_LANE,
+            "registered_slot_bytes_per_edge": REGISTERED_SLOT_BYTES_PER_EDGE,
+            "registered_bytes_per_edge": REGISTERED_BYTES_PER_EDGE,
+            "logical_one_plane_payload_bytes_per_edge": (
+                LOGICAL_ONE_PLANE_PAYLOAD_BYTES_PER_EDGE
+            ),
+            "descriptors_included": False,
+            "allocation_rule": (
+                "physical registered memory includes distinct send and receive "
+                "storage plus one 64-byte control per lane; descriptors are "
+                "excluded, and allocation is independent of the class maximum"
+            ),
+        },
+        "fixed_q_arms": fixed_q_arms,
+        "boundary_query_rows": [
+            1,
+            39,
+            40,
+            41,
+            511,
+            512,
+            513,
+            1023,
+            1024,
+            1025,
+            4095,
+            4096,
+        ],
+        "required_gates": {
+            "correctness": (
+                "all four ranks exit zero; exact integer-valued oracle has zero "
+                "mismatches; random BF16 is within the declared association gate; "
+                "fixed-seed serving output is token-identical"
+            ),
+            "lifecycle": (
+                "one physical engine is created once per rank and reused across all "
+                "plans and boundary shapes; engine, tile, generation, credit, overflow, and poison "
+                "counters agree on all ranks"
+            ),
+            "performance": (
+                "bracketed baseline/candidate p50 and p95 are reported separately "
+                "for every fixed-Q arm; no result combines kernel, protocol, or "
+                "dual-port effects under a narrower label"
+            ),
+            "serving": (
+                "shape tracing proves Q40/Q512/Q1024/Q4096 dispatch when those "
+                "shapes occur; prefill and C1/C4/C8 decode are reported under an "
+                "otherwise matched launch profile"
+            ),
+        },
+        "required_live_receipt": {
+            "per_rank_topology": {
+                "physical_transport_engine_count": 1,
+                "edge_count": 2,
+                "qp_count_per_edge": 1,
+                "registered_tile_pool_count_per_edge": 1,
+                "registered_tile_storage_bytes_per_edge": (
+                    REGISTERED_BYTES_PER_EDGE
+                ),
+                "logical_one_plane_payload_bytes_per_edge": (
+                    LOGICAL_ONE_PLANE_PAYLOAD_BYTES_PER_EDGE
+                ),
+                "descriptor_storage_accounting": "separate",
+                "logical_capacity_plan_count": len(CAPACITY_QUERY_ROWS),
+                "exact_q_prefill_session_count": 0,
+            },
+            "per_operation": [
+                "query_rows",
+                "active_bytes",
+                "capacity_plan_maximum_query_rows",
+                "first_tile_slot",
+                "logical_tile_count",
+                "generation",
+            ],
+            "per_edge_monotonic_counters": [
+                "published_generation",
+                "consumed_through_generation",
+                "tiles_acquired",
+                "tiles_recycled",
+            ],
+            "fatal_counters": {
+                "unexpected_generation": 0,
+                "poisoned_slot": 0,
+                "descriptor_overflow": 0,
+                "credit_regression": 0,
+            },
+        },
+        "live_prerequisites": live_prerequisites,
+        "transport_engine_audit": transport_engine_audit(environment),
+    }

--- a/spark_transport/integrations/vllm/spark_tp4_vocab_allgather_backend.py
+++ b/spark_transport/integrations/vllm/spark_tp4_vocab_allgather_backend.py
@@ -7,6 +7,12 @@ import logging
 import os
 from typing import Any
 
+from spark_tp4_port_namespace import (
+    eager_vocab_control_ports,
+    graph_vocab_control_ports,
+    validate_active_port_namespace,
+    validate_control_port_pair,
+)
 from spark_tp4_query_contract import SUPPORTED_QUERY_ROWS
 
 logger = logging.getLogger(__name__)
@@ -166,24 +172,16 @@ def _graph_preflight() -> tuple[int, int]:
 
 
 def _graph_control_ports() -> tuple[int, int]:
-    ports = (
-        int(os.getenv("SPARK_TP4_GRAPH_VOCAB_CONTROL_PORT0", "10110")),
-        int(os.getenv("SPARK_TP4_GRAPH_VOCAB_CONTROL_PORT1", "10111")),
-    )
-    _validate_control_ports(ports)
-    return ports
+    return graph_vocab_control_ports()
+
+
+def _eager_control_ports() -> tuple[int, int]:
+    return eager_vocab_control_ports()
 
 
 def _validate_control_ports(ports: tuple[int, int]) -> None:
-    port0, port1 = ports
-    if not (0 < port0 <= 65535 and 0 < port1 <= 65535):
-        raise ValueError(
-            "Spark TP4 vocabulary control ports must be in [1, 65535]"
-        )
-    if port0 == port1:
-        raise ValueError(
-            "Spark TP4 vocabulary control ports must be distinct"
-        )
+    validate_control_port_pair(ports, owner="vocabulary all-gather")
+    validate_active_port_namespace()
 
 
 def _record_graph_event(group: Any, event: str) -> int:
@@ -320,9 +318,10 @@ class _NativeVocabSession:
         self._capture_stream: int | None = None
 
         default_peer0, default_peer1 = _DEFAULT_PEERS[rank]
-        ports = control_ports or (
-            int(os.getenv("SPARK_TP4_VOCAB_CONTROL_PORT0", "9990")),
-            int(os.getenv("SPARK_TP4_VOCAB_CONTROL_PORT1", "9991")),
+        ports = (
+            _eager_control_ports()
+            if control_ports is None
+            else control_ports
         )
         _validate_control_ports(ports)
         port0, port1 = ports
@@ -641,6 +640,7 @@ def install() -> None:
         _graph_enabled()
     if mode == "shadow":
         _positive_integer("SPARK_TP4_VOCAB_SHADOW_COLLECTIVES", 8)
+    validate_active_port_namespace()
 
     from vllm.distributed.parallel_state import GroupCoordinator
 

--- a/spark_transport/integrations/vllm/test_spark_tp4_allgather_backend.py
+++ b/spark_transport/integrations/vllm/test_spark_tp4_allgather_backend.py
@@ -166,11 +166,13 @@ def _make_pynccl_type() -> type:
             rank: int = 2,
             disabled: bool = False,
             unique_name: str = "tp:0",
+            group: object | None = None,
         ) -> None:
             self.world_size = world_size
             self.rank = rank
             self.disabled = disabled
             self.unique_name = unique_name
+            self.group = group
             self.original_calls: list[tuple[object, object, object]] = []
 
         def all_gather(
@@ -224,6 +226,14 @@ class SparkTp4AllgatherDispatchTest(unittest.TestCase):
             patch.dict(os.environ, environment, clear=True),
             patch.dict(sys.modules, self.modules),
             patch.object(backend_module, "_Backend", backend_type),
+            patch.object(
+                backend_module,
+                "_is_indexer_communicator",
+                side_effect=lambda communicator: getattr(
+                    communicator, "unique_name", ""
+                )
+                == "tp:0",
+            ),
         )
         for patcher in patchers:
             patcher.start()
@@ -810,6 +820,12 @@ class SparkTp4AllgatherDispatchTest(unittest.TestCase):
                 self.assertEqual(len(communicator.original_calls), 1)
         self.assertEqual(_FakeBackend.created, [])
 
+    @patch.object(
+        backend_module,
+        "_is_indexer_communicator",
+        lambda communicator: getattr(communicator, "unique_name", "")
+        == "tp:0",
+    )
     def test_indexer_graph_formula_admits_every_q1_q40(self) -> None:
         communicator = self.pynccl_type()
         for q in range(1, 41):
@@ -852,6 +868,168 @@ class SparkTp4AllgatherDispatchTest(unittest.TestCase):
             )
         )
 
+    def test_indexer_identity_accepts_only_configured_group_owner(
+        self,
+    ) -> None:
+        cpu_group = object()
+        correct = self.pynccl_type(
+            unique_name="",
+            group=cpu_group,
+        )
+        wrong_group = self.pynccl_type(
+            unique_name="",
+            group=object(),
+        )
+        unnamed_nonowner = self.pynccl_type(
+            unique_name="",
+            group=cpu_group,
+        )
+        indexer_group = types.SimpleNamespace(
+            unique_name="dcp:0",
+            world_size=4,
+            rank_in_group=correct.rank,
+            cpu_group=cpu_group,
+            device_communicator=types.SimpleNamespace(
+                pynccl_comm=correct,
+            ),
+        )
+        parallel_state = types.ModuleType(
+            "vllm.distributed.parallel_state"
+        )
+
+        def get_indexer_dcp_group(expected_world_size: int) -> object:
+            self.assertEqual(expected_world_size, 4)
+            return indexer_group
+
+        parallel_state.get_indexer_dcp_group = get_indexer_dcp_group
+        modules = dict(self.modules)
+        modules["vllm.distributed.parallel_state"] = parallel_state
+        input_tensor = _FakeTensor((3, 2, 2048), "torch.int32")
+        output_tensor = _FakeTensor((12, 2, 2048), "torch.int32")
+
+        with patch.dict(sys.modules, modules):
+            self.assertTrue(
+                backend_module._is_indexer_communicator(correct)
+            )
+            self.assertIsNone(
+                backend_module._signature(
+                    correct,
+                    input_tensor,
+                    output_tensor,
+                    "custom",
+                )
+            )
+            self.assertEqual(
+                backend_module._indexer_graph_q(
+                    correct,
+                    input_tensor,
+                    output_tensor,
+                    "custom",
+                ),
+                3,
+            )
+            for reason, rejected in (
+                ("wrong-group", wrong_group),
+                ("unnamed-nonowner", unnamed_nonowner),
+            ):
+                with self.subTest(reason=reason):
+                    self.assertFalse(
+                        backend_module._is_indexer_communicator(
+                            rejected
+                        )
+                    )
+                    self.assertIsNone(
+                        backend_module._signature(
+                            rejected,
+                            input_tensor,
+                            output_tensor,
+                            "custom",
+                        )
+                    )
+                    self.assertIsNone(
+                        backend_module._indexer_graph_q(
+                            rejected,
+                            input_tensor,
+                            output_tensor,
+                            "custom",
+                        )
+                    )
+
+            indexer_group.unique_name = ""
+            self.assertFalse(
+                backend_module._is_indexer_communicator(correct)
+            )
+            indexer_group.unique_name = "dcp:0"
+            indexer_group.world_size = 3
+            self.assertFalse(
+                backend_module._is_indexer_communicator(correct)
+            )
+            indexer_group.world_size = 4
+            indexer_group.rank_in_group = correct.rank + 1
+            self.assertFalse(
+                backend_module._is_indexer_communicator(correct)
+            )
+
+    def test_indexer_identity_fails_closed_without_group_state(
+        self,
+    ) -> None:
+        communicator = self.pynccl_type(unique_name="dcp:0")
+        parallel_state = types.ModuleType(
+            "vllm.distributed.parallel_state"
+        )
+
+        def unavailable_group(expected_world_size: int) -> object:
+            del expected_world_size
+            raise RuntimeError("indexer group unavailable")
+
+        parallel_state.get_indexer_dcp_group = unavailable_group
+        modules = dict(self.modules)
+        modules["vllm.distributed.parallel_state"] = parallel_state
+        with patch.dict(sys.modules, modules):
+            self.assertFalse(
+                backend_module._is_indexer_communicator(communicator)
+            )
+
+    def test_indexer_graph_uses_selected_dcp_communicator_identity(self) -> None:
+        cpu_group = object()
+        selected = self.pynccl_type(unique_name="", group=cpu_group)
+        unrelated = self.pynccl_type(unique_name="", group=cpu_group)
+        indexer_group = types.SimpleNamespace(
+            unique_name="dcp:0",
+            world_size=4,
+            rank_in_group=selected.rank,
+            cpu_group=cpu_group,
+            device_communicator=types.SimpleNamespace(pynccl_comm=selected),
+        )
+        parallel_state = types.ModuleType("vllm.distributed.parallel_state")
+        parallel_state.get_indexer_dcp_group = (
+            lambda expected_world_size: indexer_group
+        )
+        input_tensor = _FakeTensor((3, 2, 2048), "torch.int32")
+        output_tensor = _FakeTensor((12, 2, 2048), "torch.int32")
+
+        with patch.dict(
+            sys.modules,
+            {"vllm.distributed.parallel_state": parallel_state},
+        ):
+            self.assertEqual(
+                backend_module._indexer_graph_q(
+                    selected,
+                    input_tensor,
+                    output_tensor,
+                    "custom",
+                ),
+                3,
+            )
+            self.assertIsNone(
+                backend_module._indexer_graph_q(
+                    unrelated,
+                    input_tensor,
+                    output_tensor,
+                    "custom",
+                )
+            )
+
     def test_indexer_graph_uses_one_noncolliding_port_pair(self) -> None:
         with patch.dict(
             os.environ,
@@ -866,6 +1044,8 @@ class SparkTp4AllgatherDispatchTest(unittest.TestCase):
             patch.dict(
                 os.environ,
                 {
+                    "VLLM_SPARK_TP4_ALLGATHER_MODE": "custom",
+                    "VLLM_SPARK_TP4_INDEXER_GRAPH_CUSTOM": "1",
                     "SPARK_TP4_ALLGATHER_BASE_PORT": "9490",
                     "SPARK_TP4_GRAPH_INDEXER_CONTROL_PORT0": "9490",
                     "SPARK_TP4_GRAPH_INDEXER_CONTROL_PORT1": "9491",
@@ -879,12 +1059,15 @@ class SparkTp4AllgatherDispatchTest(unittest.TestCase):
             patch.dict(
                 os.environ,
                 {
-                    "SPARK_TP4_GRAPH_INDEXER_CONTROL_PORT0": "9570",
-                    "SPARK_TP4_GRAPH_INDEXER_CONTROL_PORT1": "9571",
+                    "VLLM_SPARK_TP4_MODE": "custom",
+                    "VLLM_SPARK_TP4_ALLGATHER_MODE": "custom",
+                    "VLLM_SPARK_TP4_INDEXER_GRAPH_CUSTOM": "1",
+                    "SPARK_TP4_GRAPH_INDEXER_CONTROL_PORT0": "11002",
+                    "SPARK_TP4_GRAPH_INDEXER_CONTROL_PORT1": "11003",
                 },
                 clear=True,
             ),
-            self.assertRaisesRegex(ValueError, "reserved"),
+            self.assertRaisesRegex(ValueError, "eager_allreduce:q=2"),
         ):
             backend_module._indexer_graph_control_ports()
 

--- a/spark_transport/integrations/vllm/test_spark_tp4_backend_dispatch.py
+++ b/spark_transport/integrations/vllm/test_spark_tp4_backend_dispatch.py
@@ -131,6 +131,7 @@ class _FakeBackend:
         self.rank = rank
         self.native_sessions: dict[int, _FakeNative] = {}
         self.graph_q1_session: _FakeNative | None = None
+        self.graph_dual_port_q40_session: _FakeNative | None = None
         self.shadow_stats: dict[object, _FakeShadowStats] = {}
         self.created.append(self)
 
@@ -149,7 +150,23 @@ class _FakeBackend:
                 graph_only=True,
             )
             self.graph_q1_session = native
+        if (
+            spark_tp4_backend._graph_dual_port_q40_enabled()
+            and self.graph_dual_port_q40_session is None
+        ):
+            self.graph_dual_port_q40_session = _FakeNative(
+                40 * 6144 * 2,
+                graph_only=True,
+            )
         return native
+
+    def graph_session_for_capture(self, tensor: object) -> _FakeNative | None:
+        if (
+            tensor.shape[0] == 40
+            and self.graph_dual_port_q40_session is not None
+        ):
+            return self.graph_dual_port_q40_session
+        return self.graph_q1_session
 
     def shadow_for(self, signature: object) -> _FakeShadowStats:
         shadow = self.shadow_stats.get(signature)
@@ -174,7 +191,21 @@ class _FakeFunction:
 class _FakeLibrary:
     def __init__(self) -> None:
         self.configs: list[dict[str, object]] = []
+        self.protocols: list[int] = []
+        self.graph_kernels: list[int] = []
+        self.wire_schedules: list[int] = []
         self.spark_tp4_create = _FakeFunction(self._create)
+        self.spark_tp4_create_with_protocol = _FakeFunction(
+            self._create_with_protocol
+        )
+        self.spark_tp4_create_with_protocol_and_graph_kernel = _FakeFunction(
+            self._create_with_protocol_and_graph_kernel
+        )
+        self.spark_tp4_create_with_protocol_graph_kernel_and_schedule = (
+            _FakeFunction(
+                self._create_with_protocol_graph_kernel_and_schedule
+            )
+        )
         self.spark_tp4_all_reduce = _FakeFunction()
         self.spark_tp4_capture_q1_all_reduce = _FakeFunction()
         self.capture_calls: list[dict[str, object]] = []
@@ -192,6 +223,38 @@ class _FakeLibrary:
             }
         )
         return 1
+
+    def _create_with_protocol(
+        self, config_pointer, protocol, error, error_size
+    ) -> int:
+        self.protocols.append(int(protocol))
+        return self._create(config_pointer, error, error_size)
+
+    def _create_with_protocol_and_graph_kernel(
+        self,
+        config_pointer,
+        protocol,
+        graph_kernel,
+        error,
+        error_size,
+    ) -> int:
+        self.protocols.append(int(protocol))
+        self.graph_kernels.append(int(graph_kernel))
+        return self._create(config_pointer, error, error_size)
+
+    def _create_with_protocol_graph_kernel_and_schedule(
+        self,
+        config_pointer,
+        protocol,
+        graph_kernel,
+        wire_schedule,
+        error,
+        error_size,
+    ) -> int:
+        self.protocols.append(int(protocol))
+        self.graph_kernels.append(int(graph_kernel))
+        self.wire_schedules.append(int(wire_schedule))
+        return self._create(config_pointer, error, error_size)
 
     def _capture(
         self, handle, input_pointer, output_pointer, q, stream, error, error_size
@@ -223,6 +286,18 @@ class _FakeLibrary:
             | spark_tp4_backend._GRAPH_STATUS_SUBMIT_AFFINITY_VERIFIED
             | spark_tp4_backend._GRAPH_STATUS_PROGRESS_AFFINITY_VERIFIED
         )
+        if self.protocols and self.protocols[-1] == 1:
+            status.flags |= (
+                spark_tp4_backend._GRAPH_STATUS_TWO_SLOT_DEFERRED_ACK
+            )
+        if self.graph_kernels == [1]:
+            status.flags |= spark_tp4_backend._GRAPH_STATUS_SPLIT_64K
+        elif self.graph_kernels == [2]:
+            status.flags |= spark_tp4_backend._GRAPH_STATUS_TIERED_64K
+        if self.wire_schedules == [1]:
+            status.flags |= (
+                spark_tp4_backend._GRAPH_STATUS_DUAL_PORT_STRIPED
+            )
         status.captured_nodes = 128
         status.published_sequence = 1024
         status.consumed_sequence = 1024
@@ -243,6 +318,7 @@ class SparkTp4BackendDispatchTest(unittest.TestCase):
         self.original_all_reduce = self.communicator_type.all_reduce
         spark_tp4_backend._installed = False
         spark_tp4_backend._graph_q1_sessions.clear()
+        spark_tp4_backend._graph_dual_port_q40_sessions.clear()
         spark_tp4_backend._graph_event_counts.clear()
         spark_collective_audit._reset_for_tests()
         _FakeBackend.created.clear()
@@ -274,11 +350,85 @@ class SparkTp4BackendDispatchTest(unittest.TestCase):
     def test_invalid_mode_is_rejected_before_vllm_is_patched(self) -> None:
         with self.assertRaisesRegex(
             ValueError,
-            "VLLM_SPARK_TP4_MODE must be 'shadow', 'custom', or unset",
+            "VLLM_SPARK_TP4_MODE must be 'shadow', 'custom', 'disabled', or unset",
         ):
             self._install("fastest")
 
         self.assertIs(self.communicator_type.all_reduce, self.original_all_reduce)
+        self.assertFalse(spark_tp4_backend._installed)
+
+    def test_deferred_ack_protocol_requires_custom_graph_transport(self) -> None:
+        with self.assertRaisesRegex(
+            ValueError,
+            "two_slot_deferred_ack requires custom graph all-reduce",
+        ):
+            self._install(
+                "custom",
+                {
+                    "VLLM_SPARK_TP4_GRAPH_ALLREDUCE_PROTOCOL": (
+                        "two_slot_deferred_ack"
+                    )
+                },
+            )
+
+        self.assertIs(
+            self.communicator_type.all_reduce,
+            self.original_all_reduce,
+        )
+        self.assertFalse(spark_tp4_backend._installed)
+
+    def test_invalid_graph_allreduce_protocol_is_rejected_before_patch(
+        self,
+    ) -> None:
+        with self.assertRaisesRegex(
+            ValueError,
+            "VLLM_SPARK_TP4_GRAPH_ALLREDUCE_PROTOCOL",
+        ):
+            self._install(
+                "custom",
+                {
+                    "VLLM_SPARK_TP4_GRAPH_ALLREDUCE_PROTOCOL": "fast",
+                },
+            )
+
+        self.assertIs(
+            self.communicator_type.all_reduce,
+            self.original_all_reduce,
+        )
+        self.assertFalse(spark_tp4_backend._installed)
+
+    def test_invalid_graph_kernel_strategy_is_rejected_before_patch(
+        self,
+    ) -> None:
+        with self.assertRaisesRegex(
+            ValueError,
+            "VLLM_SPARK_TP4_GRAPH_KERNEL_STRATEGY",
+        ):
+            self._install(
+                "custom",
+                {
+                    "VLLM_SPARK_TP4_GRAPH_KERNEL_STRATEGY": "automatic",
+                },
+            )
+
+        self.assertIs(
+            self.communicator_type.all_reduce,
+            self.original_all_reduce,
+        )
+        self.assertFalse(spark_tp4_backend._installed)
+
+    def test_tiered_graph_kernel_requires_custom_graph_transport(self) -> None:
+        with self.assertRaisesRegex(
+            ValueError,
+            "research graph kernel strategies require custom graph all-reduce",
+        ):
+            self._install(
+                "custom",
+                {
+                    "VLLM_SPARK_TP4_GRAPH_KERNEL_STRATEGY": "tiered_64k",
+                },
+            )
+
         self.assertFalse(spark_tp4_backend._installed)
 
     def test_custom_mode_routes_only_mtp_rows_one_through_six(self) -> None:
@@ -460,6 +610,49 @@ class SparkTp4BackendDispatchTest(unittest.TestCase):
             {"captured_nodes": 6},
         )
         self.assertEqual(communicator.original_inputs, [])
+
+    def test_exact_q40_capture_uses_dedicated_dual_port_session(self) -> None:
+        with patch.object(
+            spark_tp4_backend,
+            "_TARGET_SHAPES",
+            frozenset({(39, 6144), (40, 6144)}),
+        ), patch.object(
+            spark_tp4_backend,
+            "MAX_QUERY_ROWS",
+            40,
+        ):
+            self._install(
+                "custom",
+                {
+                    "VLLM_SPARK_TP4_GRAPH_Q1": "1",
+                    "VLLM_SPARK_TP4_GRAPH_DUAL_PORT_Q40": "1",
+                    "SPARK_TP4_GRAPH_DUAL_PORT_Q40_PROGRESS_CPU": "15",
+                },
+            )
+            communicator = self.communicator_type(rank_in_group=1)
+            warmup = _FakeTensor(shape=(39, 6144))
+            q39 = _FakeTensor(shape=(39, 6144))
+            q40 = _FakeTensor(shape=(40, 6144))
+
+            communicator.all_reduce(warmup)
+            backend = _FakeBackend.created[0]
+            self.torch_module.cuda.capturing = True
+            q39_result = communicator.all_reduce(q39)
+            q40_result = communicator.all_reduce(q40)
+
+        self.assertEqual(
+            q39_result,
+            ("graph-candidate", 40 * 6144 * 2, 39, q39),
+        )
+        self.assertEqual(
+            q40_result,
+            ("graph-candidate", 40 * 6144 * 2, 40, q40),
+        )
+        self.assertEqual(backend.graph_q1_session.capture_inputs, [q39])
+        self.assertEqual(
+            backend.graph_dual_port_q40_session.capture_inputs,
+            [q40],
+        )
 
     def test_prefill_graph_capture_uses_one_six_mib_session(self) -> None:
         self._install("custom")
@@ -923,6 +1116,323 @@ class SparkTp4BackendDispatchTest(unittest.TestCase):
 
 
 class SparkTp4NativeSessionConfigTest(unittest.TestCase):
+    def test_native_config_layout_remains_legacy_64_bytes(self) -> None:
+        config = spark_tp4_backend._NativeConfig
+        self.assertEqual(spark_tp4_backend.ctypes.sizeof(config), 64)
+        self.assertEqual(config.rank.offset, 0)
+        self.assertEqual(config.peer0.offset, 8)
+        self.assertEqual(config.peer1.offset, 16)
+        self.assertEqual(config.device0.offset, 24)
+        self.assertEqual(config.device1.offset, 32)
+        self.assertEqual(config.gid0.offset, 40)
+        self.assertEqual(config.gid1.offset, 41)
+        self.assertEqual(config.control_port0.offset, 42)
+        self.assertEqual(config.control_port1.offset, 44)
+        self.assertEqual(config.payload_bytes.offset, 48)
+        self.assertEqual(config.graph_submit_cpu_plus_one.offset, 56)
+        self.assertEqual(config.graph_progress_cpu_plus_one.offset, 60)
+
+    def test_two_slot_protocol_uses_versioned_create_symbol(self) -> None:
+        library = _FakeLibrary()
+        environment = {"SPARK_TP4_LIBRARY": "fake.dll"}
+        with (
+            patch.dict(os.environ, environment, clear=True),
+            patch.object(
+                spark_tp4_backend.ctypes,
+                "CDLL",
+                return_value=library,
+            ),
+        ):
+            session = spark_tp4_backend._NativeSession(
+                0,
+                73728,
+                control_ports=(14000, 14001),
+                graph_only=True,
+                graph_cpu_affinity=(10, 11),
+                allreduce_protocol="two_slot_deferred_ack",
+            )
+            status = session.graph_status()
+
+        self.assertEqual(library.protocols, [1])
+        self.assertEqual(len(library.configs), 1)
+        self.assertTrue(status.two_slot_deferred_ack)
+        self.assertFalse(status.command_caught_up)
+        self.assertIsNone(status.payload_slots_retired)
+
+    def test_two_slot_protocol_is_rejected_for_eager_session(self) -> None:
+        with self.assertRaisesRegex(
+            ValueError,
+            "two_slot_deferred_ack requires a graph-only session",
+        ):
+            spark_tp4_backend._NativeSession(
+                0,
+                12288,
+                allreduce_protocol="two_slot_deferred_ack",
+            )
+
+    def test_dual_port_schedule_uses_additive_create_symbol(self) -> None:
+        library = _FakeLibrary()
+        with (
+            patch.dict(
+                os.environ,
+                {"SPARK_TP4_LIBRARY": "fake.dll"},
+                clear=True,
+            ),
+            patch.object(
+                spark_tp4_backend.ctypes,
+                "CDLL",
+                return_value=library,
+            ),
+        ):
+            session = spark_tp4_backend._NativeSession(
+                0,
+                40 * 6144 * 2,
+                control_ports=(14000, 14001),
+                graph_only=True,
+                graph_cpu_affinity=(10, 11),
+                allreduce_protocol="two_slot_deferred_ack",
+                graph_kernel_strategy="fused",
+                wire_schedule="dual_port_striped",
+            )
+            status = session.graph_status()
+
+        self.assertEqual(library.protocols, [1])
+        self.assertEqual(library.graph_kernels, [0])
+        self.assertEqual(library.wire_schedules, [1])
+        self.assertEqual(status.wire_schedule, "dual_port_striped")
+
+    def test_dual_port_schedule_rejects_incompatible_contracts(self) -> None:
+        common = {
+            "rank": 0,
+            "payload_bytes": 40 * 6144 * 2,
+            "control_ports": (14000, 14001),
+            "graph_only": True,
+            "graph_cpu_affinity": (10, 11),
+            "allreduce_protocol": "two_slot_deferred_ack",
+            "graph_kernel_strategy": "fused",
+            "wire_schedule": "dual_port_striped",
+        }
+        for field, value, message in (
+            ("graph_only", False, "graph-only"),
+            ("allreduce_protocol", "serial_ack", "two_slot_deferred_ack"),
+            ("graph_kernel_strategy", "tiered_64k", "fused graph kernel"),
+            ("payload_bytes", 39 * 6144 * 2, "Q40 or Q512 capacity"),
+        ):
+            arguments = dict(common)
+            arguments[field] = value
+            if field == "graph_only":
+                arguments["graph_cpu_affinity"] = None
+            with self.assertRaisesRegex(ValueError, message):
+                spark_tp4_backend._NativeSession(**arguments)
+
+    def test_dual_port_schedule_rejects_stale_native_library(self) -> None:
+        library = _FakeLibrary()
+        del library.spark_tp4_create_with_protocol_graph_kernel_and_schedule
+        with (
+            patch.dict(
+                os.environ,
+                {"SPARK_TP4_LIBRARY": "stale.dll"},
+                clear=True,
+            ),
+            patch.object(
+                spark_tp4_backend.ctypes,
+                "CDLL",
+                return_value=library,
+            ),
+        ):
+            with self.assertRaisesRegex(
+                RuntimeError,
+                "lacks the wire-schedule ABI",
+            ):
+                spark_tp4_backend._NativeSession(
+                    0,
+                    40 * 6144 * 2,
+                    control_ports=(14000, 14001),
+                    graph_only=True,
+                    graph_cpu_affinity=(10, 11),
+                    allreduce_protocol="two_slot_deferred_ack",
+                    wire_schedule="dual_port_striped",
+                )
+
+        self.assertEqual(library.configs, [])
+
+    def test_graph_status_rejects_wire_schedule_attestation_mismatch(self) -> None:
+        library = _FakeLibrary()
+        with (
+            patch.dict(
+                os.environ,
+                {"SPARK_TP4_LIBRARY": "fake.dll"},
+                clear=True,
+            ),
+            patch.object(
+                spark_tp4_backend.ctypes,
+                "CDLL",
+                return_value=library,
+            ),
+        ):
+            session = spark_tp4_backend._NativeSession(
+                0,
+                40 * 6144 * 2,
+                control_ports=(14000, 14001),
+                graph_only=True,
+                graph_cpu_affinity=(10, 11),
+                allreduce_protocol="two_slot_deferred_ack",
+                wire_schedule="dual_port_striped",
+            )
+            library.wire_schedules.clear()
+            with self.assertRaisesRegex(
+                RuntimeError,
+                "wire schedule attestation mismatch",
+            ):
+                session.graph_status()
+
+    def test_tiered_graph_kernel_uses_additive_create_symbol(self) -> None:
+        library = _FakeLibrary()
+        with (
+            patch.dict(
+                os.environ,
+                {"SPARK_TP4_LIBRARY": "fake.dll"},
+                clear=True,
+            ),
+            patch.object(
+                spark_tp4_backend.ctypes,
+                "CDLL",
+                return_value=library,
+            ),
+        ):
+            session = spark_tp4_backend._NativeSession(
+                0,
+                73728,
+                control_ports=(14000, 14001),
+                graph_only=True,
+                graph_cpu_affinity=(10, 11),
+                allreduce_protocol="two_slot_deferred_ack",
+                graph_kernel_strategy="tiered_64k",
+            )
+            status = session.graph_status()
+
+        self.assertEqual(library.protocols, [1])
+        self.assertEqual(library.graph_kernels, [2])
+        self.assertEqual(status.graph_kernel_strategy, "tiered_64k")
+
+    def test_tiered_graph_kernel_rejects_stale_native_library(self) -> None:
+        library = _FakeLibrary()
+        del library.spark_tp4_create_with_protocol_and_graph_kernel
+        with (
+            patch.dict(
+                os.environ,
+                {"SPARK_TP4_LIBRARY": "stale.dll"},
+                clear=True,
+            ),
+            patch.object(
+                spark_tp4_backend.ctypes,
+                "CDLL",
+                return_value=library,
+            ),
+        ):
+            with self.assertRaisesRegex(
+                RuntimeError,
+                "lacks the graph-kernel ABI",
+            ):
+                spark_tp4_backend._NativeSession(
+                    0,
+                    73728,
+                    control_ports=(14000, 14001),
+                    graph_only=True,
+                    graph_cpu_affinity=(10, 11),
+                    graph_kernel_strategy="tiered_64k",
+                )
+
+        self.assertEqual(library.configs, [])
+
+    def test_graph_status_rejects_kernel_attestation_mismatch(self) -> None:
+        library = _FakeLibrary()
+        with (
+            patch.dict(
+                os.environ,
+                {"SPARK_TP4_LIBRARY": "fake.dll"},
+                clear=True,
+            ),
+            patch.object(
+                spark_tp4_backend.ctypes,
+                "CDLL",
+                return_value=library,
+            ),
+        ):
+            session = spark_tp4_backend._NativeSession(
+                0,
+                73728,
+                control_ports=(14000, 14001),
+                graph_only=True,
+                graph_cpu_affinity=(10, 11),
+                graph_kernel_strategy="tiered_64k",
+            )
+            library.graph_kernels.clear()
+            with self.assertRaisesRegex(
+                RuntimeError,
+                "kernel attestation mismatch",
+            ):
+                session.graph_status()
+
+    def test_two_slot_protocol_rejects_stale_native_library(self) -> None:
+        library = _FakeLibrary()
+        del library.spark_tp4_create_with_protocol
+        with (
+            patch.dict(
+                os.environ,
+                {"SPARK_TP4_LIBRARY": "stale.dll"},
+                clear=True,
+            ),
+            patch.object(
+                spark_tp4_backend.ctypes,
+                "CDLL",
+                return_value=library,
+            ),
+        ):
+            with self.assertRaisesRegex(
+                RuntimeError,
+                "lacks the deferred-ACK ABI",
+            ):
+                spark_tp4_backend._NativeSession(
+                    0,
+                    73728,
+                    control_ports=(14000, 14001),
+                    graph_only=True,
+                    graph_cpu_affinity=(10, 11),
+                    allreduce_protocol="two_slot_deferred_ack",
+                )
+
+        self.assertEqual(library.configs, [])
+
+    def test_graph_status_rejects_protocol_attestation_mismatch(self) -> None:
+        library = _FakeLibrary()
+        with (
+            patch.dict(
+                os.environ,
+                {"SPARK_TP4_LIBRARY": "fake.dll"},
+                clear=True,
+            ),
+            patch.object(
+                spark_tp4_backend.ctypes,
+                "CDLL",
+                return_value=library,
+            ),
+        ):
+            session = spark_tp4_backend._NativeSession(
+                0,
+                73728,
+                control_ports=(14000, 14001),
+                graph_only=True,
+                graph_cpu_affinity=(10, 11),
+                allreduce_protocol="two_slot_deferred_ack",
+            )
+            library.protocols.clear()
+            with self.assertRaisesRegex(
+                RuntimeError,
+                "protocol attestation mismatch",
+            ):
+                session.graph_status()
+
     def test_prefill_graph_session_has_six_mib_capacity(self) -> None:
         library = _FakeLibrary()
         environment = {
@@ -969,12 +1479,12 @@ class SparkTp4NativeSessionConfigTest(unittest.TestCase):
                 for config in library.configs
             ],
             [
-                (9480, 9481),
-                (9482, 9483),
-                (9484, 9485),
-                (9486, 9487),
-                (9488, 9489),
-                (9490, 9491),
+                (11000, 11001),
+                (11002, 11003),
+                (11004, 11005),
+                (11006, 11007),
+                (11008, 11009),
+                (11010, 11011),
             ],
         )
 
@@ -1072,6 +1582,9 @@ class SparkTp4NativeSessionConfigTest(unittest.TestCase):
         self.assertTrue(status.host_native_atomics)
         self.assertTrue(status.submit_affinity_verified)
         self.assertTrue(status.progress_affinity_verified)
+        self.assertFalse(status.two_slot_deferred_ack)
+        self.assertFalse(status.command_caught_up)
+        self.assertFalse(status.payload_slots_retired)
         self.assertTrue(status.replay_advanced)
         self.assertFalse(status.replay_caught_up)
         self.assertFalse(status.fatal)
@@ -1129,6 +1642,92 @@ class SparkTp4NativeSessionConfigTest(unittest.TestCase):
         self.assertEqual(call["output"].value, 0x5678)
         self.assertEqual(call["stream"].value, 0x9ABC)
 
+    def test_backend_builds_a_separate_exact_q40_striped_session(self) -> None:
+        created: list[tuple[tuple[object, ...], dict[str, object]]] = []
+
+        class _PreparedSession:
+            def __init__(self, *args: object, **kwargs: object) -> None:
+                created.append((args, kwargs))
+
+        reporter = types.ModuleType("spark_graph_status_reporter")
+
+        def ensure_status_reporter(*, rank: int) -> None:
+            self.assertEqual(rank, 2)
+
+        reporter.ensure_status_reporter = ensure_status_reporter
+        with (
+            patch.dict(
+                os.environ,
+                {"VLLM_SPARK_TP4_GRAPH_DUAL_PORT_Q40": "1"},
+                clear=True,
+            ),
+            patch.dict(
+                sys.modules,
+                {"spark_graph_status_reporter": reporter},
+            ),
+            patch.object(
+                spark_tp4_backend,
+                "_NativeSession",
+                _PreparedSession,
+            ),
+            patch.object(
+                spark_tp4_backend,
+                "_graph_preflight",
+                return_value=(10, 11),
+            ),
+            patch.object(
+                spark_tp4_backend,
+                "_graph_dual_port_q40_cpu_affinity",
+                return_value=(10, 15),
+            ),
+            patch.object(
+                spark_tp4_backend,
+                "_graph_control_ports",
+                return_value=(9970, 9971),
+            ),
+            patch.object(
+                spark_tp4_backend,
+                "_graph_dual_port_q40_control_ports",
+                return_value=(9972, 9973),
+            ),
+            patch.dict(
+                spark_tp4_backend._graph_q1_sessions,
+                {},
+                clear=True,
+            ),
+            patch.dict(
+                spark_tp4_backend._graph_dual_port_q40_sessions,
+                {},
+                clear=True,
+            ),
+        ):
+            backend = spark_tp4_backend._Backend(2)
+            backend.prepare_graph_q1()
+
+        self.assertEqual(len(created), 2)
+        base_args, base_kwargs = created[0]
+        striped_args, striped_kwargs = created[1]
+        self.assertEqual(
+            base_args,
+            (2, spark_tp4_backend._graph_capacity_bytes()),
+        )
+        self.assertEqual(base_kwargs["control_ports"], (9970, 9971))
+        self.assertNotIn("wire_schedule", base_kwargs)
+        self.assertEqual(
+            striped_args,
+            (2, 40 * 6144 * 2),
+        )
+        self.assertEqual(striped_kwargs["control_ports"], (9972, 9973))
+        self.assertEqual(striped_kwargs["graph_cpu_affinity"], (10, 15))
+        self.assertEqual(
+            striped_kwargs["allreduce_protocol"],
+            "two_slot_deferred_ack",
+        )
+        self.assertEqual(
+            striped_kwargs["wire_schedule"],
+            "dual_port_striped",
+        )
+
     def test_generic_graph_capture_rejects_non_exact_signature(self) -> None:
         library = _FakeLibrary()
         with (
@@ -1164,6 +1763,42 @@ class SparkTp4NativeSessionConfigTest(unittest.TestCase):
 
         self.assertEqual(library.capture_calls, [])
 
+    def test_dual_port_graph_capture_requires_exact_fixed_q(self) -> None:
+        library = _FakeLibrary()
+        with (
+            patch.dict(
+                os.environ,
+                {"SPARK_TP4_LIBRARY": "fake.dll"},
+                clear=True,
+            ),
+            patch.object(
+                spark_tp4_backend.ctypes,
+                "CDLL",
+                return_value=library,
+            ),
+            patch.object(
+                spark_tp4_backend,
+                "_target_shape_eligible",
+                return_value=True,
+            ),
+        ):
+            session = spark_tp4_backend._NativeSession(
+                0,
+                40 * 6144 * 2,
+                control_ports=(14000, 14001),
+                graph_only=True,
+                graph_cpu_affinity=(10, 15),
+                allreduce_protocol="two_slot_deferred_ack",
+                wire_schedule="dual_port_striped",
+            )
+            with self.assertRaisesRegex(
+                ValueError,
+                "exact fixed Q",
+            ):
+                session.capture(_FakeTensor(shape=(39, 6144)))
+
+        self.assertEqual(library.capture_calls, [])
+
     def test_process_snapshot_is_read_only_and_rpc_serializable(self) -> None:
         class _StatusSession:
             def graph_status(self):
@@ -1182,15 +1817,30 @@ class SparkTp4NativeSessionConfigTest(unittest.TestCase):
                     progress_cpu=11,
                 )
 
-        spark_tp4_backend._graph_q1_sessions[2] = _StatusSession()
-
-        snapshot = spark_tp4_backend.graph_q1_status_snapshot()
+        with (
+            patch.dict(
+                spark_tp4_backend._graph_q1_sessions,
+                {2: _StatusSession()},
+                clear=True,
+            ),
+            patch.dict(
+                spark_tp4_backend._graph_dual_port_q40_sessions,
+                {2: _StatusSession()},
+                clear=True,
+            ),
+        ):
+            snapshot = spark_tp4_backend.graph_q1_status_snapshot()
+            diagnostic = spark_tp4_backend.graph_q1_diagnostic_snapshot()
 
         self.assertEqual(snapshot[2]["captured_nodes"], 4)
         self.assertEqual(snapshot[2]["completed_sequence"], 9)
         self.assertTrue(snapshot[2]["replay_advanced"])
         self.assertTrue(snapshot[2]["replay_caught_up"])
         self.assertFalse(snapshot[2]["fatal"])
+        self.assertEqual(
+            diagnostic["dual_port_q40_sessions"][2]["captured_nodes"],
+            4,
+        )
 
     def test_graph_preflight_requires_positive_fixed_kv_cache(self) -> None:
         environment = {
@@ -1263,6 +1913,40 @@ class SparkTp4NativeSessionConfigTest(unittest.TestCase):
                 spark_tp4_backend._graph_preflight(argv),
                 (10, 11),
             )
+
+    def test_dual_port_graph_preflight_reserves_a_distinct_progress_cpu(
+        self,
+    ) -> None:
+        argv = ["vllm", "serve", "--kv-cache-memory-bytes", "5500000000"]
+        environment = {
+            "SPARK_TP4_GRAPH_SUBMIT_CPU": "10",
+            "SPARK_TP4_GRAPH_PROGRESS_CPU": "11",
+            "SPARK_TP4_GRAPH_DUAL_PORT_Q40_PROGRESS_CPU": "15",
+            "SPARK_TP4_GRAPH_VOCAB_PROGRESS_CPU": "12",
+            "SPARK_TP4_GRAPH_DCP_PROGRESS_CPU": "13",
+            "SPARK_TP4_GRAPH_INDEXER_PROGRESS_CPU": "14",
+            "VLLM_SPARK_SHARED_CAPTURE_STREAM": "1",
+            "VLLM_SPARK_TP4_VOCAB_MODE": "custom",
+            "VLLM_SPARK_TP4_DCP_GRAPH_CUSTOM": "1",
+            "VLLM_SPARK_TP4_INDEXER_GRAPH_CUSTOM": "1",
+        }
+        with (
+            patch.dict(os.environ, environment, clear=True),
+            patch.object(spark_tp4_backend.sys, "platform", "linux"),
+        ):
+            self.assertEqual(
+                spark_tp4_backend._graph_dual_port_q40_cpu_affinity(argv),
+                (10, 15),
+            )
+            for occupied in (10, 11, 12, 13, 14):
+                os.environ[
+                    "SPARK_TP4_GRAPH_DUAL_PORT_Q40_PROGRESS_CPU"
+                ] = str(occupied)
+                with self.subTest(occupied=occupied), self.assertRaisesRegex(
+                    RuntimeError,
+                    "collides with",
+                ):
+                    spark_tp4_backend._graph_dual_port_q40_cpu_affinity(argv)
 
     def test_graph_preflight_requires_shared_capture_stream(self) -> None:
         argv = ["vllm", "serve", "--kv-cache-memory-bytes=5500000000"]

--- a/spark_transport/integrations/vllm/test_spark_tp4_dcp_backend.py
+++ b/spark_transport/integrations/vllm/test_spark_tp4_dcp_backend.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import inspect
 import os
 import sys
 import types
@@ -79,6 +80,7 @@ class _FakeTensor:
         contiguous: bool = True,
         strides: tuple[int, ...] | None = None,
         payload: float = 0,
+        layout_operations: list[str] | None = None,
     ) -> None:
         self.shape = shape
         self.dtype = dtype
@@ -90,6 +92,9 @@ class _FakeTensor:
             self._strides = (self._strides[0] + 1, *self._strides[1:])
         self.contiguous_calls = 0
         self.payload = payload
+        self.layout_operations = (
+            [] if layout_operations is None else layout_operations
+        )
         self.pointer = self._next_pointer
         _FakeTensor._next_pointer += 0x1000
 
@@ -105,6 +110,19 @@ class _FakeTensor:
             next_stride *= dimension
         return tuple(reversed(strides))
 
+    @staticmethod
+    def _strides_are_contiguous(
+        shape: tuple[int, ...], strides: tuple[int, ...]
+    ) -> bool:
+        expected = 1
+        for dimension, stride in reversed(tuple(zip(shape, strides, strict=True))):
+            if dimension == 1:
+                continue
+            if stride != expected:
+                return False
+            expected *= dimension
+        return True
+
     def stride(self) -> tuple[int, ...]:
         return self._strides
 
@@ -115,13 +133,65 @@ class _FakeTensor:
         self.contiguous_calls += 1
         if self._contiguous:
             return self
+        self.layout_operations.append("contiguous")
         return _FakeTensor(
             self.shape,
             self.dtype,
             is_cuda=self.is_cuda,
             contiguous=True,
             payload=self.payload,
+            layout_operations=self.layout_operations,
         )
+
+    def transpose(self, dim0: int, dim1: int) -> _FakeTensor:
+        dimensions = len(self.shape)
+        if dim0 not in range(dimensions) or dim1 not in range(dimensions):
+            raise IndexError("fake transpose dimension out of range")
+        self.layout_operations.append(f"transpose({dim0},{dim1})")
+        shape = list(self.shape)
+        strides = list(self._strides)
+        shape[dim0], shape[dim1] = shape[dim1], shape[dim0]
+        strides[dim0], strides[dim1] = strides[dim1], strides[dim0]
+        result_shape = tuple(shape)
+        result_strides = tuple(strides)
+        return _FakeTensor(
+            result_shape,
+            self.dtype,
+            is_cuda=self.is_cuda,
+            contiguous=self._strides_are_contiguous(result_shape, result_strides),
+            strides=result_strides,
+            payload=self.payload,
+            layout_operations=self.layout_operations,
+        )
+
+    def clone(self, *, memory_format: object) -> _FakeTensor:
+        if memory_format != "torch.contiguous_format":
+            raise AssertionError(f"unexpected memory format: {memory_format}")
+        self.layout_operations.append("clone(contiguous_format)")
+        return _FakeTensor(
+            self.shape,
+            self.dtype,
+            is_cuda=self.is_cuda,
+            contiguous=True,
+            payload=self.payload,
+            layout_operations=self.layout_operations,
+        )
+
+    def first_rows(self, rows: int) -> _FakeTensor:
+        if not 1 <= rows <= self.shape[0]:
+            raise ValueError("fake row slice is outside its source storage")
+        shape = (rows, *self.shape[1:])
+        result = _FakeTensor(
+            shape,
+            self.dtype,
+            is_cuda=self.is_cuda,
+            contiguous=self._strides_are_contiguous(shape, self._strides),
+            strides=self._strides,
+            payload=self.payload,
+            layout_operations=self.layout_operations,
+        )
+        result.pointer = self.pointer
+        return result
 
     def view(self, dtype: object) -> _FakeByteView:
         del dtype
@@ -144,6 +214,20 @@ def _live_combine_output(
         strides=(head_dimension, q * head_dimension, 1),
         payload=payload,
     )
+
+
+def _q8_padded_head_major_combine_output(
+    q: int,
+    *,
+    head_dimension: int = 512,
+    payload: float = 0,
+) -> _FakeTensor:
+    storage = _live_combine_output(
+        8,
+        head_dimension=head_dimension,
+        payload=payload,
+    )
+    return storage.first_rows(q)
 
 
 class _FakeStream:
@@ -172,6 +256,7 @@ def _fake_torch_module() -> types.ModuleType:
     module.uint8 = "torch.uint8"
     module.int64 = "torch.int64"
     module.float32 = "torch.float32"
+    module.contiguous_format = "torch.contiguous_format"
     module.cuda = _FakeCuda()
     module.allocations = []
 
@@ -266,6 +351,7 @@ def _stock_combine(
     ctx: object = None,
     return_lse: bool = False,
     is_lse_base_on_e: bool = True,
+    head_major_output: bool = False,
 ) -> object:
     cp_group.combine_original_calls.append(
         (
@@ -274,14 +360,22 @@ def _stock_combine(
             ctx,
             return_lse,
             is_lse_base_on_e,
+            head_major_output,
         )
     )
     if cp_group.fail_combine_original:
         raise RuntimeError("combine reference failed")
     q = int(cp_attn_out.shape[0])
+    head_dimension = cp_attn_out.shape[2]
     output = _FakeTensor(
-        (q, 16, cp_attn_out.shape[2]),
+        (q, 16, head_dimension),
         cp_attn_out.dtype,
+        contiguous=not head_major_output,
+        strides=(
+            (head_dimension, q * head_dimension, 1)
+            if head_major_output
+            else None
+        ),
         payload=cp_attn_out.payload,
     )
     if not return_lse:
@@ -297,6 +391,12 @@ def _fake_modules(
     distributed = types.ModuleType("vllm.distributed")
     parallel_state = types.ModuleType("vllm.distributed.parallel_state")
     parallel_state.GroupCoordinator = group_type
+    utils = types.ModuleType("vllm.utils")
+    multi_stream_utils = types.ModuleType("vllm.utils.multi_stream_utils")
+    multi_stream_utils.capture_active = False
+    multi_stream_utils.is_vllm_cudagraph_capture_active = (
+        lambda: multi_stream_utils.capture_active
+    )
     v1 = types.ModuleType("vllm.v1")
     attention = types.ModuleType("vllm.v1.attention")
     ops = types.ModuleType("vllm.v1.attention.ops")
@@ -307,6 +407,8 @@ def _fake_modules(
         "vllm": vllm,
         "vllm.distributed": distributed,
         "vllm.distributed.parallel_state": parallel_state,
+        "vllm.utils": utils,
+        "vllm.utils.multi_stream_utils": multi_stream_utils,
         "vllm.v1": v1,
         "vllm.v1.attention": attention,
         "vllm.v1.attention.ops": ops,
@@ -370,6 +472,7 @@ class _FakeNativeSession:
     ) -> None:
         if self.fail_combine_call:
             raise RuntimeError("native combine failed")
+        reduced_output.layout_operations.append("native_write")
         reduced_output.payload = output_tensor.payload + self.combine_output_delta
         reduced_lse.payload = lse_tensor.payload + self.combine_lse_delta
         q = signature[0]
@@ -411,6 +514,7 @@ class _FakeNativeSession:
     ) -> None:
         if not self.graph_only:
             raise RuntimeError("not a graph session")
+        reduced_output.layout_operations.append("native_write")
         reduced_output.payload = output_tensor.payload + self.combine_output_delta
         reduced_lse.payload = lse_tensor.payload + self.combine_lse_delta
         self.graph_combine_calls.append(
@@ -665,12 +769,8 @@ class SparkTp4DcpDispatchTest(unittest.TestCase):
             VLLM_SPARK_SHARED_CAPTURE_STREAM="1",
             SPARK_TP4_GRAPH_STATUS_PATH="/tmp/status.json",
         )
-        key = (os.getpid(), 0)
-        parallel_state = self.modules["vllm.distributed.parallel_state"]
-        parallel_state._SPARK_ACTIVE_CAPTURE_STREAMS = {key}
-        parallel_state._SPARK_SHARED_CAPTURE_STREAMS = {
-            key: self.torch_module.cuda.stream
-        }
+        multi_stream_utils = self.modules["vllm.utils.multi_stream_utils"]
+        multi_stream_utils.capture_active = True
         group = self.group_type(rank_in_group=2)
 
         query_warmup = group._all_gather_out_place(
@@ -681,6 +781,7 @@ class SparkTp4DcpDispatchTest(unittest.TestCase):
             _FakeTensor((5, 64), "torch.float32", payload=29),
             group,
             return_lse=True,
+            head_major_output=True,
         )
 
         sessions = list(_FakeNativeSession.created)
@@ -690,8 +791,10 @@ class SparkTp4DcpDispatchTest(unittest.TestCase):
         self.assertEqual(sessions[0].combine_calls, [])
         self.assertEqual(query_warmup.payload, 17)
         self.assertEqual(combine_warmup[0].payload, 23)
+        self.assertEqual(combine_warmup[0].stride(), (256, 5 * 256, 1))
         self.assertEqual(len(group.original_calls), 1)
         self.assertEqual(len(group.combine_original_calls), 1)
+        self.assertIs(group.combine_original_calls[0][5], True)
 
         self.torch_module.cuda.capturing = True
         query_capture = group._all_gather_out_place(
@@ -702,11 +805,22 @@ class SparkTp4DcpDispatchTest(unittest.TestCase):
             _FakeTensor((5, 64), "torch.float32", payload=41),
             group,
             return_lse=True,
+            head_major_output=True,
         )
         self.torch_module.cuda.capturing = False
 
         self.assertEqual(query_capture.payload, 31)
         self.assertEqual(combine_capture[0].payload, 37)
+        self.assertEqual(combine_capture[0].stride(), (256, 5 * 256, 1))
+        self.assertEqual(
+            sessions[0].graph_combine_calls[0][2].layout_operations,
+            [
+                "native_write",
+                "transpose(0,1)",
+                "clone(contiguous_format)",
+                "transpose(0,1)",
+            ],
+        )
         self.assertEqual(
             sessions[0].operation_order,
             [("graph_query", 5), ("graph_combine", 5)],
@@ -726,9 +840,6 @@ class SparkTp4DcpDispatchTest(unittest.TestCase):
             VLLM_SPARK_TP4_DCP_GRAPH_CUSTOM="1",
             VLLM_SPARK_SHARED_CAPTURE_STREAM="1",
         )
-        parallel_state = self.modules["vllm.distributed.parallel_state"]
-        parallel_state._SPARK_ACTIVE_CAPTURE_STREAMS = set()
-        parallel_state._SPARK_SHARED_CAPTURE_STREAMS = {}
         group = self.group_type(rank_in_group=2)
 
         result = group._all_gather_out_place(
@@ -747,25 +858,19 @@ class SparkTp4DcpDispatchTest(unittest.TestCase):
         self.assertEqual(result.payload, 17)
         self.assertEqual(group.original_calls, [])
 
-    def test_active_shared_capture_marker_rejects_wrong_current_stream(
-        self,
-    ) -> None:
+    def test_shared_capture_requires_public_capture_scope_marker_api(self) -> None:
         self._install(
             "custom",
             VLLM_SPARK_TP4_DCP_GRAPH_CUSTOM="1",
             VLLM_SPARK_SHARED_CAPTURE_STREAM="1",
         )
-        key = (os.getpid(), 0)
-        parallel_state = self.modules["vllm.distributed.parallel_state"]
-        parallel_state._SPARK_ACTIVE_CAPTURE_STREAMS = {key}
-        parallel_state._SPARK_SHARED_CAPTURE_STREAMS = {
-            key: types.SimpleNamespace(cuda_stream=0xBAD)
-        }
+        multi_stream_utils = self.modules["vllm.utils.multi_stream_utils"]
+        del multi_stream_utils.is_vllm_cudagraph_capture_active
         group = self.group_type(rank_in_group=2)
 
         with self.assertRaisesRegex(
             RuntimeError,
-            "warmup left its retained stream",
+            "capture-scope marker API is unavailable",
         ):
             group._all_gather_out_place(
                 _FakeTensor((5, 16, 576), payload=17), 1
@@ -912,11 +1017,13 @@ class SparkTp4DcpDispatchTest(unittest.TestCase):
             _FakeTensor((5, 64), "torch.float32", payload=29),
             group,
             return_lse=True,
+            head_major_output=True,
         )
         self.torch_module.cuda.capturing = False
 
         self.assertEqual(query_reference.payload, 17)
         self.assertEqual(combine_reference[0].payload, 23)
+        self.assertEqual(combine_reference[0].stride(), (256, 5 * 256, 1))
         graph_sessions = [
             session for session in _FakeNativeSession.created if session.graph_only
         ]
@@ -925,6 +1032,16 @@ class SparkTp4DcpDispatchTest(unittest.TestCase):
             graph_sessions[0].operation_order,
             [("graph_query", 5), ("graph_combine", 5)],
         )
+        self.assertEqual(
+            graph_sessions[0].graph_combine_calls[0][2].layout_operations,
+            [
+                "native_write",
+                "transpose(0,1)",
+                "clone(contiguous_format)",
+                "transpose(0,1)",
+            ],
+        )
+        self.assertIs(group.combine_original_calls[0][5], True)
         report = backend_module.dcp_graph_shadow_report()
         self.assertTrue(report["passed"])
         rank = report["ranks"][2]
@@ -1180,13 +1297,268 @@ class SparkTp4DcpDispatchTest(unittest.TestCase):
             lse,
             group,
             is_lse_base_on_e=True,
+            head_major_output=False,
         )
 
         self.assertNotIsInstance(reduced_output, tuple)
         self.assertEqual(reduced_output.shape, (5, 16, 256))
         self.assertEqual(reduced_output.payload, 15)
         self.assertEqual(group.combine_original_calls, [])
-        self.assertEqual(len(_FakeNativeSession.created[0].combine_calls), 1)
+        native_call = _FakeNativeSession.created[0].combine_calls[0]
+        self.assertIs(reduced_output, native_call[2])
+        self.assertTrue(reduced_output.is_contiguous())
+        self.assertEqual(reduced_output.stride(), (16 * 256, 256, 1))
+        self.assertEqual(reduced_output.layout_operations, ["native_write"])
+
+    def test_custom_combine_head_major_output_preserves_layout_and_lse(self) -> None:
+        self._install("custom")
+        group = self.group_type(rank_in_group=1)
+        output = _live_combine_output(5, payload=15)
+        lse = _FakeTensor((5, 64), "torch.float32", payload=25)
+
+        reduced_output, reduced_lse = self.flash_module.cp_lse_ag_out_rs(
+            output,
+            lse,
+            group,
+            return_lse=True,
+            is_lse_base_on_e=True,
+            head_major_output=True,
+        )
+
+        native_call = _FakeNativeSession.created[0].combine_calls[0]
+        raw_output = native_call[2]
+        self.assertIsNot(reduced_output, raw_output)
+        self.assertIs(reduced_lse, native_call[3])
+        self.assertEqual(reduced_output.shape, (5, 16, 256))
+        self.assertEqual(reduced_output.stride(), (256, 5 * 256, 1))
+        self.assertFalse(reduced_output.is_contiguous())
+        self.assertEqual(raw_output.stride(), (16 * 256, 256, 1))
+        self.assertEqual(
+            raw_output.layout_operations,
+            [
+                "native_write",
+                "transpose(0,1)",
+                "clone(contiguous_format)",
+                "transpose(0,1)",
+            ],
+        )
+
+    def test_custom_combine_head_major_output_has_exact_q1_and_q8_strides(
+        self,
+    ) -> None:
+        self._install("custom")
+
+        for q in (1, 8):
+            with self.subTest(q=q):
+                group = self.group_type(rank_in_group=1)
+                reduced_output = self.flash_module.cp_lse_ag_out_rs(
+                    _live_combine_output(q, payload=q),
+                    _FakeTensor((q, 64), "torch.float32", payload=q + 10),
+                    group,
+                    head_major_output=True,
+                )
+
+                self.assertEqual(reduced_output.shape, (q, 16, 256))
+                self.assertEqual(reduced_output.stride(), (256, q * 256, 1))
+
+    def test_custom_combine_compacts_q8_pitched_head_major_input(self) -> None:
+        self._install("custom")
+
+        with patch.object(backend_module, "_SUPPORTED_Q", frozenset(range(1, 9))):
+            for q in (1, 7, 8):
+                with self.subTest(q=q):
+                    group = self.group_type(rank_in_group=1)
+                    source = _q8_padded_head_major_combine_output(q, payload=q)
+                    lse = _FakeTensor(
+                        (q, 64), "torch.float32", payload=q + 10
+                    )
+
+                    reduced_output, reduced_lse = (
+                        self.flash_module.cp_lse_ag_out_rs(
+                            source,
+                            lse,
+                            group,
+                            return_lse=True,
+                            head_major_output=True,
+                        )
+                    )
+
+                    self.assertEqual(source.stride(), (512, 8 * 512, 1))
+                    native_call = _FakeNativeSession.created[-1].combine_calls[0]
+                    native_input = native_call[0]
+                    self.assertEqual(native_input.shape, (q, 64, 512))
+                    self.assertEqual(native_input.stride(), (512, q * 512, 1))
+                    self.assertEqual(
+                        native_call[4], (q, 512, 512, q * 512)
+                    )
+                    self.assertIs(native_call[5], self.torch_module.cuda.stream)
+                    self.assertEqual(native_input.payload, q)
+                    self.assertIs(reduced_lse, native_call[3])
+                    self.assertEqual(reduced_output.payload, q)
+                    self.assertEqual(
+                        reduced_output.stride(), (512, q * 512, 1)
+                    )
+                    if q < 8:
+                        self.assertIsNot(native_input, source)
+                        self.assertEqual(
+                            native_input.layout_operations,
+                            [
+                                "transpose(0,1)",
+                                "clone(contiguous_format)",
+                                "transpose(0,1)",
+                            ],
+                        )
+                    else:
+                        self.assertIs(native_input, source)
+                        self.assertEqual(native_input.layout_operations, [])
+                    self.assertEqual(group.combine_original_calls, [])
+
+    def test_graph_custom_combine_captures_q8_pitched_head_major_input(
+        self,
+    ) -> None:
+        self._install(
+            "custom",
+            VLLM_SPARK_TP4_DCP_GRAPH_CUSTOM="1",
+        )
+        group = self.group_type(rank_in_group=1)
+
+        with patch.object(backend_module, "_SUPPORTED_Q", frozenset(range(1, 9))):
+            # One eager call prepares the graph-only session before CUDA capture.
+            self.flash_module.cp_lse_ag_out_rs(
+                _q8_padded_head_major_combine_output(8, payload=80),
+                _FakeTensor((8, 64), "torch.float32", payload=90),
+                group,
+                head_major_output=True,
+            )
+            graph_session = next(
+                session for session in _FakeNativeSession.created if session.graph_only
+            )
+
+            self.torch_module.cuda.capturing = True
+            try:
+                results = []
+                sources = []
+                for q in (1, 7, 8):
+                    source = _q8_padded_head_major_combine_output(q, payload=q)
+                    sources.append(source)
+                    results.append(
+                        self.flash_module.cp_lse_ag_out_rs(
+                            source,
+                            _FakeTensor(
+                                (q, 64), "torch.float32", payload=q + 10
+                            ),
+                            group,
+                            head_major_output=True,
+                        )
+                    )
+            finally:
+                self.torch_module.cuda.capturing = False
+
+        self.assertEqual(len(graph_session.graph_combine_calls), 3)
+        for q, source, result, native_call in zip(
+            (1, 7, 8),
+            sources,
+            results,
+            graph_session.graph_combine_calls,
+            strict=True,
+        ):
+            native_input = native_call[0]
+            self.assertEqual(source.stride(), (512, 8 * 512, 1))
+            self.assertEqual(native_input.stride(), (512, q * 512, 1))
+            self.assertEqual(native_call[4], (q, 512, 512, q * 512))
+            self.assertIs(native_call[5], self.torch_module.cuda.stream)
+            self.assertEqual(native_input.payload, q)
+            self.assertEqual(result.payload, q)
+            self.assertEqual(result.stride(), (512, q * 512, 1))
+            if q < 8:
+                self.assertIsNot(native_input, source)
+                self.assertEqual(
+                    native_input.layout_operations,
+                    [
+                        "transpose(0,1)",
+                        "clone(contiguous_format)",
+                        "transpose(0,1)",
+                    ],
+                )
+            else:
+                self.assertIs(native_input, source)
+                self.assertEqual(native_input.layout_operations, [])
+        self.assertEqual(group.combine_original_calls, [])
+
+    def test_pitched_head_major_input_rejects_invalid_pitch(self) -> None:
+        self._install("custom")
+        group = self.group_type(rank_in_group=1)
+
+        with patch.object(backend_module, "_SUPPORTED_Q", frozenset(range(1, 9))):
+            for head_stride in (9 * 512, 8 * 512 + 1):
+                with self.subTest(head_stride=head_stride):
+                    source = _FakeTensor(
+                        (7, 64, 512),
+                        contiguous=False,
+                        strides=(512, head_stride, 1),
+                        payload=head_stride,
+                    )
+                    self.flash_module.cp_lse_ag_out_rs(
+                        source,
+                        _FakeTensor((7, 64), "torch.float32"),
+                        group,
+                        head_major_output=True,
+                    )
+
+        self.assertEqual(len(group.combine_original_calls), 2)
+        self.assertEqual(_FakeNativeSession.created, [])
+
+    def test_combine_forwards_head_major_output_to_stock_fallback(self) -> None:
+        self._install(
+            "custom",
+            VLLM_SPARK_TP4_DCP_QUERY_ENABLED="1",
+            VLLM_SPARK_TP4_DCP_COMBINE_ENABLED="0",
+        )
+        group = self.group_type()
+
+        result = self.flash_module.cp_lse_ag_out_rs(
+            _live_combine_output(5, payload=15),
+            _FakeTensor((5, 64), "torch.float32", payload=25),
+            group,
+            return_lse=True,
+            head_major_output=True,
+        )
+
+        self.assertEqual(result[0].payload, 15)
+        self.assertEqual(result[0].stride(), (256, 5 * 256, 1))
+        self.assertEqual(len(group.combine_original_calls), 1)
+        self.assertIs(group.combine_original_calls[0][5], True)
+
+    def test_combine_wrapper_preserves_exact_live_abi(self) -> None:
+        self._install("custom")
+
+        self.assertEqual(
+            tuple(inspect.signature(self.flash_module.cp_lse_ag_out_rs).parameters),
+            (
+                "cp_attn_out",
+                "cp_attn_lse",
+                "cp_group",
+                "ctx",
+                "return_lse",
+                "is_lse_base_on_e",
+                "head_major_output",
+            ),
+        )
+
+    def test_non_boolean_head_major_output_uses_stock(self) -> None:
+        self._install("custom")
+        group = self.group_type()
+
+        self.flash_module.cp_lse_ag_out_rs(
+            _live_combine_output(5, payload=15),
+            _FakeTensor((5, 64), "torch.float32", payload=25),
+            group,
+            head_major_output=1,
+        )
+
+        self.assertEqual(len(group.combine_original_calls), 1)
+        self.assertEqual(group.combine_original_calls[0][5], 1)
+        self.assertEqual(_FakeNativeSession.created, [])
 
     def test_combine_shadow_preserves_default_output_only_contract(self) -> None:
         self._install(
@@ -1200,19 +1572,24 @@ class SparkTp4DcpDispatchTest(unittest.TestCase):
             _live_combine_output(5, payload=15),
             _FakeTensor((5, 64), "torch.float32", payload=25),
             group,
+            head_major_output=True,
         )
         promoted_result = self.flash_module.cp_lse_ag_out_rs(
             _live_combine_output(5, payload=16),
             _FakeTensor((5, 64), "torch.float32", payload=26),
             group,
+            head_major_output=True,
         )
 
         self.assertNotIsInstance(shadow_result, tuple)
         self.assertNotIsInstance(promoted_result, tuple)
         self.assertEqual(shadow_result.payload, 15)
         self.assertEqual(promoted_result.payload, 16)
+        self.assertEqual(shadow_result.stride(), (256, 5 * 256, 1))
+        self.assertEqual(promoted_result.stride(), (256, 5 * 256, 1))
         self.assertEqual(len(group.combine_original_calls), 1)
         self.assertTrue(group.combine_original_calls[0][3])
+        self.assertIs(group.combine_original_calls[0][5], True)
         self.assertTrue(
             group._spark_tp4_dcp_native.combine_shadows[
                 (5, 256, 256, 5 * 256)

--- a/spark_transport/integrations/vllm/test_spark_tp4_port_namespace.py
+++ b/spark_transport/integrations/vllm/test_spark_tp4_port_namespace.py
@@ -1,0 +1,217 @@
+from __future__ import annotations
+
+import os
+import unittest
+from unittest.mock import patch
+
+import spark_tp4_allgather_backend
+import spark_tp4_backend
+import spark_tp4_dcp_backend
+import spark_tp4_port_namespace as namespace
+import spark_tp4_vocab_allgather_backend
+
+
+class Tp4PortNamespaceTest(unittest.TestCase):
+    def test_all_active_default_families_are_globally_unique(self) -> None:
+        environment = {
+            "VLLM_SPARK_TP4_MODE": "custom",
+            "VLLM_SPARK_TP4_PREFILL_Q512": "1",
+            "VLLM_SPARK_TP4_GRAPH_Q1": "1",
+            "VLLM_SPARK_TP4_GRAPH_DUAL_PORT_Q40": "1",
+            "VLLM_SPARK_TP4_ALLGATHER_MODE": "custom",
+            "VLLM_SPARK_TP4_INDEXER_GRAPH_CUSTOM": "1",
+            "VLLM_SPARK_TP4_VOCAB_MODE": "custom",
+            "VLLM_SPARK_TP4_DCP_MODE": "custom",
+            "VLLM_SPARK_TP4_DCP_GRAPH_CUSTOM": "1",
+        }
+
+        reservations = namespace.validate_active_port_namespace(environment)
+
+        self.assertEqual(len(reservations), 525)
+        assigned = [
+            port
+            for reservation in reservations
+            for port in reservation.ports
+        ]
+        self.assertEqual(len(assigned), len(set(assigned)))
+        by_owner = {
+            reservation.owner: reservation.ports
+            for reservation in reservations
+        }
+        self.assertEqual(by_owner["eager_allreduce:q=1"], (11000, 11001))
+        self.assertEqual(
+            by_owner["eager_allreduce:q=512"], (12022, 12023)
+        )
+        self.assertEqual(by_owner["eager_allgather:slot=0"], (9490, 9491))
+        self.assertNotIn("eager_allgather:slot=2", by_owner)
+        self.assertNotIn("eager_allgather:slot=7", by_owner)
+        self.assertEqual(by_owner["graph_allreduce"], (9970, 9971))
+        self.assertEqual(
+            by_owner["graph_dual_port_q40_allreduce"], (9972, 9973)
+        )
+
+    def test_ckv_slots_keep_durable_ids_and_reserve_only_when_enabled(
+        self,
+    ) -> None:
+        disabled = {"VLLM_SPARK_TP4_ALLGATHER_MODE": "custom"}
+        enabled = {
+            **disabled,
+            "SPARK_TP4_ALLGATHER_ENABLE_CKV": "1",
+        }
+
+        disabled_owners = {
+            reservation.owner
+            for reservation in namespace.validate_active_port_namespace(
+                disabled
+            )
+        }
+        enabled_by_owner = {
+            reservation.owner: reservation.ports
+            for reservation in namespace.validate_active_port_namespace(
+                enabled
+            )
+        }
+
+        self.assertNotIn("eager_allgather:slot=2", disabled_owners)
+        self.assertNotIn("eager_allgather:slot=7", disabled_owners)
+        self.assertEqual(
+            enabled_by_owner["eager_allgather:slot=2"], (9510, 9511)
+        )
+        self.assertEqual(
+            enabled_by_owner["eager_allgather:slot=7"], (9560, 9561)
+        )
+        self.assertEqual(
+            namespace.eager_allgather_control_ports(2, disabled),
+            (9510, 9511),
+        )
+        self.assertEqual(
+            namespace.eager_allgather_control_ports(7, disabled),
+            (9560, 9561),
+        )
+
+    def test_eager_allreduce_default_and_override_keep_stride_two(self) -> None:
+        self.assertEqual(
+            namespace.eager_allreduce_control_ports(1, {}),
+            (11000, 11001),
+        )
+        self.assertEqual(
+            namespace.eager_allreduce_control_ports(6, {}),
+            (11010, 11011),
+        )
+        override = {
+            "VLLM_SPARK_TP4_MODE": "custom",
+            "SPARK_TP4_CONTROL_PORT0": "9480",
+            "SPARK_TP4_CONTROL_PORT1": "9481",
+        }
+        self.assertEqual(
+            namespace.eager_allreduce_control_ports(6, override),
+            (9490, 9491),
+        )
+
+    def test_old_allreduce_default_collides_with_active_allgather(self) -> None:
+        environment = {
+            "VLLM_SPARK_TP4_MODE": "custom",
+            "SPARK_TP4_CONTROL_PORT0": "9480",
+            "SPARK_TP4_CONTROL_PORT1": "9481",
+            "VLLM_SPARK_TP4_ALLGATHER_MODE": "custom",
+        }
+
+        with self.assertRaisesRegex(
+            ValueError,
+            r"port 9490: eager_allreduce:q=6, eager_allgather:slot=0",
+        ):
+            namespace.validate_active_port_namespace(environment)
+
+    def test_only_selected_families_reserve_ports(self) -> None:
+        environment = {
+            "VLLM_SPARK_TP4_MODE": "custom",
+            "SPARK_TP4_CONTROL_PORT0": "9480",
+            "SPARK_TP4_CONTROL_PORT1": "9481",
+        }
+
+        reservations = namespace.validate_active_port_namespace(environment)
+
+        self.assertTrue(reservations)
+        self.assertTrue(
+            all(
+                reservation.owner.startswith("eager_allreduce:")
+                for reservation in reservations
+            )
+        )
+
+    def test_allreduce_override_cannot_overlap_its_next_q_slot(self) -> None:
+        environment = {
+            "VLLM_SPARK_TP4_MODE": "custom",
+            "SPARK_TP4_CONTROL_PORT0": "12000",
+            "SPARK_TP4_CONTROL_PORT1": "12002",
+        }
+
+        with self.assertRaisesRegex(
+            ValueError,
+            r"port 12002: eager_allreduce:q=1, eager_allreduce:q=2",
+        ):
+            namespace.validate_active_port_namespace(environment)
+
+    def test_active_static_family_collision_fails_closed(self) -> None:
+        environment = {
+            "VLLM_SPARK_TP4_MODE": "custom",
+            "VLLM_SPARK_TP4_GRAPH_Q1": "1",
+            "SPARK_TP4_GRAPH_CONTROL_PORT0": "9890",
+            "SPARK_TP4_GRAPH_CONTROL_PORT1": "9891",
+            "VLLM_SPARK_TP4_DCP_MODE": "custom",
+        }
+
+        with self.assertRaisesRegex(
+            ValueError, r"port 9890: graph_allreduce, eager_dcp"
+        ):
+            namespace.validate_active_port_namespace(environment)
+
+    def test_active_port_range_is_checked_before_use(self) -> None:
+        environment = {
+            "VLLM_SPARK_TP4_MODE": "custom",
+            "VLLM_SPARK_TP4_PREFILL_Q512": "1",
+            "SPARK_TP4_CONTROL_PORT0": "65000",
+            "SPARK_TP4_CONTROL_PORT1": "65001",
+        }
+
+        with self.assertRaisesRegex(ValueError, r"\[1, 65535\]"):
+            namespace.validate_active_port_namespace(environment)
+
+    def test_adapter_port_helpers_delegate_to_shared_namespace(self) -> None:
+        with patch.dict(os.environ, {}, clear=True):
+            self.assertEqual(
+                spark_tp4_backend._control_ports(12288), (11000, 11001)
+            )
+            self.assertEqual(
+                spark_tp4_backend._graph_control_ports(), (9970, 9971)
+            )
+            self.assertEqual(
+                spark_tp4_backend._graph_dual_port_q40_control_ports(),
+                (9972, 9973),
+            )
+            self.assertEqual(
+                spark_tp4_allgather_backend._allgather_control_ports(7),
+                (9560, 9561),
+            )
+            self.assertEqual(
+                spark_tp4_allgather_backend._indexer_graph_control_ports(),
+                (9462, 9463),
+            )
+            self.assertEqual(
+                spark_tp4_dcp_backend._eager_control_ports(), (9890, 9891)
+            )
+            self.assertEqual(
+                spark_tp4_dcp_backend._graph_control_ports(), (9892, 9893)
+            )
+            self.assertEqual(
+                spark_tp4_vocab_allgather_backend._eager_control_ports(),
+                (9990, 9991),
+            )
+            self.assertEqual(
+                spark_tp4_vocab_allgather_backend._graph_control_ports(),
+                (10110, 10111),
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/spark_transport/integrations/vllm/test_spark_tp4_prefill_capacity_pool.py
+++ b/spark_transport/integrations/vllm/test_spark_tp4_prefill_capacity_pool.py
@@ -1,0 +1,303 @@
+"""GPU-free tests for the research-only tiled-prefill capacity selector."""
+
+from __future__ import annotations
+
+import os
+import re
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+import spark_tp4_backend
+import spark_tp4_port_namespace
+import spark_tp4_prefill_capacity_pool as pool
+
+
+class PrefillCapacityPoolSelectorTest(unittest.TestCase):
+    def test_research_pool_is_disabled_by_default(self) -> None:
+        self.assertFalse(pool.capacity_pool_requested({}))
+
+    def test_qualification_endpoints_share_one_transport_engine(self) -> None:
+        expected = {
+            40: (40, (12500, 12501)),
+            512: (512, (12500, 12501)),
+            1024: (1024, (12500, 12501)),
+            4096: (4096, (12500, 12501)),
+        }
+
+        for query_rows, (capacity_rows, ports) in expected.items():
+            with self.subTest(query_rows=query_rows):
+                selection = pool.select_capacity_plan(query_rows, {})
+                self.assertEqual(selection.query_rows, query_rows)
+                self.assertEqual(
+                    selection.capacity_plan.maximum_query_rows,
+                    capacity_rows,
+                )
+                self.assertEqual(selection.transport_key.control_ports, ports)
+                self.assertEqual(
+                    selection.transport_key.engine_id,
+                    "prefill-tile-engine",
+                )
+                self.assertEqual(selection.active_bytes, query_rows * 12288)
+                self.assertEqual(
+                    selection.capacity_plan.maximum_payload_bytes,
+                    capacity_rows * 12288,
+                )
+
+    def test_audit_quantifies_exact_q_session_and_port_explosion(self) -> None:
+        audit = pool.transport_engine_audit({})
+
+        self.assertEqual(
+            [
+                (
+                    row["maximum_query_rows"],
+                    row["session_count_per_rank"],
+                    row["control_port_count_per_rank"],
+                    row["last_control_ports"],
+                )
+                for row in audit["exact_q_projection"]
+            ],
+            [
+                (40, 40, 80, (11078, 11079)),
+                (512, 512, 1024, (12022, 12023)),
+                (1024, 1024, 2048, (13046, 13047)),
+                (4096, 4096, 8192, (19190, 19191)),
+            ],
+        )
+        self.assertEqual(
+            audit["capacity_pool"]["physical_transport_engines_per_rank"],
+            1,
+        )
+        self.assertEqual(
+            audit["capacity_pool"]["logical_capacity_plan_count"], 4
+        )
+        self.assertEqual(audit["capacity_pool"]["control_port_count_per_rank"], 2)
+        self.assertTrue(
+            audit["capacity_pool"]["ports_disjoint_from_exact_decode_q1_q40"]
+        )
+        self.assertEqual(
+            audit["q4096_physical_engine_reduction_factor"], 4096.0
+        )
+
+    def test_executable_cache_and_namespace_are_exact_payload_indexed(self) -> None:
+        backend = spark_tp4_backend._Backend(0)
+        with patch.object(
+            spark_tp4_backend,
+            "_NativeSession",
+            side_effect=lambda rank, payload_bytes: (rank, payload_bytes),
+        ) as constructor:
+            q1 = backend.native_for(1 * pool.BYTES_PER_QUERY_ROW)
+            q40 = backend.native_for(40 * pool.BYTES_PER_QUERY_ROW)
+            q1_again = backend.native_for(1 * pool.BYTES_PER_QUERY_ROW)
+
+        self.assertIs(q1, q1_again)
+        self.assertNotEqual(q1, q40)
+        self.assertEqual(constructor.call_count, 2)
+        self.assertEqual(len(backend.native_sessions), 2)
+
+        reservations = spark_tp4_port_namespace.active_port_reservations(
+            {
+                "VLLM_SPARK_TP4_MODE": "custom",
+                "VLLM_SPARK_TP4_PREFILL_Q512": "1",
+            }
+        )
+        exact_q = [
+            reservation
+            for reservation in reservations
+            if reservation.owner.startswith("eager_allreduce:q=")
+        ]
+        self.assertEqual(len(exact_q), 512)
+        self.assertEqual(exact_q[0].ports, (11000, 11001))
+        self.assertEqual(exact_q[-1].ports, (12022, 12023))
+
+    def test_qualification_plan_is_blocked_on_exact_live_prerequisites(self) -> None:
+        plan = pool.qualification_plan({})
+
+        self.assertEqual(plan["status"], "research-only")
+        self.assertFalse(plan["runnable"])
+        self.assertEqual(
+            [arm["query_rows"] for arm in plan["fixed_q_arms"]],
+            [40, 512, 1024, 4096],
+        )
+        self.assertEqual(
+            [arm["iterations"] for arm in plan["fixed_q_arms"]],
+            [200, 50, 25, 10],
+        )
+        self.assertEqual(
+            [item["id"] for item in plan["live_prerequisites"]],
+            [
+                "native-active-bytes-submission",
+                "generation-tagged-tile-pool",
+                "cumulative-credit-retirement",
+                "capacity-port-namespace",
+                "q4096-kernel-capacity",
+                "four-rank-fixed-q-probe",
+                "serving-engine-receipt",
+            ],
+        )
+        self.assertTrue(
+            all(
+                prerequisite["satisfied"] is False
+                for prerequisite in plan["live_prerequisites"]
+            )
+        )
+        self.assertIn(513, plan["boundary_query_rows"])
+        self.assertIn(1025, plan["boundary_query_rows"])
+        self.assertEqual(
+            plan["required_live_receipt"]["per_rank_topology"],
+            {
+                "physical_transport_engine_count": 1,
+                "edge_count": 2,
+                "qp_count_per_edge": 1,
+                "registered_tile_pool_count_per_edge": 1,
+                "registered_tile_storage_bytes_per_edge": 8_389_632,
+                "logical_one_plane_payload_bytes_per_edge": 4 * 1024 * 1024,
+                "descriptor_storage_accounting": "separate",
+                "logical_capacity_plan_count": 4,
+                "exact_q_prefill_session_count": 0,
+            },
+        )
+        self.assertEqual(
+            plan["required_live_receipt"]["fatal_counters"],
+            {
+                "unexpected_generation": 0,
+                "poisoned_slot": 0,
+                "descriptor_overflow": 0,
+                "credit_regression": 0,
+            },
+        )
+
+    def test_adapter_rejects_research_enable_before_loading_native_code(self) -> None:
+        with (
+            patch.dict(
+                os.environ,
+                {
+                    "VLLM_SPARK_TP4_MODE": "custom",
+                    pool.FEATURE_ENV: "1",
+                },
+                clear=True,
+            ),
+            patch.object(spark_tp4_backend, "_installed", False),
+            patch.object(spark_tp4_backend.ctypes, "CDLL") as load_library,
+            self.assertRaisesRegex(
+                RuntimeError,
+                "active-bytes native ABI is unavailable",
+            ),
+        ):
+            spark_tp4_backend.install()
+
+        load_library.assert_not_called()
+
+    def test_boundaries_route_to_smallest_class_and_require_active_bytes(self) -> None:
+        expected = {
+            1: (40, True),
+            39: (40, True),
+            40: (40, False),
+            41: (512, True),
+            511: (512, True),
+            512: (512, False),
+            513: (1024, True),
+            1024: (1024, False),
+            1025: (4096, True),
+            4096: (4096, False),
+        }
+
+        for query_rows, (capacity_rows, requires_active_bytes) in expected.items():
+            with self.subTest(query_rows=query_rows):
+                selection = pool.select_capacity_plan(query_rows, {})
+                self.assertEqual(
+                    selection.capacity_plan.maximum_query_rows,
+                    capacity_rows,
+                )
+                self.assertEqual(
+                    selection.requires_active_bytes_submission,
+                    requires_active_bytes,
+                )
+
+    def test_python_and_cpp_capacity_maxima_are_identical(self) -> None:
+        header = (
+            Path(__file__).resolve().parents[2]
+            / "include"
+            / "spark_transport"
+            / "tp4_tiled_session.hpp"
+        ).read_text(encoding="utf-8")
+        maxima = tuple(
+            int(value)
+            for value in re.findall(
+                r"kTp4Tiled(?:Latency|Medium|Large|Streaming)MaximumQ = (\d+);",
+                header,
+            )
+        )
+
+        self.assertEqual(maxima, pool.CAPACITY_QUERY_ROWS)
+
+    def test_port_audit_proves_pool_replaces_large_exact_q_namespace(self) -> None:
+        audit = pool.transport_engine_audit(
+            {
+                "SPARK_TP4_CONTROL_PORT0": "11100",
+                "SPARK_TP4_CONTROL_PORT1": "11101",
+            }
+        )
+
+        self.assertEqual(
+            audit["exact_q_projection"][1]["last_control_ports"],
+            (12122, 12123),
+        )
+        self.assertEqual(
+            audit["first_projected_exact_q_collision_with_pool"],
+            701,
+        )
+        self.assertIn(
+            "replace exact-Q sessions above Q40",
+            audit["capacity_pool"]["coexistence_contract"],
+        )
+
+    def test_physical_tile_pool_is_bounded_independently_of_logical_q4096(self) -> None:
+        plan = pool.qualification_plan({})
+        q4096 = plan["fixed_q_arms"][-1]
+
+        self.assertEqual(plan["tile_pool"]["tile_bytes"], 512 * 1024)
+        self.assertEqual(plan["tile_pool"]["tiles_per_edge"], 8)
+        self.assertEqual(plan["tile_pool"]["lanes_per_edge"], 2)
+        self.assertEqual(plan["tile_pool"]["lane_payload_bytes"], 256 * 1024)
+        self.assertEqual(plan["tile_pool"]["control_bytes_per_lane"], 64)
+        self.assertEqual(
+            plan["tile_pool"]["logical_one_plane_payload_bytes_per_edge"],
+            4 * 1024 * 1024,
+        )
+        self.assertEqual(
+            plan["tile_pool"]["registered_bytes_per_edge"],
+            8_389_632,
+        )
+        self.assertFalse(plan["tile_pool"]["descriptors_included"])
+        topology = plan["required_live_receipt"]["per_rank_topology"]
+        self.assertEqual(
+            topology["registered_tile_storage_bytes_per_edge"],
+            8_389_632,
+        )
+        self.assertEqual(
+            topology["logical_one_plane_payload_bytes_per_edge"],
+            4 * 1024 * 1024,
+        )
+        self.assertEqual(topology["descriptor_storage_accounting"], "separate")
+        self.assertEqual(q4096["maximum_payload_bytes"], 48 * 1024 * 1024)
+        self.assertEqual(q4096["logical_payload_tiles"], 96)
+
+    def test_invalid_feature_values_shapes_and_ports_fail_closed(self) -> None:
+        with self.assertRaisesRegex(ValueError, pool.FEATURE_ENV):
+            pool.capacity_pool_requested({pool.FEATURE_ENV: "yes"})
+        for query_rows in (True, 0, -1, 4097, 1.0, "40"):
+            with self.subTest(query_rows=query_rows):
+                with self.assertRaisesRegex(ValueError, "query rows"):
+                    pool.select_capacity_plan(query_rows, {})  # type: ignore[arg-type]
+        with self.assertRaisesRegex(ValueError, "control ports"):
+            pool.shared_transport_key(
+                {
+                    pool.PORT0_ENV: "65536",
+                    pool.PORT1_ENV: "65534",
+                },
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/spark_transport/scripts/run_tp4_graph_q1_probe.ps1
+++ b/spark_transport/scripts/run_tp4_graph_q1_probe.ps1
@@ -8,9 +8,24 @@ param(
     [ValidateRange(1, 4096)]
     [int]$OperationsPerGraph = 1,
 
+    [ValidateSet("serial_ack", "two_slot_deferred_ack")]
+    [string]$AllreduceProtocol = "serial_ack",
+
+    [ValidateSet("fused", "split_64k", "tiered_64k")]
+    [string]$GraphKernel = "fused",
+
+    [ValidateSet("sequential", "dual_port_striped")]
+    [string]$WireSchedule = "sequential",
+
+    [ValidateSet("burst", "isolated")]
+    [string]$TimingMode = "burst",
+
     [switch]$MultiGraphValidation,
 
     [switch]$MixedQValidation,
+
+    [ValidateRange(1, 512)]
+    [int]$FixedQ = 1,
 
     [ValidateRange(6, 512)]
     [int]$MaximumQ = 6,
@@ -48,10 +63,11 @@ param(
     [int]$ProgressCpu = 11,
 
     [string]$ProbeBinary =
-        "/tmp/spark_tp4_graph_mixedq_q6_probe-20260726",
+        "/tmp/spark_tp4_graph_q1_probe",
     [string]$Image = "<your-vllm-image>",
     [string[]]$Targets = ($env:SPARKRING_TARGETS -split ",").Trim(),
     [string[]]$RankHosts = ($env:SPARKRING_RANK_HOSTS -split ",").Trim(),
+    [switch]$ValidateOnly,
     [switch]$KeepContainers
 )
 
@@ -83,6 +99,49 @@ if ($MultiGraphValidation -and -not $DisablePerformanceGates) {
 if ($MixedQValidation -and -not $MultiGraphValidation) {
     throw "MixedQValidation requires MultiGraphValidation"
 }
+if ($TimingMode -eq "isolated" -and `
+    ($MultiGraphValidation -or $MixedQValidation -or `
+        $OperationsPerGraph -ne 1)) {
+    throw "TimingMode=isolated requires one single-graph collective"
+}
+if ($FixedQ -ne 1 -and `
+    ($MultiGraphValidation -or $MixedQValidation -or `
+        $OperationsPerGraph -ne 1)) {
+    throw "FixedQ above one requires one single-graph collective"
+}
+if ($GraphKernel -eq "split_64k" -and `
+    ($MultiGraphValidation -or $MixedQValidation -or `
+        $OperationsPerGraph -ne 1)) {
+    throw ("GraphKernel=split_64k requires fixed Q1 through Q512 " +
+        "and one single-graph collective")
+}
+if ($WireSchedule -eq "dual_port_striped" -and `
+    (($FixedQ -ne 40 -and $FixedQ -ne 512) -or `
+        $AllreduceProtocol -ne "two_slot_deferred_ack" -or `
+        $GraphKernel -ne "fused" -or `
+        $MultiGraphValidation -or $MixedQValidation -or `
+        $OperationsPerGraph -ne 1)) {
+    throw ("WireSchedule=dual_port_striped requires FixedQ 40 or 512, " +
+        "AllreduceProtocol=two_slot_deferred_ack, GraphKernel=fused, " +
+        "and one single-graph collective")
+}
+if ($WireSchedule -eq "dual_port_striped") {
+    $selectedTransportKernelPath = "dual_port_striped_dag"
+}
+else {
+    $selectedTransportKernelPath = "sequential_$GraphKernel"
+}
+
+if ($ValidateOnly) {
+    Write-Output ("validation=pass graph_kernel=$GraphKernel " +
+        "wire_schedule=$WireSchedule protocol=$AllreduceProtocol " +
+        "transport_kernel_path=$selectedTransportKernelPath " +
+        "timing_mode=$TimingMode " +
+        "fixed_q=$FixedQ maximum_q=$MaximumQ " +
+        "multi_graph=$($MultiGraphValidation.IsPresent.ToString().ToLowerInvariant()) " +
+        "mixed_q=$($MixedQValidation.IsPresent.ToString().ToLowerInvariant())")
+    return
+}
 
 $nodes = @(
     [pscustomobject]@{
@@ -90,24 +149,32 @@ $nodes = @(
         Target = $Targets[0]
         Peer0 = $RankHosts[1]
         Peer1 = $RankHosts[3]
+        Device0 = "rocep1s0f0"
+        Device1 = "rocep1s0f1"
     },
     [pscustomobject]@{
         Rank = 1
         Target = $Targets[1]
         Peer0 = $RankHosts[0]
         Peer1 = $RankHosts[2]
+        Device0 = "rocep1s0f1"
+        Device1 = "rocep1s0f0"
     },
     [pscustomobject]@{
         Rank = 2
         Target = $Targets[2]
         Peer0 = $RankHosts[3]
         Peer1 = $RankHosts[1]
+        Device0 = "rocep1s0f0"
+        Device1 = "rocep1s0f1"
     },
     [pscustomobject]@{
         Rank = 3
         Target = $Targets[3]
         Peer0 = $RankHosts[2]
         Peer1 = $RankHosts[0]
+        Device0 = "rocep1s0f1"
+        Device1 = "rocep1s0f0"
     }
 )
 
@@ -185,6 +252,7 @@ try {
             "--cpuset-cpus=$CpuSet"
             "--ulimit memlock=-1"
             "-v ${ProbeBinary}:/probe:ro"
+            "--entrypoint /usr/bin/env"
             $Image
             "timeout --signal=TERM --kill-after=5s ${WatchdogSeconds}s"
             "env -u SPARK_TRANSPORT_TRACE"
@@ -192,13 +260,18 @@ try {
             "--rank $($node.Rank)"
             "--peer0 $($node.Peer0)"
             "--peer1 $($node.Peer1)"
-            "--device0 rocep1s0f0 --device1 rocep1s0f1"
+            "--device0 $($node.Device0) --device1 $($node.Device1)"
             "--gid0 3 --gid1 3"
             "--control-port0 $ControlPort0"
             "--control-port1 $ControlPort1"
             "--warmup $Warmup"
             "--iterations $Iterations"
             "--operations-per-graph $OperationsPerGraph"
+            "--allreduce-protocol $AllreduceProtocol"
+            "--graph-kernel $GraphKernel"
+            "--wire-schedule $WireSchedule"
+            "--timing-mode $TimingMode"
+            "--fixed-q $FixedQ"
             "--maximum-q $MaximumQ"
             "--graph-submit-cpu $SubmitCpu"
             "--graph-progress-cpu $ProgressCpu"
@@ -250,7 +323,7 @@ try {
         $expectedGraphBOperations = 0
     }
     $expectedQHistogram = @(
-        for ($q = 1; $q -le $MaximumQ; $q++) {
+        for ($q = 1; $q -le 512; $q++) {
             0L
         }
     )
@@ -281,37 +354,58 @@ try {
         $expectedMixedQ = "true"
     }
     else {
-        $expectedQHistogram[0] = $expectedCapturedNodes
-        $expectedSessionCapacityBytes = 6144L * 2L
+        $expectedQHistogram[$FixedQ - 1] = $expectedCapturedNodes
+        $expectedSessionCapacityBytes = [long]$FixedQ * 6144L * 2L
         $expectedMixedQ = "false"
     }
     $expectedActiveBytesPerGraphCycle = 0L
-    for ($q = 1; $q -le $MaximumQ; $q++) {
+    for ($q = 1; $q -le 512; $q++) {
         $expectedActiveBytesPerGraphCycle += `
             $expectedQHistogram[$q - 1] * [long]$q * 6144L * 2L
     }
     $expectedValidatedActiveBytesTotal = `
         $expectedActiveBytesPerGraphCycle * `
         ([long]$Warmup + [long]$Iterations)
-    $expectedQ48 = if ($MaximumQ -ge 48) {
-        $expectedQHistogram[47]
-    } else {
-        0L
+    $expectedQ48 = $expectedQHistogram[47]
+    $expectedQ40 = $expectedQHistogram[39]
+    $expectedQ72 = $expectedQHistogram[71]
+    $expectedQ144 = $expectedQHistogram[143]
+    $expectedQ512 = $expectedQHistogram[511]
+    if ($GraphKernel -eq "fused") {
+        $expectedKernelFusedNodes = $expectedCapturedNodes
+        $expectedKernelSplitNodes = 0L
     }
-    $expectedQ72 = if ($MaximumQ -ge 72) {
-        $expectedQHistogram[71]
-    } else {
-        0L
+    elseif ($GraphKernel -eq "split_64k") {
+        $expectedKernelFusedNodes = 0L
+        $expectedKernelSplitNodes = $expectedCapturedNodes
     }
-    $expectedQ144 = if ($MaximumQ -ge 144) {
-        $expectedQHistogram[143]
-    } else {
-        0L
+    else {
+        $expectedKernelFusedNodes = 0L
+        for ($q = 1; $q -le 6; $q++) {
+            $expectedKernelFusedNodes += $expectedQHistogram[$q - 1]
+        }
+        $expectedKernelSplitNodes = `
+            $expectedCapturedNodes - $expectedKernelFusedNodes
     }
-    $expectedQ512 = if ($MaximumQ -ge 512) {
-        $expectedQHistogram[511]
-    } else {
-        0L
+    $expectedTransportKernelPath = $selectedTransportKernelPath
+    if ($AllreduceProtocol -eq "two_slot_deferred_ack") {
+        $expectedPayloadSlots = 2
+        $expectedSlotReuse = if ($expected -ge 3) { "true" } else { "false" }
+    }
+    else {
+        $expectedPayloadSlots = 1
+        $expectedSlotReuse = "false"
+    }
+    if ($TimingMode -eq "isolated") {
+        $expectedTimingScope = "device_output_ready_single_replay"
+        $expectedDeviceGateMetric = `
+            "p95_device_output_ready_us_per_graph"
+    }
+    else {
+        $expectedTimingScope = `
+            "device_output_ready_replay_throughput"
+        $expectedDeviceGateMetric = `
+            "mean_device_output_ready_us_per_collective"
     }
 
     foreach ($node in $nodes) {
@@ -328,8 +422,18 @@ try {
             -or $gate -notmatch "publisher=device" `
             -or $gate -notmatch "mode=$expectedMode(?:\s|$)" `
             -or $gate -notmatch "mixed_q=$expectedMixedQ(?:\s|$)" `
+            -or $gate -notmatch "fixed_q=$FixedQ(?:\s|$)" `
             -or $gate -notmatch "maximum_q=$MaximumQ(?:\s|$)" `
             -or $gate -notmatch "session_capacity_bytes=$expectedSessionCapacityBytes(?:\s|$)" `
+            -or $gate -notmatch "allreduce_protocol=$AllreduceProtocol(?:\s|$)" `
+            -or $gate -notmatch "wire_schedule=$WireSchedule(?:\s|$)" `
+            -or $gate -notmatch "transport_kernel_path=$expectedTransportKernelPath(?:\s|$)" `
+            -or $gate -notmatch "graph_kernel=$GraphKernel(?:\s|$)" `
+            -or $gate -notmatch "kernel_fused_nodes=$expectedKernelFusedNodes(?:\s|$)" `
+            -or $gate -notmatch "kernel_split_64k_nodes=$expectedKernelSplitNodes(?:\s|$)" `
+            -or $gate -notmatch "payload_slots=$expectedPayloadSlots(?:\s|$)" `
+            -or $gate -notmatch "slot_reuse_exercised=$expectedSlotReuse(?:\s|$)" `
+            -or $gate -notmatch "timing_mode=$TimingMode(?:\s|$)" `
             -or $gate -notmatch "graph_a_operations=$expectedGraphAOperations(?:\s|$)" `
             -or $gate -notmatch "graph_b_operations=$expectedGraphBOperations(?:\s|$)" `
             -or $gate -notmatch "q1_nodes=$($expectedQHistogram[0])(?:\s|$)" `
@@ -338,6 +442,7 @@ try {
             -or $gate -notmatch "q4_nodes=$($expectedQHistogram[3])(?:\s|$)" `
             -or $gate -notmatch "q5_nodes=$($expectedQHistogram[4])(?:\s|$)" `
             -or $gate -notmatch "q6_nodes=$($expectedQHistogram[5])(?:\s|$)" `
+            -or $gate -notmatch "q40_nodes=$expectedQ40(?:\s|$)" `
             -or $gate -notmatch "q48_nodes=$expectedQ48(?:\s|$)" `
             -or $gate -notmatch "q72_nodes=$expectedQ72(?:\s|$)" `
             -or $gate -notmatch "q144_nodes=$expectedQ144(?:\s|$)" `
@@ -349,6 +454,9 @@ try {
             -or $gate -notmatch "captured_nodes=$expectedCapturedNodes(?:\s|$)" `
             -or $gate -notmatch "submit_affinity_verified=true(?:\s|$)" `
             -or $gate -notmatch "progress_affinity_verified=true(?:\s|$)" `
+            -or $gate -notmatch "protocol_status_match=true(?:\s|$)" `
+            -or $gate -notmatch "timing_scope=$expectedTimingScope(?:\s|$)" `
+            -or $gate -notmatch "device_gate_metric=$expectedDeviceGateMetric(?:\s|$)" `
             -or $gate -notmatch "graph_submit_cpu=$SubmitCpu(?:\s|$)" `
             -or $gate -notmatch "graph_progress_cpu=$ProgressCpu(?:\s|$)" `
             -or $gate -notmatch "pre_replay_capture_valid=true(?:\s|$)" `
@@ -362,6 +470,14 @@ try {
             $failed = $true
             Write-Output "rank=$($node.Rank) failure_log:"
             $log | Select-Object -Last 40 | Write-Output
+        }
+        if ($TimingMode -eq "isolated" -and `
+            ($gate -notmatch "timing_samples=$Iterations(?:\s|$)" `
+                -or $gate -notmatch "device_output_ready_us_per_graph_min=[0-9.eE+-]+(?:\s|$)" `
+                -or $gate -notmatch "device_output_ready_us_per_graph_p50=[0-9.eE+-]+(?:\s|$)" `
+                -or $gate -notmatch "device_output_ready_us_per_graph_p95=[0-9.eE+-]+(?:\s|$)")) {
+            $failed = $true
+            Write-Output "rank=$($node.Rank) isolated timing receipt gate failed"
         }
         if ($MultiGraphValidation `
             -and $gate -notmatch "post_replay_capture_rejected=true(?:\s|$)") {
@@ -387,4 +503,4 @@ if ($failed) {
     throw "one or more TP4 graph Q1 ranks failed"
 }
 
-Write-Output "gate=pass ranks=4 mode=$expectedMode expected_sequence=$expected input_updates=$expectedLaunches"
+Write-Output "gate=pass ranks=4 mode=$expectedMode protocol=$AllreduceProtocol wire_schedule=$WireSchedule transport_kernel_path=$expectedTransportKernelPath graph_kernel=$GraphKernel timing_mode=$TimingMode expected_sequence=$expected input_updates=$expectedLaunches"

--- a/spark_transport/src/gpu_tp4_tensor.cu
+++ b/spark_transport/src/gpu_tp4_tensor.cu
@@ -21,6 +21,31 @@ void check_cuda(cudaError_t result, const char* operation) {
 using GraphAtomicWord = unsigned long long;
 static_assert(sizeof(GraphAtomicWord) == sizeof(std::uint64_t));
 
+constexpr std::size_t kSplitGraphTileBytes = 64U * 1024U;
+
+struct SplitGraphOperationState {
+  std::uint64_t sequence{};
+  std::uint64_t doorbell_sequence{};
+  std::size_t payload_bytes{};
+  std::size_t slot{};
+};
+
+struct StripedGraphOperationState {
+  std::uint64_t sequence{};
+  std::uint64_t doorbell_sequence{};
+  std::size_t payload_bytes{};
+  std::size_t stripe_bytes{};
+  std::size_t generation{};
+};
+
+// Every split node is captured on the session's one stable caller stream.
+// Completion of each bulk grid therefore precedes its control publisher; the
+// publisher's system fence is the payload-before-doorbell release boundary.
+
+constexpr bool split_graph_q_supported(std::uint32_t q) noexcept {
+  return q >= 1 && q <= kTp4GraphAllreduceMaximumQ;
+}
+
 __device__ GraphAtomicWord* graph_atomic_word(
     std::uint64_t* address) {
   return reinterpret_cast<GraphAtomicWord*>(address);
@@ -158,7 +183,7 @@ __global__ void tp4_tensor_all_reduce(
     const __nv_bfloat16* input, __nv_bfloat16* output,
     std::size_t payload_bytes, std::uint64_t fixed_sequence,
     Tp4GraphCommandRing* graph_commands, std::uint32_t graph_q,
-    bool graph_trace) {
+    bool graph_trace, Tp4AllreduceProtocol protocol) {
   __shared__ std::uint64_t graph_sequence;
   if (graph_commands != nullptr) {
     if (threadIdx.x == 0) {
@@ -175,6 +200,9 @@ __global__ void tp4_tensor_all_reduce(
       graph_commands == nullptr
           ? sequence
           : (sequence << kTp4GraphDoorbellQBits) | graph_q;
+  const std::size_t slot = tp4_payload_slot_index(sequence, protocol);
+  round0_buffer += slot * round0_layout.total_bytes;
+  round1_buffer += slot * round1_layout.total_bytes;
 
   auto* send0 = reinterpret_cast<__nv_bfloat16*>(
       round0_buffer + round0_layout.send_offset);
@@ -192,6 +220,13 @@ __global__ void tp4_tensor_all_reduce(
   const std::size_t elements = payload_bytes / sizeof(__nv_bfloat16);
   const std::size_t pairs = elements / 2;
 
+  if (tp4_protocol_uses_deferred_ack(protocol)) {
+    const std::uint64_t prior_sequence =
+        tp4_expected_reuse_credit(sequence, protocol);
+    wait_for_sequence_block(&control0->acknowledgement_sequence,
+                            prior_sequence, graph_commands, sequence);
+  }
+
   for (std::size_t index = threadIdx.x; index < elements;
        index += blockDim.x) {
     send0[index] = input[index];
@@ -205,6 +240,12 @@ __global__ void tp4_tensor_all_reduce(
   const auto* receive0_pairs =
       reinterpret_cast<const __nv_bfloat162*>(receive0);
   auto* send1_pairs = reinterpret_cast<__nv_bfloat162*>(send1);
+  if (tp4_protocol_uses_deferred_ack(protocol)) {
+    const std::uint64_t prior_sequence =
+        tp4_expected_reuse_credit(sequence, protocol);
+    wait_for_sequence_block(&control1->acknowledgement_sequence,
+                            prior_sequence, graph_commands, sequence);
+  }
   for (std::size_t index = threadIdx.x; index < pairs;
        index += blockDim.x) {
     send1_pairs[index] =
@@ -216,8 +257,10 @@ __global__ void tp4_tensor_all_reduce(
   }
   publish_sequence_block(&control0->consumer_sequence,
                          doorbell_sequence);
-  wait_for_sequence_block(&control0->acknowledgement_sequence,
-                          doorbell_sequence, graph_commands, sequence);
+  if (!tp4_protocol_uses_deferred_ack(protocol)) {
+    wait_for_sequence_block(&control0->acknowledgement_sequence,
+                            doorbell_sequence, graph_commands, sequence);
+  }
 
   wait_for_sequence_block(&control1->remote_sequence, doorbell_sequence,
                           graph_commands, sequence);
@@ -237,10 +280,468 @@ __global__ void tp4_tensor_all_reduce(
   }
   publish_sequence_block(&control1->consumer_sequence,
                          doorbell_sequence);
-  wait_for_sequence_block(&control1->acknowledgement_sequence,
-                          doorbell_sequence, graph_commands, sequence);
+  if (!tp4_protocol_uses_deferred_ack(protocol)) {
+    wait_for_sequence_block(&control1->acknowledgement_sequence,
+                            doorbell_sequence, graph_commands, sequence);
+  }
   publish_sequence_block(&control1->observed_sequence,
                          doorbell_sequence);
+}
+
+__global__ void tp4_split_claim_command(
+    Tp4GraphCommandRing* graph_commands,
+    std::uint8_t* round0_buffer, Tp2BufferLayout round0_layout,
+    SplitGraphOperationState* state, std::uint32_t graph_q,
+    std::uint32_t payload_bytes, bool graph_trace,
+    Tp4AllreduceProtocol protocol) {
+  if (threadIdx.x == 0) {
+    const std::uint64_t sequence = graph_publish_command(
+        graph_commands, graph_trace, graph_q, payload_bytes);
+    state->sequence = sequence;
+    state->doorbell_sequence =
+        (sequence << kTp4GraphDoorbellQBits) | graph_q;
+    state->payload_bytes = payload_bytes;
+    state->slot = tp4_payload_slot_index(sequence, protocol);
+  }
+  __syncthreads();
+  if (tp4_protocol_uses_deferred_ack(protocol)) {
+    // acknowledgement_sequence is a raw logical sequence in deferred mode,
+    // not the q-encoded transport token. This exact credit retires the prior
+    // generation of the selected round-0 slot. Stream ordering prevents the
+    // following staging grid from overwriting that slot until this returns.
+    round0_buffer += state->slot * round0_layout.total_bytes;
+    const auto* control0 = reinterpret_cast<const DoorbellControl*>(
+        round0_buffer + round0_layout.control_offset);
+    const std::uint64_t prior_sequence =
+        tp4_expected_reuse_credit(state->sequence, protocol);
+    wait_for_sequence_block(&control0->acknowledgement_sequence,
+                            prior_sequence, graph_commands,
+                            state->sequence);
+  }
+}
+
+__global__ void tp4_split_stage_round0(
+    std::uint8_t* round0_buffer, Tp2BufferLayout round0_layout,
+    const __nv_bfloat16* input,
+    const SplitGraphOperationState* state) {
+  round0_buffer += state->slot * round0_layout.total_bytes;
+  auto* send0 = reinterpret_cast<__nv_bfloat16*>(
+      round0_buffer + round0_layout.send_offset);
+  const std::size_t begin_byte =
+      static_cast<std::size_t>(blockIdx.x) * kSplitGraphTileBytes;
+  const std::size_t candidate_end = begin_byte + kSplitGraphTileBytes;
+  const std::size_t end_byte =
+      candidate_end < state->payload_bytes
+          ? candidate_end
+          : state->payload_bytes;
+  const std::size_t begin = begin_byte / sizeof(__nv_bfloat16);
+  const std::size_t end = end_byte / sizeof(__nv_bfloat16);
+  for (std::size_t index = begin + threadIdx.x; index < end;
+       index += blockDim.x) {
+    send0[index] = input[index];
+  }
+}
+
+__global__ void tp4_split_publish_round0(
+    std::uint8_t* round0_buffer, Tp2BufferLayout round0_layout,
+    const SplitGraphOperationState* state) {
+  round0_buffer += state->slot * round0_layout.total_bytes;
+  auto* control0 = reinterpret_cast<DoorbellControl*>(
+      round0_buffer + round0_layout.control_offset);
+  publish_sequence_block(&control0->producer_sequence,
+                         state->doorbell_sequence);
+}
+
+__global__ void tp4_split_wait_round0(
+    std::uint8_t* round0_buffer, Tp2BufferLayout round0_layout,
+    std::uint8_t* round1_buffer, Tp2BufferLayout round1_layout,
+    const SplitGraphOperationState* state,
+    Tp4GraphCommandRing* graph_commands,
+    Tp4AllreduceProtocol protocol) {
+  round0_buffer += state->slot * round0_layout.total_bytes;
+  const auto* control0 = reinterpret_cast<const DoorbellControl*>(
+      round0_buffer + round0_layout.control_offset);
+  wait_for_sequence_block(&control0->remote_sequence,
+                          state->doorbell_sequence, graph_commands,
+                          state->sequence);
+  if (tp4_protocol_uses_deferred_ack(protocol)) {
+    // The reduce grid writes round-1 send storage. Its stream dependency on
+    // this exact raw credit is the round-1 slot-reuse ownership barrier.
+    round1_buffer += state->slot * round1_layout.total_bytes;
+    const auto* control1 = reinterpret_cast<const DoorbellControl*>(
+        round1_buffer + round1_layout.control_offset);
+    const std::uint64_t prior_sequence =
+        tp4_expected_reuse_credit(state->sequence, protocol);
+    wait_for_sequence_block(&control1->acknowledgement_sequence,
+                            prior_sequence, graph_commands,
+                            state->sequence);
+  }
+}
+
+__global__ void tp4_split_reduce_round0(
+    std::uint8_t* round0_buffer, Tp2BufferLayout round0_layout,
+    std::uint8_t* round1_buffer, Tp2BufferLayout round1_layout,
+    const SplitGraphOperationState* state) {
+  round0_buffer += state->slot * round0_layout.total_bytes;
+  round1_buffer += state->slot * round1_layout.total_bytes;
+  const auto* send0 = reinterpret_cast<const __nv_bfloat162*>(
+      round0_buffer + round0_layout.send_offset);
+  const auto* receive0 = reinterpret_cast<const __nv_bfloat162*>(
+      round0_buffer + round0_layout.receive_offset);
+  auto* send1 = reinterpret_cast<__nv_bfloat162*>(
+      round1_buffer + round1_layout.send_offset);
+  const std::size_t begin_byte =
+      static_cast<std::size_t>(blockIdx.x) * kSplitGraphTileBytes;
+  const std::size_t candidate_end = begin_byte + kSplitGraphTileBytes;
+  const std::size_t end_byte =
+      candidate_end < state->payload_bytes
+          ? candidate_end
+          : state->payload_bytes;
+  const std::size_t begin = begin_byte / sizeof(__nv_bfloat162);
+  const std::size_t end = end_byte / sizeof(__nv_bfloat162);
+  for (std::size_t index = begin + threadIdx.x; index < end;
+       index += blockDim.x) {
+    send1[index] = __hadd2(send0[index], receive0[index]);
+  }
+}
+
+__global__ void tp4_split_handoff_round1(
+    std::uint8_t* round0_buffer, Tp2BufferLayout round0_layout,
+    std::uint8_t* round1_buffer, Tp2BufferLayout round1_layout,
+    const SplitGraphOperationState* state,
+    Tp4GraphCommandRing* graph_commands,
+    Tp4AllreduceProtocol protocol) {
+  round0_buffer += state->slot * round0_layout.total_bytes;
+  round1_buffer += state->slot * round1_layout.total_bytes;
+  auto* control0 = reinterpret_cast<DoorbellControl*>(
+      round0_buffer + round0_layout.control_offset);
+  const auto* control1 = reinterpret_cast<const DoorbellControl*>(
+      round1_buffer + round1_layout.control_offset);
+  publish_sequence_block(&control0->consumer_sequence,
+                         state->doorbell_sequence);
+  if (!tp4_protocol_uses_deferred_ack(protocol)) {
+    wait_for_sequence_block(&control0->acknowledgement_sequence,
+                            state->doorbell_sequence, graph_commands,
+                            state->sequence);
+  }
+  // The CPU progress worker observes round-0 consumption and publishes the
+  // round-1 producer doorbell before its ordered payload RDMA. The GPU must not
+  // create a second round-1 producer.
+  wait_for_sequence_block(&control1->remote_sequence,
+                          state->doorbell_sequence, graph_commands,
+                          state->sequence);
+}
+
+__global__ void tp4_split_reduce_round1(
+    std::uint8_t* round1_buffer, Tp2BufferLayout round1_layout,
+    __nv_bfloat16* output,
+    const SplitGraphOperationState* state) {
+  round1_buffer += state->slot * round1_layout.total_bytes;
+  const auto* send1 = reinterpret_cast<const __nv_bfloat162*>(
+      round1_buffer + round1_layout.send_offset);
+  const auto* receive1 = reinterpret_cast<const __nv_bfloat162*>(
+      round1_buffer + round1_layout.receive_offset);
+  auto* output_pairs = reinterpret_cast<__nv_bfloat162*>(output);
+  const std::size_t begin_byte =
+      static_cast<std::size_t>(blockIdx.x) * kSplitGraphTileBytes;
+  const std::size_t candidate_end = begin_byte + kSplitGraphTileBytes;
+  const std::size_t end_byte =
+      candidate_end < state->payload_bytes
+          ? candidate_end
+          : state->payload_bytes;
+  const std::size_t begin = begin_byte / sizeof(__nv_bfloat162);
+  const std::size_t end = end_byte / sizeof(__nv_bfloat162);
+  for (std::size_t index = begin + threadIdx.x; index < end;
+       index += blockDim.x) {
+    output_pairs[index] = __hadd2(send1[index], receive1[index]);
+  }
+}
+
+__global__ void tp4_split_finish(
+    std::uint8_t* round1_buffer, Tp2BufferLayout round1_layout,
+    const SplitGraphOperationState* state,
+    Tp4GraphCommandRing* graph_commands,
+    Tp4AllreduceProtocol protocol) {
+  round1_buffer += state->slot * round1_layout.total_bytes;
+  auto* control1 = reinterpret_cast<DoorbellControl*>(
+      round1_buffer + round1_layout.control_offset);
+  publish_sequence_block(&control1->consumer_sequence,
+                         state->doorbell_sequence);
+  if (!tp4_protocol_uses_deferred_ack(protocol)) {
+    wait_for_sequence_block(&control1->acknowledgement_sequence,
+                            state->doorbell_sequence, graph_commands,
+                            state->sequence);
+  }
+  publish_sequence_block(&control1->observed_sequence,
+                         state->doorbell_sequence);
+}
+
+__device__ std::size_t tp4_striped_lane_offset(
+    const Tp4StripedEndpointLayout& layout, std::size_t generation,
+    Tp4TensorStripe stripe) {
+  return generation * layout.generation_stride +
+         static_cast<std::size_t>(stripe) * layout.lane_stride;
+}
+
+__device__ DoorbellControl* tp4_striped_control(
+    std::uint8_t* endpoint_buffer,
+    const Tp4StripedEndpointLayout& layout, std::size_t generation,
+    Tp4TensorStripe stripe) {
+  return reinterpret_cast<DoorbellControl*>(
+      endpoint_buffer +
+      tp4_striped_lane_offset(layout, generation, stripe) +
+      layout.lane_control_offset);
+}
+
+__global__ void tp4_striped_claim_and_gate(
+    Tp4GraphCommandRing* graph_commands,
+    std::uint8_t* endpoint0_buffer, std::uint8_t* endpoint1_buffer,
+    Tp4StripedEndpointLayout layout,
+    StripedGraphOperationState* state, std::uint32_t graph_q,
+    std::uint32_t payload_bytes, bool graph_trace,
+    Tp4AllreduceProtocol protocol) {
+  if (threadIdx.x == 0) {
+    const std::uint64_t sequence = graph_publish_command(
+        graph_commands, graph_trace, graph_q, payload_bytes);
+    state->sequence = sequence;
+    state->doorbell_sequence =
+        (sequence << kTp4GraphDoorbellQBits) | graph_q;
+    state->payload_bytes = payload_bytes;
+    state->stripe_bytes = payload_bytes / 2U;
+    state->generation = static_cast<std::size_t>(
+        (sequence - 1U) % kTp4StripedGenerationCount);
+  }
+  __syncthreads();
+
+  // This is one generation-ownership transaction. No lane may be overwritten
+  // until the peer has returned the exact raw S-2 credit for all four lane
+  // controls in the selected generation.
+  const std::uint64_t prior_sequence =
+      tp4_expected_reuse_credit(state->sequence, protocol);
+  const auto* endpoint0_lower = tp4_striped_control(
+      endpoint0_buffer, layout, state->generation,
+      Tp4TensorStripe::kLowerHalf);
+  const auto* endpoint0_upper = tp4_striped_control(
+      endpoint0_buffer, layout, state->generation,
+      Tp4TensorStripe::kUpperHalf);
+  const auto* endpoint1_lower = tp4_striped_control(
+      endpoint1_buffer, layout, state->generation,
+      Tp4TensorStripe::kLowerHalf);
+  const auto* endpoint1_upper = tp4_striped_control(
+      endpoint1_buffer, layout, state->generation,
+      Tp4TensorStripe::kUpperHalf);
+  wait_for_sequence_block(
+      &endpoint0_lower->acknowledgement_sequence, prior_sequence,
+      graph_commands, state->sequence);
+  wait_for_sequence_block(
+      &endpoint0_upper->acknowledgement_sequence, prior_sequence,
+      graph_commands, state->sequence);
+  wait_for_sequence_block(
+      &endpoint1_lower->acknowledgement_sequence, prior_sequence,
+      graph_commands, state->sequence);
+  wait_for_sequence_block(
+      &endpoint1_upper->acknowledgement_sequence, prior_sequence,
+      graph_commands, state->sequence);
+}
+
+__global__ void tp4_striped_stage_phase1(
+    std::uint8_t* endpoint0_buffer, std::uint8_t* endpoint1_buffer,
+    Tp4StripedEndpointLayout layout, const __nv_bfloat16* input,
+    const StripedGraphOperationState* state) {
+  const std::size_t block = static_cast<std::size_t>(blockIdx.x);
+  const std::size_t stripe_index = block & 1U;
+  const std::size_t tile = block >> 1U;
+  const Tp4TensorStripe stripe =
+      stripe_index == 0 ? Tp4TensorStripe::kLowerHalf
+                        : Tp4TensorStripe::kUpperHalf;
+  std::uint8_t* endpoint =
+      stripe == Tp4TensorStripe::kLowerHalf
+          ? endpoint0_buffer
+          : endpoint1_buffer;
+  auto* send = reinterpret_cast<__nv_bfloat16*>(
+      endpoint + tp4_striped_lane_offset(
+                     layout, state->generation, stripe));
+  const std::size_t begin_byte = tile * kSplitGraphTileBytes;
+  const std::size_t candidate_end = begin_byte + kSplitGraphTileBytes;
+  const std::size_t end_byte =
+      candidate_end < state->stripe_bytes
+          ? candidate_end
+          : state->stripe_bytes;
+  const std::size_t begin = begin_byte / sizeof(__nv_bfloat16);
+  const std::size_t end = end_byte / sizeof(__nv_bfloat16);
+  const std::size_t input_offset =
+      stripe_index * (state->stripe_bytes / sizeof(__nv_bfloat16));
+  for (std::size_t index = begin + threadIdx.x; index < end;
+       index += blockDim.x) {
+    send[index] = input[input_offset + index];
+  }
+}
+
+__global__ void tp4_striped_publish_phase1(
+    std::uint8_t* endpoint0_buffer, std::uint8_t* endpoint1_buffer,
+    Tp4StripedEndpointLayout layout,
+    const StripedGraphOperationState* state) {
+  auto* endpoint0_lower = tp4_striped_control(
+      endpoint0_buffer, layout, state->generation,
+      Tp4TensorStripe::kLowerHalf);
+  auto* endpoint1_upper = tp4_striped_control(
+      endpoint1_buffer, layout, state->generation,
+      Tp4TensorStripe::kUpperHalf);
+  publish_sequence_block(&endpoint0_lower->producer_sequence,
+                         state->doorbell_sequence);
+  publish_sequence_block(&endpoint1_upper->producer_sequence,
+                         state->doorbell_sequence);
+}
+
+__global__ void tp4_striped_wait_phase1(
+    std::uint8_t* endpoint0_buffer, std::uint8_t* endpoint1_buffer,
+    Tp4StripedEndpointLayout layout,
+    const StripedGraphOperationState* state,
+    Tp4GraphCommandRing* graph_commands) {
+  const auto* endpoint0_lower = tp4_striped_control(
+      endpoint0_buffer, layout, state->generation,
+      Tp4TensorStripe::kLowerHalf);
+  const auto* endpoint1_upper = tp4_striped_control(
+      endpoint1_buffer, layout, state->generation,
+      Tp4TensorStripe::kUpperHalf);
+  wait_for_sequence_block(&endpoint0_lower->remote_sequence,
+                          state->doorbell_sequence, graph_commands,
+                          state->sequence);
+  wait_for_sequence_block(&endpoint1_upper->remote_sequence,
+                          state->doorbell_sequence, graph_commands,
+                          state->sequence);
+}
+
+__global__ void tp4_striped_reduce_phase1(
+    std::uint8_t* endpoint0_buffer, std::uint8_t* endpoint1_buffer,
+    Tp4StripedEndpointLayout layout,
+    const StripedGraphOperationState* state) {
+  const std::size_t block = static_cast<std::size_t>(blockIdx.x);
+  const std::size_t stripe_index = block & 1U;
+  const std::size_t tile = block >> 1U;
+  const Tp4TensorStripe stripe =
+      stripe_index == 0 ? Tp4TensorStripe::kLowerHalf
+                        : Tp4TensorStripe::kUpperHalf;
+  std::uint8_t* source_endpoint =
+      stripe == Tp4TensorStripe::kLowerHalf
+          ? endpoint0_buffer
+          : endpoint1_buffer;
+  std::uint8_t* destination_endpoint =
+      stripe == Tp4TensorStripe::kLowerHalf
+          ? endpoint1_buffer
+          : endpoint0_buffer;
+  const std::size_t source_lane = tp4_striped_lane_offset(
+      layout, state->generation, stripe);
+  const std::size_t destination_lane = tp4_striped_lane_offset(
+      layout, state->generation, stripe);
+  const auto* send = reinterpret_cast<const __nv_bfloat162*>(
+      source_endpoint + source_lane);
+  const auto* receive = reinterpret_cast<const __nv_bfloat162*>(
+      source_endpoint + source_lane + layout.lane_receive_offset);
+  auto* phase2_send = reinterpret_cast<__nv_bfloat162*>(
+      destination_endpoint + destination_lane);
+  const std::size_t begin_byte = tile * kSplitGraphTileBytes;
+  const std::size_t candidate_end = begin_byte + kSplitGraphTileBytes;
+  const std::size_t end_byte =
+      candidate_end < state->stripe_bytes
+          ? candidate_end
+          : state->stripe_bytes;
+  const std::size_t begin = begin_byte / sizeof(__nv_bfloat162);
+  const std::size_t end = end_byte / sizeof(__nv_bfloat162);
+  for (std::size_t index = begin + threadIdx.x; index < end;
+       index += blockDim.x) {
+    phase2_send[index] = __hadd2(send[index], receive[index]);
+  }
+}
+
+__global__ void tp4_striped_handoff_phase2(
+    std::uint8_t* endpoint0_buffer, std::uint8_t* endpoint1_buffer,
+    Tp4StripedEndpointLayout layout,
+    const StripedGraphOperationState* state,
+    Tp4GraphCommandRing* graph_commands) {
+  auto* endpoint0_lower = tp4_striped_control(
+      endpoint0_buffer, layout, state->generation,
+      Tp4TensorStripe::kLowerHalf);
+  auto* endpoint1_upper = tp4_striped_control(
+      endpoint1_buffer, layout, state->generation,
+      Tp4TensorStripe::kUpperHalf);
+  const auto* endpoint1_lower = tp4_striped_control(
+      endpoint1_buffer, layout, state->generation,
+      Tp4TensorStripe::kLowerHalf);
+  const auto* endpoint0_upper = tp4_striped_control(
+      endpoint0_buffer, layout, state->generation,
+      Tp4TensorStripe::kUpperHalf);
+  publish_sequence_block(&endpoint0_lower->consumer_sequence,
+                         state->doorbell_sequence);
+  publish_sequence_block(&endpoint1_upper->consumer_sequence,
+                         state->doorbell_sequence);
+  // The host progress engine owns both phase-2 producer publications after it
+  // observes the phase-1 consumers. The GPU only waits for the ordered remote
+  // phase-2 payload+doorbell writes.
+  wait_for_sequence_block(&endpoint1_lower->remote_sequence,
+                          state->doorbell_sequence, graph_commands,
+                          state->sequence);
+  wait_for_sequence_block(&endpoint0_upper->remote_sequence,
+                          state->doorbell_sequence, graph_commands,
+                          state->sequence);
+}
+
+__global__ void tp4_striped_reduce_phase2(
+    std::uint8_t* endpoint0_buffer, std::uint8_t* endpoint1_buffer,
+    Tp4StripedEndpointLayout layout, __nv_bfloat16* output,
+    const StripedGraphOperationState* state) {
+  const std::size_t block = static_cast<std::size_t>(blockIdx.x);
+  const std::size_t stripe_index = block & 1U;
+  const std::size_t tile = block >> 1U;
+  const Tp4TensorStripe stripe =
+      stripe_index == 0 ? Tp4TensorStripe::kLowerHalf
+                        : Tp4TensorStripe::kUpperHalf;
+  std::uint8_t* endpoint =
+      stripe == Tp4TensorStripe::kLowerHalf
+          ? endpoint1_buffer
+          : endpoint0_buffer;
+  const std::size_t lane = tp4_striped_lane_offset(
+      layout, state->generation, stripe);
+  const auto* send = reinterpret_cast<const __nv_bfloat162*>(
+      endpoint + lane);
+  const auto* receive = reinterpret_cast<const __nv_bfloat162*>(
+      endpoint + lane + layout.lane_receive_offset);
+  auto* output_pairs = reinterpret_cast<__nv_bfloat162*>(output);
+  const std::size_t begin_byte = tile * kSplitGraphTileBytes;
+  const std::size_t candidate_end = begin_byte + kSplitGraphTileBytes;
+  const std::size_t end_byte =
+      candidate_end < state->stripe_bytes
+          ? candidate_end
+          : state->stripe_bytes;
+  const std::size_t begin = begin_byte / sizeof(__nv_bfloat162);
+  const std::size_t end = end_byte / sizeof(__nv_bfloat162);
+  const std::size_t output_offset =
+      stripe_index * (state->stripe_bytes / sizeof(__nv_bfloat162));
+  for (std::size_t index = begin + threadIdx.x; index < end;
+       index += blockDim.x) {
+    output_pairs[output_offset + index] =
+        __hadd2(send[index], receive[index]);
+  }
+}
+
+__global__ void tp4_striped_finish(
+    std::uint8_t* endpoint0_buffer, std::uint8_t* endpoint1_buffer,
+    Tp4StripedEndpointLayout layout,
+    const StripedGraphOperationState* state) {
+  auto* endpoint1_lower = tp4_striped_control(
+      endpoint1_buffer, layout, state->generation,
+      Tp4TensorStripe::kLowerHalf);
+  auto* endpoint0_upper = tp4_striped_control(
+      endpoint0_buffer, layout, state->generation,
+      Tp4TensorStripe::kUpperHalf);
+  publish_sequence_block(&endpoint1_lower->consumer_sequence,
+                         state->doorbell_sequence);
+  publish_sequence_block(&endpoint0_upper->consumer_sequence,
+                         state->doorbell_sequence);
+  publish_sequence_block(&endpoint1_lower->observed_sequence,
+                         state->doorbell_sequence);
+  publish_sequence_block(&endpoint0_upper->observed_sequence,
+                         state->doorbell_sequence);
 }
 
 }  // namespace
@@ -249,12 +750,18 @@ GpuTp4TensorWorker::GpuTp4TensorWorker(
     std::size_t payload_bytes, void* round0_mapped_device_buffer,
     const Tp2BufferLayout& round0_layout,
     void* round1_mapped_device_buffer,
-    const Tp2BufferLayout& round1_layout)
+    const Tp2BufferLayout& round1_layout,
+    Tp4AllreduceProtocol protocol,
+    Tp4GraphKernelStrategy graph_kernel_strategy,
+    Tp4AllreduceSchedule schedule)
     : round0_buffer_(round0_mapped_device_buffer),
       round1_buffer_(round1_mapped_device_buffer),
       round0_layout_(round0_layout),
       round1_layout_(round1_layout),
-      payload_bytes_(payload_bytes) {
+      payload_bytes_(payload_bytes),
+      protocol_(protocol),
+      graph_kernel_strategy_(graph_kernel_strategy),
+      schedule_(schedule) {
   if (payload_bytes_ == 0 ||
       payload_bytes_ % sizeof(__nv_bfloat16) != 0) {
     throw std::invalid_argument(
@@ -263,7 +770,39 @@ GpuTp4TensorWorker::GpuTp4TensorWorker(
   if (round0_buffer_ == nullptr || round1_buffer_ == nullptr) {
     throw std::invalid_argument("TP4 tensor worker received a null buffer");
   }
+  if (!tp4_graph_kernel_strategy_valid(graph_kernel_strategy_)) {
+    throw std::invalid_argument("invalid graph TP4 kernel strategy");
+  }
+  if (!tp4_allreduce_schedule_valid(schedule_)) {
+    throw std::invalid_argument("invalid TP4 all-reduce schedule");
+  }
+  if (schedule_ == Tp4AllreduceSchedule::kDualPortStriped) {
+    if (!tp4_protocol_uses_deferred_ack(protocol_) ||
+        graph_kernel_strategy_ != Tp4GraphKernelStrategy::kFused) {
+      throw std::invalid_argument(
+          "dual_port_striped graph TP4 requires fused kernel selection "
+          "and two_slot_deferred_ack");
+    }
+    static_cast<void>(
+        make_tp4_striped_endpoint_layout(payload_bytes_));
+    check_cuda(cudaMalloc(&striped_graph_state_,
+                          sizeof(StripedGraphOperationState)),
+               "cudaMalloc striped graph TP4 state");
+  } else if (tp4_graph_kernel_strategy_is_graph_only(
+                 graph_kernel_strategy_)) {
+    check_cuda(cudaMalloc(&split_graph_state_,
+                          sizeof(SplitGraphOperationState)),
+               "cudaMalloc split graph TP4 state");
+  }
+}
 
+GpuTp4TensorWorker::~GpuTp4TensorWorker() {
+  if (split_graph_state_ != nullptr) {
+    (void)cudaFree(split_graph_state_);
+  }
+  if (striped_graph_state_ != nullptr) {
+    (void)cudaFree(striped_graph_state_);
+  }
 }
 
 void GpuTp4TensorWorker::enqueue(const void* external_input,
@@ -272,6 +811,18 @@ void GpuTp4TensorWorker::enqueue(const void* external_input,
   if (external_input == nullptr || external_output == nullptr ||
       sequence == 0) {
     throw std::invalid_argument("invalid TP4 tensor operation");
+  }
+  if (schedule_ != Tp4AllreduceSchedule::kSequential) {
+    throw std::logic_error(
+        "dual_port_striped TP4 is restricted to graph all-reduce");
+  }
+  if (tp4_protocol_uses_deferred_ack(protocol_)) {
+    throw std::logic_error(
+        "two-slot deferred ACK is restricted to graph TP4 all-reduce");
+  }
+  if (graph_kernel_strategy_ != Tp4GraphKernelStrategy::kFused) {
+    throw std::logic_error(
+        "research TP4 kernel strategies are restricted to graph all-reduce");
   }
   const auto caller_stream = static_cast<cudaStream_t>(cuda_stream);
   constexpr int threads = 256;
@@ -283,7 +834,7 @@ void GpuTp4TensorWorker::enqueue(const void* external_input,
       static_cast<std::uint8_t*>(round1_buffer_), round1_layout_,
       static_cast<const __nv_bfloat16*>(external_input),
       static_cast<__nv_bfloat16*>(external_output), payload_bytes_, sequence,
-      nullptr, 0, false);
+      nullptr, 0, false, protocol_);
   check_cuda(cudaGetLastError(), "tp4_tensor_all_reduce launch");
 }
 
@@ -304,13 +855,115 @@ void GpuTp4TensorWorker::enqueue_graph(
     throw std::invalid_argument("invalid graph TP4 tensor operation");
   }
   const auto caller_stream = static_cast<cudaStream_t>(cuda_stream);
+  if (schedule_ == Tp4AllreduceSchedule::kDualPortStriped) {
+    if (active_payload_bytes != payload_bytes_ ||
+        !tp4_protocol_uses_deferred_ack(protocol_) ||
+        graph_kernel_strategy_ != Tp4GraphKernelStrategy::kFused ||
+        striped_graph_state_ == nullptr) {
+      throw std::invalid_argument(
+          "dual_port_striped graph TP4 requires one fixed-Q fused/deferred "
+          "session with initialized striped state");
+    }
+    const Tp4StripedEndpointLayout striped_layout =
+        make_tp4_striped_endpoint_layout(active_payload_bytes);
+    constexpr int control_threads = 32;
+    constexpr int bulk_threads = 256;
+    const int stripe_blocks = static_cast<int>(
+        (striped_layout.stripe_bytes + kSplitGraphTileBytes - 1) /
+        kSplitGraphTileBytes);
+    const int bulk_blocks = 2 * stripe_blocks;
+    auto* const state = static_cast<StripedGraphOperationState*>(
+        striped_graph_state_);
+    auto* const endpoint0 = static_cast<std::uint8_t*>(round0_buffer_);
+    auto* const endpoint1 = static_cast<std::uint8_t*>(round1_buffer_);
+
+    tp4_striped_claim_and_gate<<<1, control_threads, 0, caller_stream>>>(
+        command_ring, endpoint0, endpoint1, striped_layout, state, q,
+        active_payload_bytes, trace, protocol_);
+    check_cuda(cudaGetLastError(), "striped graph TP4 claim/gate launch");
+    tp4_striped_stage_phase1<<<bulk_blocks, bulk_threads, 0, caller_stream>>>(
+        endpoint0, endpoint1, striped_layout,
+        static_cast<const __nv_bfloat16*>(external_input), state);
+    check_cuda(cudaGetLastError(), "striped graph TP4 phase-1 stage launch");
+    tp4_striped_publish_phase1<<<1, control_threads, 0, caller_stream>>>(
+        endpoint0, endpoint1, striped_layout, state);
+    check_cuda(cudaGetLastError(),
+               "striped graph TP4 phase-1 publish launch");
+    tp4_striped_wait_phase1<<<1, control_threads, 0, caller_stream>>>(
+        endpoint0, endpoint1, striped_layout, state, command_ring);
+    check_cuda(cudaGetLastError(), "striped graph TP4 phase-1 wait launch");
+    tp4_striped_reduce_phase1<<<bulk_blocks, bulk_threads, 0, caller_stream>>>(
+        endpoint0, endpoint1, striped_layout, state);
+    check_cuda(cudaGetLastError(),
+               "striped graph TP4 phase-1 reduce launch");
+    tp4_striped_handoff_phase2<<<1, control_threads, 0, caller_stream>>>(
+        endpoint0, endpoint1, striped_layout, state, command_ring);
+    check_cuda(cudaGetLastError(),
+               "striped graph TP4 phase-2 handoff launch");
+    tp4_striped_reduce_phase2<<<bulk_blocks, bulk_threads, 0, caller_stream>>>(
+        endpoint0, endpoint1, striped_layout,
+        static_cast<__nv_bfloat16*>(external_output), state);
+    check_cuda(cudaGetLastError(),
+               "striped graph TP4 phase-2 reduce launch");
+    tp4_striped_finish<<<1, control_threads, 0, caller_stream>>>(
+        endpoint0, endpoint1, striped_layout, state);
+    check_cuda(cudaGetLastError(), "striped graph TP4 finish launch");
+    return;
+  }
+  if (tp4_graph_kernel_uses_split(graph_kernel_strategy_, q)) {
+    if (!split_graph_q_supported(q) || split_graph_state_ == nullptr) {
+      throw std::invalid_argument(
+          "split_64k graph TP4 requires Q1 through Q512 and initialized "
+          "split state");
+    }
+    constexpr int control_threads = 32;
+    constexpr int bulk_threads = 256;
+    const int bulk_blocks = static_cast<int>(
+        (active_payload_bytes + kSplitGraphTileBytes - 1) /
+        kSplitGraphTileBytes);
+    auto* const state = static_cast<SplitGraphOperationState*>(
+        split_graph_state_);
+    auto* const round0 = static_cast<std::uint8_t*>(round0_buffer_);
+    auto* const round1 = static_cast<std::uint8_t*>(round1_buffer_);
+
+    tp4_split_claim_command<<<1, control_threads, 0, caller_stream>>>(
+        command_ring, round0, round0_layout_, state, q,
+        active_payload_bytes, trace, protocol_);
+    check_cuda(cudaGetLastError(), "split graph TP4 claim launch");
+    tp4_split_stage_round0<<<bulk_blocks, bulk_threads, 0, caller_stream>>>(
+        round0, round0_layout_,
+        static_cast<const __nv_bfloat16*>(external_input), state);
+    check_cuda(cudaGetLastError(), "split graph TP4 round-0 stage launch");
+    tp4_split_publish_round0<<<1, control_threads, 0, caller_stream>>>(
+        round0, round0_layout_, state);
+    check_cuda(cudaGetLastError(), "split graph TP4 round-0 publish launch");
+    tp4_split_wait_round0<<<1, control_threads, 0, caller_stream>>>(
+        round0, round0_layout_, round1, round1_layout_, state,
+        command_ring, protocol_);
+    check_cuda(cudaGetLastError(), "split graph TP4 round-0 wait launch");
+    tp4_split_reduce_round0<<<bulk_blocks, bulk_threads, 0, caller_stream>>>(
+        round0, round0_layout_, round1, round1_layout_, state);
+    check_cuda(cudaGetLastError(), "split graph TP4 round-0 reduce launch");
+    tp4_split_handoff_round1<<<1, control_threads, 0, caller_stream>>>(
+        round0, round0_layout_, round1, round1_layout_, state,
+        command_ring, protocol_);
+    check_cuda(cudaGetLastError(), "split graph TP4 round-1 handoff launch");
+    tp4_split_reduce_round1<<<bulk_blocks, bulk_threads, 0, caller_stream>>>(
+        round1, round1_layout_,
+        static_cast<__nv_bfloat16*>(external_output), state);
+    check_cuda(cudaGetLastError(), "split graph TP4 round-1 reduce launch");
+    tp4_split_finish<<<1, control_threads, 0, caller_stream>>>(
+        round1, round1_layout_, state, command_ring, protocol_);
+    check_cuda(cudaGetLastError(), "split graph TP4 finish launch");
+    return;
+  }
   constexpr int threads = 256;
   tp4_tensor_all_reduce<<<1, threads, 0, caller_stream>>>(
       static_cast<std::uint8_t*>(round0_buffer_), round0_layout_,
       static_cast<std::uint8_t*>(round1_buffer_), round1_layout_,
       static_cast<const __nv_bfloat16*>(external_input),
       static_cast<__nv_bfloat16*>(external_output), active_payload_bytes, 0,
-      command_ring, q, trace);
+      command_ring, q, trace, protocol_);
   check_cuda(cudaGetLastError(), "graph tp4_tensor_all_reduce launch");
 }
 

--- a/spark_transport/src/tp4_c_api.cpp
+++ b/spark_transport/src/tp4_c_api.cpp
@@ -9,6 +9,7 @@
 #include <exception>
 #include <memory>
 #include <stdexcept>
+#include <utility>
 
 namespace {
 
@@ -129,17 +130,94 @@ spark_transport::Tp4DcpOptions translate(
   return options;
 }
 
+spark_transport::Tp4GraphKernelStrategy graph_kernel_from_wire(
+    std::uint32_t value) {
+  using spark_transport::Tp4GraphKernelStrategy;
+  switch (value) {
+    case SPARK_TP4_GRAPH_KERNEL_FUSED:
+      return Tp4GraphKernelStrategy::kFused;
+    case SPARK_TP4_GRAPH_KERNEL_SPLIT_64K:
+      return Tp4GraphKernelStrategy::kSplit64KiB;
+    case SPARK_TP4_GRAPH_KERNEL_TIERED_64K:
+      return Tp4GraphKernelStrategy::kTiered64KiB;
+    default:
+      throw std::invalid_argument("invalid TP4 graph kernel strategy");
+  }
+}
+
+spark_transport::Tp4AllreduceSchedule schedule_from_wire(
+    std::uint32_t value) {
+  using spark_transport::Tp4AllreduceSchedule;
+  switch (value) {
+    case SPARK_TP4_WIRE_SCHEDULE_SEQUENTIAL:
+      return Tp4AllreduceSchedule::kSequential;
+    case SPARK_TP4_WIRE_SCHEDULE_DUAL_PORT_STRIPED:
+      return Tp4AllreduceSchedule::kDualPortStriped;
+    default:
+      throw std::invalid_argument("invalid TP4 wire schedule");
+  }
+}
+
+struct Tp4CAllreduceHandle {
+  explicit Tp4CAllreduceHandle(
+      spark_transport::Tp4AllreduceOptions options)
+      : graph_kernel_strategy(options.graph_kernel_strategy),
+        schedule(options.schedule),
+        session(std::move(options)) {}
+
+  spark_transport::Tp4GraphKernelStrategy graph_kernel_strategy;
+  spark_transport::Tp4AllreduceSchedule schedule;
+  spark_transport::Tp4AllreduceSession session;
+};
+
+Tp4CAllreduceHandle* tp4_allreduce_handle(spark_tp4_handle handle) {
+  return static_cast<Tp4CAllreduceHandle*>(handle);
+}
+
 }  // namespace
 
 extern "C" spark_tp4_handle spark_tp4_create(
     const spark_tp4_config* config, char* error, std::size_t error_bytes) {
+  return spark_tp4_create_with_protocol_and_graph_kernel(
+      config, SPARK_TP4_ALLREDUCE_PROTOCOL_SERIAL_ACK,
+      SPARK_TP4_GRAPH_KERNEL_FUSED, error, error_bytes);
+}
+
+extern "C" spark_tp4_handle spark_tp4_create_with_protocol(
+    const spark_tp4_config* config, std::uint32_t protocol, char* error,
+    std::size_t error_bytes) {
+  return spark_tp4_create_with_protocol_and_graph_kernel(
+      config, protocol, SPARK_TP4_GRAPH_KERNEL_FUSED, error,
+      error_bytes);
+}
+
+extern "C" spark_tp4_handle
+spark_tp4_create_with_protocol_and_graph_kernel(
+    const spark_tp4_config* config, std::uint32_t protocol,
+    std::uint32_t graph_kernel, char* error,
+    std::size_t error_bytes) {
+  return spark_tp4_create_with_protocol_graph_kernel_and_schedule(
+      config, protocol, graph_kernel,
+      SPARK_TP4_WIRE_SCHEDULE_SEQUENTIAL, error, error_bytes);
+}
+
+extern "C" spark_tp4_handle
+spark_tp4_create_with_protocol_graph_kernel_and_schedule(
+    const spark_tp4_config* config, std::uint32_t protocol,
+    std::uint32_t graph_kernel, std::uint32_t wire_schedule,
+    char* error, std::size_t error_bytes) {
   try {
     if (config == nullptr) {
       throw std::invalid_argument("TP4 C API config is null");
     }
-    auto session = std::make_unique<spark_transport::Tp4AllreduceSession>(
-        translate(*config));
-    return session.release();
+    auto options = translate(*config);
+    options.protocol =
+        spark_transport::tp4_allreduce_protocol_from_wire(protocol);
+    options.graph_kernel_strategy = graph_kernel_from_wire(graph_kernel);
+    options.schedule = schedule_from_wire(wire_schedule);
+    auto handle =
+        std::make_unique<Tp4CAllreduceHandle>(std::move(options));
+    return handle.release();
   } catch (const std::exception& exception) {
     copy_error(exception.what(), error, error_bytes);
     return nullptr;
@@ -156,8 +234,8 @@ extern "C" int spark_tp4_all_reduce(
     if (handle == nullptr) {
       throw std::invalid_argument("TP4 C API handle is null");
     }
-    static_cast<spark_transport::Tp4AllreduceSession*>(handle)->all_reduce(
-        input, output, cuda_stream);
+    tp4_allreduce_handle(handle)->session.all_reduce(input, output,
+                                                      cuda_stream);
     return 0;
   } catch (const std::exception& exception) {
     copy_error(exception.what(), error, error_bytes);
@@ -176,8 +254,8 @@ extern "C" int spark_tp4_capture_all_reduce(
     if (handle == nullptr) {
       throw std::invalid_argument("TP4 C API handle is null");
     }
-    static_cast<spark_transport::Tp4AllreduceSession*>(handle)
-        ->capture_all_reduce(input, output, q, cuda_stream);
+    tp4_allreduce_handle(handle)->session.capture_all_reduce(
+        input, output, q, cuda_stream);
     return 0;
   } catch (const std::exception& exception) {
     copy_error(exception.what(), error, error_bytes);
@@ -209,9 +287,8 @@ extern "C" int spark_tp4_get_graph_status(
       throw std::invalid_argument("TP4 graph status buffer is too small");
     }
 
-    const auto snapshot =
-        static_cast<spark_transport::Tp4AllreduceSession*>(handle)
-            ->graph_replay_status();
+    const auto* c_handle = tp4_allreduce_handle(handle);
+    const auto snapshot = c_handle->session.graph_replay_status();
     spark_tp4_graph_status result{};
     result.struct_size = sizeof(result);
     if (snapshot.capture_configured) {
@@ -228,6 +305,20 @@ extern "C" int spark_tp4_get_graph_status(
     }
     if (snapshot.progress_affinity_verified) {
       result.flags |= SPARK_TP4_GRAPH_STATUS_PROGRESS_AFFINITY_VERIFIED;
+    }
+    if (snapshot.two_slot_deferred_ack) {
+      result.flags |= SPARK_TP4_GRAPH_STATUS_TWO_SLOT_DEFERRED_ACK;
+    }
+    if (c_handle->graph_kernel_strategy ==
+        spark_transport::Tp4GraphKernelStrategy::kSplit64KiB) {
+      result.flags |= SPARK_TP4_GRAPH_STATUS_SPLIT_64K;
+    } else if (c_handle->graph_kernel_strategy ==
+               spark_transport::Tp4GraphKernelStrategy::kTiered64KiB) {
+      result.flags |= SPARK_TP4_GRAPH_STATUS_TIERED_64K;
+    }
+    if (c_handle->schedule ==
+        spark_transport::Tp4AllreduceSchedule::kDualPortStriped) {
+      result.flags |= SPARK_TP4_GRAPH_STATUS_DUAL_PORT_STRIPED;
     }
     if (snapshot.overflow_sequence != 0) {
       result.flags |= SPARK_TP4_GRAPH_STATUS_OVERFLOW_FATAL;
@@ -257,7 +348,7 @@ extern "C" int spark_tp4_get_graph_status(
 }
 
 extern "C" void spark_tp4_destroy(spark_tp4_handle handle) {
-  delete static_cast<spark_transport::Tp4AllreduceSession*>(handle);
+  delete tp4_allreduce_handle(handle);
 }
 
 extern "C" spark_tp4_allgather_handle spark_tp4_allgather_create(

--- a/spark_transport/src/tp4_dual_port_striped_host.hpp
+++ b/spark_transport/src/tp4_dual_port_striped_host.hpp
@@ -1,0 +1,63 @@
+#pragma once
+
+#include "spark_transport/tp4_graph_command.hpp"
+#include "spark_transport/tp4_session.hpp"
+
+#include <cstdint>
+#include <limits>
+#include <stdexcept>
+
+namespace spark_transport::detail {
+
+// A peer that only understands the legacy or ordinary two-slot layout must
+// fail the setup handshake before either side posts RDMA into a striped arena.
+constexpr std::uint16_t kTp4DualPortStripedEndpointVersion = 3;
+constexpr std::uint16_t kTp4DualPortStripedEndpointTag = 0xc204;
+
+enum class Tp4StripedWorkEvent : std::uint64_t {
+  kPhase1Doorbell = 1,
+  kPhase1Credit = 2,
+  kPhase2Doorbell = 3,
+  kPhase2Credit = 4,
+};
+
+constexpr bool tp4_striped_work_event_valid(
+    Tp4StripedWorkEvent event) noexcept {
+  switch (event) {
+    case Tp4StripedWorkEvent::kPhase1Doorbell:
+    case Tp4StripedWorkEvent::kPhase1Credit:
+    case Tp4StripedWorkEvent::kPhase2Doorbell:
+    case Tp4StripedWorkEvent::kPhase2Credit:
+      return true;
+  }
+  return false;
+}
+
+constexpr std::uint64_t tp4_striped_work_id(
+    std::uint64_t sequence, Tp4StripedWorkEvent event) {
+  if (sequence == 0 || !tp4_striped_work_event_valid(event)) {
+    throw std::invalid_argument(
+        "TP4 striped WR ID requires a positive sequence and valid event");
+  }
+  if (sequence > std::numeric_limits<std::uint64_t>::max() / 4U) {
+    throw std::overflow_error("TP4 striped WR ID overflow");
+  }
+  return 4U * (sequence - 1U) + static_cast<std::uint64_t>(event);
+}
+
+inline bool tp4_dual_port_striped_options_valid(
+    const Tp4AllreduceOptions& options) noexcept {
+  const bool graph_cpus_valid =
+      options.graph_submit_cpu.has_value() &&
+      options.graph_progress_cpu.has_value() &&
+      options.graph_submit_cpu != options.graph_progress_cpu;
+  const bool capacity_valid =
+      options.payload_bytes == tp4_graph_payload_bytes(40) ||
+      options.payload_bytes == tp4_graph_payload_bytes(512);
+  return options.schedule == Tp4AllreduceSchedule::kDualPortStriped &&
+         options.protocol == Tp4AllreduceProtocol::kTwoSlotDeferredAck &&
+         options.graph_kernel_strategy == Tp4GraphKernelStrategy::kFused &&
+         graph_cpus_valid && capacity_valid;
+}
+
+}  // namespace spark_transport::detail

--- a/spark_transport/src/tp4_session.cpp
+++ b/spark_transport/src/tp4_session.cpp
@@ -2,6 +2,7 @@
 
 #include "cuda_event_gate.hpp"
 #include "cuda_stream_handoff.hpp"
+#include "tp4_dual_port_striped_host.hpp"
 #include "spark_transport/control_channel.hpp"
 #include "spark_transport/eager_staging_timeout.hpp"
 #include "spark_transport/gpu_doorbell.hpp"
@@ -45,6 +46,10 @@ constexpr std::uint64_t kMaximumMaxInflight = 4096;
 constexpr auto kGraphProtocolTimeout = std::chrono::seconds(5);
 constexpr std::size_t kQ1PayloadBytes =
     tp4_graph_payload_bytes(1);
+// The record layout remains EndpointInfo v1. A distinct wire version makes a
+// mixed old/new deferred-credit deployment fail on both peers before either
+// peer enters the data path; old binaries otherwise ignore reserved tags.
+constexpr std::uint16_t kTwoSlotDeferredEndpointVersion = 2;
 
 bool graph_capacity_supported(std::size_t payload_bytes) {
   for (std::uint32_t q = 1;
@@ -121,25 +126,107 @@ ControlChannel open_channel(const Tp4RoundPlan& plan,
                      : ControlChannel::connect(peer, port);
 }
 
+void exchange_and_connect_endpoint(
+    ControlChannel& channel, VerbsEndpoint& endpoint,
+    Tp4AllreduceProtocol protocol, Tp4AllreduceSchedule schedule) {
+  EndpointInfo local = endpoint.local_info();
+  if (schedule == Tp4AllreduceSchedule::kDualPortStriped) {
+    local.version = detail::kTp4DualPortStripedEndpointVersion;
+    local.reserved = detail::kTp4DualPortStripedEndpointTag;
+  } else if (tp4_protocol_uses_deferred_ack(protocol)) {
+    local.version = kTwoSlotDeferredEndpointVersion;
+    local.reserved = tp4_endpoint_protocol_tag(protocol);
+  } else {
+    local.reserved = tp4_endpoint_protocol_tag(protocol);
+  }
+  const EndpointInfo remote = channel.exchange(local);
+  if (remote.version != local.version) {
+    throw std::runtime_error(
+        "TP4 all-reduce endpoint version mismatch between peers");
+  }
+  if (remote.reserved != local.reserved) {
+    throw std::runtime_error(
+        "TP4 all-reduce protocol mismatch between peers");
+  }
+  if (remote.buffer_bytes != local.buffer_bytes) {
+    throw std::runtime_error(
+        "TP4 all-reduce payload arena mismatch between peers");
+  }
+  endpoint.connect(remote, local.version);
+}
+
+DoorbellControl* slot_control(MemoryBuffer& buffer,
+                              const Tp2BufferLayout& layout,
+                              std::size_t slot) {
+  return reinterpret_cast<DoorbellControl*>(
+      static_cast<std::uint8_t*>(buffer.host_data()) +
+       slot * layout.total_bytes + layout.control_offset);
+}
+
+DoorbellControl* striped_lane_control(
+    MemoryBuffer& buffer, const Tp4StripedEndpointLayout& layout,
+    std::size_t generation, Tp4TensorStripe stripe) {
+  const Tp4StripedLaneRegion region =
+      tp4_striped_lane_region(layout, generation, stripe);
+  return reinterpret_cast<DoorbellControl*>(
+      static_cast<std::uint8_t*>(buffer.host_data()) +
+      region.control_offset);
+}
+
+void post_striped_transfer(
+    VerbsEndpoint& endpoint, const Tp4StripedLaneRegion& region,
+    std::size_t bytes, std::uint64_t doorbell_token,
+    std::uint64_t work_id) {
+  endpoint.write(region.send_offset, region.receive_offset, bytes,
+                 work_id, false);
+  endpoint.write(
+      region.control_offset +
+          offsetof(DoorbellControl, producer_sequence),
+      region.control_offset +
+          offsetof(DoorbellControl, remote_sequence),
+      sizeof(doorbell_token), work_id);
+}
+
+void post_striped_credit(
+    VerbsEndpoint& endpoint, DoorbellControl& control,
+    const Tp4StripedLaneRegion& region, std::uint64_t sequence,
+    std::uint64_t work_id) {
+  store_sequence(&control.reserved, sequence);
+  endpoint.write(
+      region.control_offset + offsetof(DoorbellControl, reserved),
+      region.control_offset +
+          offsetof(DoorbellControl, acknowledgement_sequence),
+      sizeof(sequence), work_id, true);
+}
+
 void exchange_round(VerbsEndpoint& endpoint, DoorbellControl& control,
                     const Tp2BufferLayout& layout, std::size_t bytes,
+                    std::size_t slot_offset, std::uint64_t sequence,
                     std::uint64_t doorbell_token, std::uint32_t rank,
                     std::uint32_t round, bool trace,
+                    Tp4AllreduceProtocol protocol,
                     bool require_exact_doorbell,
                     std::chrono::seconds timeout) {
   store_sequence(&control.producer_sequence, doorbell_token);
-  endpoint.write(layout.send_offset, layout.receive_offset, bytes,
+  endpoint.write(slot_offset + layout.send_offset,
+                 slot_offset + layout.receive_offset, bytes,
                  doorbell_token, false);
   endpoint.write(
-      layout.control_offset + offsetof(DoorbellControl, producer_sequence),
-      layout.control_offset + offsetof(DoorbellControl, remote_sequence),
+      slot_offset + layout.control_offset +
+          offsetof(DoorbellControl, producer_sequence),
+      slot_offset + layout.control_offset +
+          offsetof(DoorbellControl, remote_sequence),
       sizeof(doorbell_token), doorbell_token);
   if (trace) {
     std::fprintf(stderr,
                  "EXCHANGE rank=%u round=%u state=doorbell_posted\n",
                  rank, round);
   }
-  endpoint.wait_for_send(doorbell_token);
+  if (tp4_protocol_uses_deferred_ack(protocol)) {
+    endpoint.wait_for_send_through(doorbell_token);
+  } else {
+    endpoint.wait_for_send(doorbell_token);
+  }
   if (trace) {
     std::fprintf(stderr,
                  "EXCHANGE rank=%u round=%u state=send_complete\n",
@@ -154,18 +241,34 @@ void exchange_round(VerbsEndpoint& endpoint, DoorbellControl& control,
                  "EXCHANGE rank=%u round=%u state=gpu_complete\n",
                  rank, round);
   }
-  endpoint.write(
-      layout.control_offset + offsetof(DoorbellControl, consumer_sequence),
-      layout.control_offset +
-          offsetof(DoorbellControl, acknowledgement_sequence),
-      sizeof(doorbell_token), doorbell_token, false);
-  wait_for_sequence(&control.acknowledgement_sequence, doorbell_token,
-                    "peer tensor consumption", require_exact_doorbell,
-                    timeout);
-  if (trace) {
-    std::fprintf(stderr,
-                 "EXCHANGE rank=%u round=%u state=peer_consumed\n",
-                 rank, round);
+  if (tp4_protocol_uses_deferred_ack(protocol)) {
+    store_sequence(&control.reserved, sequence);
+    endpoint.write(
+        slot_offset + layout.control_offset +
+            offsetof(DoorbellControl, reserved),
+        slot_offset + layout.control_offset +
+            offsetof(DoorbellControl, acknowledgement_sequence),
+        sizeof(sequence), doorbell_token, true);
+    if (trace) {
+      std::fprintf(stderr,
+                   "EXCHANGE rank=%u round=%u state=credit_posted\n",
+                   rank, round);
+    }
+  } else {
+    endpoint.write(
+        slot_offset + layout.control_offset +
+            offsetof(DoorbellControl, consumer_sequence),
+        slot_offset + layout.control_offset +
+            offsetof(DoorbellControl, acknowledgement_sequence),
+        sizeof(doorbell_token), doorbell_token, false);
+    wait_for_sequence(&control.acknowledgement_sequence, doorbell_token,
+                      "peer tensor consumption", require_exact_doorbell,
+                      timeout);
+    if (trace) {
+      std::fprintf(stderr,
+                   "EXCHANGE rank=%u round=%u state=peer_consumed\n",
+                   rank, round);
+    }
   }
 }
 
@@ -256,14 +359,49 @@ class Tp4AllreduceSession::Impl {
     if (options_.rank >= 4 || options_.peer0.empty() ||
         options_.peer1.empty() || options_.device0.empty() ||
         options_.device1.empty() || options_.payload_bytes == 0 ||
-        options_.payload_bytes % 2 != 0) {
+        options_.payload_bytes % 2 != 0 || options_.control_port0 == 0 ||
+        options_.control_port1 == 0) {
       throw std::invalid_argument("invalid TP4 all-reduce options");
+    }
+    (void)tp4_allreduce_protocol_from_wire(
+        static_cast<std::uint32_t>(options_.protocol));
+    if (!tp4_graph_kernel_strategy_valid(
+            options_.graph_kernel_strategy)) {
+      throw std::invalid_argument("invalid graph TP4 kernel strategy");
+    }
+    if (!tp4_allreduce_schedule_valid(options_.schedule)) {
+      throw std::invalid_argument("invalid TP4 all-reduce schedule");
     }
     const bool submit_cpu_set = options_.graph_submit_cpu.has_value();
     const bool progress_cpu_set = options_.graph_progress_cpu.has_value();
     if (submit_cpu_set != progress_cpu_set) {
       throw std::invalid_argument(
           "graph submit/progress CPUs must be configured together");
+    }
+    if (options_.schedule == Tp4AllreduceSchedule::kDualPortStriped &&
+        !detail::tp4_dual_port_striped_options_valid(options_)) {
+      throw std::invalid_argument(
+          "dual-port striped TP4 requires distinct graph submit/progress "
+          "CPUs, two-slot deferred ACK, the fused graph selector, and an "
+          "exact Q40 or Q512 session capacity");
+    }
+    if (tp4_protocol_uses_deferred_ack(options_.protocol) &&
+        (!submit_cpu_set ||
+         !graph_capacity_supported(options_.payload_bytes))) {
+      throw std::invalid_argument(
+          "two-slot deferred ACK requires a graph-only TP4 all-reduce "
+          "session with a supported graph payload capacity");
+    }
+    if (tp4_graph_kernel_strategy_is_graph_only(
+            options_.graph_kernel_strategy)) {
+      if (!submit_cpu_set ||
+          !graph_capacity_supported(options_.payload_bytes)) {
+        throw std::invalid_argument(
+            std::string(tp4_graph_kernel_strategy_name(
+                            options_.graph_kernel_strategy)) +
+            " graph TP4 requires a graph-only session with exact Q1 "
+            "through Q512 capacity");
+      }
     }
     if (submit_cpu_set) {
       if (options_.graph_submit_cpu == options_.graph_progress_cpu) {
@@ -283,29 +421,32 @@ class Tp4AllreduceSession::Impl {
     const auto plan0 = make_tp4_round_plan(options_.rank, 0);
     const auto plan1 = make_tp4_round_plan(options_.rank, 1);
     layout_ = make_tp2_buffer_layout(options_.payload_bytes);
+    if (options_.schedule == Tp4AllreduceSchedule::kDualPortStriped) {
+      striped_layout_ =
+          make_tp4_striped_endpoint_layout(options_.payload_bytes);
+      arena_bytes_ = striped_layout_.total_bytes;
+    } else {
+      arena_bytes_ =
+          tp4_payload_arena_bytes(layout_.total_bytes, options_.protocol);
+    }
 
     channel0_.emplace(
         open_channel(plan0, options_.peer0, options_.control_port0));
     buffer0_ =
-        MemoryBuffer::allocate(MemoryKind::kCudaMapped, layout_.total_bytes);
+        MemoryBuffer::allocate(MemoryKind::kCudaMapped, arena_bytes_);
     endpoint0_ = std::make_unique<VerbsEndpoint>(
         options_.device0, 1, options_.gid0, *buffer0_);
-    endpoint0_->connect(channel0_->exchange(endpoint0_->local_info()));
+    exchange_and_connect_endpoint(*channel0_, *endpoint0_,
+                                  options_.protocol, options_.schedule);
 
     channel1_.emplace(
         open_channel(plan1, options_.peer1, options_.control_port1));
     buffer1_ =
-        MemoryBuffer::allocate(MemoryKind::kCudaMapped, layout_.total_bytes);
+        MemoryBuffer::allocate(MemoryKind::kCudaMapped, arena_bytes_);
     endpoint1_ = std::make_unique<VerbsEndpoint>(
         options_.device1, 1, options_.gid1, *buffer1_);
-    endpoint1_->connect(channel1_->exchange(endpoint1_->local_info()));
-
-    control0_ = reinterpret_cast<DoorbellControl*>(
-        static_cast<std::uint8_t*>(buffer0_->host_data()) +
-        layout_.control_offset);
-    control1_ = reinterpret_cast<DoorbellControl*>(
-        static_cast<std::uint8_t*>(buffer1_->host_data()) +
-        layout_.control_offset);
+    exchange_and_connect_endpoint(*channel1_, *endpoint1_,
+                                  options_.protocol, options_.schedule);
 
     if (graph_capacity_supported(options_.payload_bytes)) {
       int device{};
@@ -327,7 +468,8 @@ class Tp4AllreduceSession::Impl {
 
     worker_ = std::make_unique<GpuTp4TensorWorker>(
         options_.payload_bytes, buffer0_->device_data(), layout_,
-        buffer1_->device_data(), layout_);
+        buffer1_->device_data(), layout_, options_.protocol,
+        options_.graph_kernel_strategy, options_.schedule);
     channel0_->barrier();
     channel1_->barrier();
     start_progress_thread();
@@ -344,6 +486,17 @@ class Tp4AllreduceSession::Impl {
         fatal_async_failure(cudaGetErrorString(result));
       }
     }
+    if (tp4_protocol_uses_deferred_ack(options_.protocol)) {
+      try {
+        const std::uint64_t published =
+            tp4_graph_command_published(graph_commands_host_);
+        wait_for_sequence(
+            &graph_commands_host_->consumer.completed_sequence, published,
+            "graph TP4 teardown completion", true);
+      } catch (const std::exception& error) {
+        fatal_async_failure(error.what());
+      }
+    }
     {
       std::lock_guard<std::mutex> lock(submission_mutex_);
       stopping_ = true;
@@ -353,6 +506,15 @@ class Tp4AllreduceSession::Impl {
     completion_cv_.notify_all();
     if (progress_thread_.joinable()) {
       progress_thread_.join();
+    }
+    if (tp4_protocol_uses_deferred_ack(options_.protocol)) {
+      try {
+        drain_deferred_credits();
+      } catch (const std::exception& error) {
+        fatal_async_failure(error.what());
+      } catch (...) {
+        fatal_async_failure("unknown deferred-credit drain failure");
+      }
     }
     worker_.reset();
   }
@@ -514,6 +676,7 @@ class Tp4AllreduceSession::Impl {
         graph_host_native_atomics_supported_,
         submit_affinity_verified_,
         progress_affinity_verified_.load(std::memory_order_acquire),
+        tp4_protocol_uses_deferred_ack(options_.protocol),
         options_.graph_submit_cpu.has_value()
             ? static_cast<int>(*options_.graph_submit_cpu)
             : -1,
@@ -527,6 +690,76 @@ class Tp4AllreduceSession::Impl {
     std::uint64_t sequence;
     bool trace;
   };
+
+  void drain_striped_deferred_credits() {
+    if (last_credit_work_id0_ != 0) {
+      endpoint0_->wait_for_send(last_credit_work_id0_);
+    }
+    if (last_credit_work_id1_ != 0) {
+      endpoint1_->wait_for_send(last_credit_work_id1_);
+    }
+
+    for (std::size_t generation = 0;
+         generation < kTp4StripedGenerationCount; ++generation) {
+      const std::uint64_t expected0 = tp4_latest_slot_sequence(
+          last_credit_sequence0_, generation, options_.protocol);
+      const std::uint64_t expected1 = tp4_latest_slot_sequence(
+          last_credit_sequence1_, generation, options_.protocol);
+      for (const Tp4TensorStripe stripe :
+           {Tp4TensorStripe::kLowerHalf,
+            Tp4TensorStripe::kUpperHalf}) {
+        if (expected0 != 0) {
+          wait_for_sequence(
+              &striped_lane_control(*buffer0_, striped_layout_,
+                                    generation, stripe)
+                   ->acknowledgement_sequence,
+              expected0, "endpoint-0 striped deferred-credit retirement",
+              true);
+        }
+        if (expected1 != 0) {
+          wait_for_sequence(
+              &striped_lane_control(*buffer1_, striped_layout_,
+                                    generation, stripe)
+                   ->acknowledgement_sequence,
+              expected1, "endpoint-1 striped deferred-credit retirement",
+              true);
+        }
+      }
+    }
+  }
+
+  void drain_deferred_credits() {
+    if (options_.schedule == Tp4AllreduceSchedule::kDualPortStriped) {
+      drain_striped_deferred_credits();
+      return;
+    }
+    if (last_credit_work_id0_ != 0) {
+      endpoint0_->wait_for_send(last_credit_work_id0_);
+    }
+    if (last_credit_work_id1_ != 0) {
+      endpoint1_->wait_for_send(last_credit_work_id1_);
+    }
+
+    const std::size_t slots = tp4_payload_slot_count(options_.protocol);
+    for (std::size_t slot = 0; slot < slots; ++slot) {
+      const std::uint64_t expected0 = tp4_latest_slot_sequence(
+          last_credit_sequence0_, slot, options_.protocol);
+      const std::uint64_t expected1 = tp4_latest_slot_sequence(
+          last_credit_sequence1_, slot, options_.protocol);
+      if (expected0 != 0) {
+        wait_for_sequence(
+            &slot_control(*buffer0_, layout_, slot)
+                 ->acknowledgement_sequence,
+            expected0, "round-0 deferred-credit retirement", true);
+      }
+      if (expected1 != 0) {
+        wait_for_sequence(
+            &slot_control(*buffer1_, layout_, slot)
+                 ->acknowledgement_sequence,
+            expected1, "round-1 deferred-credit retirement", true);
+      }
+    }
+  }
 
   void start_progress_thread() {
     std::promise<std::string> startup_promise;
@@ -642,35 +875,198 @@ class Tp4AllreduceSession::Impl {
              eager_protocol_timeout_);
   }
 
+  void progress_dual_port_striped(
+      std::uint64_t sequence, bool trace, std::size_t payload_bytes,
+      std::uint64_t doorbell_token, bool require_exact_doorbell,
+      std::chrono::seconds timeout) {
+    if (!require_exact_doorbell || payload_bytes == 0 ||
+        payload_bytes % 4U != 0 ||
+        payload_bytes / 2U > striped_layout_.stripe_bytes) {
+      throw std::logic_error(
+          "invalid dual-port striped graph progress request");
+    }
+
+    const std::size_t generation =
+        tp4_striped_generation_slot(sequence);
+    const std::size_t stripe_bytes = payload_bytes / 2U;
+    const Tp4StripedLaneRegion phase1_endpoint0_region =
+        tp4_striped_lane_region(
+            striped_layout_, generation,
+            Tp4TensorStripe::kLowerHalf);
+    const Tp4StripedLaneRegion phase1_endpoint1_region =
+        tp4_striped_lane_region(
+            striped_layout_, generation,
+            Tp4TensorStripe::kUpperHalf);
+    const Tp4StripedLaneRegion phase2_endpoint0_region =
+        tp4_striped_lane_region(
+            striped_layout_, generation,
+            Tp4TensorStripe::kUpperHalf);
+    const Tp4StripedLaneRegion phase2_endpoint1_region =
+        tp4_striped_lane_region(
+            striped_layout_, generation,
+            Tp4TensorStripe::kLowerHalf);
+    DoorbellControl* const phase1_endpoint0_control =
+        striped_lane_control(*buffer0_, striped_layout_, generation,
+                             Tp4TensorStripe::kLowerHalf);
+    DoorbellControl* const phase1_endpoint1_control =
+        striped_lane_control(*buffer1_, striped_layout_, generation,
+                             Tp4TensorStripe::kUpperHalf);
+    DoorbellControl* const phase2_endpoint0_control =
+        striped_lane_control(*buffer0_, striped_layout_, generation,
+                             Tp4TensorStripe::kUpperHalf);
+    DoorbellControl* const phase2_endpoint1_control =
+        striped_lane_control(*buffer1_, striped_layout_, generation,
+                             Tp4TensorStripe::kLowerHalf);
+
+    wait_for_sequence(
+        &phase1_endpoint0_control->producer_sequence, doorbell_token,
+        "GPU striped phase-1 endpoint-0 staging", true, timeout);
+    wait_for_sequence(
+        &phase1_endpoint1_control->producer_sequence, doorbell_token,
+        "GPU striped phase-1 endpoint-1 staging", true, timeout);
+
+    const std::uint64_t phase1_work_id =
+        detail::tp4_striped_work_id(
+            sequence, detail::Tp4StripedWorkEvent::kPhase1Doorbell);
+    post_striped_transfer(*endpoint0_, phase1_endpoint0_region,
+                          stripe_bytes, doorbell_token, phase1_work_id);
+    post_striped_transfer(*endpoint1_, phase1_endpoint1_region,
+                          stripe_bytes, doorbell_token, phase1_work_id);
+    endpoint0_->wait_for_send_through(phase1_work_id);
+    endpoint1_->wait_for_send_through(phase1_work_id);
+    if (trace) {
+      std::fprintf(
+          stderr,
+          "SESSION rank=%u state=striped_phase1_sent sequence=%llu "
+          "token=%llu bytes=%zu generation=%zu\n",
+          options_.rank, static_cast<unsigned long long>(sequence),
+          static_cast<unsigned long long>(doorbell_token), stripe_bytes,
+          generation);
+    }
+
+    wait_for_sequence(
+        &phase1_endpoint0_control->consumer_sequence, doorbell_token,
+        "GPU striped phase-1 endpoint-0 reduction", true, timeout);
+    wait_for_sequence(
+        &phase1_endpoint1_control->consumer_sequence, doorbell_token,
+        "GPU striped phase-1 endpoint-1 reduction", true, timeout);
+    const std::uint64_t phase1_credit_work_id =
+        detail::tp4_striped_work_id(
+            sequence, detail::Tp4StripedWorkEvent::kPhase1Credit);
+    post_striped_credit(*endpoint0_, *phase1_endpoint0_control,
+                         phase1_endpoint0_region, sequence,
+                         phase1_credit_work_id);
+    post_striped_credit(*endpoint1_, *phase1_endpoint1_control,
+                         phase1_endpoint1_region, sequence,
+                         phase1_credit_work_id);
+
+    // Phase-1 consumer publication is the system-fenced GPU-to-host handoff
+    // for both phase-2 send lanes. The host owns phase-2 producer publication.
+    store_sequence(&phase2_endpoint0_control->producer_sequence,
+                   doorbell_token);
+    store_sequence(&phase2_endpoint1_control->producer_sequence,
+                   doorbell_token);
+    const std::uint64_t phase2_work_id =
+        detail::tp4_striped_work_id(
+            sequence, detail::Tp4StripedWorkEvent::kPhase2Doorbell);
+    post_striped_transfer(*endpoint0_, phase2_endpoint0_region,
+                          stripe_bytes, doorbell_token, phase2_work_id);
+    post_striped_transfer(*endpoint1_, phase2_endpoint1_region,
+                          stripe_bytes, doorbell_token, phase2_work_id);
+    endpoint0_->wait_for_send_through(phase2_work_id);
+    endpoint1_->wait_for_send_through(phase2_work_id);
+    if (trace) {
+      std::fprintf(
+          stderr,
+          "SESSION rank=%u state=striped_phase2_sent sequence=%llu "
+          "token=%llu bytes=%zu generation=%zu\n",
+          options_.rank, static_cast<unsigned long long>(sequence),
+          static_cast<unsigned long long>(doorbell_token), stripe_bytes,
+          generation);
+    }
+
+    wait_for_sequence(
+        &phase2_endpoint0_control->consumer_sequence, doorbell_token,
+        "GPU striped phase-2 endpoint-0 reduction", true, timeout);
+    wait_for_sequence(
+        &phase2_endpoint1_control->consumer_sequence, doorbell_token,
+        "GPU striped phase-2 endpoint-1 reduction", true, timeout);
+    const std::uint64_t phase2_credit_work_id =
+        detail::tp4_striped_work_id(
+            sequence, detail::Tp4StripedWorkEvent::kPhase2Credit);
+    post_striped_credit(*endpoint0_, *phase2_endpoint0_control,
+                         phase2_endpoint0_region, sequence,
+                         phase2_credit_work_id);
+    post_striped_credit(*endpoint1_, *phase2_endpoint1_control,
+                         phase2_endpoint1_region, sequence,
+                         phase2_credit_work_id);
+    last_credit_work_id0_ = phase2_credit_work_id;
+    last_credit_work_id1_ = phase2_credit_work_id;
+    last_credit_sequence0_ = sequence;
+    last_credit_sequence1_ = sequence;
+    if (trace) {
+      std::fprintf(stderr,
+                   "SESSION rank=%u state=striped_output_ready\n",
+                   options_.rank);
+    }
+  }
+
   void progress(std::uint64_t sequence, bool trace,
                 std::size_t payload_bytes,
                 std::uint64_t doorbell_token,
                 bool require_exact_doorbell,
                 std::chrono::seconds timeout =
                     kGraphProtocolTimeout) {
-    wait_for_sequence(&control0_->producer_sequence, doorbell_token,
+    if (options_.schedule == Tp4AllreduceSchedule::kDualPortStriped) {
+      progress_dual_port_striped(
+          sequence, trace, payload_bytes, doorbell_token,
+          require_exact_doorbell, timeout);
+      return;
+    }
+    const std::size_t slot =
+        tp4_payload_slot_index(sequence, options_.protocol);
+    const std::size_t slot_offset = slot * layout_.total_bytes;
+    DoorbellControl* const control0 =
+        slot_control(*buffer0_, layout_, slot);
+    DoorbellControl* const control1 =
+        slot_control(*buffer1_, layout_, slot);
+    wait_for_sequence(&control0->producer_sequence, doorbell_token,
                       "GPU tensor input staging",
                       require_exact_doorbell, timeout);
     if (trace) {
       std::fprintf(
           stderr,
-          "SESSION rank=%u state=round0 sequence=%llu token=%llu bytes=%zu\n",
+          "SESSION rank=%u state=round0 sequence=%llu token=%llu "
+          "bytes=%zu slot=%zu\n",
           options_.rank, static_cast<unsigned long long>(sequence),
-          static_cast<unsigned long long>(doorbell_token), payload_bytes);
+          static_cast<unsigned long long>(doorbell_token), payload_bytes,
+          slot);
     }
-    exchange_round(*endpoint0_, *control0_, layout_, payload_bytes,
-                   doorbell_token, options_.rank, 0, trace,
+    exchange_round(*endpoint0_, *control0, layout_, payload_bytes,
+                   slot_offset, sequence, doorbell_token, options_.rank, 0,
+                   trace, options_.protocol,
                    require_exact_doorbell, timeout);
+    if (tp4_protocol_uses_deferred_ack(options_.protocol)) {
+      last_credit_work_id0_ = doorbell_token;
+      last_credit_sequence0_ = sequence;
+    }
     if (trace) {
       std::fprintf(
           stderr,
-          "SESSION rank=%u state=round1 sequence=%llu token=%llu bytes=%zu\n",
+          "SESSION rank=%u state=round1 sequence=%llu token=%llu "
+          "bytes=%zu slot=%zu\n",
           options_.rank, static_cast<unsigned long long>(sequence),
-          static_cast<unsigned long long>(doorbell_token), payload_bytes);
+          static_cast<unsigned long long>(doorbell_token), payload_bytes,
+          slot);
     }
-    exchange_round(*endpoint1_, *control1_, layout_, payload_bytes,
-                   doorbell_token, options_.rank, 1, trace,
+    exchange_round(*endpoint1_, *control1, layout_, payload_bytes,
+                   slot_offset, sequence, doorbell_token, options_.rank, 1,
+                   trace, options_.protocol,
                    require_exact_doorbell, timeout);
+    if (tp4_protocol_uses_deferred_ack(options_.protocol)) {
+      last_credit_work_id1_ = doorbell_token;
+      last_credit_sequence1_ = sequence;
+    }
     if (trace) {
       std::fprintf(stderr, "SESSION rank=%u state=output_ready\n",
                    options_.rank);
@@ -679,14 +1075,14 @@ class Tp4AllreduceSession::Impl {
 
   Tp4AllreduceOptions options_;
   Tp2BufferLayout layout_{};
+  Tp4StripedEndpointLayout striped_layout_{};
+  std::size_t arena_bytes_{};
   std::optional<ControlChannel> channel0_;
   std::optional<ControlChannel> channel1_;
   std::unique_ptr<MemoryBuffer> buffer0_;
   std::unique_ptr<MemoryBuffer> buffer1_;
   std::unique_ptr<VerbsEndpoint> endpoint0_;
   std::unique_ptr<VerbsEndpoint> endpoint1_;
-  DoorbellControl* control0_{};
-  DoorbellControl* control1_{};
   std::unique_ptr<MemoryBuffer> graph_commands_buffer_;
   Tp4GraphCommandRing* graph_commands_host_{};
   Tp4GraphCommandRing* graph_commands_device_{};
@@ -706,6 +1102,10 @@ class Tp4AllreduceSession::Impl {
   std::uint64_t sequence_{};
   std::uint64_t completed_sequence_{};
   std::uint64_t graph_consumed_sequence_{};
+  std::uint64_t last_credit_work_id0_{};
+  std::uint64_t last_credit_work_id1_{};
+  std::uint64_t last_credit_sequence0_{};
+  std::uint64_t last_credit_sequence1_{};
   void* caller_stream_{};
   bool caller_stream_set_{};
   std::atomic<bool> graph_capture_configured_{false};

--- a/spark_transport/src/verbs_endpoint.cpp
+++ b/spark_transport/src/verbs_endpoint.cpp
@@ -142,9 +142,10 @@ EndpointInfo VerbsEndpoint::local_info() const {
   return info;
 }
 
-void VerbsEndpoint::connect(const EndpointInfo& remote) {
+void VerbsEndpoint::connect(const EndpointInfo& remote,
+                            std::uint16_t expected_version) {
   if (remote.magic != kEndpointMagic ||
-      remote.version != kEndpointVersion) {
+      remote.version != expected_version) {
     throw std::runtime_error("incompatible remote endpoint metadata");
   }
   if (remote.qp_number == 0 || remote.rkey == 0 || remote.address == 0 ||
@@ -229,26 +230,58 @@ void VerbsEndpoint::write(std::size_t local_offset,
 }
 
 void VerbsEndpoint::wait_for_send(std::uint64_t expected_work_id) {
-  const auto deadline =
-      std::chrono::steady_clock::now() + std::chrono::seconds(5);
-  while (std::chrono::steady_clock::now() < deadline) {
+  wait_for_send_completion(expected_work_id, false);
+}
+
+void VerbsEndpoint::wait_for_send_through(
+    std::uint64_t expected_work_id) {
+  wait_for_send_completion(expected_work_id, true);
+}
+
+SendCompletionPollState VerbsEndpoint::poll_send_through(
+    std::uint64_t expected_work_id) {
+  return poll_send_completion(expected_work_id, true);
+}
+
+SendCompletionPollState VerbsEndpoint::poll_send_completion(
+    std::uint64_t expected_work_id, bool allow_older) {
+  while (true) {
     ibv_wc completion{};
     const int count = ibv_poll_cq(completion_queue_, 1, &completion);
     if (count < 0) {
       throw std::runtime_error("ibv_poll_cq failed");
     }
     if (count == 0) {
-      continue;
+      return SendCompletionPollState::kPending;
     }
     if (completion.status != IBV_WC_SUCCESS) {
       throw std::runtime_error(
           std::string("RDMA completion failed: ") +
           ibv_wc_status_str(completion.status));
     }
-    if (completion.wr_id != expected_work_id) {
-      throw std::runtime_error("unexpected RDMA completion work ID");
+
+    switch (detail::classify_send_completion(
+        expected_work_id, completion.wr_id, allow_older)) {
+      case detail::SendCompletionDisposition::kRetire:
+        continue;
+      case detail::SendCompletionDisposition::kComplete:
+        return SendCompletionPollState::kComplete;
+      case detail::SendCompletionDisposition::kUnexpected:
+        throw std::runtime_error(
+            "unexpected RDMA completion work ID");
     }
-    return;
+  }
+}
+
+void VerbsEndpoint::wait_for_send_completion(
+    std::uint64_t expected_work_id, bool allow_older) {
+  const auto deadline =
+      std::chrono::steady_clock::now() + std::chrono::seconds(5);
+  while (std::chrono::steady_clock::now() < deadline) {
+    if (poll_send_completion(expected_work_id, allow_older) ==
+        SendCompletionPollState::kComplete) {
+      return;
+    }
   }
   throw std::runtime_error("timed out waiting for RDMA completion");
 }

--- a/spark_transport/tests/gpu_doorbell_layout_test.cpp
+++ b/spark_transport/tests/gpu_doorbell_layout_test.cpp
@@ -2,6 +2,7 @@
 
 #include <cassert>
 #include <cstddef>
+#include <type_traits>
 
 int main() {
   using spark_transport::DoorbellControl;
@@ -9,6 +10,16 @@ int main() {
 
   static_assert(alignof(DoorbellControl) == 64);
   static_assert(sizeof(DoorbellControl) == 64);
+  static_assert(std::is_standard_layout_v<DoorbellControl>);
+  static_assert(std::is_trivially_copyable_v<DoorbellControl>);
+  static_assert(offsetof(DoorbellControl, command_sequence) == 0);
+  static_assert(offsetof(DoorbellControl, producer_sequence) == 8);
+  static_assert(offsetof(DoorbellControl, remote_sequence) == 16);
+  static_assert(offsetof(DoorbellControl, consumer_sequence) == 24);
+  static_assert(offsetof(DoorbellControl, acknowledgement_sequence) == 32);
+  static_assert(offsetof(DoorbellControl, observed_sequence) == 40);
+  static_assert(offsetof(DoorbellControl, mismatch_count) == 48);
+  static_assert(offsetof(DoorbellControl, reserved) == 56);
   assert(aligned_control_offset(1) == 64);
   assert(aligned_control_offset(64) == 64);
   assert(aligned_control_offset(65) == 128);

--- a/spark_transport/tests/syntax_stubs/cuda_runtime.h
+++ b/spark_transport/tests/syntax_stubs/cuda_runtime.h
@@ -1,17 +1,26 @@
 #pragma once
 
 typedef void* cudaStream_t;
+typedef void* cudaEvent_t;
 typedef int cudaError_t;
 typedef int cudaStreamCaptureStatus;
 
 static constexpr cudaError_t cudaSuccess = 0;
+static constexpr cudaError_t cudaErrorNotReady = 1;
 static constexpr cudaStreamCaptureStatus
     cudaStreamCaptureStatusActive = 1;
 static constexpr int cudaDevAttrHostNativeAtomicSupported = 0;
+static constexpr unsigned int cudaEventDisableTiming = 2;
 
 const char* cudaGetErrorString(cudaError_t);
 cudaError_t cudaGetDevice(int*);
+cudaError_t cudaSetDevice(int);
 cudaError_t cudaDeviceGetAttribute(int*, int, int);
+cudaError_t cudaEventCreateWithFlags(cudaEvent_t*, unsigned int);
+cudaError_t cudaEventDestroy(cudaEvent_t);
+cudaError_t cudaEventQuery(cudaEvent_t);
+cudaError_t cudaEventRecord(cudaEvent_t, cudaStream_t);
+cudaError_t cudaStreamWaitEvent(cudaStream_t, cudaEvent_t, unsigned int);
 cudaError_t cudaStreamIsCapturing(
     cudaStream_t, cudaStreamCaptureStatus*);
 cudaError_t cudaStreamSynchronize(cudaStream_t);

--- a/spark_transport/tests/test_tp4_deferred_ack_source_contract.py
+++ b/spark_transport/tests/test_tp4_deferred_ack_source_contract.py
@@ -1,0 +1,118 @@
+"""Offline wiring checks for the graph-only deferred-ACK experiment.
+
+These checks do not prove CUDA, RDMA, or numerical correctness. They keep the
+reviewed ownership barriers connected until the native Spark probe can compile
+and run on the target hardware.
+"""
+
+from pathlib import Path
+
+
+_TRANSPORT = Path(__file__).resolve().parents[1]
+
+
+def _read(relative: str) -> str:
+    return (_TRANSPORT / relative).read_text(encoding="utf-8")
+
+
+def test_gpu_reuse_credit_precedes_each_slot_send_write() -> None:
+    source = _read("src/gpu_tp4_tensor.cu")
+    kernel = source[
+        source.index("__global__ void tp4_tensor_all_reduce") : source.index(
+            "GpuTp4TensorWorker::GpuTp4TensorWorker"
+        )
+    ]
+
+    round0_credit = kernel.index(
+        "wait_for_sequence_block(&control0->acknowledgement_sequence"
+    )
+    round0_write = kernel.index("send0[index] = input[index]")
+    round1_credit = kernel.index(
+        "wait_for_sequence_block(&control1->acknowledgement_sequence"
+    )
+    round1_write = kernel.index("send1_pairs[index] =")
+
+    assert round0_credit < round0_write
+    assert round1_credit < round1_write
+    assert "tp4_payload_slot_index(sequence, protocol)" in kernel
+    assert "round0_buffer += slot * round0_layout.total_bytes" in kernel
+    assert "round1_buffer += slot * round1_layout.total_bytes" in kernel
+
+
+def test_host_posts_signaled_raw_credit_and_drains_final_generation() -> None:
+    source = _read("src/tp4_session.cpp")
+
+    assert "store_sequence(&control.reserved, sequence)" in source
+    assert "offsetof(DoorbellControl, reserved)" in source
+    assert "offsetof(DoorbellControl, acknowledgement_sequence)" in source
+    assert "sizeof(sequence), doorbell_token, true" in source
+    assert "endpoint.wait_for_send_through(doorbell_token)" in source
+    assert "drain_deferred_credits();" in source
+    assert "round-0 deferred-credit retirement" in source
+    assert "round-1 deferred-credit retirement" in source
+
+
+def test_deferred_endpoint_version_rejects_mixed_binaries_before_data() -> None:
+    session = _read("src/tp4_session.cpp")
+    endpoint_header = _read("include/spark_transport/verbs_endpoint.hpp")
+
+    assert "kTwoSlotDeferredEndpointVersion = 2" in session
+    assert "local.version = kTwoSlotDeferredEndpointVersion" in session
+    assert "remote.version != local.version" in session
+    assert "endpoint.connect(remote, local.version)" in session
+    assert "expected_version = kEndpointVersion" in endpoint_header
+
+
+def test_default_constructor_stays_on_serial_ack_protocol() -> None:
+    header = _read("include/spark_transport/tp4_c_api.h")
+    source = _read("src/tp4_c_api.cpp")
+
+    assert "spark_tp4_create_with_protocol" in header
+    default_create = source[
+        source.index('extern "C" spark_tp4_handle spark_tp4_create(') :
+        source.index(
+            'extern "C" spark_tp4_handle spark_tp4_create_with_protocol('
+        )
+    ]
+    assert "SPARK_TP4_ALLREDUCE_PROTOCOL_SERIAL_ACK" in default_create
+
+
+def test_native_contract_targets_are_registered() -> None:
+    cmake = _read("CMakeLists.txt")
+    assert "tp4_allreduce_protocol_test" in cmake
+    assert "tp4_c_api_layout_test" in cmake
+
+
+def test_graph_runner_forwards_and_attests_selected_protocol() -> None:
+    runner = _read("scripts/run_tp4_graph_q1_probe.ps1")
+    assert '[ValidateSet("serial_ack", "two_slot_deferred_ack")]' in runner
+    assert '"--allreduce-protocol $AllreduceProtocol"' in runner
+    assert "allreduce_protocol=$AllreduceProtocol" in runner
+    assert "protocol_status_match=true" in runner
+    assert '[ValidateSet("burst", "isolated")]' in runner
+    assert '"--timing-mode $TimingMode"' in runner
+    assert '"--fixed-q $FixedQ"' in runner
+    assert '"--entrypoint /usr/bin/env"' in runner
+    assert '"--device0 $($node.Device0) --device1 $($node.Device1)"' in runner
+    assert runner.count('Device0 = "rocep1s0f1"') == 2
+    assert runner.count('Device1 = "rocep1s0f0"') == 2
+    assert "device_output_ready_single_replay" in runner
+    assert "device_output_ready_replay_throughput" in runner
+    assert "p95_device_output_ready_us_per_graph" in runner
+
+
+def test_isolated_timing_excludes_input_preparation_and_validation() -> None:
+    source = _read("app/tp4_graph_q1_probe.cu")
+    launch = source[
+        source.index("const auto launch_graph =") : source.index(
+            "for (int iteration = 0; iteration < options.warmup"
+        )
+    ]
+
+    prepare = launch.index("prepare_replay<<<")
+    start = launch.index("cudaEventRecord(start, stream)")
+    graph = launch.index("cudaGraphLaunch(graph.executable, stream)")
+    stop = launch.index("cudaEventRecord(stop, stream)")
+    validation = launch.index("validate_active_output<<<")
+    assert prepare < start < graph < stop < validation
+    assert "options.timing_mode == TimingMode::kBurst" in source

--- a/spark_transport/tests/test_tp4_dual_port_striped_gpu_source_contract.py
+++ b/spark_transport/tests/test_tp4_dual_port_striped_gpu_source_contract.py
@@ -1,0 +1,140 @@
+"""Offline wiring checks for the research-only striped GPU schedule.
+
+These checks preserve the reviewed graph-node order and lane ownership. They
+do not prove CUDA execution, mapped-memory ordering, RDMA progress, numerical
+correctness, or performance on a four-rank Spark cluster.
+"""
+
+from pathlib import Path
+import re
+
+
+_TRANSPORT = Path(__file__).resolve().parents[1]
+
+
+def _read(relative: str) -> str:
+    return (_TRANSPORT / relative).read_text(encoding="utf-8")
+
+
+def _function_body(source: str, signature: str) -> str:
+    start = source.index(signature)
+    opening = source.index("{", start)
+    depth = 0
+    for index in range(opening, len(source)):
+        if source[index] == "{":
+            depth += 1
+        elif source[index] == "}":
+            depth -= 1
+            if depth == 0:
+                return source[opening + 1 : index]
+    raise AssertionError(f"unterminated function: {signature}")
+
+
+def test_striped_graph_launches_the_reviewed_eight_node_dag() -> None:
+    source = _read("src/gpu_tp4_tensor.cu")
+    enqueue = _function_body(source, "void GpuTp4TensorWorker::enqueue_graph(")
+    striped_start = enqueue.index(
+        "if (schedule_ == Tp4AllreduceSchedule::kDualPortStriped)"
+    )
+    sequential_start = enqueue.index(
+        "if (tp4_graph_kernel_uses_split(graph_kernel_strategy_, q))"
+    )
+    striped = enqueue[striped_start:sequential_start]
+    expected = [
+        "tp4_striped_claim_and_gate<<<",
+        "tp4_striped_stage_phase1<<<",
+        "tp4_striped_publish_phase1<<<",
+        "tp4_striped_wait_phase1<<<",
+        "tp4_striped_reduce_phase1<<<",
+        "tp4_striped_handoff_phase2<<<",
+        "tp4_striped_reduce_phase2<<<",
+        "tp4_striped_finish<<<",
+    ]
+
+    assert re.findall(r"tp4_striped_[a-z0-9_]+<<<", striped) == expected
+    assert striped_start < sequential_start
+    assert "active_payload_bytes != payload_bytes_" in striped
+    assert "tp4_protocol_uses_deferred_ack(protocol_)" in striped
+    assert "graph_kernel_strategy_ != Tp4GraphKernelStrategy::kFused" in striped
+    assert "striped_graph_state_ == nullptr" in striped
+    assert "bulk_blocks = 2 * stripe_blocks" in striped
+    assert "kSplitGraphTileBytes = 64U * 1024U" in source
+
+
+def test_striped_claim_gates_all_four_lanes_before_phase1_writes() -> None:
+    source = _read("src/gpu_tp4_tensor.cu")
+    claim = _function_body(source, "__global__ void tp4_striped_claim_and_gate(")
+    stage = _function_body(source, "__global__ void tp4_striped_stage_phase1(")
+
+    assert "__syncthreads();" in claim
+    assert "tp4_expected_reuse_credit(state->sequence, protocol)" in claim
+    assert claim.count("->acknowledgement_sequence") == 4
+    for lane in (
+        "endpoint0_lower",
+        "endpoint0_upper",
+        "endpoint1_lower",
+        "endpoint1_upper",
+    ):
+        assert f"&{lane}->acknowledgement_sequence" in claim
+    assert source.index("__global__ void tp4_striped_claim_and_gate(") < source.index(
+        "__global__ void tp4_striped_stage_phase1("
+    )
+    assert "send[index] = input[input_offset + index]" in stage
+
+
+def test_striped_lane_mapping_and_phase_handoffs_match_the_wire_schedule() -> None:
+    source = _read("src/gpu_tp4_tensor.cu")
+    stage = _function_body(source, "__global__ void tp4_striped_stage_phase1(")
+    publish1 = _function_body(source, "__global__ void tp4_striped_publish_phase1(")
+    wait1 = _function_body(source, "__global__ void tp4_striped_wait_phase1(")
+    reduce1 = _function_body(source, "__global__ void tp4_striped_reduce_phase1(")
+    handoff2 = _function_body(source, "__global__ void tp4_striped_handoff_phase2(")
+    reduce2 = _function_body(source, "__global__ void tp4_striped_reduce_phase2(")
+    finish = _function_body(source, "__global__ void tp4_striped_finish(")
+
+    # Phase 1 stages lower/A on endpoint 0 and upper/B on endpoint 1.
+    assert "? endpoint0_buffer\n          : endpoint1_buffer" in stage
+    assert "&endpoint0_lower->producer_sequence" in publish1
+    assert "&endpoint1_upper->producer_sequence" in publish1
+    assert publish1.count("->producer_sequence") == 2
+    assert "&endpoint0_lower->remote_sequence" in wait1
+    assert "&endpoint1_upper->remote_sequence" in wait1
+
+    # Cross-buffer reduction places lower/A on endpoint 1 and upper/B on
+    # endpoint 0 for the opposite-order second phase.
+    assert "source_endpoint" in reduce1
+    assert "destination_endpoint" in reduce1
+    assert "? endpoint1_buffer\n          : endpoint0_buffer" in reduce1
+    assert "phase2_send[index] = __hadd2(send[index], receive[index])" in reduce1
+    assert "? endpoint1_buffer\n          : endpoint0_buffer" in reduce2
+
+    # GPU consumption releases phase 1. Only the host publishes phase-2
+    # producers after observing both releases.
+    assert "&endpoint0_lower->consumer_sequence" in handoff2
+    assert "&endpoint1_upper->consumer_sequence" in handoff2
+    assert "->producer_sequence" not in handoff2
+    assert "&endpoint1_lower->remote_sequence" in handoff2
+    assert "&endpoint0_upper->remote_sequence" in handoff2
+
+    assert "&endpoint1_lower->consumer_sequence" in finish
+    assert "&endpoint0_upper->consumer_sequence" in finish
+    assert "&endpoint1_lower->observed_sequence" in finish
+    assert "&endpoint0_upper->observed_sequence" in finish
+
+
+def test_striped_schedule_is_graph_only_and_default_remains_sequential() -> None:
+    source = _read("src/gpu_tp4_tensor.cu")
+    worker_header = _read("include/spark_transport/gpu_tp4_tensor.hpp")
+    schedule_header = _read(
+        "include/spark_transport/tp4_dual_port_striped_allreduce.hpp"
+    )
+    eager = _function_body(source, "void GpuTp4TensorWorker::enqueue(")
+    constructor = _function_body(source, "GpuTp4TensorWorker::GpuTp4TensorWorker(")
+
+    assert "schedule_ != Tp4AllreduceSchedule::kSequential" in eager
+    assert "restricted to graph all-reduce" in eager
+    assert "tp4_protocol_uses_deferred_ack(protocol_)" in constructor
+    assert "graph_kernel_strategy_ != Tp4GraphKernelStrategy::kFused" in constructor
+    assert "Tp4AllreduceSchedule::kSequential" in worker_header
+    assert 'return "sequential";' in schedule_header
+    assert 'return "dual_port_striped";' in schedule_header

--- a/spark_transport/tests/test_tp4_dual_port_striped_host_source_contract.py
+++ b/spark_transport/tests/test_tp4_dual_port_striped_host_source_contract.py
@@ -1,0 +1,117 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _function_body(source: str, signature: str) -> str:
+    start = source.index(signature)
+    opening = source.index("{", start)
+    depth = 0
+    for index in range(opening, len(source)):
+        if source[index] == "{":
+            depth += 1
+        elif source[index] == "}":
+            depth -= 1
+            if depth == 0:
+                return source[opening + 1 : index]
+    raise AssertionError(f"unterminated function: {signature}")
+
+
+def test_striped_progress_joins_each_dual_port_phase_before_advancing() -> None:
+    source = (ROOT / "src" / "tp4_session.cpp").read_text(encoding="utf-8")
+    body = _function_body(source, "void progress_dual_port_striped(")
+
+    ordered_markers = (
+        "&phase1_endpoint0_control->producer_sequence",
+        "&phase1_endpoint1_control->producer_sequence",
+        "post_striped_transfer(*endpoint0_",
+        "post_striped_transfer(*endpoint1_",
+        "endpoint0_->wait_for_send_through(phase1_work_id)",
+        "endpoint1_->wait_for_send_through(phase1_work_id)",
+        "&phase1_endpoint0_control->consumer_sequence",
+        "&phase1_endpoint1_control->consumer_sequence",
+        "post_striped_credit(*endpoint0_",
+        "post_striped_credit(*endpoint1_",
+        "&phase2_endpoint0_control->producer_sequence",
+        "&phase2_endpoint1_control->producer_sequence",
+        "post_striped_transfer(*endpoint0_",
+        "post_striped_transfer(*endpoint1_",
+        "endpoint0_->wait_for_send_through(phase2_work_id)",
+        "endpoint1_->wait_for_send_through(phase2_work_id)",
+        "&phase2_endpoint0_control->consumer_sequence",
+        "&phase2_endpoint1_control->consumer_sequence",
+        "post_striped_credit(*endpoint0_",
+        "post_striped_credit(*endpoint1_",
+        "last_credit_work_id0_ = phase2_credit_work_id",
+        "last_credit_work_id1_ = phase2_credit_work_id",
+    )
+    cursor = 0
+    for marker in ordered_markers:
+        position = body.find(marker, cursor)
+        assert position >= 0, marker
+        cursor = position + len(marker)
+
+    graph_progress = _function_body(source, "void progress_graph_commands()")
+    assert graph_progress.index("progress(command.sequence") < graph_progress.index(
+        "tp4_graph_command_complete(graph_commands_host_, command.sequence)"
+    )
+
+
+def test_striped_setup_uses_a_distinct_exact_arena_handshake() -> None:
+    source = (ROOT / "src" / "tp4_session.cpp").read_text(encoding="utf-8")
+    constructor = _function_body(source, "explicit Impl(Tp4AllreduceOptions options)")
+    handshake = _function_body(source, "void exchange_and_connect_endpoint(")
+
+    assert "tp4_allreduce_schedule_valid(options_.schedule)" in constructor
+    assert "tp4_dual_port_striped_options_valid(options_)" in constructor
+    assert "make_tp4_striped_endpoint_layout(options_.payload_bytes)" in constructor
+    assert "arena_bytes_ = striped_layout_.total_bytes" in constructor
+    assert constructor.count("options_.protocol, options_.schedule") == 2
+    assert "options_.graph_kernel_strategy, options_.schedule" in constructor
+
+    assert "kTp4DualPortStripedEndpointVersion" in handshake
+    assert "kTp4DualPortStripedEndpointTag" in handshake
+    assert "remote.buffer_bytes != local.buffer_bytes" in handshake
+    assert handshake.index("remote.version != local.version") < handshake.index(
+        "endpoint.connect(remote, local.version)"
+    )
+
+
+def test_striped_teardown_reaps_both_qps_then_all_lane_generations() -> None:
+    source = (ROOT / "src" / "tp4_session.cpp").read_text(encoding="utf-8")
+    body = _function_body(source, "void drain_striped_deferred_credits()")
+
+    endpoint0_reap = body.index("endpoint0_->wait_for_send(last_credit_work_id0_)")
+    endpoint1_reap = body.index("endpoint1_->wait_for_send(last_credit_work_id1_)")
+    generation_loop = body.index("generation < kTp4StripedGenerationCount")
+    assert endpoint0_reap < endpoint1_reap < generation_loop
+    assert body.count("tp4_latest_slot_sequence(") == 2
+    assert "Tp4TensorStripe::kLowerHalf" in body
+    assert "Tp4TensorStripe::kUpperHalf" in body
+    assert body.count("->acknowledgement_sequence") == 2
+    assert body.count("striped deferred-credit retirement") == 2
+
+
+def test_striped_schedule_has_an_additive_attested_c_abi() -> None:
+    header = (ROOT / "include" / "spark_transport" / "tp4_c_api.h").read_text(
+        encoding="utf-8"
+    )
+    source = (ROOT / "src" / "tp4_c_api.cpp").read_text(encoding="utf-8")
+    constructor = _function_body(
+        source,
+        "spark_tp4_create_with_protocol_graph_kernel_and_schedule(",
+    )
+    legacy_constructor = _function_body(
+        source,
+        'extern "C" spark_tp4_handle\n'
+        "spark_tp4_create_with_protocol_and_graph_kernel(",
+    )
+    status = _function_body(source, 'extern "C" int spark_tp4_get_graph_status(')
+
+    assert "SPARK_TP4_WIRE_SCHEDULE_SEQUENTIAL = 0" in header
+    assert "SPARK_TP4_WIRE_SCHEDULE_DUAL_PORT_STRIPED = 1" in header
+    assert "SPARK_TP4_GRAPH_STATUS_DUAL_PORT_STRIPED = 1U << 10" in header
+    assert "options.schedule = schedule_from_wire(wire_schedule)" in constructor
+    assert "SPARK_TP4_WIRE_SCHEDULE_SEQUENTIAL" in legacy_constructor
+    assert "SPARK_TP4_GRAPH_STATUS_DUAL_PORT_STRIPED" in status

--- a/spark_transport/tests/test_tp4_split_graph_source_contract.py
+++ b/spark_transport/tests/test_tp4_split_graph_source_contract.py
@@ -1,0 +1,267 @@
+"""Offline wiring checks for split and tiered graph-kernel strategies.
+
+These checks keep the research selector narrow and preserve the reviewed
+transport handoffs. They do not prove CUDA execution, mapped-memory ordering,
+RDMA progress, numerical correctness, or performance.
+"""
+
+from pathlib import Path
+
+
+_TRANSPORT = Path(__file__).resolve().parents[1]
+
+
+def _read(relative: str) -> str:
+    return (_TRANSPORT / relative).read_text(encoding="utf-8")
+
+
+def _function(source: str, start: str, end: str) -> str:
+    return source[source.index(start) : source.index(end)]
+
+
+def test_split_graph_launches_the_reviewed_eight_node_dag() -> None:
+    source = _read("src/gpu_tp4_tensor.cu")
+    enqueue = _function(
+        source,
+        "void GpuTp4TensorWorker::enqueue_graph(",
+        "}  // namespace spark_transport",
+    )
+    launches = [
+        "tp4_split_claim_command<<<",
+        "tp4_split_stage_round0<<<",
+        "tp4_split_publish_round0<<<",
+        "tp4_split_wait_round0<<<",
+        "tp4_split_reduce_round0<<<",
+        "tp4_split_handoff_round1<<<",
+        "tp4_split_reduce_round1<<<",
+        "tp4_split_finish<<<",
+    ]
+
+    positions = [enqueue.index(launch) for launch in launches]
+    assert positions == sorted(positions)
+    assert enqueue.count("tp4_split_") == len(launches)
+    assert "kSplitGraphTileBytes = 64U * 1024U" in source
+
+
+def test_split_round_handoffs_retain_system_fences_and_cpu_round1_publish() -> None:
+    source = _read("src/gpu_tp4_tensor.cu")
+    publish0 = _function(
+        source,
+        "__global__ void tp4_split_publish_round0(",
+        "__global__ void tp4_split_wait_round0(",
+    )
+    handoff1 = _function(
+        source,
+        "__global__ void tp4_split_handoff_round1(",
+        "__global__ void tp4_split_reduce_round1(",
+    )
+    finish = _function(
+        source,
+        "__global__ void tp4_split_finish(",
+        "}  // namespace",
+    )
+
+    assert "publish_sequence_block(&control0->producer_sequence" in publish0
+    assert "publish_sequence_block(&control0->consumer_sequence" in handoff1
+    assert "wait_for_sequence_block(&control0->acknowledgement_sequence" in handoff1
+    assert "if (!tp4_protocol_uses_deferred_ack(protocol))" in handoff1
+    assert "wait_for_sequence_block(&control1->remote_sequence" in handoff1
+    assert "producer_sequence" not in handoff1
+    assert "publish_sequence_block(&control1->consumer_sequence" in finish
+    assert "wait_for_sequence_block(&control1->acknowledgement_sequence" in finish
+    assert "if (!tp4_protocol_uses_deferred_ack(protocol))" in finish
+    assert "publish_sequence_block(&control1->observed_sequence" in finish
+
+    helper = _function(
+        source,
+        "__device__ void publish_sequence_block(",
+        "__global__ void tp4_tensor_all_reduce(",
+    )
+    assert "__threadfence_system();" in helper
+
+
+def test_tiered_selector_is_explicit_and_legacy_c_api_defaults_to_fused() -> None:
+    session_header = _read("include/spark_transport/tp4_session.hpp")
+    c_api_header = _read("include/spark_transport/tp4_c_api.h")
+    c_api_source = _read("src/tp4_c_api.cpp")
+    probe = _read("app/tp4_graph_q1_probe.cu")
+
+    assert "Tp4GraphKernelStrategy::kFused" in session_header
+    assert "spark_tp4_create_with_protocol_and_graph_kernel" in c_api_header
+    assert "SPARK_TP4_GRAPH_KERNEL_TIERED_64K" in c_api_header
+    assert "SPARK_TP4_GRAPH_STATUS_TIERED_64K" in c_api_header
+    assert "SPARK_TP4_GRAPH_KERNEL_FUSED" in c_api_source
+    assert "options.graph_kernel_strategy" in c_api_source
+    assert 'argument == "--graph-kernel"' in probe
+    assert 'graph_kernel == "tiered_64k"' in probe
+    assert "fixed Q1 through Q512" in probe
+    assert "options.operations_per_graph != 1" in probe
+    assert '<< " graph_kernel="' in probe
+    assert '<< " kernel_fused_nodes="' in probe
+    assert '<< " kernel_split_64k_nodes="' in probe
+
+
+def test_probe_runner_forwards_and_attests_graph_kernel_strategy() -> None:
+    runner = _read("scripts/run_tp4_graph_q1_probe.ps1")
+
+    assert '[ValidateSet("fused", "split_64k", "tiered_64k")]' in runner
+    assert '[string]$GraphKernel = "fused"' in runner
+    assert '"--graph-kernel $GraphKernel"' in runner
+    assert '"graph_kernel=$GraphKernel(?:\\s|$)"' in runner
+    assert '"kernel_fused_nodes=$expectedKernelFusedNodes' in runner
+    assert '"kernel_split_64k_nodes=$expectedKernelSplitNodes' in runner
+    assert '"slot_reuse_exercised=$expectedSlotReuse' in runner
+
+
+def test_tiered_worker_rejects_eager_but_accepts_both_graph_protocols() -> None:
+    worker = _read("src/gpu_tp4_tensor.cu")
+    session = _read("src/tp4_session.cpp")
+    strategy = _read("include/spark_transport/tp4_graph_kernel_strategy.hpp")
+
+    assert "split_graph_q_supported(q)" in worker
+    assert "research TP4 kernel strategies are restricted to graph all-reduce" in worker
+    enqueue_graph = _function(
+        worker,
+        "void GpuTp4TensorWorker::enqueue_graph(",
+        "}  // namespace spark_transport",
+    )
+    sequential_graph = enqueue_graph[
+        enqueue_graph.index(
+            "if (tp4_graph_kernel_uses_split(graph_kernel_strategy_, q))"
+        ) :
+    ]
+    assert "tp4_protocol_uses_deferred_ack" not in sequential_graph
+    assert "tp4_graph_kernel_uses_split(graph_kernel_strategy_, q)" in enqueue_graph
+    assert "q >= 1 && q <= kTp4GraphAllreduceMaximumQ" in worker
+    assert "tp4_graph_kernel_strategy_is_graph_only" in session
+    assert "graph_capacity_supported(options_.payload_bytes)" in session
+    assert "kTp4TieredSplitMinimumQ = 7" in strategy
+    assert "q >= kTp4TieredSplitMinimumQ" in strategy
+
+
+def test_deferred_split_waits_for_exact_prior_slot_generations() -> None:
+    source = _read("src/gpu_tp4_tensor.cu")
+    claim = _function(
+        source,
+        "__global__ void tp4_split_claim_command(",
+        "__global__ void tp4_split_stage_round0(",
+    )
+    wait0 = _function(
+        source,
+        "__global__ void tp4_split_wait_round0(",
+        "__global__ void tp4_split_reduce_round0(",
+    )
+    enqueue = _function(
+        source,
+        "void GpuTp4TensorWorker::enqueue_graph(",
+        "}  // namespace spark_transport",
+    )
+
+    for barrier in (claim, wait0):
+        assert "tp4_expected_reuse_credit(state->sequence, protocol)" in barrier
+        assert "acknowledgement_sequence" in barrier
+        assert "state->sequence" in barrier
+    assert source.index("__global__ void tp4_split_claim_command(") < source.index(
+        "__global__ void tp4_split_stage_round0("
+    )
+    assert source.index("__global__ void tp4_split_wait_round0(") < source.index(
+        "__global__ void tp4_split_reduce_round0("
+    )
+    assert enqueue.index("tp4_split_claim_command<<<") < enqueue.index(
+        "tp4_split_stage_round0<<<"
+    )
+    assert enqueue.index("tp4_split_wait_round0<<<") < enqueue.index(
+        "tp4_split_reduce_round0<<<"
+    )
+
+
+def test_probe_receipt_requires_sequence_three_for_deferred_slot_reuse() -> None:
+    probe = _read("app/tp4_graph_q1_probe.cu")
+    runner = _read("scripts/run_tp4_graph_q1_probe.ps1")
+
+    assert "status.completed_sequence >= 3" in probe
+    assert '<< " payload_slots=" << payload_slots' in probe
+    assert '<< " slot_reuse_exercised="' in probe
+    assert '$expectedSlotReuse = if ($expected -ge 3)' in runner
+    assert '$expectedPayloadSlots = 2' in runner
+
+
+def test_probe_input_epoch_is_not_aligned_with_two_slot_reuse() -> None:
+    probe = _read("app/tp4_graph_q1_probe.cu")
+
+    assert "kInputEpochPeriod = 7" in probe
+    assert "kInputEpochPeriod % 2 != 0" in probe
+    assert "input_epoch % kInputEpochPeriod" in probe
+    assert "kMaximumInputValue == 32" in probe
+    assert "kMaximumReducedValue == 128" in probe
+    assert "kBfloat16ConsecutiveIntegerLimit = 256" in probe
+
+    # A physical slot's immediately prior generation is S-2. The odd period
+    # guarantees a different exactly representable input epoch at every reuse.
+    for sequence in range(3, 4097):
+        assert sequence % 7 != (sequence - 2) % 7
+
+    # Reproduce the probe's integer-valued inputs. BF16 has an eight-bit
+    # significand, so every integer through 256 is exact; both reduction
+    # stages remain below that consecutive-integer limit.
+    for epoch in range(7):
+        for element in range(8):
+            values = [
+                ((element * 3 + rank * 5) & 7) + 1 + epoch * 4
+                for rank in range(4)
+            ]
+            assert max(values) <= 32
+            assert values[0] + values[1] <= 64
+            assert values[2] + values[3] <= 64
+            assert sum(values) <= 128
+
+
+def test_mixed_graph_restages_and_validates_each_node_epoch() -> None:
+    probe = _read("app/tp4_graph_q1_probe.cu")
+    capture = _function(
+        probe,
+        "CapturedGraph capture_mixed_q_graph(",
+        "bool attempt_post_replay_capture(",
+    )
+
+    prepare = capture.index("prepare_mixed_node_input<<<")
+    collective = capture.index("session.capture_all_reduce(")
+    validate = capture.index("validate_mixed_node_output<<<")
+    assert prepare < collective < validate
+    assert "graph_epoch_offset + operation" in capture
+    assert capture.count("operations_per_cycle);") == 2
+
+    epoch = _function(
+        probe,
+        "__device__ unsigned long long mixed_node_input_epoch(",
+        "__global__ void prepare_replay(",
+    )
+    assert "(replay - 1ULL) / 2ULL" in epoch
+    assert "operations_per_cycle" in epoch
+    assert "node_epoch_offset" in epoch
+
+    # Reproduce the accepted A/B launch order and prove the generated node
+    # epoch is exactly the logical sequence, including graph boundaries.
+    graph_a = 3
+    graph_b = 128
+    operations_per_cycle = graph_a + graph_b
+    epochs: list[int] = []
+    replay = 0
+    for _ in range(10):
+        replay += 1
+        cycle = (replay - 1) // 2
+        epochs.extend(
+            cycle * operations_per_cycle + operation + 1
+            for operation in range(graph_a)
+        )
+        replay += 1
+        cycle = (replay - 1) // 2
+        epochs.extend(
+            cycle * operations_per_cycle + graph_a + operation + 1
+            for operation in range(graph_b)
+        )
+    assert epochs == list(range(1, 1311))
+    assert all(
+        epochs[index] % 7 != epochs[index - 2] % 7
+        for index in range(2, len(epochs))
+    )

--- a/spark_transport/tests/tp4_allreduce_protocol_test.cpp
+++ b/spark_transport/tests/tp4_allreduce_protocol_test.cpp
@@ -1,0 +1,88 @@
+#include "spark_transport/tp4_allreduce_protocol.hpp"
+
+#include <cassert>
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <stdexcept>
+#include <string>
+
+int main() {
+  using spark_transport::Tp4AllreduceProtocol;
+  using spark_transport::Tp4CreditReuseState;
+  using spark_transport::parse_tp4_allreduce_protocol;
+  using spark_transport::tp4_allreduce_protocol_from_wire;
+  using spark_transport::tp4_credit_reuse_state;
+  using spark_transport::tp4_expected_reuse_credit;
+  using spark_transport::tp4_latest_slot_sequence;
+  using spark_transport::tp4_payload_arena_bytes;
+  using spark_transport::tp4_payload_slot_count;
+  using spark_transport::tp4_payload_slot_index;
+
+  const auto serial = Tp4AllreduceProtocol::kSerialAck;
+  const auto deferred = Tp4AllreduceProtocol::kTwoSlotDeferredAck;
+  assert(tp4_payload_slot_count(serial) == 1);
+  assert(tp4_payload_slot_count(deferred) == 2);
+  assert(tp4_payload_slot_index(1, deferred) == 0);
+  assert(tp4_payload_slot_index(2, deferred) == 1);
+  assert(tp4_payload_slot_index(3, deferred) == 0);
+  assert(tp4_expected_reuse_credit(1, deferred) == 0);
+  assert(tp4_expected_reuse_credit(2, deferred) == 0);
+  assert(tp4_expected_reuse_credit(3, deferred) == 1);
+
+  // Sequence 2 can occupy slot 1 while slot 0 remains uncredited.
+  assert(tp4_credit_reuse_state(2, 0, deferred) ==
+         Tp4CreditReuseState::kReady);
+  // Sequence 3 cannot reuse slot 0 until its exact sequence-1 credit arrives.
+  assert(tp4_credit_reuse_state(3, 0, deferred) ==
+         Tp4CreditReuseState::kWaiting);
+  assert(tp4_credit_reuse_state(3, 1, deferred) ==
+         Tp4CreditReuseState::kReady);
+  assert(tp4_credit_reuse_state(3, 2, deferred) ==
+         Tp4CreditReuseState::kFutureGeneration);
+
+  // The two edges retire independently; one edge cannot release the other.
+  assert(tp4_credit_reuse_state(5, 3, deferred) ==
+         Tp4CreditReuseState::kReady);
+  assert(tp4_credit_reuse_state(5, 1, deferred) ==
+         Tp4CreditReuseState::kWaiting);
+
+  for (std::uint64_t sequence = 1; sequence <= 133; ++sequence) {
+    const std::uint64_t expected =
+        tp4_expected_reuse_credit(sequence, deferred);
+    assert(tp4_credit_reuse_state(sequence, expected, deferred) ==
+           Tp4CreditReuseState::kReady);
+    if (expected != 0) {
+      assert(tp4_credit_reuse_state(sequence, expected - 1, deferred) ==
+             Tp4CreditReuseState::kWaiting);
+    }
+  }
+  assert(tp4_latest_slot_sequence(133, 0, deferred) == 133);
+  assert(tp4_latest_slot_sequence(133, 1, deferred) == 132);
+  assert(tp4_latest_slot_sequence(2, 0, deferred) == 1);
+  assert(tp4_latest_slot_sequence(2, 1, deferred) == 2);
+
+  assert(tp4_payload_arena_bytes(64, serial) == 64);
+  assert(tp4_payload_arena_bytes(64, deferred) == 128);
+  bool rejected_overflow{};
+  try {
+    (void)tp4_payload_arena_bytes(
+        std::numeric_limits<std::size_t>::max(), deferred);
+  } catch (const std::overflow_error&) {
+    rejected_overflow = true;
+  }
+  assert(rejected_overflow);
+
+  assert(parse_tp4_allreduce_protocol("serial_ack") == serial);
+  assert(parse_tp4_allreduce_protocol("two_slot_deferred_ack") == deferred);
+  assert(tp4_allreduce_protocol_from_wire(0) == serial);
+  assert(tp4_allreduce_protocol_from_wire(1) == deferred);
+  bool rejected_protocol{};
+  try {
+    (void)tp4_allreduce_protocol_from_wire(2);
+  } catch (const std::invalid_argument& error) {
+    rejected_protocol =
+        std::string(error.what()).find("protocol") != std::string::npos;
+  }
+  assert(rejected_protocol);
+}

--- a/spark_transport/tests/tp4_c_api_layout_test.cpp
+++ b/spark_transport/tests/tp4_c_api_layout_test.cpp
@@ -1,0 +1,58 @@
+#include "spark_transport/tp4_c_api.h"
+
+#include <cstddef>
+#include <type_traits>
+
+static_assert(std::is_standard_layout_v<spark_tp4_config>);
+static_assert(std::is_trivially_copyable_v<spark_tp4_config>);
+static_assert(sizeof(void*) != 8 || sizeof(spark_tp4_config) == 64);
+static_assert(sizeof(void*) != 8 || offsetof(spark_tp4_config, rank) == 0);
+static_assert(sizeof(void*) != 8 || offsetof(spark_tp4_config, peer0) == 8);
+static_assert(sizeof(void*) != 8 || offsetof(spark_tp4_config, peer1) == 16);
+static_assert(sizeof(void*) != 8 || offsetof(spark_tp4_config, device0) == 24);
+static_assert(sizeof(void*) != 8 || offsetof(spark_tp4_config, device1) == 32);
+static_assert(sizeof(void*) != 8 || offsetof(spark_tp4_config, gid0) == 40);
+static_assert(sizeof(void*) != 8 || offsetof(spark_tp4_config, gid1) == 41);
+static_assert(
+    sizeof(void*) != 8 || offsetof(spark_tp4_config, control_port0) == 42);
+static_assert(
+    sizeof(void*) != 8 || offsetof(spark_tp4_config, control_port1) == 44);
+static_assert(
+    sizeof(void*) != 8 || offsetof(spark_tp4_config, payload_bytes) == 48);
+static_assert(
+    sizeof(void*) != 8 ||
+    offsetof(spark_tp4_config, graph_submit_cpu_plus_one) == 56);
+static_assert(
+    sizeof(void*) != 8 ||
+    offsetof(spark_tp4_config, graph_progress_cpu_plus_one) == 60);
+
+static_assert(std::is_standard_layout_v<spark_tp4_graph_status>);
+static_assert(std::is_trivially_copyable_v<spark_tp4_graph_status>);
+static_assert(sizeof(spark_tp4_graph_status) == 56);
+static_assert(offsetof(spark_tp4_graph_status, struct_size) == 0);
+static_assert(offsetof(spark_tp4_graph_status, flags) == 4);
+static_assert(offsetof(spark_tp4_graph_status, captured_nodes) == 8);
+static_assert(offsetof(spark_tp4_graph_status, published_sequence) == 16);
+static_assert(offsetof(spark_tp4_graph_status, consumed_sequence) == 24);
+static_assert(offsetof(spark_tp4_graph_status, completed_sequence) == 32);
+static_assert(offsetof(spark_tp4_graph_status, overflow_sequence) == 40);
+static_assert(
+    offsetof(spark_tp4_graph_status, graph_submit_cpu_plus_one) == 48);
+static_assert(
+    offsetof(spark_tp4_graph_status, graph_progress_cpu_plus_one) == 52);
+static_assert(SPARK_TP4_ALLREDUCE_PROTOCOL_SERIAL_ACK == 0);
+static_assert(SPARK_TP4_ALLREDUCE_PROTOCOL_TWO_SLOT_DEFERRED_ACK == 1);
+static_assert(SPARK_TP4_GRAPH_KERNEL_FUSED == 0);
+static_assert(SPARK_TP4_GRAPH_KERNEL_SPLIT_64K == 1);
+static_assert(SPARK_TP4_GRAPH_KERNEL_TIERED_64K == 2);
+static_assert(SPARK_TP4_GRAPH_STATUS_TWO_SLOT_DEFERRED_ACK == (1U << 7));
+static_assert(SPARK_TP4_GRAPH_STATUS_SPLIT_64K == (1U << 8));
+static_assert(SPARK_TP4_GRAPH_STATUS_TIERED_64K == (1U << 9));
+static_assert(SPARK_TP4_GRAPH_STATUS_DUAL_PORT_STRIPED == (1U << 10));
+static_assert(SPARK_TP4_WIRE_SCHEDULE_SEQUENTIAL == 0);
+static_assert(SPARK_TP4_WIRE_SCHEDULE_DUAL_PORT_STRIPED == 1);
+static_assert(
+    (SPARK_TP4_GRAPH_STATUS_SPLIT_64K &
+     SPARK_TP4_GRAPH_STATUS_TIERED_64K) == 0);
+
+int main() { return 0; }

--- a/spark_transport/tests/tp4_c_api_test.cpp
+++ b/spark_transport/tests/tp4_c_api_test.cpp
@@ -14,6 +14,52 @@ void expect_message_contains(const char* message, const char* needle) {
 int main() {
   char error[256]{};
 
+  assert(spark_tp4_create_with_protocol(
+             nullptr, SPARK_TP4_ALLREDUCE_PROTOCOL_TWO_SLOT_DEFERRED_ACK,
+             error, sizeof(error)) == nullptr);
+  expect_message_contains(error, "config is null");
+
+  spark_tp4_config protocol_config{};
+  protocol_config.rank = 0;
+  protocol_config.peer0 = "127.0.0.1";
+  protocol_config.peer1 = "127.0.0.1";
+  protocol_config.device0 = "unused0";
+  protocol_config.device1 = "unused1";
+  protocol_config.control_port0 = 9470;
+  protocol_config.control_port1 = 9471;
+  protocol_config.payload_bytes = 12288;
+  std::memset(error, 0, sizeof(error));
+  assert(spark_tp4_create_with_protocol(
+             &protocol_config, 99, error, sizeof(error)) == nullptr);
+  expect_message_contains(error, "invalid TP4 all-reduce protocol");
+
+  std::memset(error, 0, sizeof(error));
+  assert(spark_tp4_create_with_protocol_and_graph_kernel(
+             nullptr, SPARK_TP4_ALLREDUCE_PROTOCOL_TWO_SLOT_DEFERRED_ACK,
+             SPARK_TP4_GRAPH_KERNEL_TIERED_64K, error,
+             sizeof(error)) == nullptr);
+  expect_message_contains(error, "config is null");
+
+  std::memset(error, 0, sizeof(error));
+  assert(spark_tp4_create_with_protocol_and_graph_kernel(
+             &protocol_config, 99, SPARK_TP4_GRAPH_KERNEL_TIERED_64K,
+             error, sizeof(error)) == nullptr);
+  expect_message_contains(error, "invalid TP4 all-reduce protocol");
+
+  std::memset(error, 0, sizeof(error));
+  assert(spark_tp4_create_with_protocol_and_graph_kernel(
+             &protocol_config, SPARK_TP4_ALLREDUCE_PROTOCOL_SERIAL_ACK,
+             99, error, sizeof(error)) == nullptr);
+  expect_message_contains(error, "invalid TP4 graph kernel strategy");
+
+  std::memset(error, 0, sizeof(error));
+  assert(spark_tp4_create_with_protocol_graph_kernel_and_schedule(
+             &protocol_config,
+             SPARK_TP4_ALLREDUCE_PROTOCOL_TWO_SLOT_DEFERRED_ACK,
+             SPARK_TP4_GRAPH_KERNEL_FUSED, 99, error,
+             sizeof(error)) == nullptr);
+  expect_message_contains(error, "invalid TP4 wire schedule");
+
   assert(spark_tp4_capture_q1_all_reduce(
              nullptr, nullptr, nullptr, nullptr, error, sizeof(error)) == 1);
   expect_message_contains(error, "handle is null");
@@ -74,6 +120,7 @@ int main() {
   expect_message_contains(error, "handle is null");
 
   // Destroying a null handle follows delete-null semantics and is harmless.
+  spark_tp4_destroy(nullptr);
   spark_tp4_allgather_destroy(nullptr);
   return 0;
 }

--- a/spark_transport/tests/tp4_dual_port_striped_allreduce_test.cpp
+++ b/spark_transport/tests/tp4_dual_port_striped_allreduce_test.cpp
@@ -1,0 +1,151 @@
+#include "spark_transport/tp4_dual_port_striped_allreduce.hpp"
+#include "spark_transport/tp4_session.hpp"
+
+#include <array>
+#include <cassert>
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <stdexcept>
+
+int main() {
+  using spark_transport::Tp4AllreduceOptions;
+  using spark_transport::Tp4AllreduceSchedule;
+  using spark_transport::Tp4TensorStripe;
+  using spark_transport::kTp4DualPortOppositeOrderStrategy;
+  using spark_transport::tp4_striped_phase_transfer;
+  using spark_transport::verify_tp4_striped_allreduce;
+
+  const Tp4AllreduceOptions default_options;
+  assert(default_options.schedule == Tp4AllreduceSchedule::kSequential);
+
+  constexpr auto verification =
+      verify_tp4_striped_allreduce(kTp4DualPortOppositeOrderStrategy);
+  static_assert(verification.valid);
+  static_assert(verification.complete());
+
+  constexpr spark_transport::Tp4DualPortStripedAllreduceStrategy
+      incomplete_strategy{
+          std::array<spark_transport::Tp4StripedPhaseStrategy, 2>{
+              spark_transport::Tp4StripedPhaseStrategy{
+                  Tp4TensorStripe::kLowerHalf,
+                  Tp4TensorStripe::kUpperHalf},
+              spark_transport::Tp4StripedPhaseStrategy{
+                  Tp4TensorStripe::kLowerHalf,
+                  Tp4TensorStripe::kUpperHalf},
+          }};
+  constexpr auto incomplete_verification =
+      verify_tp4_striped_allreduce(incomplete_strategy);
+  static_assert(incomplete_verification.valid);
+  static_assert(!incomplete_verification.complete());
+
+  constexpr spark_transport::Tp4DualPortStripedAllreduceStrategy
+      malformed_strategy{
+          std::array<spark_transport::Tp4StripedPhaseStrategy, 2>{
+              spark_transport::Tp4StripedPhaseStrategy{
+                  Tp4TensorStripe::kLowerHalf,
+                  Tp4TensorStripe::kLowerHalf},
+              spark_transport::Tp4StripedPhaseStrategy{
+                  Tp4TensorStripe::kUpperHalf,
+                  Tp4TensorStripe::kLowerHalf},
+          }};
+  constexpr auto malformed_verification =
+      verify_tp4_striped_allreduce(malformed_strategy);
+  static_assert(!malformed_verification.valid);
+  static_assert(!malformed_verification.complete());
+
+  for (std::uint32_t rank = 0; rank < 4; ++rank) {
+    const auto phase0_endpoint0 = tp4_striped_phase_transfer(
+        kTp4DualPortOppositeOrderStrategy, rank, 0, 0);
+    const auto phase0_endpoint1 = tp4_striped_phase_transfer(
+        kTp4DualPortOppositeOrderStrategy, rank, 0, 1);
+    const auto phase1_endpoint0 = tp4_striped_phase_transfer(
+        kTp4DualPortOppositeOrderStrategy, rank, 1, 0);
+    const auto phase1_endpoint1 = tp4_striped_phase_transfer(
+        kTp4DualPortOppositeOrderStrategy, rank, 1, 1);
+
+    // Tensor half A uses M0 then M1. Tensor half B uses M1 then M0.
+    assert(phase0_endpoint0.stripe == Tp4TensorStripe::kLowerHalf);
+    assert(phase0_endpoint0.peer_rank == (rank ^ 1U));
+    assert(phase0_endpoint1.stripe == Tp4TensorStripe::kUpperHalf);
+    assert(phase0_endpoint1.peer_rank == (rank ^ 3U));
+    assert(phase1_endpoint0.stripe == Tp4TensorStripe::kUpperHalf);
+    assert(phase1_endpoint0.peer_rank == (rank ^ 1U));
+    assert(phase1_endpoint1.stripe == Tp4TensorStripe::kLowerHalf);
+    assert(phase1_endpoint1.peer_rank == (rank ^ 3U));
+
+    assert(verification.lower_half_contributors[rank] == 0x0fU);
+    assert(verification.upper_half_contributors[rank] == 0x0fU);
+  }
+
+  constexpr std::size_t q40_payload_bytes = 40U * 6144U * 2U;
+  constexpr auto layout =
+      spark_transport::make_tp4_striped_endpoint_layout(q40_payload_bytes);
+  static_assert(layout.stripe_bytes == q40_payload_bytes / 2U);
+  static_assert(layout.lane_stride == q40_payload_bytes + 64U);
+  static_assert(layout.generation_stride == 2U * layout.lane_stride);
+  static_assert(layout.total_bytes == 2U * layout.generation_stride);
+
+  constexpr std::size_t q512_payload_bytes = 512U * 6144U * 2U;
+  constexpr auto q512_layout =
+      spark_transport::make_tp4_striped_endpoint_layout(
+          q512_payload_bytes);
+  static_assert(q512_layout.stripe_bytes == 3'145'728U);
+  static_assert(q512_layout.lane_stride == 6'291'520U);
+  static_assert(q512_layout.total_bytes == 25'166'080U);
+
+  const std::array<spark_transport::Tp4StripedLaneRegion, 4> regions{
+      spark_transport::tp4_striped_lane_region(
+          layout, 0, Tp4TensorStripe::kLowerHalf),
+      spark_transport::tp4_striped_lane_region(
+          layout, 0, Tp4TensorStripe::kUpperHalf),
+      spark_transport::tp4_striped_lane_region(
+          layout, 1, Tp4TensorStripe::kLowerHalf),
+      spark_transport::tp4_striped_lane_region(
+          layout, 1, Tp4TensorStripe::kUpperHalf),
+  };
+  for (std::size_t index = 0; index < regions.size(); ++index) {
+    const auto& region = regions[index];
+    assert(region.send_offset == index * layout.lane_stride);
+    assert(region.receive_offset ==
+           region.send_offset + layout.stripe_bytes);
+    assert(region.control_offset ==
+           region.receive_offset + layout.stripe_bytes);
+    assert(region.end_offset == region.control_offset + 64U);
+    assert(region.send_offset % 64U == 0);
+    assert(region.receive_offset % 64U == 0);
+    assert(region.control_offset % 64U == 0);
+    if (index != 0) {
+      assert(regions[index - 1].end_offset <= region.send_offset);
+    }
+  }
+
+  static_assert(spark_transport::tp4_striped_generation_slot(1) == 0);
+  static_assert(spark_transport::tp4_striped_generation_slot(2) == 1);
+  static_assert(spark_transport::tp4_striped_generation_slot(3) == 0);
+  bool rejected_zero_sequence{};
+  try {
+    static_cast<void>(spark_transport::tp4_striped_generation_slot(0));
+  } catch (const std::out_of_range&) {
+    rejected_zero_sequence = true;
+  }
+  assert(rejected_zero_sequence);
+
+  bool rejected_layout_overflow{};
+  try {
+    static_cast<void>(spark_transport::make_tp4_striped_endpoint_layout(
+        std::numeric_limits<std::size_t>::max() - 3U));
+  } catch (const std::overflow_error&) {
+    rejected_layout_overflow = true;
+  }
+  assert(rejected_layout_overflow);
+
+  bool rejected_partial_bf16_stripes{};
+  try {
+    static_cast<void>(
+        spark_transport::make_tp4_striped_endpoint_layout(2));
+  } catch (const std::invalid_argument&) {
+    rejected_partial_bf16_stripes = true;
+  }
+  assert(rejected_partial_bf16_stripes);
+}

--- a/spark_transport/tests/tp4_dual_port_striped_host_test.cpp
+++ b/spark_transport/tests/tp4_dual_port_striped_host_test.cpp
@@ -1,0 +1,64 @@
+#include "tp4_dual_port_striped_host.hpp"
+
+#include <array>
+#include <cassert>
+
+int main() {
+  using spark_transport::Tp4AllreduceOptions;
+  using spark_transport::Tp4AllreduceProtocol;
+  using spark_transport::Tp4AllreduceSchedule;
+  using spark_transport::Tp4GraphKernelStrategy;
+  using spark_transport::detail::kTp4DualPortStripedEndpointTag;
+  using spark_transport::detail::kTp4DualPortStripedEndpointVersion;
+  using spark_transport::detail::Tp4StripedWorkEvent;
+  using spark_transport::detail::tp4_dual_port_striped_options_valid;
+  using spark_transport::detail::tp4_striped_work_id;
+
+  static_assert(kTp4DualPortStripedEndpointVersion != 1);
+  static_assert(kTp4DualPortStripedEndpointVersion != 2);
+  static_assert(kTp4DualPortStripedEndpointTag != 0);
+  static_assert(kTp4DualPortStripedEndpointTag !=
+                spark_transport::kTp4TwoSlotEndpointTag);
+
+  constexpr std::array<std::uint64_t, 4> sequence1_work_ids{
+      tp4_striped_work_id(1, Tp4StripedWorkEvent::kPhase1Doorbell),
+      tp4_striped_work_id(1, Tp4StripedWorkEvent::kPhase1Credit),
+      tp4_striped_work_id(1, Tp4StripedWorkEvent::kPhase2Doorbell),
+      tp4_striped_work_id(1, Tp4StripedWorkEvent::kPhase2Credit),
+  };
+  static_assert(sequence1_work_ids[0] == 1);
+  static_assert(sequence1_work_ids[1] == 2);
+  static_assert(sequence1_work_ids[2] == 3);
+  static_assert(sequence1_work_ids[3] == 4);
+  static_assert(
+      tp4_striped_work_id(2, Tp4StripedWorkEvent::kPhase1Doorbell) == 5);
+
+  Tp4AllreduceOptions options;
+  options.schedule = Tp4AllreduceSchedule::kDualPortStriped;
+  options.protocol = Tp4AllreduceProtocol::kTwoSlotDeferredAck;
+  options.graph_kernel_strategy = Tp4GraphKernelStrategy::kFused;
+  options.payload_bytes = spark_transport::tp4_graph_payload_bytes(40);
+  options.graph_submit_cpu = 10;
+  options.graph_progress_cpu = 11;
+  assert(tp4_dual_port_striped_options_valid(options));
+
+  options.payload_bytes = spark_transport::tp4_graph_payload_bytes(512);
+  assert(tp4_dual_port_striped_options_valid(options));
+
+  options.protocol = Tp4AllreduceProtocol::kSerialAck;
+  assert(!tp4_dual_port_striped_options_valid(options));
+  options.protocol = Tp4AllreduceProtocol::kTwoSlotDeferredAck;
+
+  options.graph_kernel_strategy = Tp4GraphKernelStrategy::kSplit64KiB;
+  assert(!tp4_dual_port_striped_options_valid(options));
+  options.graph_kernel_strategy = Tp4GraphKernelStrategy::kTiered64KiB;
+  assert(!tp4_dual_port_striped_options_valid(options));
+  options.graph_kernel_strategy = Tp4GraphKernelStrategy::kFused;
+
+  options.graph_progress_cpu.reset();
+  assert(!tp4_dual_port_striped_options_valid(options));
+  options.graph_progress_cpu = 11;
+
+  options.payload_bytes = spark_transport::tp4_graph_payload_bytes(39);
+  assert(!tp4_dual_port_striped_options_valid(options));
+}

--- a/spark_transport/tests/tp4_graph_kernel_strategy_test.cpp
+++ b/spark_transport/tests/tp4_graph_kernel_strategy_test.cpp
@@ -1,0 +1,52 @@
+#include "spark_transport/tp4_graph_kernel_strategy.hpp"
+#include "spark_transport/tp4_session.hpp"
+
+#include <cassert>
+#include <cstdint>
+#include <string_view>
+
+int main() {
+  using spark_transport::Tp4AllreduceOptions;
+  using spark_transport::Tp4GraphKernelStrategy;
+  using spark_transport::kTp4TieredSplitMinimumQ;
+  using spark_transport::tp4_graph_kernel_strategy_is_graph_only;
+  using spark_transport::tp4_graph_kernel_strategy_name;
+  using spark_transport::tp4_graph_kernel_strategy_valid;
+  using spark_transport::tp4_graph_kernel_uses_split;
+
+  constexpr auto fused = Tp4GraphKernelStrategy::kFused;
+  constexpr auto split = Tp4GraphKernelStrategy::kSplit64KiB;
+  constexpr auto tiered = Tp4GraphKernelStrategy::kTiered64KiB;
+  constexpr auto invalid =
+      static_cast<Tp4GraphKernelStrategy>(UINT8_C(255));
+
+  static_assert(kTp4TieredSplitMinimumQ == 7);
+  static_assert(tp4_graph_kernel_strategy_valid(fused));
+  static_assert(tp4_graph_kernel_strategy_valid(split));
+  static_assert(tp4_graph_kernel_strategy_valid(tiered));
+  static_assert(!tp4_graph_kernel_strategy_valid(invalid));
+  static_assert(!tp4_graph_kernel_strategy_is_graph_only(fused));
+  static_assert(tp4_graph_kernel_strategy_is_graph_only(split));
+  static_assert(tp4_graph_kernel_strategy_is_graph_only(tiered));
+
+  static_assert(!tp4_graph_kernel_uses_split(fused, 512));
+  static_assert(tp4_graph_kernel_uses_split(split, 1));
+  static_assert(!tp4_graph_kernel_uses_split(tiered, 1));
+  static_assert(!tp4_graph_kernel_uses_split(tiered, 6));
+  static_assert(tp4_graph_kernel_uses_split(tiered, 7));
+  static_assert(tp4_graph_kernel_uses_split(tiered, 512));
+  static_assert(!tp4_graph_kernel_uses_split(invalid, 512));
+
+  assert(std::string_view(tp4_graph_kernel_strategy_name(fused)) ==
+         "fused");
+  assert(std::string_view(tp4_graph_kernel_strategy_name(split)) ==
+         "split_64k");
+  assert(std::string_view(tp4_graph_kernel_strategy_name(tiered)) ==
+         "tiered_64k");
+  assert(std::string_view(tp4_graph_kernel_strategy_name(invalid)) ==
+         "invalid");
+
+  // Default construction is part of the public C++ compatibility contract.
+  const Tp4AllreduceOptions options;
+  assert(options.graph_kernel_strategy == fused);
+}

--- a/spark_transport/tests/verbs_completion_test.cpp
+++ b/spark_transport/tests/verbs_completion_test.cpp
@@ -1,0 +1,71 @@
+#include "spark_transport/verbs_endpoint.hpp"
+
+#include <cassert>
+#include <cstdint>
+#include <limits>
+#include <type_traits>
+#include <utility>
+
+namespace {
+
+using spark_transport::detail::SendCompletionDisposition;
+
+void exact_completion_is_complete() {
+  assert(spark_transport::detail::classify_send_completion(
+             41, 41, false) == SendCompletionDisposition::kComplete);
+  assert(spark_transport::detail::classify_send_completion(
+             41, 41, true) == SendCompletionDisposition::kComplete);
+}
+
+void strict_poll_rejects_every_other_work_id() {
+  assert(spark_transport::detail::classify_send_completion(
+             41, 40, false) == SendCompletionDisposition::kUnexpected);
+  assert(spark_transport::detail::classify_send_completion(
+             41, 42, false) == SendCompletionDisposition::kUnexpected);
+}
+
+void through_poll_retires_only_older_work_ids() {
+  assert(spark_transport::detail::classify_send_completion(
+             41, 40, true) == SendCompletionDisposition::kRetire);
+  assert(spark_transport::detail::classify_send_completion(
+             41, 42, true) == SendCompletionDisposition::kUnexpected);
+}
+
+void work_id_order_does_not_wrap() {
+  constexpr auto maximum = std::numeric_limits<std::uint64_t>::max();
+  assert(spark_transport::detail::classify_send_completion(
+             maximum, maximum - 1, true) ==
+         SendCompletionDisposition::kRetire);
+  assert(spark_transport::detail::classify_send_completion(
+             maximum, maximum, true) ==
+         SendCompletionDisposition::kComplete);
+  assert(spark_transport::detail::classify_send_completion(
+             0, maximum, true) ==
+         SendCompletionDisposition::kUnexpected);
+}
+
+}  // namespace
+
+int main() {
+  static_assert(std::is_same_v<
+                std::underlying_type_t<
+                    spark_transport::SendCompletionPollState>,
+                std::uint8_t>);
+  static_assert(std::is_same_v<
+                decltype(std::declval<spark_transport::VerbsEndpoint&>()
+                             .poll_send_through(std::uint64_t{})),
+                spark_transport::SendCompletionPollState>);
+  static_assert(std::is_same_v<
+                decltype(&spark_transport::VerbsEndpoint::wait_for_send),
+                void (spark_transport::VerbsEndpoint::*)(std::uint64_t)>);
+  static_assert(std::is_same_v<
+                decltype(
+                    &spark_transport::VerbsEndpoint::wait_for_send_through),
+                void (spark_transport::VerbsEndpoint::*)(std::uint64_t)>);
+  static_assert(spark_transport::SendCompletionPollState::kPending !=
+                spark_transport::SendCompletionPollState::kComplete);
+  exact_completion_is_complete();
+  strict_poll_rejects_every_other_work_id();
+  through_poll_retires_only_older_work_ids();
+  work_id_order_does_not_wrap();
+}


### PR DESCRIPTION
## Resulting behavior

Publishes the versioned SIRCL graph all-reduce ABI used by the operator-accepted EXL3 R7 profile:

- two generation-tagged payload slots with deferred retirement credits;
- per-captured-Q fused versus split-64-KiB tier selection;
- additive C ABI that preserves the legacy serial/fused entry point;
- fail-closed vLLM selector and native-status attestation;
- one shared process-local control-port namespace;
- an SM121 build, mount, qualification, and rollback guide.

The accepted serving selector is 	wo_slot_deferred_ack + 	iered_64k, sequential schedule, Q1-Q40, with Q512 prefill disabled.

## Scope

The dual-port striped schedule and prefill-capacity pool are published as default-off, research-only ABI companions. This PR makes no serving-performance claim for those paths.

The +19.34% exact-Q40 result is not attributed to SIRCL. It comes from a separate target-only EXL3 routed-MoE overlay, which will be published independently with its pre-graph numerical attestation.

## Validation

- full offline suite: 3049 passed, 17 skipped
- focused native/adapter/source contracts: 187 passed
- public overlay and selector contracts: 106 passed
- uff check --select E,F,W --ignore E501 .
- git diff --check

## Compatibility

Legacy spark_tp4_create remains serial/fused. Unsupported signatures retain explicit fallback. Protocol mismatch, ABI mismatch, port collision, native failure after enqueue, and graph-status disagreement fail closed.