### PR TITLE
Width-4096 SIRCL graph collectives for DeepSeek decode

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,8 +211,9 @@ reference remains in the [historical lane](docs/history/AIDEN_MXFP4_GPTQ.md).
 
 ## What SparkRing provides
 
-- A GLM/vLLM-oriented direct-cable transport implementation, with reusable
-  low-level transport primitives.
+- A GLM/vLLM deployment plus versioned graph-row geometry for model adapters
+  such as the DeepSeek `[Q,4096]` candidate, with reusable low-level transport
+  primitives.
 - Two- and four-rank collective schedules used by the current GLM/vLLM paths.
 - Registered mapped-host RDMA arenas.
 - GPU doorbells and device-published command rings.

--- a/spark_transport/README.md
+++ b/spark_transport/README.md
@@ -66,6 +66,20 @@ attestation, qualification, and rollback contract. The exact-Q40 routed-MoE
 optimization is a separate EXL3 overlay; compiling the transport library does
 not install it.
 
+### Versioned graph row geometry
+
+The legacy `spark_tp4_create` ABI retains GLM's BF16 row geometry: 6,144
+elements and 12,288 bytes per row. Model adapters with a different hidden width
+use `spark_tp4_create_v2` and set `struct_size`, `elements_per_row`, and
+`bytes_per_row`. The current DeepSeek candidate uses 4,096 elements and 8,192
+bytes per row. `bytes_per_row` must equal `elements_per_row * 2`.
+
+Graph descriptor validation and capacity checks use the configured byte width.
+The graph all-reduce command ABI admits exact contiguous rows from Q1 through
+Q1024; provision one maximum-capacity session to capture mixed Q values. The
+expanded doorbell layout is wire-incompatible with older builds, so graph and
+dual-port endpoint handshakes reject mixed versions before posting RDMA work.
+
 ## Pair probe
 
 Server on `spark1`:

