### PR TITLE
Start the status reporter whenever the collective audit is armed

### DIFF
--- a/spark_transport/integrations/vllm/spark_tp4_backend.py
+++ b/spark_transport/integrations/vllm/spark_tp4_backend.py
@@ -339,6 +339,19 @@ def _record_stock_path(
             ),
             unique_name=str(getattr(communicator, "unique_name", "")),
         )
+    if enabled():
+        # The reporter historically started only when the width-6144
+        # graph session was prepared, so on any other profile an armed
+        # audit accumulated in memory without ever writing the status
+        # file. Starting it from the recording path keeps the
+        # contract: an armed audit always produces a status file,
+        # regardless of model width or graph eligibility.
+        from spark_graph_status_reporter import ensure_status_reporter
+
+        reporter_rank = getattr(communicator, "rank_in_group", None)
+        if reporter_rank is None:
+            reporter_rank = 0
+        ensure_status_reporter(rank=int(reporter_rank))
     record_stock(
         "all_reduce",
         capturing=capturing,

--- a/spark_transport/integrations/vllm/test_spark_collective_audit.py
+++ b/spark_transport/integrations/vllm/test_spark_collective_audit.py
@@ -379,3 +379,26 @@ def test_rejects_empty_unbounded_keys(
         audit.record_stock("", capturing=False, reason="x")
     with pytest.raises(ValueError, match="nonempty"):
         audit.record_stock("x", capturing=False, reason="")
+
+
+def test_armed_audit_starts_status_reporter_from_recording_path(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    """An armed audit must produce a status file regardless of model
+    width or graph eligibility, so recording a stock collective must
+    start the reporter even when no graph session was ever prepared."""
+    import spark_graph_status_reporter as reporter
+    import spark_tp4_backend as backend
+
+    status_path = tmp_path / "status-rank0.json"
+    monkeypatch.setenv("SPARK_TP4_GRAPH_STATUS_PATH", str(status_path))
+    started: list[int] = []
+    monkeypatch.setattr(
+        reporter,
+        "ensure_status_reporter",
+        lambda *, rank, interval_seconds=0.25: started.append(rank),
+    )
+    backend._record_stock_path(
+        capturing=False, reason="ineligible_signature"
+    )
+    assert started == [0]

--- a/sparkring_plugin/src/sparkring/_vendor/spark_tp4_backend.py
+++ b/sparkring_plugin/src/sparkring/_vendor/spark_tp4_backend.py
@@ -339,6 +339,19 @@ def _record_stock_path(
             ),
             unique_name=str(getattr(communicator, "unique_name", "")),
         )
+    if enabled():
+        # The reporter historically started only when the width-6144
+        # graph session was prepared, so on any other profile an armed
+        # audit accumulated in memory without ever writing the status
+        # file. Starting it from the recording path keeps the
+        # contract: an armed audit always produces a status file,
+        # regardless of model width or graph eligibility.
+        from spark_graph_status_reporter import ensure_status_reporter
+
+        reporter_rank = getattr(communicator, "rank_in_group", None)
+        if reporter_rank is None:
+            reporter_rank = 0
+        ensure_status_reporter(rank=int(reporter_rank))
     record_stock(
         "all_reduce",
         capturing=capturing,


### PR DESCRIPTION
## Summary
- `_record_stock_path` starts the graph status reporter (idempotent under its process lock) whenever the collective audit is armed via `SPARK_TP4_GRAPH_STATUS_PATH`.
- Invariant this enforces: an armed audit always produces a status file, regardless of model width or graph eligibility. Without it, the reporter thread starts only inside `prepare_graph_q1()`, so a serving profile that never prepares the width-6144 graph session records stock-collective signatures in memory that are never written to disk.
- Regression test: recording a stock collective with the status path set must start the reporter even when no graph session was prepared.
- No behavior change when the audit is unarmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)