### PR TITLE
Correct the leg-1 serve-configuration description

### DIFF
--- a/docs/EAGER_WIDTH_VALIDATION_RUNBOOK.md
+++ b/docs/EAGER_WIDTH_VALIDATION_RUNBOOK.md
@@ -24,7 +24,9 @@ directly cabled Sparks, and serving performance.
 Purpose: prove the refactor is inert for the GLM-5.2 EXL3-R7 3.5bpw four-Spark serving configuration.
 
 Two arms, identical serve config otherwise (the 2026-08-11-qualified
-`--enforce-eager` TP4 configuration):
+TP4 configuration: full-and-piecewise CUDA-graph capture with the
+SparkRing graph all-reduce serving in-graph collectives — not an
+eager-mode launch; `--enforce-eager` is the leg-3 method only):
 
 - Arm 1a: `VLLM_SPARK_TP4_EAGER_WIDTHS` unset (the serving configuration's default).
 - Arm 1b: `VLLM_SPARK_TP4_EAGER_WIDTHS=6144` (explicit; must be


### PR DESCRIPTION
Docs only: one-line factual correction. The runbook described the qualified GLM TP4 configuration as --enforce-eager; the reference container's recorded command runs cudagraph_mode FULL_AND_PIECEWISE with VLLM_SPARK_TP4_GRAPH_Q1=1 (SparkRing graph all-reduce in-graph). --enforce-eager is the leg-3 shadow-matrix method only. No behaviour change, no measurement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)