### PR TITLE
Trim the front page to identities, headlines, and links

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,9 +80,11 @@ label denotes the LMCache `chunk_size: 512` setting pinned in the recipe.
 | Cache | native prefix cache + one LMCache CS512 server/rank; SparkCache disabled | Bounded live validation |
 | Public bootstrap | Receipt-gated EXL3 derived image | Clean-checkout identical-image four-Spark run validated |
 
-One exact image served identically on all four ranks through the full
-bounded-gate sequence; the run receipt (preflight, graph capture, KV
-accounting, byte-identical fixed-seed outputs) is in the
+Validated image identity:
+`sha256:20c4099f2e7e3dd3c8ab64f7d7930bde4f372df1895aa3ffa593252ca04ae96f`,
+served identically on all four ranks through the full bounded-gate
+sequence; the run receipt (preflight, graph capture, KV accounting,
+byte-identical fixed-seed outputs) is in the
 [evidence-scoped recipe](docs/EXL3_RECIPE.md), with the executable path in
 the [EXL3 quickstart](docs/EXL3_QUICKSTART.md).
 

--- a/README.md
+++ b/README.md
@@ -12,27 +12,21 @@ The stack combines SIRCL custom RDMA collectives, CUDA-graph-replayable command 
 DCP4, support for fixed and adaptive MTP speculative decoding, and a patched ring-safe NCCL fallback for communication the custom path does not handle.
 A pip-installable plugin (`sparkring_plugin/`) packages the vLLM adapters as a `vllm.general_plugins` entry point: fail-closed like the overlay, but feature-detected rather than source-attested, and offline-validated only.
 
-Serving admission is model-agnostic: the eager TP4 all-reduce admits any
-hidden width whose payloads divide across the four ranks
-(`VLLM_SPARK_TP4_EAGER_WIDTHS`), and default-width row policy resolves
-through a generic query-row provider seam
-(`VLLM_SPARK_TP4_QUERY_ROW_PROVIDER`). The transport carries no
-model-specific policy; models qualify against it through the shadow-mode
-comparison windows recorded per profile.
+Serving admission is model-agnostic: the transport carries no
+model-specific policy, and models qualify against it through the
+shadow-mode comparison windows recorded per profile (admission mechanics:
+the [vLLM integration README](spark_transport/integrations/vllm/README.md)).
 
 Use the [documentation map](docs/README.md) to find the canonical specification,
 runnable procedure, evidence record, or historical reference for a task.
 
 ## Acknowledgements
 