--- a/spark_transport/app/tp4_graph_q1_probe.cu
+++ b/spark_transport/app/tp4_graph_q1_probe.cu
@@ -24,8 +24,10 @@ namespace {
 constexpr std::size_t kElements = 6144;
 constexpr std::size_t kPayloadBytes =
     kElements * sizeof(__nv_bfloat16);
-constexpr std::size_t kMaximumQ =
-    spark_transport::kTp4GraphAllreduceMaximumQ;
+// This GLM qualification surface remains intentionally bounded at Q512 even
+// though the versioned transport descriptor also admits DeepSeek Q1024.
+constexpr std::size_t kMaximumQ = 512;
+static_assert(kMaximumQ <= spark_transport::kTp4GraphAllreduceMaximumQ);
 constexpr std::size_t kMaximumElements = kMaximumQ * kElements;
 constexpr std::size_t kMaximumPayloadBytes =
     kMaximumElements * sizeof(__nv_bfloat16);

--- a/spark_transport/app/tp4_graph_q1_probe.cu
+++ b/spark_transport/app/tp4_graph_q1_probe.cu
@@ -25,7 +25,7 @@ constexpr std::size_t kElements = 6144;
 constexpr std::size_t kPayloadBytes =
     kElements * sizeof(__nv_bfloat16);
 // This GLM qualification surface remains intentionally bounded at Q512 even
-// though the versioned transport descriptor also admits DeepSeek Q1024.
+// though the versioned transport descriptor also serves DeepSeek row widths.
 constexpr std::size_t kMaximumQ = 512;
 static_assert(kMaximumQ <= spark_transport::kTp4GraphAllreduceMaximumQ);
 constexpr std::size_t kMaximumElements = kMaximumQ * kElements;

--- a/spark_transport/app/tp4_graph_q1_probe.cu
+++ b/spark_transport/app/tp4_graph_q1_probe.cu
@@ -331,7 +331,10 @@ Options parse_options(int argc, char** argv) {
   if (options.maximum_q < 6 || options.maximum_q > kMaximumQ) {
     throw std::invalid_argument("maximum Q must be in [6, 512]");
   }
-  if (options.elements != kElements && options.multi_graph_validation) {
+  if (options.elements != kElements && options.multi_graph_validation &&
+      !options.mixed_q_validation) {
+    // The plain multi-graph path validates through the Q1-specific
+    // kernel; the mixed-Q path is fully row-parameterized.
     throw std::invalid_argument(
         "multi-graph validation requires the default row width");
   }

--- a/spark_transport/app/tp4_graph_q1_probe.cu
+++ b/spark_transport/app/tp4_graph_q1_probe.cu
@@ -65,6 +65,7 @@ struct Options {
   bool mixed_q_validation{};
   std::uint32_t fixed_q{1};
   std::uint32_t maximum_q{6};
+  std::size_t elements{kElements};
   int graph_a_operations{3};
   int graph_b_operations{128};
   TimingMode timing_mode{TimingMode::kBurst};
@@ -89,6 +90,7 @@ struct Options {
       << "  --multi-graph-validation\n"
       << "  --mixed-q-validation\n"
       << "  --fixed-q Q\n"
+      << "  --elements-per-row 6144|4096\n"
       << "  --maximum-q Q\n"
       << "  --graph-a-operations COUNT\n"
       << "  --graph-b-operations COUNT\n"
@@ -178,6 +180,19 @@ Options parse_options(int argc, char** argv) {
         throw std::invalid_argument("fixed Q must be in [1, 512]");
       }
       options.fixed_q = static_cast<std::uint32_t>(fixed_q);
+    } else if (argument == "--elements-per-row") {
+      const std::uint64_t elements =
+          unsigned_value(take_value(), "elements per row");
+      if (elements != 6144 && elements != 4096) {
+        throw std::invalid_argument(
+            "elements per row must be 6144 or 4096");
+      }
+      options.elements = static_cast<std::size_t>(elements);
+      options.transport.elements_per_row =
+          static_cast<std::uint32_t>(elements);
+      options.transport.bytes_per_row =
+          static_cast<std::uint32_t>(elements) *
+          spark_transport::kTp4GraphBytesPerElement;
     } else if (argument == "--maximum-q") {
       const std::uint64_t maximum_q =
           unsigned_value(take_value(), "maximum Q");
@@ -316,12 +331,18 @@ Options parse_options(int argc, char** argv) {
   if (options.maximum_q < 6 || options.maximum_q > kMaximumQ) {
     throw std::invalid_argument("maximum Q must be in [6, 512]");
   }
+  if (options.elements != kElements && options.multi_graph_validation) {
+    throw std::invalid_argument(
+        "multi-graph validation requires the default row width");
+  }
   if (options.mixed_q_validation) {
     options.transport.payload_bytes =
-        spark_transport::tp4_graph_payload_bytes(options.maximum_q);
+        spark_transport::tp4_graph_payload_bytes(
+            options.maximum_q, options.transport.bytes_per_row);
   } else {
     options.transport.payload_bytes =
-        spark_transport::tp4_graph_payload_bytes(options.fixed_q);
+        spark_transport::tp4_graph_payload_bytes(
+            options.fixed_q, options.transport.bytes_per_row);
   }
   return options;
 }
@@ -514,10 +535,11 @@ CapturedGraph capture_fixed_q_graph(
     spark_transport::Tp4AllreduceSession& session,
     const __nv_bfloat16* input, __nv_bfloat16* output,
     unsigned long long* replay_marker, unsigned long long* mismatches,
-    cudaStream_t stream, std::uint32_t q, bool capture_validation) {
+    cudaStream_t stream, std::uint32_t q, std::size_t elements,
+    bool capture_validation) {
   constexpr int threads = 256;
   const std::size_t active_elements =
-      static_cast<std::size_t>(q) * kElements;
+      static_cast<std::size_t>(q) * elements;
   const int validation_blocks = static_cast<int>(
       (active_elements + threads - 1) / threads);
 
@@ -552,7 +574,8 @@ CapturedGraph capture_mixed_q_graph(
     unsigned long long* replay_marker, unsigned long long* mismatches,
     cudaStream_t stream, std::uint32_t rank,
     const std::vector<std::uint32_t>& q_values,
-    std::size_t graph_epoch_offset, std::size_t operations_per_cycle) {
+    std::size_t graph_epoch_offset, std::size_t operations_per_cycle,
+    std::size_t elements) {
   constexpr int threads = 256;
   cudaGraph_t graph{};
   check_cuda(cudaStreamBeginCapture(stream, cudaStreamCaptureModeGlobal),
@@ -565,7 +588,7 @@ CapturedGraph capture_mixed_q_graph(
     // arena instead of reserving hundreds of MiB for distinct node outputs.
     __nv_bfloat16* operation_output = output;
     const std::size_t active_elements =
-        static_cast<std::size_t>(q) * kElements;
+        static_cast<std::size_t>(q) * elements;
     const int validation_blocks = static_cast<int>(
         (active_elements + threads - 1) / threads);
     const std::size_t node_epoch_offset = graph_epoch_offset + operation;
@@ -653,14 +676,14 @@ int main(int argc, char** argv) {
             : static_cast<std::size_t>(options.operations_per_graph);
     const std::size_t input_elements =
         options.mixed_q_validation
-            ? static_cast<std::size_t>(options.maximum_q) * kElements
-            : static_cast<std::size_t>(options.fixed_q) * kElements;
+            ? static_cast<std::size_t>(options.maximum_q) * options.elements
+            : static_cast<std::size_t>(options.fixed_q) * options.elements;
     const int input_blocks = static_cast<int>(
         (input_elements + threads - 1) / threads);
     const std::size_t output_stride_elements =
         options.mixed_q_validation
-            ? static_cast<std::size_t>(options.maximum_q) * kElements
-            : static_cast<std::size_t>(options.fixed_q) * kElements;
+            ? static_cast<std::size_t>(options.maximum_q) * options.elements
+            : static_cast<std::size_t>(options.fixed_q) * options.elements;
     const std::size_t output_elements =
         options.mixed_q_validation
             ? output_stride_elements
@@ -673,7 +696,8 @@ int main(int argc, char** argv) {
     const auto account_q = [&](std::uint32_t q) {
       ++q_histogram.at(q - 1);
       active_bytes_per_graph_cycle +=
-          spark_transport::tp4_graph_payload_bytes(q);
+          spark_transport::tp4_graph_payload_bytes(
+              q, options.transport.bytes_per_row);
     };
     if (options.mixed_q_validation) {
       constexpr std::array<std::uint32_t, 3> graph_a_pattern{
@@ -720,7 +744,8 @@ int main(int argc, char** argv) {
       q_histogram[options.fixed_q - 1] = total_output_operations;
       active_bytes_per_graph_cycle =
           total_output_operations *
-          spark_transport::tp4_graph_payload_bytes(options.fixed_q);
+          spark_transport::tp4_graph_payload_bytes(
+              options.fixed_q, options.transport.bytes_per_row);
     }
     std::uint64_t kernel_split_nodes{};
     for (std::size_t index = 0; index < q_histogram.size(); ++index) {
@@ -770,11 +795,11 @@ int main(int argc, char** argv) {
         graphs.push_back(capture_mixed_q_graph(
             session, input, output, replay_marker, mismatches, stream,
             options.transport.rank, graph_a_q, 0,
-            operations_per_cycle));
+            operations_per_cycle, options.elements));
         graphs.push_back(capture_mixed_q_graph(
             session, input, output, replay_marker, mismatches, stream,
             options.transport.rank, graph_b_q, graph_a_q.size(),
-            operations_per_cycle));
+            operations_per_cycle, options.elements));
       } else if (options.multi_graph_validation) {
         graphs.push_back(capture_graph(
             session, input, output, replay_marker, mismatches, stream,
@@ -785,7 +810,7 @@ int main(int argc, char** argv) {
             static_cast<std::size_t>(options.graph_a_operations) *
                 kElements,
             true));
-      } else if (options.fixed_q == 1) {
+      } else if (options.fixed_q == 1 && options.elements == kElements) {
         graphs.push_back(capture_graph(
             session, input, output, replay_marker, mismatches, stream,
             options.operations_per_graph, 0,
@@ -793,7 +818,7 @@ int main(int argc, char** argv) {
       } else {
         graphs.push_back(capture_fixed_q_graph(
             session, input, output, replay_marker, mismatches, stream,
-            options.fixed_q,
+            options.fixed_q, options.elements,
             options.timing_mode == TimingMode::kBurst));
       }
 
@@ -849,7 +874,7 @@ int main(int argc, char** argv) {
 
         if (isolated_timing) {
           const std::size_t validation_elements =
-              static_cast<std::size_t>(options.fixed_q) * kElements;
+              static_cast<std::size_t>(options.fixed_q) * options.elements;
           const int validation_blocks = static_cast<int>(
               (validation_elements + threads - 1) / threads);
           validate_active_output<<<validation_blocks, threads, 0, stream>>>(

--- a/spark_transport/include/spark_transport/gpu_tp4_tensor.hpp
+++ b/spark_transport/include/spark_transport/gpu_tp4_tensor.hpp
@@ -17,6 +17,7 @@ class GpuTp4TensorWorker {
   GpuTp4TensorWorker& operator=(const GpuTp4TensorWorker&) = delete;
 
   GpuTp4TensorWorker(std::size_t payload_bytes,
+                     std::uint32_t bytes_per_row,
                      void* round0_mapped_device_buffer,
                      const Tp2BufferLayout& round0_layout,
                      void* round1_mapped_device_buffer,
@@ -47,6 +48,7 @@ class GpuTp4TensorWorker {
   Tp2BufferLayout round0_layout_{};
   Tp2BufferLayout round1_layout_{};
   std::size_t payload_bytes_{};
+  std::uint32_t bytes_per_row_{};
   Tp4AllreduceProtocol protocol_{Tp4AllreduceProtocol::kSerialAck};
   Tp4GraphKernelStrategy graph_kernel_strategy_{
       Tp4GraphKernelStrategy::kFused};

--- a/spark_transport/include/spark_transport/tp4_c_api.h
+++ b/spark_transport/include/spark_transport/tp4_c_api.h
@@ -144,7 +144,7 @@ int spark_tp4_all_reduce(spark_tp4_handle handle, const void* input,
 
 /*
  * Adds one exact contiguous BF16 [q, elements_per_row] all-reduce to an active
- * CUDA stream capture. q must be in [1, 1024], and the handle's payload
+ * CUDA stream capture. q must be in [1, 512], and the handle's payload
  * capacity must be at least q * bytes_per_row. One maximum-capacity handle serves
  * every supported mixed/adaptive concurrency bucket.
  */

--- a/spark_transport/include/spark_transport/tp4_c_api.h
+++ b/spark_transport/include/spark_transport/tp4_c_api.h
@@ -27,6 +27,19 @@ typedef struct spark_tp4_config {
   uint32_t graph_progress_cpu_plus_one;
 } spark_tp4_config;
 
+/*
+ * Versioned graph-row geometry. The embedded v1 configuration preserves the
+ * established eager and GLM graph ABI. New callers set struct_size, then use
+ * elements_per_row=4096 and bytes_per_row=8192 for DeepSeek BF16 tensors.
+ * bytes_per_row must equal elements_per_row * 2.
+ */
+typedef struct spark_tp4_config_v2 {
+  uint32_t struct_size;
+  spark_tp4_config base;
+  uint32_t elements_per_row;
+  uint32_t bytes_per_row;
+} spark_tp4_config_v2;
+
 typedef void* spark_tp4_handle;
 
 enum {
@@ -119,14 +132,20 @@ spark_tp4_create_with_protocol_graph_kernel_and_schedule(
     uint32_t graph_kernel, uint32_t wire_schedule, char* error,
     size_t error_bytes);
 
+/* Additive constructor for a non-GLM graph row layout. */
+spark_tp4_handle spark_tp4_create_v2(
+    const spark_tp4_config_v2* config, uint32_t protocol,
+    uint32_t graph_kernel, uint32_t wire_schedule, char* error,
+    size_t error_bytes);
+
 int spark_tp4_all_reduce(spark_tp4_handle handle, const void* input,
                          void* output, void* cuda_stream, char* error,
                          size_t error_bytes);
 
 /*
- * Adds one exact contiguous BF16 [q, 6144] all-reduce to an active CUDA
- * stream capture. q must be in [1, 512], and the handle's payload capacity
- * must be at least q * 12,288 bytes. One maximum-capacity handle serves
+ * Adds one exact contiguous BF16 [q, elements_per_row] all-reduce to an active
+ * CUDA stream capture. q must be in [1, 1024], and the handle's payload
+ * capacity must be at least q * bytes_per_row. One maximum-capacity handle serves
  * every supported mixed/adaptive concurrency bucket.
  */
 int spark_tp4_capture_all_reduce(
@@ -134,7 +153,7 @@ int spark_tp4_capture_all_reduce(
     void* cuda_stream, char* error, size_t error_bytes);
 
 /*
- * Adds a Q1 BF16 [1, 6144] all-reduce to an active CUDA stream capture.
+ * Adds a Q1 BF16 [1, elements_per_row] all-reduce to capture.
  * The graph is bound to the supplied tensor addresses, must replay on the
  * capture stream, and the handle must outlive all graph replays. The function
  * may be called repeatedly on that stream before the first replay so one

--- a/spark_transport/include/spark_transport/tp4_graph_command.hpp
+++ b/spark_transport/include/spark_transport/tp4_graph_command.hpp
@@ -16,9 +16,9 @@ constexpr std::uint32_t kTp4GraphBytesPerRow =
 constexpr std::uint32_t kTp4GraphMaximumQ = 40;
 // All-reduce alone admits the first bounded prefill tier. Vocabulary and
 // DCP descriptors remain capped by kTp4GraphMaximumQ.
-constexpr std::uint32_t kTp4GraphAllreduceMaximumQ = 1024;
-// Q is encoded directly (not Q-1), so Q1024 needs eleven low-order bits.
-constexpr std::uint32_t kTp4GraphDoorbellQBits = 11;
+constexpr std::uint32_t kTp4GraphAllreduceMaximumQ = 512;
+// Q is encoded directly (not Q-1), so Q512 needs ten low-order bits.
+constexpr std::uint32_t kTp4GraphDoorbellQBits = 10;
 constexpr std::uint64_t kTp4GraphDoorbellQMask =
     (std::uint64_t{1} << kTp4GraphDoorbellQBits) - 1;
 constexpr std::uint64_t kTp4GraphMaximumDoorbellSequence =
@@ -161,7 +161,7 @@ bool tp4_graph_command_publish_descriptor(
     std::uint32_t payload_bytes, std::uint64_t* sequence) noexcept;
 
 // All-reduce-only publisher. Unlike the shared Q40 descriptor entrypoint,
-// this accepts exact contiguous BF16 rows through Q1024.
+// this accepts exact contiguous BF16 rows through Q512.
 bool tp4_graph_allreduce_command_publish_descriptor(
     Tp4GraphCommandRing* ring, bool trace, std::uint32_t q,
     std::uint32_t payload_bytes, std::uint64_t* sequence) noexcept;

--- a/spark_transport/include/spark_transport/tp4_graph_command.hpp
+++ b/spark_transport/include/spark_transport/tp4_graph_command.hpp
@@ -10,13 +10,15 @@ namespace spark_transport {
 constexpr std::size_t kTp4GraphCommandCapacity = 64;
 constexpr std::uint32_t kTp4GraphElementsPerRow = 6144;
 constexpr std::uint32_t kTp4GraphBytesPerElement = 2;
+constexpr std::uint32_t kTp4GraphBytesPerRow =
+    kTp4GraphElementsPerRow * kTp4GraphBytesPerElement;
 // Eight active sequences at maximum MTP4 produce at most Q40.
 constexpr std::uint32_t kTp4GraphMaximumQ = 40;
 // All-reduce alone admits the first bounded prefill tier. Vocabulary and
 // DCP descriptors remain capped by kTp4GraphMaximumQ.
-constexpr std::uint32_t kTp4GraphAllreduceMaximumQ = 512;
-// Q is encoded directly (not Q-1), so Q512 needs ten low-order bits.
-constexpr std::uint32_t kTp4GraphDoorbellQBits = 10;
+constexpr std::uint32_t kTp4GraphAllreduceMaximumQ = 1024;
+// Q is encoded directly (not Q-1), so Q1024 needs eleven low-order bits.
+constexpr std::uint32_t kTp4GraphDoorbellQBits = 11;
 constexpr std::uint64_t kTp4GraphDoorbellQMask =
     (std::uint64_t{1} << kTp4GraphDoorbellQBits) - 1;
 constexpr std::uint64_t kTp4GraphMaximumDoorbellSequence =
@@ -30,8 +32,9 @@ static_assert(
     std::numeric_limits<std::uint32_t>::max());
 
 constexpr std::uint32_t tp4_graph_payload_bytes(
-    std::uint32_t q) noexcept {
-  return q * kTp4GraphElementsPerRow * kTp4GraphBytesPerElement;
+    std::uint32_t q,
+    std::uint32_t bytes_per_row = kTp4GraphBytesPerRow) noexcept {
+  return q * bytes_per_row;
 }
 
 constexpr bool tp4_graph_command_layout_valid(
@@ -47,7 +50,7 @@ constexpr bool tp4_graph_command_descriptor_valid(
     std::uint32_t q, std::uint32_t payload_bytes) noexcept {
   return tp4_graph_command_layout_valid(
       q, payload_bytes,
-      kTp4GraphElementsPerRow * kTp4GraphBytesPerElement,
+      kTp4GraphBytesPerRow,
       kTp4GraphMaximumQ);
 }
 
@@ -55,7 +58,7 @@ constexpr bool tp4_graph_allreduce_command_descriptor_valid(
     std::uint32_t q, std::uint32_t payload_bytes) noexcept {
   return tp4_graph_command_layout_valid(
       q, payload_bytes,
-      kTp4GraphElementsPerRow * kTp4GraphBytesPerElement,
+      kTp4GraphBytesPerRow,
       kTp4GraphAllreduceMaximumQ);
 }
 
@@ -158,7 +161,7 @@ bool tp4_graph_command_publish_descriptor(
     std::uint32_t payload_bytes, std::uint64_t* sequence) noexcept;
 
 // All-reduce-only publisher. Unlike the shared Q40 descriptor entrypoint,
-// this accepts exact contiguous BF16 [Q, 6144] through Q512.
+// this accepts exact contiguous BF16 rows through Q1024.
 bool tp4_graph_allreduce_command_publish_descriptor(
     Tp4GraphCommandRing* ring, bool trace, std::uint32_t q,
     std::uint32_t payload_bytes, std::uint64_t* sequence) noexcept;

--- a/spark_transport/include/spark_transport/tp4_session.hpp
+++ b/spark_transport/include/spark_transport/tp4_session.hpp
@@ -8,6 +8,7 @@
 
 #include "spark_transport/tp4_allreduce_protocol.hpp"
 #include "spark_transport/tp4_dual_port_striped_allreduce.hpp"
+#include "spark_transport/tp4_graph_command.hpp"
 #include "spark_transport/tp4_graph_kernel_strategy.hpp"
 
 namespace spark_transport {
@@ -23,6 +24,10 @@ struct Tp4AllreduceOptions {
   std::uint16_t control_port0{9470};
   std::uint16_t control_port1{9471};
   std::size_t payload_bytes{12288};
+  // Graph all-reduce row geometry. Legacy callers retain the GLM BF16
+  // [Q, 6144] contract; versioned callers may select another BF16 width.
+  std::uint32_t elements_per_row{kTp4GraphElementsPerRow};
+  std::uint32_t bytes_per_row{kTp4GraphBytesPerRow};
   Tp4AllreduceProtocol protocol{Tp4AllreduceProtocol::kSerialAck};
   Tp4GraphKernelStrategy graph_kernel_strategy{
       Tp4GraphKernelStrategy::kFused};
@@ -66,7 +71,7 @@ class Tp4AllreduceSession {
   // saturating CUDA's launch queue.
   void all_reduce(const void* input, void* output, void* cuda_stream);
 
-  // Adds a Q1 BF16 [1, 6144] all-reduce to an active CUDA stream capture.
+  // Adds a Q1 BF16 [1, elements_per_row] all-reduce to capture.
   // The captured graph is tied to these stable input/output addresses and
   // must be replayed on the same stream. This session must outlive every
   // graph replay. Replay sequences are device-published through mapped host
@@ -76,9 +81,9 @@ class Tp4AllreduceSession {
   void capture_q1_all_reduce(const void* input, void* output,
                              void* cuda_stream);
 
-  // Adds one exact contiguous BF16 [q, 6144] all-reduce to an active CUDA
-  // stream capture. q must be in [1, 512] and the session capacity must be at
-  // least q rows. The Q512 maximum-capacity session has a 6 MiB payload
+  // Adds one exact contiguous BF16 [q, elements_per_row] all-reduce to CUDA
+  // stream capture. q must be in [1, 1024] and the session capacity must be at
+  // least q rows. GLM may retain Q512 while DeepSeek can provision Q1024.
   // arena and can serve decode plus bounded-prefill graph nodes while
   // preserving one ordered sequence.
   void capture_all_reduce(const void* input, void* output, std::uint32_t q,

--- a/spark_transport/include/spark_transport/tp4_session.hpp
+++ b/spark_transport/include/spark_transport/tp4_session.hpp
@@ -82,8 +82,8 @@ class Tp4AllreduceSession {
                              void* cuda_stream);
 
   // Adds one exact contiguous BF16 [q, elements_per_row] all-reduce to CUDA
-  // stream capture. q must be in [1, 1024] and the session capacity must be at
-  // least q rows. GLM may retain Q512 while DeepSeek can provision Q1024.
+  // stream capture. q must be in [1, 512] and the session capacity must be at
+  // least q rows for the session's configured row geometry.
   // arena and can serve decode plus bounded-prefill graph nodes while
   // preserving one ordered sequence.
   void capture_all_reduce(const void* input, void* output, std::uint32_t q,

--- a/spark_transport/integrations/vllm/spark_tp4_backend.py
+++ b/spark_transport/integrations/vllm/spark_tp4_backend.py
@@ -38,6 +38,15 @@ _ALLREDUCE_PREFILL_CAPACITY_BYTES = (
 )
 _DUAL_PORT_Q40_CAPACITY_BYTES = ABSOLUTE_MAX_QUERY_ROWS * _BYTES_PER_ROW
 _GRAPH_CAPACITY_BYTES = MAX_QUERY_ROWS * _BYTES_PER_ROW
+# Research-only width-4096 graph geometry (DeepSeek decode shapes). One
+# maximum-capacity session serves every [Q <= 512, 4096] bucket; the
+# command ring carries the active Q.
+_RESEARCH_GRAPH_WIDTH = 4096
+_RESEARCH_GRAPH_ROW_BYTES = _RESEARCH_GRAPH_WIDTH * _BF16_BYTES
+_RESEARCH_GRAPH_MAX_QUERY_ROWS = 512
+_RESEARCH_GRAPH_CAPACITY_BYTES = (
+    _RESEARCH_GRAPH_MAX_QUERY_ROWS * _RESEARCH_GRAPH_ROW_BYTES
+)
 _GRAPH_STATUS_CAPTURE_CONFIGURED = 1 << 0
 _GRAPH_STATUS_POLLING_ENABLED = 1 << 1
 _GRAPH_STATUS_HOST_NATIVE_ATOMICS = 1 << 2
@@ -71,6 +80,7 @@ _WIRE_SCHEDULE_WIRE = {
 _MAX_PERSISTENT_OUTPUT_SLOTS = 4096
 _graph_q1_sessions: dict[int, "_NativeSession"] = {}
 _graph_dual_port_q40_sessions: dict[int, "_NativeSession"] = {}
+_graph_width4096_sessions: dict[int, "_NativeSession"] = {}
 _graph_event_counts: dict[str, int] = {}
 # PLACEHOLDER ring peers (RFC 5737 TEST-NET-1): 192.0.2.N stands in for
 # rank N-1's direct-cable address. These are NOT routable and MUST be
@@ -103,6 +113,15 @@ class _NativeConfig(ctypes.Structure):
         ("payload_bytes", ctypes.c_size_t),
         ("graph_submit_cpu_plus_one", ctypes.c_uint32),
         ("graph_progress_cpu_plus_one", ctypes.c_uint32),
+    ]
+
+
+class _NativeConfigV2(ctypes.Structure):
+    _fields_ = [
+        ("struct_size", ctypes.c_uint32),
+        ("base", _NativeConfig),
+        ("elements_per_row", ctypes.c_uint32),
+        ("bytes_per_row", ctypes.c_uint32),
     ]
 
 
@@ -360,6 +379,61 @@ def _record_stock_path(
     )
 
 
+def _research_graph_all_reduce(
+    communicator: Any, tensor: Any, capturing: bool
+) -> Any | None:
+    """Route research-admitted width-4096 collectives.
+
+    Returns the collective output when this path handled the call, or
+    None to fall through to the unchanged default dispatch. Eager calls
+    are never handled here: the eager pass only prepares the session so
+    it exists before vLLM's first capture.
+    """
+    if (
+        getattr(communicator, "world_size", None) != 4
+        or getattr(communicator, "unique_name", "") != "tp:0"
+    ):
+        return None
+    backend = getattr(communicator, "_spark_tp4_native", None)
+    if backend is None:
+        backend = _Backend(int(communicator.rank_in_group))
+        communicator._spark_tp4_native = backend
+    if not capturing:
+        if backend.graph_width4096_session is None:
+            backend.prepare_graph_width4096()
+        return None
+    shape = _tensor_shape(tensor)
+    if (
+        not _research_graph_shape_eligible(shape)
+        or str(tensor.dtype) != "torch.bfloat16"
+        or not bool(tensor.is_cuda)
+        or not bool(tensor.is_contiguous())
+    ):
+        return None
+    session = backend.graph_width4096_session
+    if session is None:
+        # Fail closed: an admitted capture-phase collective must never
+        # silently take the stock path in the research profile.
+        logger.error(
+            "research width-4096 graph capture reached before session "
+            "preparation; terminating worker"
+        )
+        _abort_after_native_failure()
+        raise AssertionError("unreachable after worker termination")
+    try:
+        output = session.capture(tensor)
+        _record_graph_event(communicator, "width4096_captured_nodes")
+        return output
+    except BaseException:
+        logger.exception(
+            "fatal Spark TP4 width-4096 graph-capture error; terminating "
+            "worker because a partially captured native graph cannot "
+            "safely fall back"
+        )
+        _abort_after_native_failure()
+        raise AssertionError("unreachable after worker termination")
+
+
 def _payload_bytes(tensor: Any) -> int:
     rows, width = _tensor_shape(tensor)
     return rows * width * _BF16_BYTES
@@ -382,6 +456,30 @@ def _graph_q1_enabled() -> bool:
     if value not in {"0", "1"}:
         raise ValueError("VLLM_SPARK_TP4_GRAPH_Q1 must be '0' or '1'")
     return value == "1"
+
+
+def _graph_width4096_research_enabled() -> bool:
+    """Research-only graph admission for BF16 [Q <= 512, 4096].
+
+    Explicitly opt-in and unqualified: enabling it routes captured
+    width-4096 all-reduces through one maximum-capacity native graph
+    session (sequential tiered_64k, two-slot deferred ACK) instead of
+    the stock path. Default behavior is byte-identical when unset.
+    """
+    value = os.getenv("VLLM_SPARK_TP4_GRAPH_WIDTH4096_RESEARCH", "0")
+    if value not in {"0", "1"}:
+        raise ValueError(
+            "VLLM_SPARK_TP4_GRAPH_WIDTH4096_RESEARCH must be '0' or '1'"
+        )
+    return value == "1"
+
+
+def _research_graph_shape_eligible(shape: tuple[int, ...]) -> bool:
+    return (
+        len(shape) == 2
+        and shape[1] == _RESEARCH_GRAPH_WIDTH
+        and 1 <= shape[0] <= _RESEARCH_GRAPH_MAX_QUERY_ROWS
+    )
 
 
 def _graph_dual_port_q40_enabled() -> bool:
@@ -560,12 +658,31 @@ class _NativeSession:
         allreduce_protocol: str = _SERIAL_ACK_PROTOCOL,
         graph_kernel_strategy: str = _FUSED_GRAPH_KERNEL,
         wire_schedule: str = _SEQUENTIAL_WIRE_SCHEDULE,
+        row_bytes: int = _BYTES_PER_ROW,
     ) -> None:
         if rank not in _DEFAULT_PEERS:
             raise ValueError(f"TP4 rank must be in [0, 3], got {rank}")
+        if row_bytes != _BYTES_PER_ROW:
+            if not graph_only:
+                raise ValueError(
+                    "non-default TP4 row geometry requires a graph-only "
+                    "session"
+                )
+            if row_bytes != _RESEARCH_GRAPH_ROW_BYTES:
+                raise ValueError(
+                    "TP4 row geometry must be the default width or the "
+                    f"research width ({_RESEARCH_GRAPH_ROW_BYTES} bytes "
+                    "per row)"
+                )
+            if payload_bytes != _RESEARCH_GRAPH_CAPACITY_BYTES:
+                raise ValueError(
+                    "research row-geometry graph session requires "
+                    f"Q{_RESEARCH_GRAPH_MAX_QUERY_ROWS} capacity"
+                )
         expected_graph_capacity = _graph_capacity_bytes()
         if (
             graph_only
+            and row_bytes == _BYTES_PER_ROW
             and wire_schedule == _SEQUENTIAL_WIRE_SCHEDULE
             and payload_bytes != expected_graph_capacity
         ):
@@ -634,7 +751,25 @@ class _NativeSession:
         ]
         self._library.spark_tp4_create.restype = ctypes.c_void_p
         create_session = self._library.spark_tp4_create
-        if wire_schedule != _SEQUENTIAL_WIRE_SCHEDULE:
+        use_v2_geometry = row_bytes != _BYTES_PER_ROW
+        if use_v2_geometry:
+            try:
+                create_session = self._library.spark_tp4_create_v2
+            except AttributeError as error:
+                raise RuntimeError(
+                    "Spark TP4 native library lacks the v2 row-geometry "
+                    "ABI; rebuild and deploy a matching library"
+                ) from error
+            create_session.argtypes = [
+                ctypes.POINTER(_NativeConfigV2),
+                ctypes.c_uint32,
+                ctypes.c_uint32,
+                ctypes.c_uint32,
+                ctypes.c_char_p,
+                ctypes.c_size_t,
+            ]
+            create_session.restype = ctypes.c_void_p
+        elif wire_schedule != _SEQUENTIAL_WIRE_SCHEDULE:
             try:
                 create_session = (
                     self._library
@@ -723,8 +858,10 @@ class _NativeSession:
         self._allreduce_protocol = allreduce_protocol
         self._graph_kernel_strategy = graph_kernel_strategy
         self._wire_schedule = wire_schedule
+        self._row_bytes = row_bytes
+        self._elements_per_row = row_bytes // _BF16_BYTES
         self._graph_max_query_rows = (
-            payload_bytes // _BYTES_PER_ROW if graph_only else 0
+            payload_bytes // row_bytes if graph_only else 0
         )
         persistent_slots = 0 if graph_only else _persistent_output_slots()
         self._persistent_outputs = (
@@ -758,7 +895,22 @@ class _NativeSession:
             graph_progress_cpu_plus_one=progress_cpu + 1,
         )
         error = ctypes.create_string_buffer(512)
-        if wire_schedule != _SEQUENTIAL_WIRE_SCHEDULE:
+        if use_v2_geometry:
+            config_v2 = _NativeConfigV2(
+                struct_size=ctypes.sizeof(_NativeConfigV2),
+                base=config,
+                elements_per_row=self._elements_per_row,
+                bytes_per_row=row_bytes,
+            )
+            self._handle = create_session(
+                ctypes.byref(config_v2),
+                _ALLREDUCE_PROTOCOL_WIRE[allreduce_protocol],
+                _GRAPH_KERNEL_WIRE[graph_kernel_strategy],
+                _WIRE_SCHEDULE_WIRE[wire_schedule],
+                error,
+                len(error),
+            )
+        elif wire_schedule != _SEQUENTIAL_WIRE_SCHEDULE:
             self._handle = create_session(
                 ctypes.byref(config),
                 _ALLREDUCE_PROTOCOL_WIRE[allreduce_protocol],
@@ -937,8 +1089,16 @@ class _NativeSession:
             not dual_port_session
             or shape == (self._graph_max_query_rows, _TARGET_WIDTH)
         )
+        if self._row_bytes == _BYTES_PER_ROW:
+            shape_admitted = _target_shape_eligible(shape)
+        else:
+            shape_admitted = (
+                len(shape) == 2
+                and shape[1] == self._elements_per_row
+                and 1 <= shape[0] <= self._graph_max_query_rows
+            )
         if (
-            not _target_shape_eligible(shape)
+            not shape_admitted
             or shape[0] > self._graph_max_query_rows
             or not exact_dual_port_shape
             or str(tensor.dtype) != "torch.bfloat16"
@@ -952,8 +1112,8 @@ class _NativeSession:
             )
             raise ValueError(
                 "Spark TP4 graph capture requires contiguous CUDA BF16 "
-                f"[Q, 6144] with {query_requirement}; dual-port striped "
-                "sessions require their exact fixed Q"
+                f"[Q, {self._elements_per_row}] with {query_requirement}; "
+                "dual-port striped sessions require their exact fixed Q"
             )
         q = shape[0]
 
@@ -1081,6 +1241,7 @@ class _Backend:
         self.native_sessions: dict[int, _NativeSession] = {}
         self.graph_q1_session: _NativeSession | None = None
         self.graph_dual_port_q40_session: _NativeSession | None = None
+        self.graph_width4096_session: _NativeSession | None = None
         self.shadow_stats: dict[tuple[int, tuple[int, ...], str], _ShadowStats] = {}
 
     def native_for(self, payload_bytes: int) -> _NativeSession:
@@ -1128,6 +1289,36 @@ class _Backend:
             _graph_dual_port_q40_sessions[self.rank] = dual_port_session
         return session
 
+    def prepare_graph_width4096(self) -> _NativeSession:
+        """Research-only [Q <= 512, 4096] graph session.
+
+        Sequential tiered_64k on two-slot deferred ACK: the split-class
+        kernels are the measured fix for the fused kernel's
+        large-payload pathology, and tiered keeps fused behavior for
+        small Q (see docs/DUAL_PORT_STRIPING_PROBE_20260818.md).
+        """
+        session = self.graph_width4096_session
+        if session is None:
+            graph_cpu_affinity = _graph_preflight()
+            session = _NativeSession(
+                self.rank,
+                _RESEARCH_GRAPH_CAPACITY_BYTES,
+                control_ports=_graph_control_ports(),
+                graph_only=True,
+                graph_cpu_affinity=graph_cpu_affinity,
+                allreduce_protocol=_TWO_SLOT_DEFERRED_ACK_PROTOCOL,
+                graph_kernel_strategy=_TIERED_64K_GRAPH_KERNEL,
+                row_bytes=_RESEARCH_GRAPH_ROW_BYTES,
+            )
+            self.graph_width4096_session = session
+            _graph_width4096_sessions[self.rank] = session
+            from spark_graph_status_reporter import (
+                ensure_status_reporter,
+            )
+
+            ensure_status_reporter(rank=self.rank)
+        return session
+
     def graph_session_for_capture(
         self, tensor: Any
     ) -> _NativeSession | None:
@@ -1162,10 +1353,19 @@ def graph_dual_port_q40_status_snapshot() -> dict[int, dict[str, object]]:
     }
 
 
+def graph_width4096_status_snapshot() -> dict[int, dict[str, object]]:
+    """Return research width-4096 graph progress for process-local ranks."""
+    return {
+        rank: session.graph_status().to_dict()
+        for rank, session in sorted(_graph_width4096_sessions.items())
+    }
+
+
 def graph_q1_diagnostic_snapshot() -> dict[str, object]:
     return {
         "sessions": graph_q1_status_snapshot(),
         "dual_port_q40_sessions": graph_dual_port_q40_status_snapshot(),
+        "width4096_sessions": graph_width4096_status_snapshot(),
         "events": dict(sorted(_graph_event_counts.items())),
     }
 
@@ -1176,6 +1376,18 @@ def install() -> None:
     graph_protocol = _graph_allreduce_protocol()
     graph_kernel = _graph_kernel_strategy()
     graph_dual_port_q40 = _graph_dual_port_q40_enabled()
+    if _graph_width4096_research_enabled():
+        if mode != "custom":
+            raise ValueError(
+                "VLLM_SPARK_TP4_GRAPH_WIDTH4096_RESEARCH requires "
+                "VLLM_SPARK_TP4_MODE=custom"
+            )
+        if _graph_q1_enabled() or graph_dual_port_q40:
+            raise ValueError(
+                "VLLM_SPARK_TP4_GRAPH_WIDTH4096_RESEARCH is mutually "
+                "exclusive with the width-6144 graph paths: they share "
+                "the graph control-port pair"
+            )
     if capacity_pool_requested():
         raise RuntimeError(
             "VLLM_SPARK_TP4_PREFILL_CAPACITY_POOL is research-only: "
@@ -1224,6 +1436,14 @@ def install() -> None:
 
     def spark_all_reduce(self: Any, input_: Any) -> Any:
         mode = _mode()
+        if mode == "custom" and _graph_width4096_research_enabled():
+            import torch
+
+            handled = _research_graph_all_reduce(
+                self, input_, _is_stream_capturing(torch)
+            )
+            if handled is not None:
+                return handled
         if not _eligible(self, input_, mode):
             import torch
 

--- a/spark_transport/integrations/vllm/spark_tp4_backend.py
+++ b/spark_transport/integrations/vllm/spark_tp4_backend.py
@@ -359,12 +359,10 @@ def _record_stock_path(
             unique_name=str(getattr(communicator, "unique_name", "")),
         )
     if enabled():
-        # The reporter historically started only when the width-6144
-        # graph session was prepared, so on any other profile an armed
-        # audit accumulated in memory without ever writing the status
-        # file. Starting it from the recording path keeps the
-        # contract: an armed audit always produces a status file,
-        # regardless of model width or graph eligibility.
+        # Invariant: an armed audit always produces a status file,
+        # regardless of model width or graph eligibility. The recording
+        # path must start the reporter itself because no graph-session
+        # preparation is guaranteed to run in the serving profile.
         from spark_graph_status_reporter import ensure_status_reporter
 
         reporter_rank = getattr(communicator, "rank_in_group", None)

--- a/spark_transport/integrations/vllm/test_spark_tp4_backend_dispatch.py
+++ b/spark_transport/integrations/vllm/test_spark_tp4_backend_dispatch.py
@@ -132,6 +132,7 @@ class _FakeBackend:
         self.native_sessions: dict[int, _FakeNative] = {}
         self.graph_q1_session: _FakeNative | None = None
         self.graph_dual_port_q40_session: _FakeNative | None = None
+        self.graph_width4096_session: _FakeNative | None = None
         self.shadow_stats: dict[object, _FakeShadowStats] = {}
         self.created.append(self)
 
@@ -158,6 +159,16 @@ class _FakeBackend:
                 40 * 6144 * 2,
                 graph_only=True,
             )
+        return native
+
+    def prepare_graph_width4096(self) -> _FakeNative:
+        native = self.graph_width4096_session
+        if native is None:
+            native = _FakeNative(
+                spark_tp4_backend._RESEARCH_GRAPH_CAPACITY_BYTES,
+                graph_only=True,
+            )
+            self.graph_width4096_session = native
         return native
 
     def graph_session_for_capture(self, tensor: object) -> _FakeNative | None:
@@ -2178,6 +2189,141 @@ class SparkTp4EagerWidthAdmissionTest(unittest.TestCase):
             self.original_all_reduce,
         )
         self.assertFalse(spark_tp4_backend._installed)
+
+
+class SparkTp4ResearchWidth4096Test(unittest.TestCase):
+    """Research-only [Q <= 512, 4096] graph admission."""
+
+    def setUp(self) -> None:
+        self.communicator_type = _make_communicator_type()
+        self.modules = _fake_vllm_modules(self.communicator_type)
+        self.torch_module = types.ModuleType("torch")
+        self.torch_module.cuda = _FakeCuda()
+        self.modules["torch"] = self.torch_module
+        self.original_all_reduce = self.communicator_type.all_reduce
+        spark_tp4_backend._installed = False
+        spark_tp4_backend._graph_q1_sessions.clear()
+        spark_tp4_backend._graph_dual_port_q40_sessions.clear()
+        spark_tp4_backend._graph_width4096_sessions.clear()
+        spark_tp4_backend._graph_event_counts.clear()
+        spark_collective_audit._reset_for_tests()
+        _FakeBackend.created.clear()
+
+    def _install(
+        self,
+        mode: str | None,
+        extra_environment: dict[str, str] | None = None,
+    ) -> None:
+        environment = dict(extra_environment or {})
+        if mode is not None:
+            environment["VLLM_SPARK_TP4_MODE"] = mode
+        patchers = (
+            patch.dict(os.environ, environment, clear=True),
+            patch.dict(sys.modules, self.modules),
+            patch.object(spark_tp4_backend, "_Backend", _FakeBackend),
+        )
+        for patcher in patchers:
+            patcher.start()
+            self.addCleanup(patcher.stop)
+        spark_tp4_backend.install()
+
+    def _research_environment(self) -> dict[str, str]:
+        return {"VLLM_SPARK_TP4_GRAPH_WIDTH4096_RESEARCH": "1"}
+
+    def test_research_requires_custom_mode(self) -> None:
+        with self.assertRaisesRegex(
+            ValueError, "VLLM_SPARK_TP4_MODE=custom"
+        ):
+            self._install("shadow", self._research_environment())
+        self.assertIs(
+            self.communicator_type.all_reduce, self.original_all_reduce
+        )
+
+    def test_research_rejects_width6144_graph_paths(self) -> None:
+        environment = self._research_environment()
+        environment["VLLM_SPARK_TP4_GRAPH_Q1"] = "1"
+        with self.assertRaisesRegex(ValueError, "mutually"):
+            self._install("custom", environment)
+        self.assertIs(
+            self.communicator_type.all_reduce, self.original_all_reduce
+        )
+
+    def test_absent_environment_keeps_stock_dispatch_for_width4096(
+        self,
+    ) -> None:
+        self._install("custom")
+        communicator = self.communicator_type()
+        tensor = _FakeTensor(shape=(256, 4096))
+        self.torch_module.cuda.capturing = True
+
+        result = communicator.all_reduce(tensor)
+
+        self.assertEqual(result, ("reference", tensor))
+        self.assertEqual(_FakeBackend.created, [])
+
+    def test_eager_width4096_call_prepares_session_and_stays_stock(
+        self,
+    ) -> None:
+        self._install("custom", self._research_environment())
+        communicator = self.communicator_type()
+        tensor = _FakeTensor(shape=(256, 4096))
+
+        result = communicator.all_reduce(tensor)
+
+        self.assertEqual(result, ("reference", tensor))
+        self.assertEqual(len(_FakeBackend.created), 1)
+        backend = _FakeBackend.created[0]
+        self.assertIsNotNone(backend.graph_width4096_session)
+        self.assertEqual(backend.graph_width4096_session.capture_inputs, [])
+
+    def test_capturing_admitted_width4096_shape_uses_research_session(
+        self,
+    ) -> None:
+        self._install("custom", self._research_environment())
+        communicator = self.communicator_type()
+        eager_tensor = _FakeTensor(shape=(256, 4096))
+        communicator.all_reduce(eager_tensor)
+        backend = _FakeBackend.created[0]
+        self.torch_module.cuda.capturing = True
+        capture_tensor = _FakeTensor(shape=(256, 4096))
+
+        result = communicator.all_reduce(capture_tensor)
+
+        session = backend.graph_width4096_session
+        self.assertEqual(session.capture_inputs, [capture_tensor])
+        self.assertEqual(
+            result,
+            ("graph-candidate", session.payload_bytes, 256, capture_tensor),
+        )
+        self.assertEqual(communicator.original_inputs, [eager_tensor])
+
+    def test_capturing_oversized_or_wrong_width_falls_through(self) -> None:
+        self._install("custom", self._research_environment())
+        communicator = self.communicator_type()
+        communicator.all_reduce(_FakeTensor(shape=(256, 4096)))
+        backend = _FakeBackend.created[0]
+        self.torch_module.cuda.capturing = True
+
+        for shape in ((600, 4096), (256, 2048), (256,)):
+            communicator.all_reduce(_FakeTensor(shape=shape))
+
+        self.assertEqual(backend.graph_width4096_session.capture_inputs, [])
+
+    def test_admitted_capture_without_session_terminates_worker(self) -> None:
+        self._install("custom", self._research_environment())
+        communicator = self.communicator_type()
+        self.torch_module.cuda.capturing = True
+        tensor = _FakeTensor(shape=(256, 4096))
+
+        def _fail() -> None:
+            raise RuntimeError("worker terminated")
+
+        with patch.object(
+            spark_tp4_backend, "_abort_after_native_failure", _fail
+        ):
+            with self.assertRaisesRegex(RuntimeError, "worker terminated"):
+                communicator.all_reduce(tensor)
+        self.assertEqual(communicator.original_inputs, [])
 
 
 if __name__ == "__main__":

--- a/spark_transport/src/gpu_tp4_tensor.cu
+++ b/spark_transport/src/gpu_tp4_tensor.cu
@@ -747,7 +747,8 @@ __global__ void tp4_striped_finish(
 }  // namespace
 
 GpuTp4TensorWorker::GpuTp4TensorWorker(
-    std::size_t payload_bytes, void* round0_mapped_device_buffer,
+    std::size_t payload_bytes, std::uint32_t bytes_per_row,
+    void* round0_mapped_device_buffer,
     const Tp2BufferLayout& round0_layout,
     void* round1_mapped_device_buffer,
     const Tp2BufferLayout& round1_layout,
@@ -759,10 +760,11 @@ GpuTp4TensorWorker::GpuTp4TensorWorker(
       round0_layout_(round0_layout),
       round1_layout_(round1_layout),
       payload_bytes_(payload_bytes),
+      bytes_per_row_(bytes_per_row),
       protocol_(protocol),
       graph_kernel_strategy_(graph_kernel_strategy),
       schedule_(schedule) {
-  if (payload_bytes_ == 0 ||
+  if (payload_bytes_ == 0 || bytes_per_row_ == 0 ||
       payload_bytes_ % sizeof(__nv_bfloat16) != 0) {
     throw std::invalid_argument(
         "TP4 tensor size must be nonzero BF16 data");
@@ -842,12 +844,14 @@ void GpuTp4TensorWorker::enqueue_graph(
     const void* external_input, void* external_output, std::uint32_t q,
     void* cuda_stream, Tp4GraphCommandRing* command_ring, bool trace) {
   const std::uint32_t active_payload_bytes =
-      tp4_graph_payload_bytes(q);
-  if (!tp4_graph_allreduce_command_descriptor_valid(
-          q, active_payload_bytes) ||
+      tp4_graph_payload_bytes(q, bytes_per_row_);
+  if (!tp4_graph_command_layout_valid(
+          q, active_payload_bytes, bytes_per_row_,
+          kTp4GraphAllreduceMaximumQ) ||
       active_payload_bytes > payload_bytes_) {
     throw std::invalid_argument(
-        "graph TP4 all-reduce requires BF16 [q, 6144], q in [1, 512], "
+        "graph TP4 all-reduce requires the configured BF16 [q, width], "
+        "q in [1, 1024], "
         "within session capacity");
   }
   if (external_input == nullptr || external_output == nullptr ||
@@ -913,7 +917,7 @@ void GpuTp4TensorWorker::enqueue_graph(
   if (tp4_graph_kernel_uses_split(graph_kernel_strategy_, q)) {
     if (!split_graph_q_supported(q) || split_graph_state_ == nullptr) {
       throw std::invalid_argument(
-          "split_64k graph TP4 requires Q1 through Q512 and initialized "
+          "split_64k graph TP4 requires Q1 through Q1024 and initialized "
           "split state");
     }
     constexpr int control_threads = 32;

--- a/spark_transport/src/gpu_tp4_tensor.cu
+++ b/spark_transport/src/gpu_tp4_tensor.cu
@@ -851,7 +851,7 @@ void GpuTp4TensorWorker::enqueue_graph(
       active_payload_bytes > payload_bytes_) {
     throw std::invalid_argument(
         "graph TP4 all-reduce requires the configured BF16 [q, width], "
-        "q in [1, 1024], "
+        "q in [1, 512], "
         "within session capacity");
   }
   if (external_input == nullptr || external_output == nullptr ||
@@ -917,7 +917,7 @@ void GpuTp4TensorWorker::enqueue_graph(
   if (tp4_graph_kernel_uses_split(graph_kernel_strategy_, q)) {
     if (!split_graph_q_supported(q) || split_graph_state_ == nullptr) {
       throw std::invalid_argument(
-          "split_64k graph TP4 requires Q1 through Q1024 and initialized "
+          "split_64k graph TP4 requires Q1 through Q512 and initialized "
           "split state");
     }
     constexpr int control_threads = 32;

--- a/spark_transport/src/tp4_c_api.cpp
+++ b/spark_transport/src/tp4_c_api.cpp
@@ -57,6 +57,17 @@ spark_transport::Tp4AllreduceOptions translate(
   return options;
 }
 
+spark_transport::Tp4AllreduceOptions translate(
+    const spark_tp4_config_v2& config) {
+  if (config.struct_size < sizeof(spark_tp4_config_v2)) {
+    throw std::invalid_argument("TP4 C API v2 config is too small");
+  }
+  auto options = translate(config.base);
+  options.elements_per_row = config.elements_per_row;
+  options.bytes_per_row = config.bytes_per_row;
+  return options;
+}
+
 spark_transport::Tp4AllgatherOptions translate(
     const spark_tp4_allgather_config& config) {
   if (config.peer0 == nullptr || config.peer1 == nullptr ||
@@ -223,6 +234,31 @@ spark_tp4_create_with_protocol_graph_kernel_and_schedule(
     return nullptr;
   } catch (...) {
     copy_error("unknown TP4 create failure", error, error_bytes);
+    return nullptr;
+  }
+}
+
+extern "C" spark_tp4_handle spark_tp4_create_v2(
+    const spark_tp4_config_v2* config, std::uint32_t protocol,
+    std::uint32_t graph_kernel, std::uint32_t wire_schedule,
+    char* error, std::size_t error_bytes) {
+  try {
+    if (config == nullptr) {
+      throw std::invalid_argument("TP4 C API v2 config is null");
+    }
+    auto options = translate(*config);
+    options.protocol =
+        spark_transport::tp4_allreduce_protocol_from_wire(protocol);
+    options.graph_kernel_strategy = graph_kernel_from_wire(graph_kernel);
+    options.schedule = schedule_from_wire(wire_schedule);
+    auto handle =
+        std::make_unique<Tp4CAllreduceHandle>(std::move(options));
+    return handle.release();
+  } catch (const std::exception& exception) {
+    copy_error(exception.what(), error, error_bytes);
+    return nullptr;
+  } catch (...) {
+    copy_error("unknown TP4 v2 create failure", error, error_bytes);
     return nullptr;
   }
 }

--- a/spark_transport/src/tp4_dual_port_striped_host.hpp
+++ b/spark_transport/src/tp4_dual_port_striped_host.hpp
@@ -12,16 +12,11 @@ namespace spark_transport::detail {
 // A peer that only understands the legacy or ordinary two-slot layout must
 // fail the setup handshake before either side posts RDMA into a striped arena.
 constexpr std::uint16_t kTp4DualPortStripedEndpointVersion = 4;
+// The tag stays a constant: row geometry is not folded into this 16-bit
+// field. Version 4 peers additionally exchange the exact GraphGeometryInfo
+// record and compare every field, so geometry identity is never hashed or
+// truncated.
 constexpr std::uint16_t kTp4DualPortStripedEndpointTag = 0xc204;
-
-constexpr std::uint16_t tp4_dual_port_striped_endpoint_tag(
-    std::uint32_t elements_per_row,
-    std::uint32_t bytes_per_row) noexcept {
-  return static_cast<std::uint16_t>(
-      kTp4DualPortStripedEndpointTag ^ elements_per_row ^
-      (elements_per_row >> 16U) ^ bytes_per_row ^
-      (bytes_per_row >> 16U));
-}
 
 enum class Tp4StripedWorkEvent : std::uint64_t {
   kPhase1Doorbell = 1,

--- a/spark_transport/src/tp4_dual_port_striped_host.hpp
+++ b/spark_transport/src/tp4_dual_port_striped_host.hpp
@@ -11,8 +11,17 @@ namespace spark_transport::detail {
 
 // A peer that only understands the legacy or ordinary two-slot layout must
 // fail the setup handshake before either side posts RDMA into a striped arena.
-constexpr std::uint16_t kTp4DualPortStripedEndpointVersion = 3;
+constexpr std::uint16_t kTp4DualPortStripedEndpointVersion = 4;
 constexpr std::uint16_t kTp4DualPortStripedEndpointTag = 0xc204;
+
+constexpr std::uint16_t tp4_dual_port_striped_endpoint_tag(
+    std::uint32_t elements_per_row,
+    std::uint32_t bytes_per_row) noexcept {
+  return static_cast<std::uint16_t>(
+      kTp4DualPortStripedEndpointTag ^ elements_per_row ^
+      (elements_per_row >> 16U) ^ bytes_per_row ^
+      (bytes_per_row >> 16U));
+}
 
 enum class Tp4StripedWorkEvent : std::uint64_t {
   kPhase1Doorbell = 1,
@@ -52,8 +61,10 @@ inline bool tp4_dual_port_striped_options_valid(
       options.graph_progress_cpu.has_value() &&
       options.graph_submit_cpu != options.graph_progress_cpu;
   const bool capacity_valid =
-      options.payload_bytes == tp4_graph_payload_bytes(40) ||
-      options.payload_bytes == tp4_graph_payload_bytes(512);
+      options.payload_bytes ==
+          tp4_graph_payload_bytes(40, options.bytes_per_row) ||
+      options.payload_bytes ==
+          tp4_graph_payload_bytes(512, options.bytes_per_row);
   return options.schedule == Tp4AllreduceSchedule::kDualPortStriped &&
          options.protocol == Tp4AllreduceProtocol::kTwoSlotDeferredAck &&
          options.graph_kernel_strategy == Tp4GraphKernelStrategy::kFused &&

--- a/spark_transport/src/tp4_session.cpp
+++ b/spark_transport/src/tp4_session.cpp
@@ -44,17 +44,25 @@ namespace {
 constexpr std::uint64_t kDefaultMaxInflight = 64;
 constexpr std::uint64_t kMaximumMaxInflight = 4096;
 constexpr auto kGraphProtocolTimeout = std::chrono::seconds(5);
-constexpr std::size_t kQ1PayloadBytes =
-    tp4_graph_payload_bytes(1);
 // The record layout remains EndpointInfo v1. A distinct wire version makes a
 // mixed old/new deferred-credit deployment fail on both peers before either
 // peer enters the data path; old binaries otherwise ignore reserved tags.
 constexpr std::uint16_t kTwoSlotDeferredEndpointVersion = 2;
+constexpr std::uint16_t kGraphLayoutEndpointVersion = 4;
 
-bool graph_capacity_supported(std::size_t payload_bytes) {
+constexpr std::uint16_t graph_layout_endpoint_tag(
+    std::uint32_t elements_per_row,
+    std::uint32_t bytes_per_row) noexcept {
+  return static_cast<std::uint16_t>(
+      0xc211U ^ elements_per_row ^ (elements_per_row >> 16U) ^
+      bytes_per_row ^ (bytes_per_row >> 16U));
+}
+
+bool graph_capacity_supported(std::size_t payload_bytes,
+                              std::uint32_t bytes_per_row) {
   for (std::uint32_t q = 1;
        q <= kTp4GraphAllreduceMaximumQ; ++q) {
-    if (payload_bytes == tp4_graph_payload_bytes(q)) {
+    if (payload_bytes == tp4_graph_payload_bytes(q, bytes_per_row)) {
       return true;
     }
   }
@@ -128,11 +136,18 @@ ControlChannel open_channel(const Tp4RoundPlan& plan,
 
 void exchange_and_connect_endpoint(
     ControlChannel& channel, VerbsEndpoint& endpoint,
-    Tp4AllreduceProtocol protocol, Tp4AllreduceSchedule schedule) {
+    Tp4AllreduceProtocol protocol, Tp4AllreduceSchedule schedule,
+    bool graph_session, std::uint32_t elements_per_row,
+    std::uint32_t bytes_per_row) {
   EndpointInfo local = endpoint.local_info();
   if (schedule == Tp4AllreduceSchedule::kDualPortStriped) {
     local.version = detail::kTp4DualPortStripedEndpointVersion;
-    local.reserved = detail::kTp4DualPortStripedEndpointTag;
+    local.reserved = detail::tp4_dual_port_striped_endpoint_tag(
+        elements_per_row, bytes_per_row);
+  } else if (graph_session) {
+    local.version = kGraphLayoutEndpointVersion;
+    local.reserved =
+        graph_layout_endpoint_tag(elements_per_row, bytes_per_row);
   } else if (tp4_protocol_uses_deferred_ack(protocol)) {
     local.version = kTwoSlotDeferredEndpointVersion;
     local.reserved = tp4_endpoint_protocol_tag(protocol);
@@ -363,6 +378,16 @@ class Tp4AllreduceSession::Impl {
         options_.control_port1 == 0) {
       throw std::invalid_argument("invalid TP4 all-reduce options");
     }
+    if (options_.elements_per_row == 0 || options_.bytes_per_row == 0 ||
+        static_cast<std::uint64_t>(options_.bytes_per_row) !=
+            static_cast<std::uint64_t>(options_.elements_per_row) *
+                kTp4GraphBytesPerElement ||
+        static_cast<std::uint64_t>(options_.bytes_per_row) *
+                kTp4GraphAllreduceMaximumQ >
+            std::numeric_limits<std::uint32_t>::max()) {
+      throw std::invalid_argument(
+          "TP4 graph row geometry must describe contiguous BF16 rows");
+    }
     (void)tp4_allreduce_protocol_from_wire(
         static_cast<std::uint32_t>(options_.protocol));
     if (!tp4_graph_kernel_strategy_valid(
@@ -387,7 +412,8 @@ class Tp4AllreduceSession::Impl {
     }
     if (tp4_protocol_uses_deferred_ack(options_.protocol) &&
         (!submit_cpu_set ||
-         !graph_capacity_supported(options_.payload_bytes))) {
+         !graph_capacity_supported(options_.payload_bytes,
+                                   options_.bytes_per_row))) {
       throw std::invalid_argument(
           "two-slot deferred ACK requires a graph-only TP4 all-reduce "
           "session with a supported graph payload capacity");
@@ -395,12 +421,13 @@ class Tp4AllreduceSession::Impl {
     if (tp4_graph_kernel_strategy_is_graph_only(
             options_.graph_kernel_strategy)) {
       if (!submit_cpu_set ||
-          !graph_capacity_supported(options_.payload_bytes)) {
+          !graph_capacity_supported(options_.payload_bytes,
+                                    options_.bytes_per_row)) {
         throw std::invalid_argument(
             std::string(tp4_graph_kernel_strategy_name(
                             options_.graph_kernel_strategy)) +
             " graph TP4 requires a graph-only session with exact Q1 "
-            "through Q512 capacity");
+            "through Q1024 capacity");
       }
     }
     if (submit_cpu_set) {
@@ -437,7 +464,9 @@ class Tp4AllreduceSession::Impl {
     endpoint0_ = std::make_unique<VerbsEndpoint>(
         options_.device0, 1, options_.gid0, *buffer0_);
     exchange_and_connect_endpoint(*channel0_, *endpoint0_,
-                                  options_.protocol, options_.schedule);
+                                  options_.protocol, options_.schedule,
+                                  submit_cpu_set, options_.elements_per_row,
+                                  options_.bytes_per_row);
 
     channel1_.emplace(
         open_channel(plan1, options_.peer1, options_.control_port1));
@@ -446,9 +475,12 @@ class Tp4AllreduceSession::Impl {
     endpoint1_ = std::make_unique<VerbsEndpoint>(
         options_.device1, 1, options_.gid1, *buffer1_);
     exchange_and_connect_endpoint(*channel1_, *endpoint1_,
-                                  options_.protocol, options_.schedule);
+                                  options_.protocol, options_.schedule,
+                                  submit_cpu_set, options_.elements_per_row,
+                                  options_.bytes_per_row);
 
-    if (graph_capacity_supported(options_.payload_bytes)) {
+    if (graph_capacity_supported(options_.payload_bytes,
+                                 options_.bytes_per_row)) {
       int device{};
       int host_native_atomics{};
       check_cuda(cudaGetDevice(&device), "cudaGetDevice graph TP4");
@@ -467,7 +499,8 @@ class Tp4AllreduceSession::Impl {
     }
 
     worker_ = std::make_unique<GpuTp4TensorWorker>(
-        options_.payload_bytes, buffer0_->device_data(), layout_,
+        options_.payload_bytes, options_.bytes_per_row,
+        buffer0_->device_data(), layout_,
         buffer1_->device_data(), layout_, options_.protocol,
         options_.graph_kernel_strategy, options_.schedule);
     channel0_->barrier();
@@ -595,13 +628,15 @@ class Tp4AllreduceSession::Impl {
           "graph TP4 all-reduce tensor pointer is null");
     }
     const std::uint32_t active_payload_bytes =
-        tp4_graph_payload_bytes(q);
-    if (!tp4_graph_allreduce_command_descriptor_valid(
-            q, active_payload_bytes) ||
+        tp4_graph_payload_bytes(q, options_.bytes_per_row);
+    if (!tp4_graph_command_layout_valid(
+            q, active_payload_bytes, options_.bytes_per_row,
+            kTp4GraphAllreduceMaximumQ) ||
         active_payload_bytes > options_.payload_bytes ||
         graph_commands_host_ == nullptr) {
       throw std::invalid_argument(
-          "graph TP4 all-reduce requires BF16 [q, 6144], q in [1, 512], "
+          "graph TP4 all-reduce requires the configured BF16 [q, width], "
+          "q in [1, 1024], "
           "within session capacity");
     }
     if (!graph_host_native_atomics_supported_) {
@@ -844,8 +879,9 @@ class Tp4AllreduceSession::Impl {
 
       Tp4GraphCommand command{};
       const std::uint64_t expected = graph_consumed_sequence_ + 1;
-      if (!tp4_graph_allreduce_command_try_consume_descriptor(
-              graph_commands_host_, expected, &command)) {
+      if (!tp4_graph_command_try_consume_layout(
+              graph_commands_host_, expected, options_.bytes_per_row,
+              kTp4GraphAllreduceMaximumQ, &command)) {
         adaptive_graph_poll_pause(poll_misses);
         continue;
       }

--- a/spark_transport/src/tp4_session.cpp
+++ b/spark_transport/src/tp4_session.cpp
@@ -49,14 +49,27 @@ constexpr auto kGraphProtocolTimeout = std::chrono::seconds(5);
 // peer enters the data path; old binaries otherwise ignore reserved tags.
 constexpr std::uint16_t kTwoSlotDeferredEndpointVersion = 2;
 constexpr std::uint16_t kGraphLayoutEndpointVersion = 4;
+// Constant tag: version-4 graph peers exchange the exact
+// GraphGeometryInfo record below instead of folding geometry into
+// this 16-bit field.
+constexpr std::uint16_t kGraphLayoutEndpointTag = 0xc211;
 
-constexpr std::uint16_t graph_layout_endpoint_tag(
-    std::uint32_t elements_per_row,
-    std::uint32_t bytes_per_row) noexcept {
-  return static_cast<std::uint16_t>(
-      0xc211U ^ elements_per_row ^ (elements_per_row >> 16U) ^
-      bytes_per_row ^ (bytes_per_row >> 16U));
-}
+// Exact graph-row geometry record, exchanged over the control channel
+// after EndpointInfo for every graph session. Both peers must present
+// identical values in every field; geometry identity is never hashed
+// or truncated.
+constexpr std::uint32_t kGraphGeometryMagic = 0x53474d47;  // "SGMG"
+
+struct GraphGeometryInfo {
+  std::uint32_t magic{kGraphGeometryMagic};
+  std::uint16_t version{1};
+  std::uint16_t reserved{};
+  std::uint32_t elements_per_row{};
+  std::uint32_t bytes_per_row{};
+};
+
+static_assert(sizeof(GraphGeometryInfo) == 16);
+static_assert(std::is_trivially_copyable_v<GraphGeometryInfo>);
 
 bool graph_capacity_supported(std::size_t payload_bytes,
                               std::uint32_t bytes_per_row) {
@@ -142,12 +155,10 @@ void exchange_and_connect_endpoint(
   EndpointInfo local = endpoint.local_info();
   if (schedule == Tp4AllreduceSchedule::kDualPortStriped) {
     local.version = detail::kTp4DualPortStripedEndpointVersion;
-    local.reserved = detail::tp4_dual_port_striped_endpoint_tag(
-        elements_per_row, bytes_per_row);
+    local.reserved = detail::kTp4DualPortStripedEndpointTag;
   } else if (graph_session) {
     local.version = kGraphLayoutEndpointVersion;
-    local.reserved =
-        graph_layout_endpoint_tag(elements_per_row, bytes_per_row);
+    local.reserved = kGraphLayoutEndpointTag;
   } else if (tp4_protocol_uses_deferred_ack(protocol)) {
     local.version = kTwoSlotDeferredEndpointVersion;
     local.reserved = tp4_endpoint_protocol_tag(protocol);
@@ -166,6 +177,25 @@ void exchange_and_connect_endpoint(
   if (remote.buffer_bytes != local.buffer_bytes) {
     throw std::runtime_error(
         "TP4 all-reduce payload arena mismatch between peers");
+  }
+  if (graph_session) {
+    GraphGeometryInfo local_geometry{};
+    local_geometry.elements_per_row = elements_per_row;
+    local_geometry.bytes_per_row = bytes_per_row;
+    const GraphGeometryInfo remote_geometry =
+        channel.exchange(local_geometry);
+    if (remote_geometry.magic != local_geometry.magic ||
+        remote_geometry.version != local_geometry.version ||
+        remote_geometry.reserved != local_geometry.reserved) {
+      throw std::runtime_error(
+          "TP4 graph geometry record mismatch between peers");
+    }
+    if (remote_geometry.elements_per_row !=
+            local_geometry.elements_per_row ||
+        remote_geometry.bytes_per_row != local_geometry.bytes_per_row) {
+      throw std::runtime_error(
+          "TP4 graph row-geometry mismatch between peers");
+    }
   }
   endpoint.connect(remote, local.version);
 }
@@ -427,7 +457,7 @@ class Tp4AllreduceSession::Impl {
             std::string(tp4_graph_kernel_strategy_name(
                             options_.graph_kernel_strategy)) +
             " graph TP4 requires a graph-only session with exact Q1 "
-            "through Q1024 capacity");
+            "through Q512 capacity");
       }
     }
     if (submit_cpu_set) {
@@ -636,7 +666,7 @@ class Tp4AllreduceSession::Impl {
         graph_commands_host_ == nullptr) {
       throw std::invalid_argument(
           "graph TP4 all-reduce requires the configured BF16 [q, width], "
-          "q in [1, 1024], "
+          "q in [1, 512], "
           "within session capacity");
     }
     if (!graph_host_native_atomics_supported_) {

--- a/spark_transport/tests/test_tp4_split_graph_source_contract.py
+++ b/spark_transport/tests/test_tp4_split_graph_source_contract.py
@@ -134,7 +134,8 @@ def test_tiered_worker_rejects_eager_but_accepts_both_graph_protocols() -> None:
     assert "tp4_graph_kernel_uses_split(graph_kernel_strategy_, q)" in enqueue_graph
     assert "q >= 1 && q <= kTp4GraphAllreduceMaximumQ" in worker
     assert "tp4_graph_kernel_strategy_is_graph_only" in session
-    assert "graph_capacity_supported(options_.payload_bytes)" in session
+    assert "graph_capacity_supported(options_.payload_bytes," in session
+    assert "options_.bytes_per_row" in session
     assert "kTp4TieredSplitMinimumQ = 7" in strategy
     assert "q >= kTp4TieredSplitMinimumQ" in strategy
 

--- a/spark_transport/tests/tp4_c_api_layout_test.cpp
+++ b/spark_transport/tests/tp4_c_api_layout_test.cpp
@@ -26,6 +26,17 @@ static_assert(
     sizeof(void*) != 8 ||
     offsetof(spark_tp4_config, graph_progress_cpu_plus_one) == 60);
 
+static_assert(std::is_standard_layout_v<spark_tp4_config_v2>);
+static_assert(std::is_trivially_copyable_v<spark_tp4_config_v2>);
+static_assert(sizeof(void*) != 8 || sizeof(spark_tp4_config_v2) == 80);
+static_assert(offsetof(spark_tp4_config_v2, struct_size) == 0);
+static_assert(sizeof(void*) != 8 ||
+              offsetof(spark_tp4_config_v2, base) == 8);
+static_assert(sizeof(void*) != 8 ||
+              offsetof(spark_tp4_config_v2, elements_per_row) == 72);
+static_assert(sizeof(void*) != 8 ||
+              offsetof(spark_tp4_config_v2, bytes_per_row) == 76);
+
 static_assert(std::is_standard_layout_v<spark_tp4_graph_status>);
 static_assert(std::is_trivially_copyable_v<spark_tp4_graph_status>);
 static_assert(sizeof(spark_tp4_graph_status) == 56);

--- a/spark_transport/tests/tp4_c_api_test.cpp
+++ b/spark_transport/tests/tp4_c_api_test.cpp
@@ -60,6 +60,37 @@ int main() {
              sizeof(error)) == nullptr);
   expect_message_contains(error, "invalid TP4 wire schedule");
 
+  std::memset(error, 0, sizeof(error));
+  assert(spark_tp4_create_v2(
+             nullptr, SPARK_TP4_ALLREDUCE_PROTOCOL_SERIAL_ACK,
+             SPARK_TP4_GRAPH_KERNEL_FUSED,
+             SPARK_TP4_WIRE_SCHEDULE_SEQUENTIAL, error,
+             sizeof(error)) == nullptr);
+  expect_message_contains(error, "v2 config is null");
+
+  spark_tp4_config_v2 deepseek_config{};
+  deepseek_config.struct_size = sizeof(deepseek_config) - 1;
+  deepseek_config.base = protocol_config;
+  deepseek_config.elements_per_row = 4096;
+  deepseek_config.bytes_per_row = 8192;
+  std::memset(error, 0, sizeof(error));
+  assert(spark_tp4_create_v2(
+             &deepseek_config, SPARK_TP4_ALLREDUCE_PROTOCOL_SERIAL_ACK,
+             SPARK_TP4_GRAPH_KERNEL_FUSED,
+             SPARK_TP4_WIRE_SCHEDULE_SEQUENTIAL, error,
+             sizeof(error)) == nullptr);
+  expect_message_contains(error, "v2 config is too small");
+
+  deepseek_config.struct_size = sizeof(deepseek_config);
+  deepseek_config.bytes_per_row = 12288;
+  std::memset(error, 0, sizeof(error));
+  assert(spark_tp4_create_v2(
+             &deepseek_config, SPARK_TP4_ALLREDUCE_PROTOCOL_SERIAL_ACK,
+             SPARK_TP4_GRAPH_KERNEL_FUSED,
+             SPARK_TP4_WIRE_SCHEDULE_SEQUENTIAL, error,
+             sizeof(error)) == nullptr);
+  expect_message_contains(error, "contiguous BF16 rows");
+
   assert(spark_tp4_capture_q1_all_reduce(
              nullptr, nullptr, nullptr, nullptr, error, sizeof(error)) == 1);
   expect_message_contains(error, "handle is null");

--- a/spark_transport/tests/tp4_dual_port_striped_host_test.cpp
+++ b/spark_transport/tests/tp4_dual_port_striped_host_test.cpp
@@ -11,17 +11,17 @@ int main() {
   using spark_transport::detail::kTp4DualPortStripedEndpointTag;
   using spark_transport::detail::kTp4DualPortStripedEndpointVersion;
   using spark_transport::detail::Tp4StripedWorkEvent;
-  using spark_transport::detail::tp4_dual_port_striped_endpoint_tag;
   using spark_transport::detail::tp4_dual_port_striped_options_valid;
   using spark_transport::detail::tp4_striped_work_id;
 
   static_assert(kTp4DualPortStripedEndpointVersion != 1);
   static_assert(kTp4DualPortStripedEndpointVersion != 2);
+  // Version 3 predates the exact geometry-record exchange; version-4
+  // peers must never complete a handshake with one.
+  static_assert(kTp4DualPortStripedEndpointVersion != 3);
   static_assert(kTp4DualPortStripedEndpointTag != 0);
   static_assert(kTp4DualPortStripedEndpointTag !=
                 spark_transport::kTp4TwoSlotEndpointTag);
-  static_assert(tp4_dual_port_striped_endpoint_tag(6144, 12288) !=
-                tp4_dual_port_striped_endpoint_tag(4096, 8192));
 
   constexpr std::array<std::uint64_t, 4> sequence1_work_ids{
       tp4_striped_work_id(1, Tp4StripedWorkEvent::kPhase1Doorbell),

--- a/spark_transport/tests/tp4_dual_port_striped_host_test.cpp
+++ b/spark_transport/tests/tp4_dual_port_striped_host_test.cpp
@@ -11,6 +11,7 @@ int main() {
   using spark_transport::detail::kTp4DualPortStripedEndpointTag;
   using spark_transport::detail::kTp4DualPortStripedEndpointVersion;
   using spark_transport::detail::Tp4StripedWorkEvent;
+  using spark_transport::detail::tp4_dual_port_striped_endpoint_tag;
   using spark_transport::detail::tp4_dual_port_striped_options_valid;
   using spark_transport::detail::tp4_striped_work_id;
 
@@ -19,6 +20,8 @@ int main() {
   static_assert(kTp4DualPortStripedEndpointTag != 0);
   static_assert(kTp4DualPortStripedEndpointTag !=
                 spark_transport::kTp4TwoSlotEndpointTag);
+  static_assert(tp4_dual_port_striped_endpoint_tag(6144, 12288) !=
+                tp4_dual_port_striped_endpoint_tag(4096, 8192));
 
   constexpr std::array<std::uint64_t, 4> sequence1_work_ids{
       tp4_striped_work_id(1, Tp4StripedWorkEvent::kPhase1Doorbell),

--- a/spark_transport/tests/tp4_graph_command_test.cpp
+++ b/spark_transport/tests/tp4_graph_command_test.cpp
@@ -74,9 +74,9 @@ int main() {
       kTp4GraphMaximumQ + 1,
       tp4_graph_payload_bytes(kTp4GraphMaximumQ + 1)));
   static_assert(kTp4GraphMaximumQ == 40);
-  static_assert(kTp4GraphAllreduceMaximumQ == 512);
+  static_assert(kTp4GraphAllreduceMaximumQ == 1024);
   static_assert(tp4_graph_payload_bytes(kTp4GraphAllreduceMaximumQ) ==
-                6U * 1024U * 1024U);
+                12U * 1024U * 1024U);
   assert(tp4_graph_allreduce_command_descriptor_valid(
       kTp4GraphAllreduceMaximumQ,
       tp4_graph_payload_bytes(kTp4GraphAllreduceMaximumQ)));
@@ -88,6 +88,20 @@ int main() {
   assert(!tp4_graph_command_layout_valid(7, 7 * 77440, 77440, 6));
   assert(!tp4_graph_command_layout_valid(6, 6 * 77440 - 1, 77440, 6));
   assert(!tp4_graph_command_layout_valid(1, 1, 0, 6));
+  constexpr std::uint32_t deepseek_bytes_per_row = 4096U * 2U;
+  static_assert(tp4_graph_payload_bytes(1, deepseek_bytes_per_row) ==
+                8192U);
+  static_assert(tp4_graph_payload_bytes(1024, deepseek_bytes_per_row) ==
+                8U * 1024U * 1024U);
+  assert(tp4_graph_command_layout_valid(
+      30, tp4_graph_payload_bytes(30, deepseek_bytes_per_row),
+      deepseek_bytes_per_row, kTp4GraphAllreduceMaximumQ));
+  assert(tp4_graph_command_layout_valid(
+      1024, tp4_graph_payload_bytes(1024, deepseek_bytes_per_row),
+      deepseek_bytes_per_row, kTp4GraphAllreduceMaximumQ));
+  assert(!tp4_graph_command_layout_valid(
+      30, tp4_graph_payload_bytes(30), deepseek_bytes_per_row,
+      kTp4GraphAllreduceMaximumQ));
   assert(!tp4_graph_doorbell_token_valid(0, 1));
   assert(!tp4_graph_doorbell_token_valid(1, 0));
   assert(tp4_graph_doorbell_token_valid(
@@ -112,25 +126,26 @@ int main() {
       previous = token;
     }
   }
-  const auto q512_token = tp4_graph_doorbell_token(
+  const auto maximum_q_token = tp4_graph_doorbell_token(
       7, kTp4GraphAllreduceMaximumQ);
-  assert((q512_token >> kTp4GraphDoorbellQBits) == 7);
-  assert((q512_token & kTp4GraphDoorbellQMask) ==
+  assert((maximum_q_token >> kTp4GraphDoorbellQBits) == 7);
+  assert((maximum_q_token & kTp4GraphDoorbellQMask) ==
          kTp4GraphAllreduceMaximumQ);
-  assert(q512_token < tp4_graph_doorbell_token(8, 1));
+  assert(maximum_q_token < tp4_graph_doorbell_token(8, 1));
 
-  Tp4GraphCommandRing allreduce_q512{};
-  std::uint64_t allreduce_q512_sequence{};
+  Tp4GraphCommandRing allreduce_maximum_q{};
+  std::uint64_t allreduce_maximum_q_sequence{};
   assert(tp4_graph_allreduce_command_publish_descriptor(
-      &allreduce_q512, true, kTp4GraphAllreduceMaximumQ,
+      &allreduce_maximum_q, true, kTp4GraphAllreduceMaximumQ,
       tp4_graph_payload_bytes(kTp4GraphAllreduceMaximumQ),
-      &allreduce_q512_sequence));
-  assert(allreduce_q512_sequence == 1);
-  Tp4GraphCommand allreduce_q512_command{};
+      &allreduce_maximum_q_sequence));
+  assert(allreduce_maximum_q_sequence == 1);
+  Tp4GraphCommand allreduce_maximum_q_command{};
   assert(tp4_graph_allreduce_command_try_consume_descriptor(
-      &allreduce_q512, 1, &allreduce_q512_command));
-  assert(allreduce_q512_command.q == kTp4GraphAllreduceMaximumQ);
-  assert(allreduce_q512_command.payload_bytes == 6U * 1024U * 1024U);
+      &allreduce_maximum_q, 1, &allreduce_maximum_q_command));
+  assert(allreduce_maximum_q_command.q == kTp4GraphAllreduceMaximumQ);
+  assert(allreduce_maximum_q_command.payload_bytes ==
+         12U * 1024U * 1024U);
 
   std::uint64_t sequence{99};
   assert(!tp4_graph_command_publish_descriptor(

--- a/sparkring_plugin/src/sparkring/_vendor/spark_tp4_backend.py
+++ b/sparkring_plugin/src/sparkring/_vendor/spark_tp4_backend.py
@@ -38,6 +38,15 @@ _ALLREDUCE_PREFILL_CAPACITY_BYTES = (
 )
 _DUAL_PORT_Q40_CAPACITY_BYTES = ABSOLUTE_MAX_QUERY_ROWS * _BYTES_PER_ROW
 _GRAPH_CAPACITY_BYTES = MAX_QUERY_ROWS * _BYTES_PER_ROW
+# Research-only width-4096 graph geometry (DeepSeek decode shapes). One
+# maximum-capacity session serves every [Q <= 512, 4096] bucket; the
+# command ring carries the active Q.
+_RESEARCH_GRAPH_WIDTH = 4096
+_RESEARCH_GRAPH_ROW_BYTES = _RESEARCH_GRAPH_WIDTH * _BF16_BYTES
+_RESEARCH_GRAPH_MAX_QUERY_ROWS = 512
+_RESEARCH_GRAPH_CAPACITY_BYTES = (
+    _RESEARCH_GRAPH_MAX_QUERY_ROWS * _RESEARCH_GRAPH_ROW_BYTES
+)
 _GRAPH_STATUS_CAPTURE_CONFIGURED = 1 << 0
 _GRAPH_STATUS_POLLING_ENABLED = 1 << 1
 _GRAPH_STATUS_HOST_NATIVE_ATOMICS = 1 << 2
@@ -71,6 +80,7 @@ _WIRE_SCHEDULE_WIRE = {
 _MAX_PERSISTENT_OUTPUT_SLOTS = 4096
 _graph_q1_sessions: dict[int, "_NativeSession"] = {}
 _graph_dual_port_q40_sessions: dict[int, "_NativeSession"] = {}
+_graph_width4096_sessions: dict[int, "_NativeSession"] = {}
 _graph_event_counts: dict[str, int] = {}
 # PLACEHOLDER ring peers (RFC 5737 TEST-NET-1): 192.0.2.N stands in for
 # rank N-1's direct-cable address. These are NOT routable and MUST be
@@ -103,6 +113,15 @@ class _NativeConfig(ctypes.Structure):
         ("payload_bytes", ctypes.c_size_t),
         ("graph_submit_cpu_plus_one", ctypes.c_uint32),
         ("graph_progress_cpu_plus_one", ctypes.c_uint32),
+    ]
+
+
+class _NativeConfigV2(ctypes.Structure):
+    _fields_ = [
+        ("struct_size", ctypes.c_uint32),
+        ("base", _NativeConfig),
+        ("elements_per_row", ctypes.c_uint32),
+        ("bytes_per_row", ctypes.c_uint32),
     ]
 
 
@@ -339,12 +358,78 @@ def _record_stock_path(
             ),
             unique_name=str(getattr(communicator, "unique_name", "")),
         )
+    if enabled():
+        # Invariant: an armed audit always produces a status file,
+        # regardless of model width or graph eligibility. The recording
+        # path must start the reporter itself because no graph-session
+        # preparation is guaranteed to run in the serving profile.
+        from spark_graph_status_reporter import ensure_status_reporter
+
+        reporter_rank = getattr(communicator, "rank_in_group", None)
+        if reporter_rank is None:
+            reporter_rank = 0
+        ensure_status_reporter(rank=int(reporter_rank))
     record_stock(
         "all_reduce",
         capturing=capturing,
         reason=reason,
         signature=signature,
     )
+
+
+def _research_graph_all_reduce(
+    communicator: Any, tensor: Any, capturing: bool
+) -> Any | None:
+    """Route research-admitted width-4096 collectives.
+
+    Returns the collective output when this path handled the call, or
+    None to fall through to the unchanged default dispatch. Eager calls
+    are never handled here: the eager pass only prepares the session so
+    it exists before vLLM's first capture.
+    """
+    if (
+        getattr(communicator, "world_size", None) != 4
+        or getattr(communicator, "unique_name", "") != "tp:0"
+    ):
+        return None
+    backend = getattr(communicator, "_spark_tp4_native", None)
+    if backend is None:
+        backend = _Backend(int(communicator.rank_in_group))
+        communicator._spark_tp4_native = backend
+    if not capturing:
+        if backend.graph_width4096_session is None:
+            backend.prepare_graph_width4096()
+        return None
+    shape = _tensor_shape(tensor)
+    if (
+        not _research_graph_shape_eligible(shape)
+        or str(tensor.dtype) != "torch.bfloat16"
+        or not bool(tensor.is_cuda)
+        or not bool(tensor.is_contiguous())
+    ):
+        return None
+    session = backend.graph_width4096_session
+    if session is None:
+        # Fail closed: an admitted capture-phase collective must never
+        # silently take the stock path in the research profile.
+        logger.error(
+            "research width-4096 graph capture reached before session "
+            "preparation; terminating worker"
+        )
+        _abort_after_native_failure()
+        raise AssertionError("unreachable after worker termination")
+    try:
+        output = session.capture(tensor)
+        _record_graph_event(communicator, "width4096_captured_nodes")
+        return output
+    except BaseException:
+        logger.exception(
+            "fatal Spark TP4 width-4096 graph-capture error; terminating "
+            "worker because a partially captured native graph cannot "
+            "safely fall back"
+        )
+        _abort_after_native_failure()
+        raise AssertionError("unreachable after worker termination")
 
 
 def _payload_bytes(tensor: Any) -> int:
@@ -369,6 +454,30 @@ def _graph_q1_enabled() -> bool:
     if value not in {"0", "1"}:
         raise ValueError("VLLM_SPARK_TP4_GRAPH_Q1 must be '0' or '1'")
     return value == "1"
+
+
+def _graph_width4096_research_enabled() -> bool:
+    """Research-only graph admission for BF16 [Q <= 512, 4096].
+
+    Explicitly opt-in and unqualified: enabling it routes captured
+    width-4096 all-reduces through one maximum-capacity native graph
+    session (sequential tiered_64k, two-slot deferred ACK) instead of
+    the stock path. Default behavior is byte-identical when unset.
+    """
+    value = os.getenv("VLLM_SPARK_TP4_GRAPH_WIDTH4096_RESEARCH", "0")
+    if value not in {"0", "1"}:
+        raise ValueError(
+            "VLLM_SPARK_TP4_GRAPH_WIDTH4096_RESEARCH must be '0' or '1'"
+        )
+    return value == "1"
+
+
+def _research_graph_shape_eligible(shape: tuple[int, ...]) -> bool:
+    return (
+        len(shape) == 2
+        and shape[1] == _RESEARCH_GRAPH_WIDTH
+        and 1 <= shape[0] <= _RESEARCH_GRAPH_MAX_QUERY_ROWS
+    )
 
 
 def _graph_dual_port_q40_enabled() -> bool:
@@ -547,12 +656,31 @@ class _NativeSession:
         allreduce_protocol: str = _SERIAL_ACK_PROTOCOL,
         graph_kernel_strategy: str = _FUSED_GRAPH_KERNEL,
         wire_schedule: str = _SEQUENTIAL_WIRE_SCHEDULE,
+        row_bytes: int = _BYTES_PER_ROW,
     ) -> None:
         if rank not in _DEFAULT_PEERS:
             raise ValueError(f"TP4 rank must be in [0, 3], got {rank}")
+        if row_bytes != _BYTES_PER_ROW:
+            if not graph_only:
+                raise ValueError(
+                    "non-default TP4 row geometry requires a graph-only "
+                    "session"
+                )
+            if row_bytes != _RESEARCH_GRAPH_ROW_BYTES:
+                raise ValueError(
+                    "TP4 row geometry must be the default width or the "
+                    f"research width ({_RESEARCH_GRAPH_ROW_BYTES} bytes "
+                    "per row)"
+                )
+            if payload_bytes != _RESEARCH_GRAPH_CAPACITY_BYTES:
+                raise ValueError(
+                    "research row-geometry graph session requires "
+                    f"Q{_RESEARCH_GRAPH_MAX_QUERY_ROWS} capacity"
+                )
         expected_graph_capacity = _graph_capacity_bytes()
         if (
             graph_only
+            and row_bytes == _BYTES_PER_ROW
             and wire_schedule == _SEQUENTIAL_WIRE_SCHEDULE
             and payload_bytes != expected_graph_capacity
         ):
@@ -621,7 +749,25 @@ class _NativeSession:
         ]
         self._library.spark_tp4_create.restype = ctypes.c_void_p
         create_session = self._library.spark_tp4_create
-        if wire_schedule != _SEQUENTIAL_WIRE_SCHEDULE:
+        use_v2_geometry = row_bytes != _BYTES_PER_ROW
+        if use_v2_geometry:
+            try:
+                create_session = self._library.spark_tp4_create_v2
+            except AttributeError as error:
+                raise RuntimeError(
+                    "Spark TP4 native library lacks the v2 row-geometry "
+                    "ABI; rebuild and deploy a matching library"
+                ) from error
+            create_session.argtypes = [
+                ctypes.POINTER(_NativeConfigV2),
+                ctypes.c_uint32,
+                ctypes.c_uint32,
+                ctypes.c_uint32,
+                ctypes.c_char_p,
+                ctypes.c_size_t,
+            ]
+            create_session.restype = ctypes.c_void_p
+        elif wire_schedule != _SEQUENTIAL_WIRE_SCHEDULE:
             try:
                 create_session = (
                     self._library
@@ -710,8 +856,10 @@ class _NativeSession:
         self._allreduce_protocol = allreduce_protocol
         self._graph_kernel_strategy = graph_kernel_strategy
         self._wire_schedule = wire_schedule
+        self._row_bytes = row_bytes
+        self._elements_per_row = row_bytes // _BF16_BYTES
         self._graph_max_query_rows = (
-            payload_bytes // _BYTES_PER_ROW if graph_only else 0
+            payload_bytes // row_bytes if graph_only else 0
         )
         persistent_slots = 0 if graph_only else _persistent_output_slots()
         self._persistent_outputs = (
@@ -745,7 +893,22 @@ class _NativeSession:
             graph_progress_cpu_plus_one=progress_cpu + 1,
         )
         error = ctypes.create_string_buffer(512)
-        if wire_schedule != _SEQUENTIAL_WIRE_SCHEDULE:
+        if use_v2_geometry:
+            config_v2 = _NativeConfigV2(
+                struct_size=ctypes.sizeof(_NativeConfigV2),
+                base=config,
+                elements_per_row=self._elements_per_row,
+                bytes_per_row=row_bytes,
+            )
+            self._handle = create_session(
+                ctypes.byref(config_v2),
+                _ALLREDUCE_PROTOCOL_WIRE[allreduce_protocol],
+                _GRAPH_KERNEL_WIRE[graph_kernel_strategy],
+                _WIRE_SCHEDULE_WIRE[wire_schedule],
+                error,
+                len(error),
+            )
+        elif wire_schedule != _SEQUENTIAL_WIRE_SCHEDULE:
             self._handle = create_session(
                 ctypes.byref(config),
                 _ALLREDUCE_PROTOCOL_WIRE[allreduce_protocol],
@@ -924,8 +1087,16 @@ class _NativeSession:
             not dual_port_session
             or shape == (self._graph_max_query_rows, _TARGET_WIDTH)
         )
+        if self._row_bytes == _BYTES_PER_ROW:
+            shape_admitted = _target_shape_eligible(shape)
+        else:
+            shape_admitted = (
+                len(shape) == 2
+                and shape[1] == self._elements_per_row
+                and 1 <= shape[0] <= self._graph_max_query_rows
+            )
         if (
-            not _target_shape_eligible(shape)
+            not shape_admitted
             or shape[0] > self._graph_max_query_rows
             or not exact_dual_port_shape
             or str(tensor.dtype) != "torch.bfloat16"
@@ -939,8 +1110,8 @@ class _NativeSession:
             )
             raise ValueError(
                 "Spark TP4 graph capture requires contiguous CUDA BF16 "
-                f"[Q, 6144] with {query_requirement}; dual-port striped "
-                "sessions require their exact fixed Q"
+                f"[Q, {self._elements_per_row}] with {query_requirement}; "
+                "dual-port striped sessions require their exact fixed Q"
             )
         q = shape[0]
 
@@ -1068,6 +1239,7 @@ class _Backend:
         self.native_sessions: dict[int, _NativeSession] = {}
         self.graph_q1_session: _NativeSession | None = None
         self.graph_dual_port_q40_session: _NativeSession | None = None
+        self.graph_width4096_session: _NativeSession | None = None
         self.shadow_stats: dict[tuple[int, tuple[int, ...], str], _ShadowStats] = {}
 
     def native_for(self, payload_bytes: int) -> _NativeSession:
@@ -1115,6 +1287,36 @@ class _Backend:
             _graph_dual_port_q40_sessions[self.rank] = dual_port_session
         return session
 
+    def prepare_graph_width4096(self) -> _NativeSession:
+        """Research-only [Q <= 512, 4096] graph session.
+
+        Sequential tiered_64k on two-slot deferred ACK: the split-class
+        kernels are the measured fix for the fused kernel's
+        large-payload pathology, and tiered keeps fused behavior for
+        small Q (see docs/DUAL_PORT_STRIPING_PROBE_20260818.md).
+        """
+        session = self.graph_width4096_session
+        if session is None:
+            graph_cpu_affinity = _graph_preflight()
+            session = _NativeSession(
+                self.rank,
+                _RESEARCH_GRAPH_CAPACITY_BYTES,
+                control_ports=_graph_control_ports(),
+                graph_only=True,
+                graph_cpu_affinity=graph_cpu_affinity,
+                allreduce_protocol=_TWO_SLOT_DEFERRED_ACK_PROTOCOL,
+                graph_kernel_strategy=_TIERED_64K_GRAPH_KERNEL,
+                row_bytes=_RESEARCH_GRAPH_ROW_BYTES,
+            )
+            self.graph_width4096_session = session
+            _graph_width4096_sessions[self.rank] = session
+            from spark_graph_status_reporter import (
+                ensure_status_reporter,
+            )
+
+            ensure_status_reporter(rank=self.rank)
+        return session
+
     def graph_session_for_capture(
         self, tensor: Any
     ) -> _NativeSession | None:
@@ -1149,10 +1351,19 @@ def graph_dual_port_q40_status_snapshot() -> dict[int, dict[str, object]]:
     }
 
 
+def graph_width4096_status_snapshot() -> dict[int, dict[str, object]]:
+    """Return research width-4096 graph progress for process-local ranks."""
+    return {
+        rank: session.graph_status().to_dict()
+        for rank, session in sorted(_graph_width4096_sessions.items())
+    }
+
+
 def graph_q1_diagnostic_snapshot() -> dict[str, object]:
     return {
         "sessions": graph_q1_status_snapshot(),
         "dual_port_q40_sessions": graph_dual_port_q40_status_snapshot(),
+        "width4096_sessions": graph_width4096_status_snapshot(),
         "events": dict(sorted(_graph_event_counts.items())),
     }
 
@@ -1163,6 +1374,18 @@ def install() -> None:
     graph_protocol = _graph_allreduce_protocol()
     graph_kernel = _graph_kernel_strategy()
     graph_dual_port_q40 = _graph_dual_port_q40_enabled()
+    if _graph_width4096_research_enabled():
+        if mode != "custom":
+            raise ValueError(
+                "VLLM_SPARK_TP4_GRAPH_WIDTH4096_RESEARCH requires "
+                "VLLM_SPARK_TP4_MODE=custom"
+            )
+        if _graph_q1_enabled() or graph_dual_port_q40:
+            raise ValueError(
+                "VLLM_SPARK_TP4_GRAPH_WIDTH4096_RESEARCH is mutually "
+                "exclusive with the width-6144 graph paths: they share "
+                "the graph control-port pair"
+            )
     if capacity_pool_requested():
         raise RuntimeError(
             "VLLM_SPARK_TP4_PREFILL_CAPACITY_POOL is research-only: "
@@ -1211,6 +1434,14 @@ def install() -> None:
 
     def spark_all_reduce(self: Any, input_: Any) -> Any:
         mode = _mode()
+        if mode == "custom" and _graph_width4096_research_enabled():
+            import torch
+
+            handled = _research_graph_all_reduce(
+                self, input_, _is_stream_capturing(torch)
+            )
+            if handled is not None:
+                return handled
         if not _eligible(self, input_, mode):
             import torch
 


### PR DESCRIPTION
## Summary
Builds on the configurable graph-row ABI contributed by @jonyang-88 in #23. The original commit is preserved with its authorship; this PR completes it with the collision-safe handshake, vLLM binding, and live gates.

- Adds a versioned row-geometry session ABI: `spark_tp4_config_v2` and `spark_tp4_create_v2` accept explicit `elements_per_row`/`bytes_per_row`, while every existing constructor keeps the BF16 [Q, 6144] contract byte-for-byte. The graph all-reduce ceiling remains Q512 with ten-bit doorbell encoding.
- Graph-session peers exchange an exact versioned `GraphGeometryInfo` record over the control channel and compare every field; geometry identity is never hashed or truncated into the 16-bit endpoint tag.
- The vLLM adapter gains a research-only graph admission, enabled by `VLLM_SPARK_TP4_GRAPH_WIDTH4096_RESEARCH=1` in custom mode: one maximum-capacity BF16 [Q <= 512, 4096] native session (sequential tiered_64k kernel, two-slot deferred ACK), prepared during eager warmup, which captures admitted width-4096 all-reduces into CUDA graphs. An admitted capture-phase collective never silently falls back to the stock path (the worker terminates instead). Behavior is byte-identical when the input is absent, and the input is mutually exclusive with the width-6144 graph paths.
- The four-rank graph probe accepts `--elements-per-row 6144|4096` for its fixed-Q and mixed-Q legs.
- Includes the audit reporter-arming invariant from #34: an armed collective audit always produces a status file regardless of model width or graph eligibility.

## Validation (2026-08-18, four directly cabled DGX Sparks)
- Model-free gate at width 4096, sequential tiered_64k, two-slot deferred ACK: fixed-Q legs Q8/Q48/Q256/Q288/Q320/Q512 and a 134-node mixed-Q leg on one maximum-capacity session, all reporting `mismatched_elements=0 overflow=0 correct=true passed=true` on all four ranks, with port byte counters bracketing every leg.
- Isolated single-replay device timing: 436 µs p50 at [256, 4096] (a graph-captured NCCL control at the same 2 MiB payload measures 811-1,140 µs across sessions); 809 µs p50 at [512, 4096] (NCCL at 4 MiB: 1,016 µs).
- Serving validation: DeepSeek-V4-Flash-0731 on the four-rank ring with CUDA graphs and DSpark speculation, research admission enabled. Each rank captured 7,445 width-4096 all-reduce graph nodes through the session, with zero capture-phase stock fallbacks for admitted [Q <= 512, 4096] signatures; after a 32-way request burst the session had completed 9,501 replay commands with zero overflow, and greedy correctness probes returned correct results.

Status: research-only. No qualified-profile default changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)