### PR TITLE
Publish the complete accepted R7 performance matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,15 +32,25 @@ Q40. Eligible pure-prefill work uses the B12X transient full-CKV DCP gather.
 The target-only exact-Q40 routed-MoE state uses capacity 40 and route block 8;
 Q1-Q32, other prefill shapes, and the draft model retain their prior states.
 
-| Measurement | TTFT | Bounded result | Samples |
-|---|---:|---:|---:|
-| 8K unique-context C1 prefill | 12.06 s | **679 tok/s** | 2 |
-| 16K unique-context C1 prefill | 24.36 s | **673 tok/s** | 1 |
-| 32K unique-context C1 prefill | 49.17 s | **666 tok/s** | 1 |
-| 64K unique-context C1 prefill | 99.72 s | **657 tok/s** | 1 |
-| 128K unique-context C1 prefill | 203.09 s | **645 tok/s** | 1 |
-| Unique-16K C8 warm sustained decode | - | **73.208 tok/s aggregate** | 2 candidate arms |
-| Reported KV capacity | - | **1,156,864 tokens** | all four ranks |
+| Prefill context | Prompt tokens | TTFT | C1 prefill | Samples |
+|---|---:|---:|---:|---:|
+| 8K | 8,194 | 12.06 s | **679 tok/s** | 2 |
+| 16K | 16,386 | 24.36 s | **673 tok/s** | 1 |
+| 32K | 32,770 | 49.17 s | **666 tok/s** | 1 |
+| 64K | 65,538 | 99.72 s | **657 tok/s** | 1 |
+| 128K | 131,074 | 203.09 s | **645 tok/s** | 1 |
+
+| Aggregate decode tok/s | C1 | C2 | C4 | C8 |
+|---|---:|---:|---:|---:|
+| 4K context | 22.6 | 32.7 | 50.3 | **78.4** |
+| 8K context | 22.0 | 35.3 | 51.9 | **71.3** |
+| 16K context | 21.3 | 32.9 | 49.2 | **70.0** |
+| 32K context | 20.4 | 32.3 | 45.6 | **65.5** |
+| 64K context | 21.4 | 30.4 | 47.2 | **67.8** |
+
+The separate coding-peak C1 probe completed 5/5 runs at 27.3 tok/s median
+and mean, with a 28.8 tok/s maximum and zero CJK runs. Reported KV capacity is
+1,156,864 tokens across the four-rank serving profile.
 
 The matched exact-Q40 decode bracket replayed the same eight unique 16K
 payloads with full 8/8 residency and a 25-second measurement window. Its
@@ -49,12 +59,13 @@ the slower candidate repeat exceeded the fastest control repeat by 14.93%.
 All 75 target layers passed exact BF16 parity, deterministic 16K and 32K output
 equality passed, and final graph, API, transport, and capacity gates passed.
 
-The 8K-128K prefill rows are the operator-accepted current-best client-timed
-snapshot with 100% unique generated contexts. Several operator runs produced
-similar throughput, but the table reports only the visible samples and does
-not treat them as a statistical distribution. Server-side cached-token
-accounting was unavailable for these cells, so cache misses are not
-independently proven by the benchmark artifact.
+The prefill and decode tables form the operator-accepted current-best matrix
+snapshot. Prefill used 100% unique generated contexts. Several operator runs
+produced similar throughput, but only the displayed prefill sample counts and
+five coding-probe repeats are retained here; the decode cells are not presented
+as repeat distributions. Server-side cached-token accounting was unavailable
+for the prefill cells, so cache misses are not independently proven by the
+benchmark artifact.
 The predeclared exact-Q40 prefill reducer separately remains a machine failure:
 its sole primary miss was 0.1215% at 64K. Operator acceptance treats that
 bounded difference as measurement-neutral without relabelling the machine
@@ -67,8 +78,8 @@ public-functional default or an accepted public deployment matrix. Read the
 [optimization record](docs/EXL3_R7_OPTIMIZATION_20260811.md), and
 [machine-readable operator acceptance](docs/configurations/glm52-exl3-r7-mtp4-q40-block8-20260812.json)
 before reproducing or extending it.
