### PR TITLE
Document accepted current-best R7 prefill results

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,11 @@ Q1-Q32, other prefill shapes, and the draft model retain their prior states.
 
 | Measurement | TTFT | Bounded result | Samples |
 |---|---:|---:|---:|
-| 8K standalone-cold C1 prefill | 12.273 s | **668 tok/s** | 2 |
-| 16K standalone-cold C1 prefill | 24.875 s | **659 tok/s** | 1 |
-| 32K standalone-cold C1 prefill | 50.172 s | **653 tok/s** | 1 |
+| 8K unique-context C1 prefill | 12.06 s | **679 tok/s** | 2 |
+| 16K unique-context C1 prefill | 24.36 s | **673 tok/s** | 1 |
+| 32K unique-context C1 prefill | 49.17 s | **666 tok/s** | 1 |
+| 64K unique-context C1 prefill | 99.72 s | **657 tok/s** | 1 |
+| 128K unique-context C1 prefill | 203.09 s | **645 tok/s** | 1 |
 | Unique-16K C8 warm sustained decode | - | **73.208 tok/s aggregate** | 2 candidate arms |
 | Reported KV capacity | - | **1,156,864 tokens** | all four ranks |
 
@@ -47,10 +49,12 @@ the slower candidate repeat exceeded the fastest control repeat by 14.93%.
 All 75 target layers passed exact BF16 parity, deterministic 16K and 32K output
 equality passed, and final graph, API, transport, and capacity gates passed.
 
-The 8K-32K prefill rows are client-timed `llm_decode_bench` v0.4.31
-observations with 100% unique generated contexts. Their low sample counts and
-unavailable server-side cached-token accounting make them bounded operating
-snapshots, not throughput distributions or independently proven cache misses.
+The 8K-128K prefill rows are the operator-accepted current-best client-timed
+snapshot with 100% unique generated contexts. Several operator runs produced
+similar throughput, but the table reports only the visible samples and does
+not treat them as a statistical distribution. Server-side cached-token
+accounting was unavailable for these cells, so cache misses are not
+independently proven by the benchmark artifact.
 The predeclared exact-Q40 prefill reducer separately remains a machine failure:
 its sole primary miss was 0.1215% at 64K. Operator acceptance treats that
 bounded difference as measurement-neutral without relabelling the machine
@@ -63,6 +67,8 @@ public-functional default or an accepted public deployment matrix. Read the
 [optimization record](docs/EXL3_R7_OPTIMIZATION_20260811.md), and
 [machine-readable operator acceptance](docs/configurations/glm52-exl3-r7-mtp4-q40-block8-20260812.json)
 before reproducing or extending it.
+The accepted prefill snapshot is preserved separately in
+[machine-readable form](docs/configurations/glm52-exl3-r7-current-best-prefill-20260813.json).
 The clean source/profile composition and local build commands are in
 [the operator-profile reproduction guide](docs/EXL3_R7_OPERATOR_REPRODUCTION.md).
 

--- a/docs/EXL3_R7_FIXED_MTP4_PROFILE.md
+++ b/docs/EXL3_R7_FIXED_MTP4_PROFILE.md
@@ -29,6 +29,8 @@ qualification remains separately preserved in
 [glm52-exl3-r7-mtp4-kv925-20260811.json](configurations/glm52-exl3-r7-mtp4-kv925-20260811.json).
 The exact-Q40 acceptance result is
 [glm52-exl3-r7-mtp4-q40-block8-20260812.json](configurations/glm52-exl3-r7-mtp4-q40-block8-20260812.json).
+The operator-accepted current-best prefill snapshot is
+[glm52-exl3-r7-current-best-prefill-20260813.json](configurations/glm52-exl3-r7-current-best-prefill-20260813.json).
 
 ## Serving contract
 
@@ -114,6 +116,26 @@ Fixed-prompt non-Q40 checks measured C1 at 22.218 versus 22.362 tokens/s
 (-0.65%) and C4 at 45.703 versus 46.578 tokens/s (-1.88%). These
 source-identical paths are treated as bounded measurement noise, not as
 optimization results.
