### PR TITLE
Correct README claims to the merged tree

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@
 #
 # WHAT THIS WORKFLOW EXPLICITLY DOES **NOT** PROVE  (manual gates — see
 # CONTRIBUTING.md "Test suites and where they run"):
-#   * The `spark_transport` native library and its 20-executable CTest suite.
+#   * The `spark_transport` native library and its 26-executable CTest suite.
 #     `spark_transport/CMakeLists.txt` hard-requires `CUDAToolkit` and
 #     `libibverbs`; it cannot even be configured on a GPU-free runner.
 #     -> MANUAL GATE: reviewer or contributor runs it on a DGX Spark.

--- a/README.md
+++ b/README.md
@@ -5,8 +5,9 @@ SparkRing is a low-latency collective transport and inference runtime for switch
 It runs GLM-5.2 across four directly connected DGX Sparks. Four 200 Gb/s ConnectX-7 links form a physical ring, 
 with no external Ethernet or InfiniBand switch in the inference fabric.
 
-The stack combines SIRCL custom RDMA collectives, CUDA-graph-replayable command rings, a source-attested and fail-closed vLLM overlay, 
+The stack combines SIRCL custom RDMA collectives, CUDA-graph-replayable command rings, a source-attested and fail-closed vLLM overlay,
 DCP4, support for fixed and adaptive MTP speculative decoding, and a patched ring-safe NCCL fallback for communication the custom path does not handle.
+A pip-installable plugin (`sparkring_plugin/`) packages the vLLM adapters as a `vllm.general_plugins` entry point: fail-closed like the overlay, but feature-detected rather than source-attested, and offline-validated only.
 
 The long-term goal is a model-agnostic runtime for efficient, switchless multi-node inference on DGX Spark.
 
@@ -292,11 +293,17 @@ See [docs/SIRCL.md](docs/SIRCL.md) and
 
 ### Fail-closed vLLM integration
 
-SparkRing applies a thin overlay through `PYTHONPATH`. Each adapter verifies
-the exact source SHA-256 and ABI it expects before installation.
+The container deployment applies a thin overlay through `PYTHONPATH`. Each
+adapter verifies the exact source SHA-256 and ABI it expects before
+installation. A source mismatch stops startup. The orchestrator also attests
+native libraries, mounts, launch arguments, and rank topology.
 
-A source mismatch stops startup. The orchestrator also attests native
-libraries, mounts, launch arguments, and rank topology.
+The pip-installable plugin (`sparkring_plugin/`) is the second integration
+path: it registers through `vllm.general_plugins`, feature-detects the vLLM
+integration point by signature instead of pinning a source hash, and
+terminates before serving on any installation failure. It is fail-closed but
+not source-attested at runtime; vendored-module parity with the source tree
+is enforced in CI, not at serving install.
 
 ### DCP4 and adaptive MTP
 
@@ -351,6 +358,7 @@ python -m pip install \
   --index-url https://download.pytorch.org/whl/cpu \
   "torch==2.11.0"
 python -m pytest spark_transport sparkcache runtime scripts -q