-The accepted prefill snapshot is preserved separately in
-[machine-readable form](docs/configurations/glm52-exl3-r7-current-best-prefill-20260813.json).
+The accepted performance matrix is preserved separately in
+[machine-readable form](docs/configurations/glm52-exl3-r7-current-best-matrix-20260813.json).
 The clean source/profile composition and local build commands are in
 [the operator-profile reproduction guide](docs/EXL3_R7_OPERATOR_REPRODUCTION.md).
 

--- a/docs/EXL3_R7_FIXED_MTP4_PROFILE.md
+++ b/docs/EXL3_R7_FIXED_MTP4_PROFILE.md
@@ -31,6 +31,8 @@ The exact-Q40 acceptance result is
 [glm52-exl3-r7-mtp4-q40-block8-20260812.json](configurations/glm52-exl3-r7-mtp4-q40-block8-20260812.json).
 The operator-accepted current-best prefill snapshot is
 [glm52-exl3-r7-current-best-prefill-20260813.json](configurations/glm52-exl3-r7-current-best-prefill-20260813.json).
+The full prefill, decode, and coding snapshot is
+[glm52-exl3-r7-current-best-matrix-20260813.json](configurations/glm52-exl3-r7-current-best-matrix-20260813.json).
 
 ## Serving contract
 
@@ -117,7 +119,7 @@ Fixed-prompt non-Q40 checks measured C1 at 22.218 versus 22.362 tokens/s
 source-identical paths are treated as bounded measurement noise, not as
 optimization results.
 
-## Current-best operator prefill snapshot
+## Current-best operator performance snapshot
 
 The operator accepts the following 100%-unique-context C1 results as the best
 measured prefill snapshot for this exact four-Spark profile:
@@ -136,6 +138,25 @@ snapshot with low visible sample counts rather than a throughput distribution.
 Server-side cached-token accounting was unavailable for these cells; the
 100%-unique request construction is recorded, but the captured result does not
 independently prove cache misses.
+
+The same benchmark display reported this aggregate decode matrix:
+
+| Context | C1 | C2 | C4 | C8 |
+|---|---:|---:|---:|---:|
+| 4K | 22.6 | 32.7 | 50.3 | **78.4** |
+| 8K | 22.0 | 35.3 | 51.9 | **71.3** |
+| 16K | 21.3 | 32.9 | 49.2 | **70.0** |
+| 32K | 20.4 | 32.3 | 45.6 | **65.5** |
+| 64K | 21.4 | 30.4 | 47.2 | **67.8** |
+
+Values are aggregate tok/s. The matrix display does not expose repeat counts,
+so it is accepted as a bounded operating snapshot rather than a distribution.
+The separately controlled exact-Q40 bracket remains the stronger 16K/C8
+comparison because it replayed identical sealed payloads across repeated arms.
+
+The coding-peak C1 probe completed 5/5 runs at 27.3 tok/s median and mean,
+with a 28.8 tok/s maximum and zero CJK runs. It is a distinct workload result,
+not a replacement for the standardized C1 matrix.
 
 ## Exact CKV-gather delta and rollback
 

--- a/docs/RESULTS.md
+++ b/docs/RESULTS.md
@@ -129,6 +129,30 @@ misses are not independently proven by the captured result. The transcription,
 scope, and limitations are preserved in
 [machine-readable form](configurations/glm52-exl3-r7-current-best-prefill-20260813.json).
 
