### PR TITLE
Clarify SparkRing's inference-serving identity

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # SparkRing
 
-SparkRing is a low-latency collective transport and inference runtime for switchless GB1X (NVIDIA DGX Spark) clusters.
+SparkRing is a low-latency collective transport and vLLM-based
+inference-serving stack for switchless clusters of NVIDIA DGX Spark systems
+powered by the GB10 Grace Blackwell Superchip.
 
 Four 200 Gb/s ConnectX-7 links form a physical ring across four directly
 connected DGX Sparks, with no external Ethernet or InfiniBand switch in the

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,10 +1,11 @@
 # SparkRing Architecture
 
-SparkRing is a low-latency collective transport and inference-runtime stack for
-**switchless, directly cabled NVIDIA DGX Spark (GB10) clusters**. Four Sparks are
+SparkRing is a low-latency collective transport and vLLM-based
+inference-serving stack for **switchless clusters of directly cabled NVIDIA DGX
+Spark systems powered by the GB10 Grace Blackwell Superchip**. Four Sparks are
 joined into a 200 Gbit/s cycle with plain DAC cables — no switch — and a custom
-RoCE transport drives the hot decode collectives of GLM-5.2 under vLLM, with a
-patched NCCL as the attested fallback lane for everything else.
+RoCE transport drives qualified hot collectives under vLLM, with patched NCCL
+as the attested fallback lane for everything else.
 
 This document explains how the pieces fit. File paths are relative to the
 repository root so you can jump straight to code.


### PR DESCRIPTION
## Summary

Lane: public-functional documentation.

Clarifies SparkRing's project identity in the two canonical introductions:

- SparkRing provides low-latency collective transport and a vLLM-based inference-serving stack; it is not described as a standalone model-execution runtime.
- NVIDIA DGX Spark systems are identified by the GB10 Grace Blackwell Superchip rather than the imprecise GB1X label.
- The architecture introduction describes qualified model-agnostic collectives instead of a GLM-only runtime identity.

Runtime behavior and compatibility are unchanged.

## Validation

- git diff --check
- python scripts/validate_publication_consistency.py — PASS
- ruff check --select E,F,W --ignore E501 . — PASS
- python -m pytest spark_transport sparkcache runtime scripts -q — 3164 passed, 19 skipped
- python -m pytest sparkring_plugin -q — 28 passed locally; the remaining byte-parity assertion is a Windows line-ending-normalization artifact and is covered by Linux CI