+python -m pytest sparkring_plugin -q
 ruff check --select E,F,W --ignore E501 --exclude runtime/patches .
 ```
 
@@ -403,6 +411,7 @@ runtime/               pinned runtime builders and public patches
 scripts/               site, preflight, launch, and evidence tools
 scripts/config/        sanitized site and launch templates
 spark_transport/       SIRCL transport, probes, tests, and vLLM adapters
+sparkring_plugin/      pip-installable vLLM plugin packaging of the adapters
 sparkcache/            persistent NVMe context cache
 docs/ARCHITECTURE.md   transport and runtime design
 docs/QUICKSTART.md     default EXL3 four-Spark bring-up

--- a/docs/README.md
+++ b/docs/README.md
@@ -48,6 +48,7 @@ linked runbook. A document being listed here does not authorize remote action.
 | [NF3 quickstart](NF3_QUICKSTART.md) | Prepares, launches, verifies, and troubleshoots the accepted deterministic alternative. |
 | [CUDA-graph correctness gate](CUDAGRAPH_CORRECTNESS_GATE.md) | Runs the minimal live A/B and deterministic comparison required to diagnose graph replay correctness. |
 | [SparkCache DCP2 dry-run plan](SPARKCACHE_DCP2_DRY_RUN_PLAN.md) | Regenerates and inspects a SparkCache plan; embedded operator state is historical and must be rediscovered. |
+| [Eager width admission validation runbook](EAGER_WIDTH_VALIDATION_RUNBOOK.md) | Runs the three-leg validation for width-generic eager TP4 all-reduce admission; leg records are chronological evidence. |
 | [SparkCache DCP2 live runbook](SPARKCACHE_DCP2_LIVE_RUNBOOK.md) | Defines preflight, authorized cutover, evidence collection, and rollback for the offline-validated integration. |
 
 ## Present-state specifications
@@ -87,5 +88,6 @@ linked runbook. A document being listed here does not authorize remote action.
 | Document | Purpose and limitation |
 |---|---|
 | [Reference bring-up reconstruction](SETUP.md) | Reconstructs the historical reference deployment. Only stages explicitly marked runnable are supported from the public tree. |
+| [Eager width admission review handoff](REVIEW_HANDOFF_EAGER_WIDTH_ADMISSION.md) | Component map, architecture, equivalence-evidence scope, and review questions for the width-generic admission work. |
 | [Testing history](TESTING_HISTORY.md) | Preserves dated experiments, regressions, resolved failures, superseded configurations, and acceptance gaps. |
 | [Historical Aiden MXFP4/GPTQ lane](history/AIDEN_MXFP4_GPTQ.md) | Preserves the Aiden MXFP4/GPTQ reference-lane configuration and its evidence scope. |

--- a/runtime/README.md
+++ b/runtime/README.md
@@ -86,12 +86,11 @@ commit. Together the ordered series performs 73 verified operations.
    torch/FlashInfer/SparkInfer/DeepGEMM set, verifies final versions, then runs
    the **fail-closed patch apply** (`apply-patches.py`): for every patch the
    sha256 of the exact preimage file is verified *before* applying, no fuzz,
-   abort on any mismatch. Philosophy inherited from
-   `spark_transport/experiments/fail_closed_mod_overlay/` (exact hash
+   abort on any mismatch. Design principles: exact hash
    contracts, no arbitrary script execution, fail-closed validation, target
    tree never mutated on mismatch). Finally it builds `spark_transport` and
    requires the complete CTest suite to pass.
-4. The builder emits an allowlisted 30-file public Python overlay bundle with
+4. The builder emits an allowlisted 35-file public Python overlay bundle with
    a per-file SHA-256 manifest. The bundle specification, builder, capability
    gates, and entrypoint are themselves hash-pinned by `runtime-lock.json`.
 5. **Stage 3** assembles the runtime image and runs `generate-manifest.py`,

--- a/runtime/hotfixes/deployed-r34-20260810/README.md
+++ b/runtime/hotfixes/deployed-r34-20260810/README.md
@@ -20,7 +20,7 @@ all four ranks by bind-mount.
 This directory is deliberately OUTSIDE `runtime/patches/` so the fail-closed
 applier never consumes it: this hotfix's preimage
 (`6d75f777…`, the deployed image above) differs from the kernel_warmup
-preimage recorded in `runtime/patches/vllm/preimages.json` for the pinned
+preimage recorded in `runtime/patches/00-reference-vllm/preimages.json` for the pinned
 base in `runtime/runtime-lock.json`, and the applier refuses mismatched
 preimages by design.
 

--- a/spark_transport/README.md
+++ b/spark_transport/README.md
@@ -56,7 +56,7 @@ cmake --build /build --parallel
 ctest --test-dir /build --output-on-failure
 ```
 
-The gate is the full CTest suite: all 20 test executables declared in
+The gate is the full CTest suite: all 26 test executables declared in
 `CMakeLists.txt` must pass.
 
 The operator-accepted four-rank graph all-reduce uses the additive tiered

--- a/spark_transport/integrations/vllm/README.md
+++ b/spark_transport/integrations/vllm/README.md
@@ -43,8 +43,11 @@ into all four containers, and set:
 ```
 
 The adapter intercepts only TP world-size four, contiguous CUDA BF16
-`[Q, 6144]` inputs for Q1 through Q5. Every other collective uses the
-original vLLM/NCCL dispatch unchanged.
+`[Q, W]` inputs under the admitted row and width policy — by default
+`[Q, 6144]` for rows `1..VLLM_SPARK_MAX_QUERY_ROWS` (default 6), with rows
+governed by the query-row policy and widths by `VLLM_SPARK_TP4_EAGER_WIDTHS`
+as described below. Every other collective uses the original vLLM/NCCL
+dispatch unchanged.
 
 `shadow` executes both paths, returns the NCCL result, and accumulates exact
 and numerical comparison statistics on the GPU. Its summary includes bitwise


### PR DESCRIPTION
## What this changes

Nine README claims verified against the code after the width-generic
admission merge and corrected: the root README now acknowledges the
pip-installable plugin as a second, fail-closed-but-not-source-attested
integration path (repository map, attestation scoping, contributor test
commands); the overlay bundle count (35) and CTest executable count (26)
match the tree; a nonexistent directory citation is replaced with the
principles it stood for; the vLLM integrations README's opening matches
its own policy-driven admission sections; the documentation map lists
the eager-width runbook and review handoff; the hotfix README cites the
correct preimages file.

**Lane statement:** Docs only: claim corrections against the current
tree; no behaviour change, no measurement, no performance claim.

Tests: `python -m pytest spark_transport sparkcache runtime scripts -q`
→ 3158 passed, 17 skipped; `python -m pytest sparkring_plugin -q` → 29
passed; ruff clean; `validate_publication_consistency.py` PASS.

Provenance: no copied code. No runtime patch touched (one hotfix README
sentence corrects a file path only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)