+The same accepted benchmark display reported the following aggregate decode
+matrix:
+
+| Context | C1 | C2 | C4 | C8 |
+|---|---:|---:|---:|---:|
+| 4K | 22.6 tok/s | 32.7 tok/s | 50.3 tok/s | **78.4 tok/s** |
+| 8K | 22.0 tok/s | 35.3 tok/s | 51.9 tok/s | **71.3 tok/s** |
+| 16K | 21.3 tok/s | 32.9 tok/s | 49.2 tok/s | **70.0 tok/s** |
+| 32K | 20.4 tok/s | 32.3 tok/s | 45.6 tok/s | **65.5 tok/s** |
+| 64K | 21.4 tok/s | 30.4 tok/s | 47.2 tok/s | **67.8 tok/s** |
+
+These are aggregate server throughput values, not per-request values. The
+highest displayed matrix cell is 78.4 aggregate tok/s at 4K/C8. The 16K/C8
+cell is 70.0 tok/s; it is a broad matrix observation and does not replace the
+73.208 tok/s mean from the separately controlled exact-payload warm bracket.
+The display does not expose per-cell repeat counts, so this matrix is an
+accepted operating snapshot rather than a distribution.
+
+The coding-peak C1 probe completed 5/5 runs with a 27.3 tok/s median, 27.3
+tok/s mean, and 28.8 tok/s maximum. It ran zero CJK cases. This workload peak
+is reported separately and is not substituted for the standardized C1 matrix
+cells. The complete displayed snapshot is preserved in
+[machine-readable form](configurations/glm52-exl3-r7-current-best-matrix-20260813.json).
+
 The earlier bounded benchmark remains independently identified by complete
 benchmark SHA-256
 `feed67820caf37cc016473a38584b11b4205a628183f64e2b48b082a7bad2854`; it

--- a/docs/STATUS.json
+++ b/docs/STATUS.json
@@ -156,6 +156,30 @@
         "evidence": "docs/configurations/glm52-exl3-r7-current-best-prefill-20260813.json",
         "limitations": "Low visible sample counts; accepted as the operator's best measured snapshot, not a throughput distribution; server-side cache accounting unavailable."
       },