+
+## Current-best operator prefill snapshot
+
+The operator accepts the following 100%-unique-context C1 results as the best
+measured prefill snapshot for this exact four-Spark profile:
+
+| Context | Prompt tokens | Client TTFT | Client-timed prefill | Samples |
+|---|---:|---:|---:|---:|
+| 8K | 8,194 | 12.06 s | **679 tok/s** | 2 |
+| 16K | 16,386 | 24.36 s | **673 tok/s** | 1 |
+| 32K | 32,770 | 49.17 s | **666 tok/s** | 1 |
+| 64K | 65,538 | 99.72 s | **657 tok/s** | 1 |
+| 128K | 131,074 | 203.09 s | **645 tok/s** | 1 |
+
+The displayed throughput changes by 5.0% across the 16x context span. Several
+operator runs produced similar results, but the exact table is a bounded
+snapshot with low visible sample counts rather than a throughput distribution.
+Server-side cached-token accounting was unavailable for these cells; the
+100%-unique request construction is recorded, but the captured result does not
+independently prove cache misses.
 
 ## Exact CKV-gather delta and rollback
 
@@ -256,8 +278,9 @@ contract, not for the exact dynamic-NVFP4/262K/CKV-gather profile. The larger
   speculative-decoding, transport, and matched prefill/decode evidence. Its
   262,144-token request boundary and near-capacity concurrent residency remain
   unqualified.
-- Each prefill row is one cold, fully unique request. Repeat distributions and
-  longer soak testing remain open.
+- The current-best prefill table has one visible sample per context except for
+  8K, which has two. Several operator runs were consistent, but a retained
+  repeat distribution and longer soak test remain open.
 - The control benchmark's JSON destination was invalid, so the harness printed
   the complete result but did not write its JSON artifact. The preserved
   console transcript is identified by SHA-256 in the sanitized evidence file.

--- a/docs/RESULTS.md
+++ b/docs/RESULTS.md
@@ -107,20 +107,32 @@ replayed the same eight unique 16K payloads with full 8/8 residency and a
 | Slowest candidate versus fastest control | 62.907 tok/s | **72.297 tok/s** | **+14.93%** |
 | Reported KV capacity | 1,156,864 tokens | **1,156,864 tokens** | unchanged |
 
-One later bounded operator snapshot used `llm_decode_bench` v0.4.31 in
-standalone-cold C1 mode with 100% unique generated contexts:
+The operator accepts the following client-timed C1 snapshot as the current
+best measured prefill result for this configuration. The benchmark used 100%
+unique generated contexts:
 
 | Context | Client TTFT | Client-timed prefill | Samples |
 |---|---:|---:|---:|
-| 8K | 12.273 s | **668 tok/s** | 2 |
-| 16K | 24.875 s | **659 tok/s** | 1 |
-| 32K | 50.172 s | **653 tok/s** | 1 |
+| 8K | 12.06 s | **679 tok/s** | 2 |
+| 16K | 24.36 s | **673 tok/s** | 1 |
+| 32K | 49.17 s | **666 tok/s** | 1 |
+| 64K | 99.72 s | **657 tok/s** | 1 |
+| 128K | 203.09 s | **645 tok/s** | 1 |
 
-The complete benchmark JSON has SHA-256
-`feed67820caf37cc016473a38584b11b4205a628183f64e2b48b082a7bad2854`.
-These are low-sample client observations. The benchmark did not return
-server-side cached-token accounting for these cells, so they are not presented
-as distributions or independently proven cache misses.
+Throughput declines by only 5.0% from 8K to 128K while the context grows by
+16x. The 8K, 16K, and 32K rows are respectively 1.6%, 2.1%, and 2.0% above the
+earlier bounded snapshot. Several operator runs produced similar prefill
+throughput, but the table reports only the visible samples. These are therefore
+accepted best operating results, not throughput distributions. The benchmark
+did not return server-side cached-token accounting for these cells, so cache
+misses are not independently proven by the captured result. The transcription,
+scope, and limitations are preserved in
+[machine-readable form](configurations/glm52-exl3-r7-current-best-prefill-20260813.json).
+
+The earlier bounded benchmark remains independently identified by complete
+benchmark SHA-256
+`feed67820caf37cc016473a38584b11b4205a628183f64e2b48b082a7bad2854`; it
+measured 668, 659, and 653 tok/s at 8K, 16K, and 32K respectively.
 
 The exact-Q40 prefill non-regression bracket measured medians of 526.449,
 623.599, 615.930, 618.246, and 619.807 tok/s at 8K, 16K, 32K, 64K, and 128K.

--- a/docs/STATUS.json
+++ b/docs/STATUS.json
@@ -142,6 +142,20 @@
       "matched_ckv_gather_ab_complete": true,
       "matched_prefill_gain_percent_range": [14.85, 39.16],
       "matched_decode_regression_observed": false,