-SparkRing would not exist without the months of research, profiling, kernel development, runtime patching, model conversion, and operational testing shared by the RTX 6000 Pro inference community.
-https://github.com/local-inference-lab/
-
-It builds heavily on work from the contributors behind B12X, SparkInfer, vLLM, the GLM model and quantization ecosystem, and the broader NVIDIA inference community. 
-
-SparkRing’s contribution is to adapt, integrate, and extend those foundations for low-latency inference across switchless DGX Spark clusters.
-
-Detailed project and contributor credits are maintained in the acknowledgements and provenance documentation.
+SparkRing adapts, integrates, and extends foundations from the
+[RTX 6000 Pro inference community](https://github.com/local-inference-lab/)
+and the contributors behind B12X, SparkInfer, vLLM, the GLM model and
+quantization ecosystem, and the broader NVIDIA inference community.
+Detailed credits are in the acknowledgements and provenance documentation.
 
 ## Validated profiles
 
@@ -50,88 +44,25 @@ index; the rows here are the deployment entry points.
 
 ## Flagship profile: GLM-5.2 EXL3 R7 3.5-bpw fixed-MTP4
 
-The operator's accepted 3.5-bpw SparkRing profile uses
+The operator's accepted 3.5-bpw profile serves
 [`brandonmusic/GLM-5.2-EXL3-TR3v4-3.5bpw-MTP78`](https://huggingface.co/brandonmusic/GLM-5.2-EXL3-TR3v4-3.5bpw-MTP78)
-at immutable revision `9ab9579774cc432df91567a36f6e9e863e0d4c9f`. Four directly
-cabled DGX Sparks serve it with TP4/DCP4, fixed MTP4, 9.25 GB of KV memory per
-rank, dynamic per-token NVFP4 latent KV plus FP8 RoPE, a 262,144-token request
-limit, a 4,096-token prefill ceiling, and native SparkRing TP transport through
-Q40. Eligible pure-prefill work uses the B12X transient full-CKV DCP gather.
-A capacity-40, route-block-8 routed-MoE state applies only to exact-Q40
-target-model batches; Q1-Q32, other prefill shapes, and the draft model do not
-use it.
+at immutable revision `9ab9579774cc432df91567a36f6e9e863e0d4c9f` with TP4/DCP4,
+fixed MTP4, and native SparkRing TP transport through Q40. Headline
+operator-matrix numbers: 645-679 tok/s C1 prefill from 8K through 128K
+contexts, 65-78 tok/s aggregate decode at C8, and a 1,156,864-token KV
+capacity. Acceptance is scoped to one four-Spark appliance; it is not the
+reproducible public default.
 
-| Prefill context | Prompt tokens | TTFT | C1 prefill | Samples |
-|---|---:|---:|---:|---:|
-| 8K | 8,194 | 12.06 s | **679 tok/s** | 2 |
-| 16K | 16,386 | 24.36 s | **673 tok/s** | 1 |
-| 32K | 32,770 | 49.17 s | **666 tok/s** | 1 |
-| 64K | 65,538 | 99.72 s | **657 tok/s** | 1 |
-| 128K | 131,074 | 203.09 s | **645 tok/s** | 1 |
-
-| Aggregate decode tok/s | C1 | C2 | C4 | C8 |
-|---|---:|---:|---:|---:|
-| 4K context | 22.6 | 32.7 | 50.3 | **78.4** |
-| 8K context | 22.0 | 35.3 | 51.9 | **71.3** |
-| 16K context | 21.3 | 32.9 | 49.2 | **70.0** |
-| 32K context | 20.4 | 32.3 | 45.6 | **65.5** |
-| 64K context | 21.4 | 30.4 | 47.2 | **67.8** |
-
-#### Coding benchmark (C1)
-
-| Workload | Runs | Median tok/s | Mean tok/s | Maximum tok/s | CJK runs |
-|---|---:|---:|---:|---:|---:|
-| Coding peak | **5/5** | **27.3** | **27.3** | **28.8** | **0** |
-
-Reported KV capacity is **1,156,864 tokens** across the four-rank serving profile.
-
-A matched decode comparison between the exact-Q40 candidate and its control
-replayed the same eight unique 16K payloads in both arms with full 8/8
-residency and a 25-second measurement window. The
-73.208 tok/s candidate mean was 19.341% above the 61.344 tok/s control mean;
-the slower candidate repeat exceeded the fastest control repeat by 14.93%.
-All 75 target layers passed exact BF16 parity, deterministic 16K and 32K output
-equality passed, and final graph, API, transport, and capacity gates passed.
-
-The prefill and decode tables form the accepted operator performance matrix
-snapshot. Prefill used 100% unique generated contexts. Several operator runs
-produced similar throughput, but only the displayed prefill sample counts and
-five coding-probe repeats are retained here; the decode cells are not presented
-as repeat distributions. Server-side cached-token accounting was unavailable
-for the prefill cells, so cache misses are not independently proven by the
-benchmark artifact.
-One predeclared acceptance criterion, the exact-Q40 prefill reducer, is
-recorded as a machine failure:
-its sole primary miss was 0.1215% at 64K. Operator acceptance treats that
-bounded difference as measurement-neutral without relabelling the machine
-result as a pass.
-
-This configuration is the **accepted operator default for 3.5-bpw EXL3**. Its
-acceptance scope is one four-Spark appliance; it is not the reproducible
-public-functional default or an accepted public deployment matrix. Read the
-[fixed-MTP4 specification](docs/EXL3_R7_FIXED_MTP4_PROFILE.md),
-[optimization record](docs/EXL3_R7_OPTIMIZATION_20260811.md), and
-[machine-readable operator acceptance](docs/configurations/glm52-exl3-r7-mtp4-q40-block8-20260812.json)
-before reproducing or extending it.
-The accepted performance matrix is preserved separately in
-[machine-readable form](docs/configurations/glm52-exl3-r7-current-best-matrix-20260813.json).
-The clean source/profile composition and local build commands are in
-[the operator-profile reproduction guide](docs/EXL3_R7_OPERATOR_REPRODUCTION.md).
-Use the [3.5-bpw quickstart](docs/EXL3_R7_QUICKSTART.md) for the executable
-path and the [promotion checklist](docs/EXL3_R7_PROMOTION_CHECKLIST.md) before
-transferring acceptance to a rebuilt image.
-
-A live-validated LMCache NVMe candidate extension preserved the exact R7/Q40
-serving contract while adding a lazy 512 MiB L1 and bounded 50 GiB O_DIRECT L2
-per rank. One 32,506-token cold publication populated 63 NVMe chunks per rank
-and measured 56.115 seconds of client TTFT. After LMCache-server and engine
-restart cleared both volatile L1 and native vLLM prefix state, the identical
-prompt measured 1.477 seconds with a 99.2% external-cache hit, 0.0% native-
-prefix hit, and zero L1 data bytes. This single-pair result proves attributed
-NVMe persistence, not a latency distribution or deterministic-output gate.
-The extension is a candidate and does not change the accepted operator
-profile or public-functional default. See the
-[R7 LMCache evidence](docs/configurations/glm52-exl3-r7-lmcache-nvme-20260813.json).
+- Full performance matrix, matched Q40 comparison, and claim boundaries:
+  [measured results](docs/RESULTS.md) and the
+  [machine-readable matrix](docs/configurations/glm52-exl3-r7-current-best-matrix-20260813.json)
+- Serving contract: [fixed-MTP4 specification](docs/EXL3_R7_FIXED_MTP4_PROFILE.md)
+  and the [optimization record](docs/EXL3_R7_OPTIMIZATION_20260811.md)
+- Executable path: [3.5-bpw quickstart](docs/EXL3_R7_QUICKSTART.md), then the
+  [promotion checklist](docs/EXL3_R7_PROMOTION_CHECKLIST.md) before
+  transferring acceptance to a rebuilt image
+- LMCache NVMe persistence candidate (single-pair evidence, does not change
+  the accepted profile): [R7 LMCache evidence](docs/configurations/glm52-exl3-r7-lmcache-nvme-20260813.json)
 
 ## Public default: EXL3 3.25-bpw with LMCache CS512
 
@@ -149,15 +80,11 @@ label denotes the LMCache `chunk_size: 512` setting pinned in the recipe.
 | Cache | native prefix cache + one LMCache CS512 server/rank; SparkCache disabled | Bounded live validation |
 | Public bootstrap | Receipt-gated EXL3 derived image | Clean-checkout identical-image four-Spark run validated |
 
-The exact image ID
-`sha256:20c4099f2e7e3dd3c8ab64f7d7930bde4f372df1895aa3ffa593252ca04ae96f`
-was deployed identically on all four ranks. The run passed 116/116 post-stop
-preflight checks, started four engines and four LMCache servers with zero
-restarts, captured 16/16 piecewise and 12/12 full graphs, and served a
-524,288-token model limit with 562,688 reported KV tokens. Five consecutive
-bounded gates passed; ten fixed-seed 128-token completions were byte-identical.
-See the [EXL3 quickstart](docs/EXL3_QUICKSTART.md) and
-[evidence-scoped recipe](docs/EXL3_RECIPE.md).
+One exact image served identically on all four ranks through the full
+bounded-gate sequence; the run receipt (preflight, graph capture, KV
+accounting, byte-identical fixed-seed outputs) is in the
+[evidence-scoped recipe](docs/EXL3_RECIPE.md), with the executable path in
+the [EXL3 quickstart](docs/EXL3_QUICKSTART.md).
 
 This evidence qualifies EXL3+LMCache as the public default; it is not a
 blanket correctness or release-acceptance claim.
@@ -186,41 +113,20 @@ and provides the exact validation sequence.
 
 ## Measured results
 
-### EXL3 3.25-bpw + LMCache CS512
-
-| Item | Default public recipe |
-|---|---|
-| Model | `willfalco/GLM-5.2-EXL3-TR3-3.25bpw@d7d79c2...` |
-| Parallelism | TP4 / DCP4, fixed MTP2 |
-| Batch/graph contract | C8, Q32, 4,096 batched tokens |
-| Context/KV | 524,288 model limit; 4.5 GB/rank; 562,688 reported tokens |
-| KV representation | NVFP4 latent plus FP8 RoPE |
-| Cache | native prefix cache + LMCache CS512; SparkCache disabled |
-| Public maturity | clean-checkout live-validated; default and main advertised configuration |
-
-Inspect either recipe without contacting the cluster:
+Inspect either GLM recipe without contacting the cluster:
 
 ```bash
 python scripts/sparkring_recipe.py list
 python scripts/sparkring_recipe.py plan
 ```
 
-For maintainers advancing EXL3 from bounded live validation toward full
-public-functional acceptance, use the dry-run-first
-[EXL3 + LMCache acceptance runbook](docs/EXL3_ACCEPTANCE_RUNBOOK.md). The
-workflow is published and offline-validated; its remaining live gates are not
-yet an acceptance claim.
-
-Transport-only results, historical DCP1 peaks, workload-specific coding
-measurements, and superseded configurations are documented separately in
-[docs/RESULTS.md](docs/RESULTS.md) and
-[docs/TESTING_HISTORY.md](docs/TESTING_HISTORY.md).
-
-See [docs/RESULTS.md](docs/RESULTS.md) for configurations, methodology,
-evidence, and claim boundaries.
-
-See [docs/TESTING_HISTORY.md](docs/TESTING_HISTORY.md) for experiments,
+[docs/RESULTS.md](docs/RESULTS.md) is the register of measured results,
+methodology, evidence, and claim boundaries;
+[docs/TESTING_HISTORY.md](docs/TESTING_HISTORY.md) preserves experiments,
 resolved failures, superseded configurations, and pending acceptance work.
+Maintainers advancing EXL3 toward full public-functional acceptance use the
+dry-run-first
+[EXL3 + LMCache acceptance runbook](docs/EXL3_ACCEPTANCE_RUNBOOK.md).
 
 ### Archived and alternative configurations
 


### PR DESCRIPTION
## Summary
- The flagship R7 section (84 lines: three performance tables, the matched-Q40 comparison, the acceptance-criterion paragraph, the LMCache NVMe narrative) becomes one identity paragraph with headline numbers plus links to [docs/RESULTS.md](docs/RESULTS.md), the profile specification, and the machine-readable matrices — all of which already carry every detail removed (verified before cutting).
- The public-default run receipt (image SHA, 116/116 checks, graph counts) compresses to two lines pointing at the evidence-scoped recipe that owns it.
- "Measured results" loses its duplicate recipe table and doubled see-also sentences.
- Acknowledgements: four paragraphs to two sentences with the same links.
- Intro admission paragraph compressed with a pointer to the integration README.

README goes from 463 to 368 lines. Docs only; no measurement or claim removed, only relocated to its canonical owner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)