+      "current_best_decode_matrix": {
+        "status": "accepted-operator-result",
+        "metric": "aggregate_tokens_per_second",
+        "contexts_by_concurrency": {
+          "4096": {"1": 22.6, "2": 32.7, "4": 50.3, "8": 78.4},
+          "8192": {"1": 22.0, "2": 35.3, "4": 51.9, "8": 71.3},
+          "16384": {"1": 21.3, "2": 32.9, "4": 49.2, "8": 70.0},
+          "32768": {"1": 20.4, "2": 32.3, "4": 45.6, "8": 65.5},
+          "65536": {"1": 21.4, "2": 30.4, "4": 47.2, "8": 67.8}
+        },
+        "evidence": "docs/configurations/glm52-exl3-r7-current-best-matrix-20260813.json",
+        "limitations": "Displayed bounded matrix; per-cell repeat counts are not exposed."
+      },
+      "current_best_coding_peak": {
+        "status": "accepted-operator-result",
+        "concurrency": 1,
+        "runs_passed": 5,
+        "runs_total": 5,
+        "median_tokens_per_second": 27.3,
+        "mean_tokens_per_second": 27.3,
+        "maximum_tokens_per_second": 28.8,
+        "cjk_runs": 0,
+        "evidence": "docs/configurations/glm52-exl3-r7-current-best-matrix-20260813.json"
+      },
       "exact_q40_policy": {
         "status": "accepted-operator-default",
         "scope": "target mixed-EXL3 layers at exactly 40 routed rows",

--- a/docs/configurations/glm52-exl3-r7-current-best-matrix-20260813.json
+++ b/docs/configurations/glm52-exl3-r7-current-best-matrix-20260813.json
@@ -1,0 +1,53 @@
+{
+  "schema": "sparkring-operator-performance-matrix/v1",
+  "date": "2026-08-13",
+  "lane": "public-functional",
+  "maturity": "accepted",
+  "configuration_status": "accepted-operator-result",
+  "acceptance_scope": "operator-3.5-bpw-four-spark-profile",
+  "source_capture_sha256": "0ef5cb44905ad50fe28baa1f40d7be18430bc7a655f4c853ac79d28083af08ca",
+  "source_capture_bytes": 923496,
+  "hardware": "four directly cabled NVIDIA DGX Sparks / GB10 GPUs",
+  "model": "brandonmusic/GLM-5.2-EXL3-TR3v4-3.5bpw-MTP78@9ab9579774cc432df91567a36f6e9e863e0d4c9f",
+  "profile": "TP4/DCP4, fixed MTP4, dynamic per-token NVFP4 latent KV plus FP8 RoPE, exact-Q40 capacity 40 and route block 8",
+  "prefill": {
+    "metric": "client_tokens_per_second",
+    "concurrency": 1,
+    "unique_context_percent": 100,
+    "rows": [
+      {"context_label": "8K", "prompt_tokens": 8194, "client_ttft_seconds": 12.06, "tokens_per_second": 679, "visible_samples": 2},
+      {"context_label": "16K", "prompt_tokens": 16386, "client_ttft_seconds": 24.36, "tokens_per_second": 673, "visible_samples": 1},
+      {"context_label": "32K", "prompt_tokens": 32770, "client_ttft_seconds": 49.17, "tokens_per_second": 666, "visible_samples": 1},
+      {"context_label": "64K", "prompt_tokens": 65538, "client_ttft_seconds": 99.72, "tokens_per_second": 657, "visible_samples": 1},
+      {"context_label": "128K", "prompt_tokens": 131074, "client_ttft_seconds": 203.09, "tokens_per_second": 645, "visible_samples": 1}
+    ]
+  },
+  "aggregate_decode": {
+    "metric": "aggregate_tokens_per_second",
+    "rows": [
+      {"context_label": "4K", "concurrency": {"1": 22.6, "2": 32.7, "4": 50.3, "8": 78.4}},
+      {"context_label": "8K", "concurrency": {"1": 22.0, "2": 35.3, "4": 51.9, "8": 71.3}},
+      {"context_label": "16K", "concurrency": {"1": 21.3, "2": 32.9, "4": 49.2, "8": 70.0}},
+      {"context_label": "32K", "concurrency": {"1": 20.4, "2": 32.3, "4": 45.6, "8": 65.5}},
+      {"context_label": "64K", "concurrency": {"1": 21.4, "2": 30.4, "4": 47.2, "8": 67.8}}
+    ],
+    "highest_displayed_cell": {"context_label": "4K", "concurrency": 8, "tokens_per_second": 78.4}
+  },
+  "coding_peak": {
+    "concurrency": 1,
+    "runs_passed": 5,
+    "runs_total": 5,
+    "median_tokens_per_second": 27.3,
+    "mean_tokens_per_second": 27.3,
+    "maximum_tokens_per_second": 28.8,
+    "cjk_runs": 0
+  },
+  "claim_boundaries": [
+    "Decode values are aggregate server throughput, not per-request throughput.",
+    "The decode display does not expose per-cell repeat counts, so the matrix is not a throughput distribution.",
+    "The coding peak is a separate workload probe and does not replace standardized matrix cells.",
+    "The controlled exact-Q40 16K/C8 bracket remains separate because it used identical sealed payload replay and repeated arms.",
+    "Server-side cached-token accounting was unavailable for prefill, so cache misses are not independently proven by this capture.",
+    "This result is accepted only for the operator's exact four-Spark 3.5-bpw profile and does not change the repository-wide public-functional default."
+  ]
+}


### PR DESCRIPTION
## Resulting behavior\n\n- publishes all 20 aggregate decode cells at 4K-64K and C1/C2/C4/C8\n- retains the accepted 679-645 tok/s 8K-128K prefill table\n- records the five-run coding peak (27.3 median/mean, 28.8 maximum)\n- distinguishes the broad 70.0 tok/s 16K/C8 matrix cell from the controlled 73.208 tok/s exact-payload bracket\n- adds a machine-readable full-matrix record with source-capture SHA-256 and claim boundaries\n\n## Validation\n\n- python -m pytest spark_transport sparkcache runtime scripts -q (3092 passed, 17 skipped)\n- uff check --select E,F,W --ignore E501 .\n- git diff --check\n- JSON parse validation\n\nNo live serving stack was contacted or modified.