### PR TITLE
parameterize TP4 graph rows for DeepSeek

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,8 +211,9 @@ reference remains in the [historical lane](docs/history/AIDEN_MXFP4_GPTQ.md).
 
 ## What SparkRing provides
 
-- A GLM/vLLM-oriented direct-cable transport implementation, with reusable
-  low-level transport primitives.
+- A GLM/vLLM deployment plus versioned graph-row geometry for model adapters
+  such as the DeepSeek `[Q,4096]` candidate, with reusable low-level transport
+  primitives.
 - Two- and four-rank collective schedules used by the current GLM/vLLM paths.
 - Registered mapped-host RDMA arenas.
 - GPU doorbells and device-published command rings.

--- a/spark_transport/README.md
+++ b/spark_transport/README.md
@@ -66,6 +66,20 @@ attestation, qualification, and rollback contract. The exact-Q40 routed-MoE
 optimization is a separate EXL3 overlay; compiling the transport library does
 not install it.
 
+### Versioned graph row geometry
+
+The legacy `spark_tp4_create` ABI retains GLM's BF16 row geometry: 6,144
+elements and 12,288 bytes per row. Model adapters with a different hidden width
+use `spark_tp4_create_v2` and set `struct_size`, `elements_per_row`, and
+`bytes_per_row`. The current DeepSeek candidate uses 4,096 elements and 8,192
+bytes per row. `bytes_per_row` must equal `elements_per_row * 2`.
+
+Graph descriptor validation and capacity checks use the configured byte width.
+The graph all-reduce command ABI admits exact contiguous rows from Q1 through
+Q1024; provision one maximum-capacity session to capture mixed Q values. The
+expanded doorbell layout is wire-incompatible with older builds, so graph and
+dual-port endpoint handshakes reject mixed versions before posting RDMA work.
+
 ## Pair probe
 
 Server on `spark1`:

--- a/spark_transport/app/tp4_graph_q1_probe.cu
+++ b/spark_transport/app/tp4_graph_q1_probe.cu
@@ -24,8 +24,10 @@ namespace {
 constexpr std::size_t kElements = 6144;
 constexpr std::size_t kPayloadBytes =
     kElements * sizeof(__nv_bfloat16);
-constexpr std::size_t kMaximumQ =
-    spark_transport::kTp4GraphAllreduceMaximumQ;
+// This GLM qualification surface remains intentionally bounded at Q512 even
+// though the versioned transport descriptor also admits DeepSeek Q1024.
+constexpr std::size_t kMaximumQ = 512;
+static_assert(kMaximumQ <= spark_transport::kTp4GraphAllreduceMaximumQ);
 constexpr std::size_t kMaximumElements = kMaximumQ * kElements;
 constexpr std::size_t kMaximumPayloadBytes =
     kMaximumElements * sizeof(__nv_bfloat16);

--- a/spark_transport/include/spark_transport/gpu_tp4_tensor.hpp
+++ b/spark_transport/include/spark_transport/gpu_tp4_tensor.hpp
@@ -17,6 +17,7 @@ class GpuTp4TensorWorker {
   GpuTp4TensorWorker& operator=(const GpuTp4TensorWorker&) = delete;
 
   GpuTp4TensorWorker(std::size_t payload_bytes,
+                     std::uint32_t bytes_per_row,
                      void* round0_mapped_device_buffer,
                      const Tp2BufferLayout& round0_layout,
                      void* round1_mapped_device_buffer,
@@ -47,6 +48,7 @@ class GpuTp4TensorWorker {
   Tp2BufferLayout round0_layout_{};
   Tp2BufferLayout round1_layout_{};
   std::size_t payload_bytes_{};
+  std::uint32_t bytes_per_row_{};
   Tp4AllreduceProtocol protocol_{Tp4AllreduceProtocol::kSerialAck};
   Tp4GraphKernelStrategy graph_kernel_strategy_{
       Tp4GraphKernelStrategy::kFused};

--- a/spark_transport/include/spark_transport/tp4_c_api.h
+++ b/spark_transport/include/spark_transport/tp4_c_api.h
@@ -27,6 +27,19 @@ typedef struct spark_tp4_config {
   uint32_t graph_progress_cpu_plus_one;
 } spark_tp4_config;
 
+/*
+ * Versioned graph-row geometry. The embedded v1 configuration preserves the
+ * established eager and GLM graph ABI. New callers set struct_size, then use
+ * elements_per_row=4096 and bytes_per_row=8192 for DeepSeek BF16 tensors.
+ * bytes_per_row must equal elements_per_row * 2.
+ */
+typedef struct spark_tp4_config_v2 {
+  uint32_t struct_size;
+  spark_tp4_config base;
+  uint32_t elements_per_row;
+  uint32_t bytes_per_row;
+} spark_tp4_config_v2;
+
 typedef void* spark_tp4_handle;
 
 enum {
@@ -119,14 +132,20 @@ spark_tp4_create_with_protocol_graph_kernel_and_schedule(
     uint32_t graph_kernel, uint32_t wire_schedule, char* error,
     size_t error_bytes);
 
+/* Additive constructor for a non-GLM graph row layout. */
+spark_tp4_handle spark_tp4_create_v2(
+    const spark_tp4_config_v2* config, uint32_t protocol,
+    uint32_t graph_kernel, uint32_t wire_schedule, char* error,
+    size_t error_bytes);
+
 int spark_tp4_all_reduce(spark_tp4_handle handle, const void* input,
                          void* output, void* cuda_stream, char* error,
                          size_t error_bytes);
 
 /*
- * Adds one exact contiguous BF16 [q, 6144] all-reduce to an active CUDA
- * stream capture. q must be in [1, 512], and the handle's payload capacity
- * must be at least q * 12,288 bytes. One maximum-capacity handle serves
+ * Adds one exact contiguous BF16 [q, elements_per_row] all-reduce to an active
+ * CUDA stream capture. q must be in [1, 1024], and the handle's payload
+ * capacity must be at least q * bytes_per_row. One maximum-capacity handle serves
  * every supported mixed/adaptive concurrency bucket.
  */
 int spark_tp4_capture_all_reduce(
@@ -134,7 +153,7 @@ int spark_tp4_capture_all_reduce(
     void* cuda_stream, char* error, size_t error_bytes);
 
 /*
- * Adds a Q1 BF16 [1, 6144] all-reduce to an active CUDA stream capture.
+ * Adds a Q1 BF16 [1, elements_per_row] all-reduce to capture.
  * The graph is bound to the supplied tensor addresses, must replay on the
  * capture stream, and the handle must outlive all graph replays. The function
  * may be called repeatedly on that stream before the first replay so one

--- a/spark_transport/include/spark_transport/tp4_graph_command.hpp
+++ b/spark_transport/include/spark_transport/tp4_graph_command.hpp
@@ -10,13 +10,15 @@ namespace spark_transport {
 constexpr std::size_t kTp4GraphCommandCapacity = 64;
 constexpr std::uint32_t kTp4GraphElementsPerRow = 6144;
 constexpr std::uint32_t kTp4GraphBytesPerElement = 2;
+constexpr std::uint32_t kTp4GraphBytesPerRow =
+    kTp4GraphElementsPerRow * kTp4GraphBytesPerElement;
 // Eight active sequences at maximum MTP4 produce at most Q40.
 constexpr std::uint32_t kTp4GraphMaximumQ = 40;
 // All-reduce alone admits the first bounded prefill tier. Vocabulary and
 // DCP descriptors remain capped by kTp4GraphMaximumQ.
-constexpr std::uint32_t kTp4GraphAllreduceMaximumQ = 512;
-// Q is encoded directly (not Q-1), so Q512 needs ten low-order bits.
-constexpr std::uint32_t kTp4GraphDoorbellQBits = 10;
+constexpr std::uint32_t kTp4GraphAllreduceMaximumQ = 1024;
+// Q is encoded directly (not Q-1), so Q1024 needs eleven low-order bits.
+constexpr std::uint32_t kTp4GraphDoorbellQBits = 11;
 constexpr std::uint64_t kTp4GraphDoorbellQMask =
     (std::uint64_t{1} << kTp4GraphDoorbellQBits) - 1;
 constexpr std::uint64_t kTp4GraphMaximumDoorbellSequence =
@@ -30,8 +32,9 @@ static_assert(
     std::numeric_limits<std::uint32_t>::max());
 
 constexpr std::uint32_t tp4_graph_payload_bytes(
-    std::uint32_t q) noexcept {
-  return q * kTp4GraphElementsPerRow * kTp4GraphBytesPerElement;
+    std::uint32_t q,
+    std::uint32_t bytes_per_row = kTp4GraphBytesPerRow) noexcept {
+  return q * bytes_per_row;
 }
 
 constexpr bool tp4_graph_command_layout_valid(
@@ -47,7 +50,7 @@ constexpr bool tp4_graph_command_descriptor_valid(
     std::uint32_t q, std::uint32_t payload_bytes) noexcept {
   return tp4_graph_command_layout_valid(
       q, payload_bytes,
-      kTp4GraphElementsPerRow * kTp4GraphBytesPerElement,
+      kTp4GraphBytesPerRow,
       kTp4GraphMaximumQ);
 }
 
@@ -55,7 +58,7 @@ constexpr bool tp4_graph_allreduce_command_descriptor_valid(
     std::uint32_t q, std::uint32_t payload_bytes) noexcept {
   return tp4_graph_command_layout_valid(
       q, payload_bytes,
-      kTp4GraphElementsPerRow * kTp4GraphBytesPerElement,
+      kTp4GraphBytesPerRow,
       kTp4GraphAllreduceMaximumQ);
 }
 
@@ -158,7 +161,7 @@ bool tp4_graph_command_publish_descriptor(
     std::uint32_t payload_bytes, std::uint64_t* sequence) noexcept;
 
 // All-reduce-only publisher. Unlike the shared Q40 descriptor entrypoint,
-// this accepts exact contiguous BF16 [Q, 6144] through Q512.
+// this accepts exact contiguous BF16 rows through Q1024.
 bool tp4_graph_allreduce_command_publish_descriptor(
     Tp4GraphCommandRing* ring, bool trace, std::uint32_t q,
     std::uint32_t payload_bytes, std::uint64_t* sequence) noexcept;

--- a/spark_transport/include/spark_transport/tp4_session.hpp
+++ b/spark_transport/include/spark_transport/tp4_session.hpp
@@ -8,6 +8,7 @@
 
 #include "spark_transport/tp4_allreduce_protocol.hpp"
 #include "spark_transport/tp4_dual_port_striped_allreduce.hpp"
+#include "spark_transport/tp4_graph_command.hpp"
 #include "spark_transport/tp4_graph_kernel_strategy.hpp"
 
 namespace spark_transport {
@@ -23,6 +24,10 @@ struct Tp4AllreduceOptions {
   std::uint16_t control_port0{9470};
   std::uint16_t control_port1{9471};
   std::size_t payload_bytes{12288};
+  // Graph all-reduce row geometry. Legacy callers retain the GLM BF16
+  // [Q, 6144] contract; versioned callers may select another BF16 width.
+  std::uint32_t elements_per_row{kTp4GraphElementsPerRow};
+  std::uint32_t bytes_per_row{kTp4GraphBytesPerRow};
   Tp4AllreduceProtocol protocol{Tp4AllreduceProtocol::kSerialAck};
   Tp4GraphKernelStrategy graph_kernel_strategy{
       Tp4GraphKernelStrategy::kFused};
@@ -66,7 +71,7 @@ class Tp4AllreduceSession {
   // saturating CUDA's launch queue.
   void all_reduce(const void* input, void* output, void* cuda_stream);
 
-  // Adds a Q1 BF16 [1, 6144] all-reduce to an active CUDA stream capture.
+  // Adds a Q1 BF16 [1, elements_per_row] all-reduce to capture.
   // The captured graph is tied to these stable input/output addresses and
   // must be replayed on the same stream. This session must outlive every
   // graph replay. Replay sequences are device-published through mapped host
@@ -76,9 +81,9 @@ class Tp4AllreduceSession {
   void capture_q1_all_reduce(const void* input, void* output,
                              void* cuda_stream);
 
-  // Adds one exact contiguous BF16 [q, 6144] all-reduce to an active CUDA
-  // stream capture. q must be in [1, 512] and the session capacity must be at
-  // least q rows. The Q512 maximum-capacity session has a 6 MiB payload
+  // Adds one exact contiguous BF16 [q, elements_per_row] all-reduce to CUDA
+  // stream capture. q must be in [1, 1024] and the session capacity must be at
+  // least q rows. GLM may retain Q512 while DeepSeek can provision Q1024.
   // arena and can serve decode plus bounded-prefill graph nodes while
   // preserving one ordered sequence.
   void capture_all_reduce(const void* input, void* output, std::uint32_t q,

--- a/spark_transport/src/gpu_tp4_tensor.cu
+++ b/spark_transport/src/gpu_tp4_tensor.cu
@@ -747,7 +747,8 @@ __global__ void tp4_striped_finish(
 }  // namespace
 
 GpuTp4TensorWorker::GpuTp4TensorWorker(
-    std::size_t payload_bytes, void* round0_mapped_device_buffer,
+    std::size_t payload_bytes, std::uint32_t bytes_per_row,
+    void* round0_mapped_device_buffer,
     const Tp2BufferLayout& round0_layout,
     void* round1_mapped_device_buffer,
     const Tp2BufferLayout& round1_layout,
@@ -759,10 +760,11 @@ GpuTp4TensorWorker::GpuTp4TensorWorker(
       round0_layout_(round0_layout),
       round1_layout_(round1_layout),
       payload_bytes_(payload_bytes),
+      bytes_per_row_(bytes_per_row),
       protocol_(protocol),
       graph_kernel_strategy_(graph_kernel_strategy),
       schedule_(schedule) {
-  if (payload_bytes_ == 0 ||
+  if (payload_bytes_ == 0 || bytes_per_row_ == 0 ||
       payload_bytes_ % sizeof(__nv_bfloat16) != 0) {
     throw std::invalid_argument(
         "TP4 tensor size must be nonzero BF16 data");
@@ -842,12 +844,14 @@ void GpuTp4TensorWorker::enqueue_graph(
     const void* external_input, void* external_output, std::uint32_t q,
     void* cuda_stream, Tp4GraphCommandRing* command_ring, bool trace) {
   const std::uint32_t active_payload_bytes =
-      tp4_graph_payload_bytes(q);
-  if (!tp4_graph_allreduce_command_descriptor_valid(
-          q, active_payload_bytes) ||
+      tp4_graph_payload_bytes(q, bytes_per_row_);
+  if (!tp4_graph_command_layout_valid(
+          q, active_payload_bytes, bytes_per_row_,
+          kTp4GraphAllreduceMaximumQ) ||
       active_payload_bytes > payload_bytes_) {
     throw std::invalid_argument(
-        "graph TP4 all-reduce requires BF16 [q, 6144], q in [1, 512], "
+        "graph TP4 all-reduce requires the configured BF16 [q, width], "
+        "q in [1, 1024], "
         "within session capacity");
   }
   if (external_input == nullptr || external_output == nullptr ||
@@ -913,7 +917,7 @@ void GpuTp4TensorWorker::enqueue_graph(
   if (tp4_graph_kernel_uses_split(graph_kernel_strategy_, q)) {
     if (!split_graph_q_supported(q) || split_graph_state_ == nullptr) {
       throw std::invalid_argument(
-          "split_64k graph TP4 requires Q1 through Q512 and initialized "
+          "split_64k graph TP4 requires Q1 through Q1024 and initialized "
           "split state");
     }
     constexpr int control_threads = 32;

--- a/spark_transport/src/tp4_c_api.cpp
+++ b/spark_transport/src/tp4_c_api.cpp
@@ -57,6 +57,17 @@ spark_transport::Tp4AllreduceOptions translate(
   return options;
 }
 
+spark_transport::Tp4AllreduceOptions translate(
+    const spark_tp4_config_v2& config) {
+  if (config.struct_size < sizeof(spark_tp4_config_v2)) {
+    throw std::invalid_argument("TP4 C API v2 config is too small");
+  }
+  auto options = translate(config.base);
+  options.elements_per_row = config.elements_per_row;
+  options.bytes_per_row = config.bytes_per_row;
+  return options;
+}
+
 spark_transport::Tp4AllgatherOptions translate(
     const spark_tp4_allgather_config& config) {
   if (config.peer0 == nullptr || config.peer1 == nullptr ||
@@ -223,6 +234,31 @@ spark_tp4_create_with_protocol_graph_kernel_and_schedule(
     return nullptr;
   } catch (...) {
     copy_error("unknown TP4 create failure", error, error_bytes);
+    return nullptr;
+  }
+}
+
+extern "C" spark_tp4_handle spark_tp4_create_v2(
+    const spark_tp4_config_v2* config, std::uint32_t protocol,
+    std::uint32_t graph_kernel, std::uint32_t wire_schedule,
+    char* error, std::size_t error_bytes) {
+  try {
+    if (config == nullptr) {
+      throw std::invalid_argument("TP4 C API v2 config is null");
+    }
+    auto options = translate(*config);
+    options.protocol =
+        spark_transport::tp4_allreduce_protocol_from_wire(protocol);
+    options.graph_kernel_strategy = graph_kernel_from_wire(graph_kernel);
+    options.schedule = schedule_from_wire(wire_schedule);
+    auto handle =
+        std::make_unique<Tp4CAllreduceHandle>(std::move(options));
+    return handle.release();
+  } catch (const std::exception& exception) {
+    copy_error(exception.what(), error, error_bytes);
+    return nullptr;
+  } catch (...) {
+    copy_error("unknown TP4 v2 create failure", error, error_bytes);
     return nullptr;
   }
 }

--- a/spark_transport/src/tp4_dual_port_striped_host.hpp
+++ b/spark_transport/src/tp4_dual_port_striped_host.hpp
@@ -11,8 +11,17 @@ namespace spark_transport::detail {
 
 // A peer that only understands the legacy or ordinary two-slot layout must
 // fail the setup handshake before either side posts RDMA into a striped arena.
-constexpr std::uint16_t kTp4DualPortStripedEndpointVersion = 3;
+constexpr std::uint16_t kTp4DualPortStripedEndpointVersion = 4;
 constexpr std::uint16_t kTp4DualPortStripedEndpointTag = 0xc204;
+
+constexpr std::uint16_t tp4_dual_port_striped_endpoint_tag(
+    std::uint32_t elements_per_row,
+    std::uint32_t bytes_per_row) noexcept {
+  return static_cast<std::uint16_t>(
+      kTp4DualPortStripedEndpointTag ^ elements_per_row ^
+      (elements_per_row >> 16U) ^ bytes_per_row ^
+      (bytes_per_row >> 16U));
+}
 
 enum class Tp4StripedWorkEvent : std::uint64_t {
   kPhase1Doorbell = 1,
@@ -52,8 +61,10 @@ inline bool tp4_dual_port_striped_options_valid(
       options.graph_progress_cpu.has_value() &&
       options.graph_submit_cpu != options.graph_progress_cpu;
   const bool capacity_valid =
-      options.payload_bytes == tp4_graph_payload_bytes(40) ||
-      options.payload_bytes == tp4_graph_payload_bytes(512);
+      options.payload_bytes ==
+          tp4_graph_payload_bytes(40, options.bytes_per_row) ||
+      options.payload_bytes ==
+          tp4_graph_payload_bytes(512, options.bytes_per_row);
   return options.schedule == Tp4AllreduceSchedule::kDualPortStriped &&
          options.protocol == Tp4AllreduceProtocol::kTwoSlotDeferredAck &&
          options.graph_kernel_strategy == Tp4GraphKernelStrategy::kFused &&

--- a/spark_transport/src/tp4_session.cpp
+++ b/spark_transport/src/tp4_session.cpp
@@ -44,17 +44,25 @@ namespace {
 constexpr std::uint64_t kDefaultMaxInflight = 64;
 constexpr std::uint64_t kMaximumMaxInflight = 4096;
 constexpr auto kGraphProtocolTimeout = std::chrono::seconds(5);
-constexpr std::size_t kQ1PayloadBytes =
-    tp4_graph_payload_bytes(1);
 // The record layout remains EndpointInfo v1. A distinct wire version makes a
 // mixed old/new deferred-credit deployment fail on both peers before either
 // peer enters the data path; old binaries otherwise ignore reserved tags.
 constexpr std::uint16_t kTwoSlotDeferredEndpointVersion = 2;
+constexpr std::uint16_t kGraphLayoutEndpointVersion = 4;
 
-bool graph_capacity_supported(std::size_t payload_bytes) {
+constexpr std::uint16_t graph_layout_endpoint_tag(
+    std::uint32_t elements_per_row,
+    std::uint32_t bytes_per_row) noexcept {
+  return static_cast<std::uint16_t>(
+      0xc211U ^ elements_per_row ^ (elements_per_row >> 16U) ^
+      bytes_per_row ^ (bytes_per_row >> 16U));
+}
+
+bool graph_capacity_supported(std::size_t payload_bytes,
+                              std::uint32_t bytes_per_row) {
   for (std::uint32_t q = 1;
        q <= kTp4GraphAllreduceMaximumQ; ++q) {
-    if (payload_bytes == tp4_graph_payload_bytes(q)) {
+    if (payload_bytes == tp4_graph_payload_bytes(q, bytes_per_row)) {
       return true;
     }
   }
@@ -128,11 +136,18 @@ ControlChannel open_channel(const Tp4RoundPlan& plan,
 
 void exchange_and_connect_endpoint(
     ControlChannel& channel, VerbsEndpoint& endpoint,
-    Tp4AllreduceProtocol protocol, Tp4AllreduceSchedule schedule) {
+    Tp4AllreduceProtocol protocol, Tp4AllreduceSchedule schedule,
+    bool graph_session, std::uint32_t elements_per_row,
+    std::uint32_t bytes_per_row) {
   EndpointInfo local = endpoint.local_info();
   if (schedule == Tp4AllreduceSchedule::kDualPortStriped) {
     local.version = detail::kTp4DualPortStripedEndpointVersion;
-    local.reserved = detail::kTp4DualPortStripedEndpointTag;
+    local.reserved = detail::tp4_dual_port_striped_endpoint_tag(
+        elements_per_row, bytes_per_row);
+  } else if (graph_session) {
+    local.version = kGraphLayoutEndpointVersion;
+    local.reserved =
+        graph_layout_endpoint_tag(elements_per_row, bytes_per_row);
   } else if (tp4_protocol_uses_deferred_ack(protocol)) {
     local.version = kTwoSlotDeferredEndpointVersion;
     local.reserved = tp4_endpoint_protocol_tag(protocol);
@@ -363,6 +378,16 @@ class Tp4AllreduceSession::Impl {
         options_.control_port1 == 0) {
       throw std::invalid_argument("invalid TP4 all-reduce options");
     }
+    if (options_.elements_per_row == 0 || options_.bytes_per_row == 0 ||
+        static_cast<std::uint64_t>(options_.bytes_per_row) !=
+            static_cast<std::uint64_t>(options_.elements_per_row) *
+                kTp4GraphBytesPerElement ||
+        static_cast<std::uint64_t>(options_.bytes_per_row) *
+                kTp4GraphAllreduceMaximumQ >
+            std::numeric_limits<std::uint32_t>::max()) {
+      throw std::invalid_argument(
+          "TP4 graph row geometry must describe contiguous BF16 rows");
+    }
     (void)tp4_allreduce_protocol_from_wire(
         static_cast<std::uint32_t>(options_.protocol));
     if (!tp4_graph_kernel_strategy_valid(
@@ -387,7 +412,8 @@ class Tp4AllreduceSession::Impl {
     }
     if (tp4_protocol_uses_deferred_ack(options_.protocol) &&
         (!submit_cpu_set ||
-         !graph_capacity_supported(options_.payload_bytes))) {
+         !graph_capacity_supported(options_.payload_bytes,
+                                   options_.bytes_per_row))) {
       throw std::invalid_argument(
           "two-slot deferred ACK requires a graph-only TP4 all-reduce "
           "session with a supported graph payload capacity");
@@ -395,12 +421,13 @@ class Tp4AllreduceSession::Impl {
     if (tp4_graph_kernel_strategy_is_graph_only(
             options_.graph_kernel_strategy)) {
       if (!submit_cpu_set ||
-          !graph_capacity_supported(options_.payload_bytes)) {
+          !graph_capacity_supported(options_.payload_bytes,
+                                    options_.bytes_per_row)) {
         throw std::invalid_argument(
             std::string(tp4_graph_kernel_strategy_name(
                             options_.graph_kernel_strategy)) +
             " graph TP4 requires a graph-only session with exact Q1 "
-            "through Q512 capacity");
+            "through Q1024 capacity");
       }
     }
     if (submit_cpu_set) {
@@ -437,7 +464,9 @@ class Tp4AllreduceSession::Impl {
     endpoint0_ = std::make_unique<VerbsEndpoint>(
         options_.device0, 1, options_.gid0, *buffer0_);
     exchange_and_connect_endpoint(*channel0_, *endpoint0_,
-                                  options_.protocol, options_.schedule);
+                                  options_.protocol, options_.schedule,
+                                  submit_cpu_set, options_.elements_per_row,
+                                  options_.bytes_per_row);
 
     channel1_.emplace(
         open_channel(plan1, options_.peer1, options_.control_port1));
@@ -446,9 +475,12 @@ class Tp4AllreduceSession::Impl {
     endpoint1_ = std::make_unique<VerbsEndpoint>(
         options_.device1, 1, options_.gid1, *buffer1_);
     exchange_and_connect_endpoint(*channel1_, *endpoint1_,
-                                  options_.protocol, options_.schedule);
+                                  options_.protocol, options_.schedule,
+                                  submit_cpu_set, options_.elements_per_row,
+                                  options_.bytes_per_row);
 
-    if (graph_capacity_supported(options_.payload_bytes)) {
+    if (graph_capacity_supported(options_.payload_bytes,
+                                 options_.bytes_per_row)) {
       int device{};
       int host_native_atomics{};
       check_cuda(cudaGetDevice(&device), "cudaGetDevice graph TP4");
@@ -467,7 +499,8 @@ class Tp4AllreduceSession::Impl {
     }
 
     worker_ = std::make_unique<GpuTp4TensorWorker>(
-        options_.payload_bytes, buffer0_->device_data(), layout_,
+        options_.payload_bytes, options_.bytes_per_row,
+        buffer0_->device_data(), layout_,
         buffer1_->device_data(), layout_, options_.protocol,
         options_.graph_kernel_strategy, options_.schedule);
     channel0_->barrier();
@@ -595,13 +628,15 @@ class Tp4AllreduceSession::Impl {
           "graph TP4 all-reduce tensor pointer is null");
     }
     const std::uint32_t active_payload_bytes =
-        tp4_graph_payload_bytes(q);
-    if (!tp4_graph_allreduce_command_descriptor_valid(
-            q, active_payload_bytes) ||
+        tp4_graph_payload_bytes(q, options_.bytes_per_row);
+    if (!tp4_graph_command_layout_valid(
+            q, active_payload_bytes, options_.bytes_per_row,
+            kTp4GraphAllreduceMaximumQ) ||
         active_payload_bytes > options_.payload_bytes ||
         graph_commands_host_ == nullptr) {
       throw std::invalid_argument(
-          "graph TP4 all-reduce requires BF16 [q, 6144], q in [1, 512], "
+          "graph TP4 all-reduce requires the configured BF16 [q, width], "
+          "q in [1, 1024], "
           "within session capacity");
     }
     if (!graph_host_native_atomics_supported_) {
@@ -844,8 +879,9 @@ class Tp4AllreduceSession::Impl {
 
       Tp4GraphCommand command{};
       const std::uint64_t expected = graph_consumed_sequence_ + 1;
-      if (!tp4_graph_allreduce_command_try_consume_descriptor(
-              graph_commands_host_, expected, &command)) {
+      if (!tp4_graph_command_try_consume_layout(
+              graph_commands_host_, expected, options_.bytes_per_row,
+              kTp4GraphAllreduceMaximumQ, &command)) {
         adaptive_graph_poll_pause(poll_misses);
         continue;
       }

--- a/spark_transport/tests/test_tp4_split_graph_source_contract.py
+++ b/spark_transport/tests/test_tp4_split_graph_source_contract.py
@@ -134,7 +134,8 @@ def test_tiered_worker_rejects_eager_but_accepts_both_graph_protocols() -> None:
     assert "tp4_graph_kernel_uses_split(graph_kernel_strategy_, q)" in enqueue_graph
     assert "q >= 1 && q <= kTp4GraphAllreduceMaximumQ" in worker
     assert "tp4_graph_kernel_strategy_is_graph_only" in session
-    assert "graph_capacity_supported(options_.payload_bytes)" in session
+    assert "graph_capacity_supported(options_.payload_bytes," in session
+    assert "options_.bytes_per_row" in session
     assert "kTp4TieredSplitMinimumQ = 7" in strategy
     assert "q >= kTp4TieredSplitMinimumQ" in strategy
 

--- a/spark_transport/tests/tp4_c_api_layout_test.cpp
+++ b/spark_transport/tests/tp4_c_api_layout_test.cpp
@@ -26,6 +26,17 @@ static_assert(
     sizeof(void*) != 8 ||
     offsetof(spark_tp4_config, graph_progress_cpu_plus_one) == 60);
 
+static_assert(std::is_standard_layout_v<spark_tp4_config_v2>);
+static_assert(std::is_trivially_copyable_v<spark_tp4_config_v2>);
+static_assert(sizeof(void*) != 8 || sizeof(spark_tp4_config_v2) == 80);
+static_assert(offsetof(spark_tp4_config_v2, struct_size) == 0);
+static_assert(sizeof(void*) != 8 ||
+              offsetof(spark_tp4_config_v2, base) == 8);
+static_assert(sizeof(void*) != 8 ||
+              offsetof(spark_tp4_config_v2, elements_per_row) == 72);
+static_assert(sizeof(void*) != 8 ||
+              offsetof(spark_tp4_config_v2, bytes_per_row) == 76);
+
 static_assert(std::is_standard_layout_v<spark_tp4_graph_status>);
 static_assert(std::is_trivially_copyable_v<spark_tp4_graph_status>);
 static_assert(sizeof(spark_tp4_graph_status) == 56);

--- a/spark_transport/tests/tp4_c_api_test.cpp
+++ b/spark_transport/tests/tp4_c_api_test.cpp
@@ -60,6 +60,37 @@ int main() {
              sizeof(error)) == nullptr);
   expect_message_contains(error, "invalid TP4 wire schedule");
 
+  std::memset(error, 0, sizeof(error));
+  assert(spark_tp4_create_v2(
+             nullptr, SPARK_TP4_ALLREDUCE_PROTOCOL_SERIAL_ACK,
+             SPARK_TP4_GRAPH_KERNEL_FUSED,
+             SPARK_TP4_WIRE_SCHEDULE_SEQUENTIAL, error,
+             sizeof(error)) == nullptr);
+  expect_message_contains(error, "v2 config is null");
+
+  spark_tp4_config_v2 deepseek_config{};
+  deepseek_config.struct_size = sizeof(deepseek_config) - 1;
+  deepseek_config.base = protocol_config;
+  deepseek_config.elements_per_row = 4096;
+  deepseek_config.bytes_per_row = 8192;
+  std::memset(error, 0, sizeof(error));
+  assert(spark_tp4_create_v2(
+             &deepseek_config, SPARK_TP4_ALLREDUCE_PROTOCOL_SERIAL_ACK,
+             SPARK_TP4_GRAPH_KERNEL_FUSED,
+             SPARK_TP4_WIRE_SCHEDULE_SEQUENTIAL, error,
+             sizeof(error)) == nullptr);
+  expect_message_contains(error, "v2 config is too small");
+
+  deepseek_config.struct_size = sizeof(deepseek_config);
+  deepseek_config.bytes_per_row = 12288;
+  std::memset(error, 0, sizeof(error));
+  assert(spark_tp4_create_v2(
+             &deepseek_config, SPARK_TP4_ALLREDUCE_PROTOCOL_SERIAL_ACK,
+             SPARK_TP4_GRAPH_KERNEL_FUSED,
+             SPARK_TP4_WIRE_SCHEDULE_SEQUENTIAL, error,
+             sizeof(error)) == nullptr);
+  expect_message_contains(error, "contiguous BF16 rows");
+
   assert(spark_tp4_capture_q1_all_reduce(
              nullptr, nullptr, nullptr, nullptr, error, sizeof(error)) == 1);
   expect_message_contains(error, "handle is null");

--- a/spark_transport/tests/tp4_dual_port_striped_host_test.cpp
+++ b/spark_transport/tests/tp4_dual_port_striped_host_test.cpp
@@ -11,6 +11,7 @@ int main() {
   using spark_transport::detail::kTp4DualPortStripedEndpointTag;
   using spark_transport::detail::kTp4DualPortStripedEndpointVersion;
   using spark_transport::detail::Tp4StripedWorkEvent;
+  using spark_transport::detail::tp4_dual_port_striped_endpoint_tag;
   using spark_transport::detail::tp4_dual_port_striped_options_valid;
   using spark_transport::detail::tp4_striped_work_id;
 
@@ -19,6 +20,8 @@ int main() {
   static_assert(kTp4DualPortStripedEndpointTag != 0);
   static_assert(kTp4DualPortStripedEndpointTag !=
                 spark_transport::kTp4TwoSlotEndpointTag);
+  static_assert(tp4_dual_port_striped_endpoint_tag(6144, 12288) !=
+                tp4_dual_port_striped_endpoint_tag(4096, 8192));
 
   constexpr std::array<std::uint64_t, 4> sequence1_work_ids{
       tp4_striped_work_id(1, Tp4StripedWorkEvent::kPhase1Doorbell),

--- a/spark_transport/tests/tp4_graph_command_test.cpp
+++ b/spark_transport/tests/tp4_graph_command_test.cpp
@@ -74,9 +74,9 @@ int main() {
       kTp4GraphMaximumQ + 1,
       tp4_graph_payload_bytes(kTp4GraphMaximumQ + 1)));
   static_assert(kTp4GraphMaximumQ == 40);
-  static_assert(kTp4GraphAllreduceMaximumQ == 512);
+  static_assert(kTp4GraphAllreduceMaximumQ == 1024);
   static_assert(tp4_graph_payload_bytes(kTp4GraphAllreduceMaximumQ) ==
-                6U * 1024U * 1024U);
+                12U * 1024U * 1024U);
   assert(tp4_graph_allreduce_command_descriptor_valid(
       kTp4GraphAllreduceMaximumQ,
       tp4_graph_payload_bytes(kTp4GraphAllreduceMaximumQ)));
@@ -88,6 +88,20 @@ int main() {
   assert(!tp4_graph_command_layout_valid(7, 7 * 77440, 77440, 6));
   assert(!tp4_graph_command_layout_valid(6, 6 * 77440 - 1, 77440, 6));
   assert(!tp4_graph_command_layout_valid(1, 1, 0, 6));
+  constexpr std::uint32_t deepseek_bytes_per_row = 4096U * 2U;
+  static_assert(tp4_graph_payload_bytes(1, deepseek_bytes_per_row) ==
+                8192U);
+  static_assert(tp4_graph_payload_bytes(1024, deepseek_bytes_per_row) ==
+                8U * 1024U * 1024U);
+  assert(tp4_graph_command_layout_valid(
+      30, tp4_graph_payload_bytes(30, deepseek_bytes_per_row),
+      deepseek_bytes_per_row, kTp4GraphAllreduceMaximumQ));
+  assert(tp4_graph_command_layout_valid(
+      1024, tp4_graph_payload_bytes(1024, deepseek_bytes_per_row),
+      deepseek_bytes_per_row, kTp4GraphAllreduceMaximumQ));
+  assert(!tp4_graph_command_layout_valid(
+      30, tp4_graph_payload_bytes(30), deepseek_bytes_per_row,
+      kTp4GraphAllreduceMaximumQ));
   assert(!tp4_graph_doorbell_token_valid(0, 1));
   assert(!tp4_graph_doorbell_token_valid(1, 0));
   assert(tp4_graph_doorbell_token_valid(
@@ -112,25 +126,26 @@ int main() {
       previous = token;
     }
   }
-  const auto q512_token = tp4_graph_doorbell_token(
+  const auto maximum_q_token = tp4_graph_doorbell_token(
       7, kTp4GraphAllreduceMaximumQ);
-  assert((q512_token >> kTp4GraphDoorbellQBits) == 7);
-  assert((q512_token & kTp4GraphDoorbellQMask) ==
+  assert((maximum_q_token >> kTp4GraphDoorbellQBits) == 7);
+  assert((maximum_q_token & kTp4GraphDoorbellQMask) ==
          kTp4GraphAllreduceMaximumQ);
-  assert(q512_token < tp4_graph_doorbell_token(8, 1));
+  assert(maximum_q_token < tp4_graph_doorbell_token(8, 1));
 
-  Tp4GraphCommandRing allreduce_q512{};
-  std::uint64_t allreduce_q512_sequence{};
+  Tp4GraphCommandRing allreduce_maximum_q{};
+  std::uint64_t allreduce_maximum_q_sequence{};
   assert(tp4_graph_allreduce_command_publish_descriptor(
-      &allreduce_q512, true, kTp4GraphAllreduceMaximumQ,
+      &allreduce_maximum_q, true, kTp4GraphAllreduceMaximumQ,
       tp4_graph_payload_bytes(kTp4GraphAllreduceMaximumQ),
-      &allreduce_q512_sequence));
-  assert(allreduce_q512_sequence == 1);
-  Tp4GraphCommand allreduce_q512_command{};
+      &allreduce_maximum_q_sequence));
+  assert(allreduce_maximum_q_sequence == 1);
+  Tp4GraphCommand allreduce_maximum_q_command{};
   assert(tp4_graph_allreduce_command_try_consume_descriptor(
-      &allreduce_q512, 1, &allreduce_q512_command));
-  assert(allreduce_q512_command.q == kTp4GraphAllreduceMaximumQ);
-  assert(allreduce_q512_command.payload_bytes == 6U * 1024U * 1024U);
+      &allreduce_maximum_q, 1, &allreduce_maximum_q_command));
+  assert(allreduce_maximum_q_command.q == kTp4GraphAllreduceMaximumQ);
+  assert(allreduce_maximum_q_command.payload_bytes ==
+         12U * 1024U * 1024U);
 
   std::uint64_t sequence{99};
   assert(!tp4_graph_command_publish_descriptor(


### PR DESCRIPTION
<!--
  Thanks for contributing to SparkRing.

  Every box below is a real gate, not paperwork. If a section does not apply,
  write "n/a" and why — do not delete it, and do not tick a box you have not
  actually satisfied. A PR that claims a test passed when it did not is worse
  than a PR with a failing test.

  New here? Read CONTRIBUTING.md first — especially "The two-lane claim
  policy", which governs what this change is allowed to claim.
-->

## What this changes

<!-- One paragraph. What and why, not how. Link the issue or proposal. -->

Closes #

---

## 1. Which lane does this target?

<!-- Exactly one. See CONTRIBUTING.md, "The two-lane claim policy". -->

- [ ] **Public-functional** — must work from this tree, on hardware anyone can
      obtain. No claim about the published performance numbers.
- [ ] **Reference-performance** — targets the pinned reference runtime and the
      numbers measured on it. Requires evidence from an acceptance-gated
      window (see section 4).
- [ ] **Docs only** — no behaviour change, no measurement.
- [ ] **Developer experience / CI / tooling** — no serving impact.

**Lane statement (one sentence, required):**
<!-- e.g. "Public-functional: adds a shape to the TP4 dispatch table; it does
     not touch the reference runtime and makes no performance claim." -->

---

## 2. Provenance

- [ ] **This change contains no code copied or adapted from another project.**

If that box is **not** ticked, complete the following — a PR with third-party
lineage and no provenance block will not be merged:

| Field | Answer |
|---|---|
| Source project | |
| Upstream URL / commit | |
| License | |
| Files or ideas taken | |
| `THIRD_PARTY_NOTICES.md` updated? | |

### If this adds or modifies a runtime patch under `runtime/patches/`

- [ ] The patch is pinned to the exact upstream commit recorded in
      `runtime/runtime-lock.json`.
- [ ] `runtime/patches/vllm/preimages.json` records the **SHA-256 of the exact
      upstream preimage file(s)** this patch applies to.
- [ ] `git apply --check` is clean with **zero fuzz and zero offsets** against
      that pinned upstream tree.
- [ ] The patch is described in `runtime/patches/vllm/README.md`.
- [ ] I understand the overlay is fail-closed: on a preimage mismatch it must
      refuse to start rather than guess.

Preimage hash(es) added or changed:

```text

```

---

## 3. Tests

**Exact commands run, and their exact output.** Paste the summary lines —
"tests pass" is not evidence.

### Offline (CPU-only, no GPU, no cluster)

```console
$ python -m pytest spark_transport sparkcache runtime -q

```

```console
$ ruff check --select E,F,W --ignore E501 .

```

- [ ] I added or extended a test that fails without this change.
      If not, explain why the change is untestable offline:
      <!-- e.g. "pure CUDA kernel; covered by the manual gate in section 4" -->

### Native (only if this touches C++/CUDA)

CPU-only portion — this one runs in CI:

```console
$ cmake -S sparkcache/native -B build/native -DSPARK_CACHE_PLACEMENT_ENABLE_CUDA=OFF
$ cmake --build build/native --parallel
$ ctest --test-dir build/native --output-on-failure

```

CUDA / hardware portion — **CI cannot run this.** If you touched
`spark_transport/` or any `.cu` file, paste the output of the full CTest suite
run on real hardware, or state plainly that you could not run it:

```console
$ ctest --test-dir <build> --output-on-failure

```

- [ ] I ran the native suite on hardware and pasted the result above.
- [ ] I could **not** run it (no hardware). I am asking a maintainer to gate it.

---

## 4. Evidence for any performance claim

If this PR, its title, its commit messages, or any doc it edits states a
number — throughput, latency, speedup, pool size, acceptance rate — fill this
in. If it states no number, tick the first box and skip the rest.

- [ ] This PR makes **no** performance claim.

| Field | Answer |
|---|---|
| Claim (with units) | |
| Configuration label (TP/DCP, concurrency, context length, KV bytes/rank) | |
| Window length and cell count | |
| Baseline compared against | |
| Same window as the baseline, or separate windows? | |
| Gates that passed (request errors, graph census, transport audit) | |
| Link to the evidence JSON | |

- [ ] The configuration label is complete enough that someone could tell what
      the number does **not** cover (for example: shared-prefix contexts are a
      concurrency baseline, not a unique-context capacity result).
- [ ] I am not presenting a public-lane measurement as a reference-lane
      measurement, and I am not claiming reproducibility that the acceptance
      gate has not actually produced.

---

## 5. No private identifiers

SparkRing is a **public** repository.

- [ ] **I attest that this change introduces no private identifiers**: no
      RFC 1918 or other site IP addresses, no SSH accounts, no hostnames, no
      absolute host filesystem paths, no private image or repository names,
      and no credentials of any kind (keys, tokens, passwords).
- [ ] Any address I did add uses an RFC 5737 documentation range
      (`192.0.2.0/24`, `198.51.100.0/24`, `203.0.113.0/24`), and any site
      value uses a `<PLACEHOLDER>` token.
- [ ] If I leaked a credential in an earlier push to this branch, I have said
      so below and rotated it. Force-pushing does not un-leak it.

> The `release-safety` CI job is a backstop for this attestation, not a
> replacement for it — it only knows the shapes it was taught.
>
> The separate `hardware-identifiers` job is **advisory and never blocks**.
> Names like the ConnectX-7 / RoCE interfaces are deterministic Linux
> predictable-interface names produced by the GB10 PCI topology: every DGX
> Spark generates the same ones, so they identify the hardware model this
> repository openly targets, not your cluster. Prefer a flag or environment
> variable in **new** code, but an advisory hit is not a merge blocker.

---

## 6. Housekeeping

- [ ] I matched the style of the surrounding code.
- [ ] My contribution is offered under the project license, Apache-2.0.
- [ ] I updated the docs that this change makes wrong.
