### PR TITLE
Highlight the accepted R7 coding benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,13 @@ Q1-Q32, other prefill shapes, and the draft model retain their prior states.
 | 32K context | 20.4 | 32.3 | 45.6 | **65.5** |
 | 64K context | 21.4 | 30.4 | 47.2 | **67.8** |
 
-The separate coding-peak C1 probe completed 5/5 runs at 27.3 tok/s median
-and mean, with a 28.8 tok/s maximum and zero CJK runs. Reported KV capacity is
-1,156,864 tokens across the four-rank serving profile.
+#### Coding benchmark (C1)
+
+| Workload | Runs | Median tok/s | Mean tok/s | Maximum tok/s | CJK runs |
+|---|---:|---:|---:|---:|---:|
+| Coding peak | **5/5** | **27.3** | **27.3** | **28.8** | **0** |
+
+Reported KV capacity is 1,156,864 tokens across the four-rank serving profile.
 
 The matched exact-Q40 decode bracket replayed the same eight unique 16K
 payloads with full 8/8 residency and a 25-second measurement window. Its

--- a/docs/EXL3_R7_FIXED_MTP4_PROFILE.md
+++ b/docs/EXL3_R7_FIXED_MTP4_PROFILE.md
@@ -154,9 +154,14 @@ so it is accepted as a bounded operating snapshot rather than a distribution.
 The separately controlled exact-Q40 bracket remains the stronger 16K/C8
 comparison because it replayed identical sealed payloads across repeated arms.
 
-The coding-peak C1 probe completed 5/5 runs at 27.3 tok/s median and mean,
-with a 28.8 tok/s maximum and zero CJK runs. It is a distinct workload result,
-not a replacement for the standardized C1 matrix.
+### Coding benchmark (C1)
+
+| Workload | Runs | Median tok/s | Mean tok/s | Maximum tok/s | CJK runs |
+|---|---:|---:|---:|---:|---:|
+| Coding peak | **5/5** | **27.3** | **27.3** | **28.8** | **0** |
+
+This is a distinct workload result, not a replacement for the standardized C1
+matrix.
 
 ## Exact CKV-gather delta and rollback
 

--- a/docs/RESULTS.md
+++ b/docs/RESULTS.md
@@ -147,10 +147,14 @@ cell is 70.0 tok/s; it is a broad matrix observation and does not replace the
 The display does not expose per-cell repeat counts, so this matrix is an
 accepted operating snapshot rather than a distribution.
 
-The coding-peak C1 probe completed 5/5 runs with a 27.3 tok/s median, 27.3
-tok/s mean, and 28.8 tok/s maximum. It ran zero CJK cases. This workload peak
-is reported separately and is not substituted for the standardized C1 matrix
-cells. The complete displayed snapshot is preserved in
+#### Coding benchmark (C1)
+
+| Workload | Runs | Median tok/s | Mean tok/s | Maximum tok/s | CJK runs |
+|---|---:|---:|---:|---:|---:|
+| Coding peak | **5/5** | **27.3** | **27.3** | **28.8** | **0** |
+
+This workload peak is reported separately and is not substituted for the
+standardized C1 matrix cells. The complete displayed snapshot is preserved in
 [machine-readable form](configurations/glm52-exl3-r7-current-best-matrix-20260813.json).
 
 The earlier bounded benchmark remains independently identified by complete


### PR DESCRIPTION
## Resulting behavior\n\n- promotes the five-run C1 coding result from prose into a dedicated table\n- highlights 27.3 tok/s median/mean and 28.8 tok/s maximum\n- retains the 5/5 completion count and zero-CJK scope\n- adds the chart consistently to README, RESULTS, and the operator profile\n\n## Validation\n\n- uff check --select E,F,W --ignore E501 .\n- python -m pytest scripts/test_sparkring_recipe.py -q (22 passed)\n- git diff --check\n\nDocumentation-only; no serving interaction.