+      "current_best_prefill_snapshot": {
+        "status": "accepted-operator-result",
+        "concurrency": 1,
+        "unique_context_percent": 100,
+        "client_tokens_per_second": {
+          "8192": 679,
+          "16384": 673,
+          "32768": 666,
+          "65536": 657,
+          "131072": 645
+        },
+        "evidence": "docs/configurations/glm52-exl3-r7-current-best-prefill-20260813.json",
+        "limitations": "Low visible sample counts; accepted as the operator's best measured snapshot, not a throughput distribution; server-side cache accounting unavailable."
+      },
       "exact_q40_policy": {
         "status": "accepted-operator-default",
         "scope": "target mixed-EXL3 layers at exactly 40 routed rows",

--- a/docs/configurations/glm52-exl3-r7-current-best-prefill-20260813.json
+++ b/docs/configurations/glm52-exl3-r7-current-best-prefill-20260813.json
@@ -1,0 +1,69 @@
+{
+  "schema": "sparkring-operator-prefill-snapshot/v1",
+  "date": "2026-08-13",
+  "lane": "public-functional",
+  "maturity": "accepted",
+  "configuration_status": "accepted-operator-result",
+  "acceptance_scope": "operator-3.5-bpw-four-spark-profile",
+  "hardware": "four directly cabled NVIDIA DGX Sparks / GB10 GPUs",
+  "model": "brandonmusic/GLM-5.2-EXL3-TR3v4-3.5bpw-MTP78@9ab9579774cc432df91567a36f6e9e863e0d4c9f",
+  "profile": "TP4/DCP4, fixed MTP4, dynamic per-token NVFP4 latent KV plus FP8 RoPE, exact-Q40 capacity 40 and route block 8",
+  "measurement": {
+    "mode": "client-timed C1 prefill",
+    "concurrency": 1,
+    "unique_context_percent": 100,
+    "rows": [
+      {
+        "context_label": "8K",
+        "prompt_tokens": 8194,
+        "client_ttft_seconds": 12.06,
+        "displayed_client_tokens_per_second": 679,
+        "visible_samples": 2
+      },
+      {
+        "context_label": "16K",
+        "prompt_tokens": 16386,
+        "client_ttft_seconds": 24.36,
+        "displayed_client_tokens_per_second": 673,
+        "visible_samples": 1
+      },
+      {
+        "context_label": "32K",
+        "prompt_tokens": 32770,
+        "client_ttft_seconds": 49.17,
+        "displayed_client_tokens_per_second": 666,
+        "visible_samples": 1
+      },
+      {
+        "context_label": "64K",
+        "prompt_tokens": 65538,
+        "client_ttft_seconds": 99.72,
+        "displayed_client_tokens_per_second": 657,
+        "visible_samples": 1
+      },
+      {
+        "context_label": "128K",
+        "prompt_tokens": 131074,
+        "client_ttft_seconds": 203.09,
+        "displayed_client_tokens_per_second": 645,
+        "visible_samples": 1
+      }
+    ]
+  },
+  "interpretation": {
+    "operator_acceptance": "current best measured prefill snapshot",
+    "throughput_change_8k_to_128k_percent": -5.01,
+    "context_span_multiple": 16,
+    "prior_snapshot_comparison_percent": {
+      "8192": 1.65,
+      "16384": 2.12,
+      "32768": 1.99
+    }
+  },
+  "limitations": [
+    "The visible sample counts are too small to constitute throughput distributions.",
+    "Several operator runs produced similar results, but their complete per-run artifacts are not included in this record.",
+    "Server-side cached-token accounting was unavailable, so cache misses are not independently proven by this capture.",
+    "This result is accepted only for the operator's exact four-Spark 3.5-bpw profile and does not change the repository-wide public-functional default."
+  ]
+}


### PR DESCRIPTION
## Resulting behavior\n\n- promotes the operator-accepted 3.5-bpw R7 prefill snapshot to the README and results specification\n- records 679/673/666/657/645 tok/s at 8K/16K/32K/64K/128K\n- preserves the prior hashed 668/659/653 snapshot and the exact-Q40 machine-gate result separately\n- adds machine-readable evidence scope and limitations without changing the public-functional default\n\n## Validation\n\n- python -m pytest spark_transport sparkcache runtime scripts -q (3092 passed, 17 skipped)\n- uff check --select E,F,W --ignore E501 .\n- git diff --check\n- JSON parse validation for docs/STATUS.json and the new evidence record\n\nNo live serving stack was contacted or modified.