### PR TITLE
Terminate instead of serving when a TP4 install fails

### DIFF
--- a/spark_transport/integrations/vllm/sitecustomize.py
+++ b/spark_transport/integrations/vllm/sitecustomize.py
@@ -196,24 +196,27 @@ if os.getenv("SPARK_CUDAGRAPH_REPLAY_TIMING") == "1":
 if os.getenv("VLLM_SPARK_TP4_MODE"):
     from spark_tp4_backend import install as install_tp4
 
-    install_tp4()
+    _install_required("TP4 all-reduce backend", install_tp4)
 
 if os.getenv("VLLM_SPARK_TP4_ALLGATHER_MODE"):
     from spark_tp4_allgather_backend import install as install_tp4_allgather
 
-    install_tp4_allgather()
+    _install_required("TP4 all-gather backend", install_tp4_allgather)
 
 if os.getenv("VLLM_SPARK_TP4_VOCAB_MODE"):
     from spark_tp4_vocab_allgather_backend import (
         install as install_tp4_vocab_allgather,
     )
 
-    install_tp4_vocab_allgather()
+    _install_required(
+        "TP4 vocabulary all-gather backend",
+        install_tp4_vocab_allgather,
+    )
 
 if os.getenv("VLLM_SPARK_TP4_DCP_MODE"):
     from spark_tp4_dcp_backend import install as install_tp4_dcp
 
-    install_tp4_dcp()
+    _install_required("TP4 DCP backend", install_tp4_dcp)
 
 if os.getenv("SPARK_TP4_DCP_COLLECTIVE_AUDIT") == "1":
     from spark_dcp_collective_audit import (

--- a/spark_transport/integrations/vllm/test_sitecustomize_fail_closed.py
+++ b/spark_transport/integrations/vllm/test_sitecustomize_fail_closed.py
@@ -481,3 +481,81 @@ def test_broken_diagnostic_stream_still_exits(
         )
 
     assert caught.value.code == 78
+
+
+def _fake_tp4_backend_module(name: str, install_error: Exception) -> ModuleType:
+    module = ModuleType(name)
+
+    def install() -> None:
+        raise install_error
+
+    module.install = install  # type: ignore[attr-defined]
+    return module
+
+
+TP4_FAMILIES = (
+    ("VLLM_SPARK_TP4_MODE", "spark_tp4_backend"),
+    ("VLLM_SPARK_TP4_ALLGATHER_MODE", "spark_tp4_allgather_backend"),
+    ("VLLM_SPARK_TP4_VOCAB_MODE", "spark_tp4_vocab_allgather_backend"),
+    ("VLLM_SPARK_TP4_DCP_MODE", "spark_tp4_dcp_backend"),
+)
+
+
+@pytest.mark.parametrize(("flag", "module_name"), TP4_FAMILIES)
+def test_required_tp4_family_failure_is_fatal(
+    monkeypatch: pytest.MonkeyPatch,
+    flag: str,
+    module_name: str,
+) -> None:
+    """A failed TP4 install terminates rather than serving on stock NCCL.
+
+    CPython's site module suppresses exceptions raised while importing
+    sitecustomize. Without an explicit exit, an enabled TP4 family whose
+    install fails would leave vLLM serving its own collectives, which is
+    a silent transport substitution rather than a refusal.
+    """
+
+    _clear_features(monkeypatch)
+    monkeypatch.setenv(flag, "custom")
+    monkeypatch.setitem(
+        sys.modules,
+        module_name,
+        _fake_tp4_backend_module(
+            module_name, RuntimeError(f"synthetic {module_name} failure")
+        ),
+    )
+    monkeypatch.setattr(
+        os,
+        "_exit",
+        lambda code: (_ for _ in ()).throw(FatalExit(code)),
+    )
+
+    with pytest.raises(FatalExit) as caught:
+        runpy.run_path(str(SITECUSTOMIZE), run_name=f"test_{module_name}")
+
+    assert caught.value.code == 78
+
+
+@pytest.mark.parametrize(("flag", "module_name"), TP4_FAMILIES)
+def test_tp4_family_is_not_installed_when_its_flag_is_unset(
+    monkeypatch: pytest.MonkeyPatch,
+    flag: str,
+    module_name: str,
+) -> None:
+    """No TP4 family installs without its own flag, so the guard is scoped."""
+
+    _clear_features(monkeypatch)
+    monkeypatch.setitem(
+        sys.modules,
+        module_name,
+        _fake_tp4_backend_module(
+            module_name, AssertionError(f"{module_name} installed unbidden")
+        ),
+    )
+    monkeypatch.setattr(
+        os,
+        "_exit",
+        lambda code: (_ for _ in ()).throw(FatalExit(code)),
+    )
+
+    runpy.run_path(str(SITECUSTOMIZE), run_name=f"test_{module_name}_unset")


### PR DESCRIPTION
## Resulting behavior

The four TP4 collective families install through `_install_required`, so an
enabled family whose install raises terminates the process with exit code 78
before vLLM serves traffic.

## Technical reason

CPython's `site` module reports and suppresses exceptions raised while
importing `sitecustomize`. `_install_required` exists to defeat that, and its
docstring states the exit is part of the feature contract rather than nicer
error handling. The NF3 startup cap, NF3 workspace reserve, adaptive-MTP
controller, MTP index reuse, and true adaptive drafting all used it. The four
TP4 families called their install functions directly.

The consequence was a silent transport substitution. An operator sets
`VLLM_SPARK_TP4_MODE`, the install fails, `site` swallows the exception, and
vLLM serves its own collectives over stock NCCL while the run reports success.
Nothing in the log distinguishes that from the requested configuration.

## Compatibility

A deployment whose TP4 install was already failing now terminates where it
previously served. That deployment was not running the transport it requested;
the failure predates this change and is now reported rather than hidden.

No behavior changes when installs succeed, and no family installs without its
own flag set.

## Validation

Eight regression tests. Four assert exit 78 on an install failure in each
family; four assert a family whose flag is unset does not install, bounding the
guard. The four fatal-path tests were run against the previous behavior and
fail there, so they detect the defect rather than passing alongside it.

`ruff check --select E,F,W --ignore E501 .` clean, and
`python -m pytest spark_transport sparkcache runtime scripts -q` at
3174 passed, 19 skipped.