### PR TITLE
Add ring-doctor: discover, diagnose, and repair the fabric ring

### DIFF
--- a/scripts/ring_doctor.py
+++ b/scripts/ring_doctor.py
@@ -1,0 +1,1546 @@
+#!/usr/bin/env python3
+"""Discover, diagnose, repair, and verify a four-node SparkRing fabric.
+
+The default operation is read-only. Remote changes require ``--apply``. Every
+route next hop and every boot-time address guard comes from addresses observed
+through SSH during the same invocation.
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import ipaddress
+import json
+import os
+import re
+import shlex
+import subprocess
+import sys
+from collections import deque
+from pathlib import Path
+from typing import Any, Mapping, Protocol, Sequence
+
+FABRIC_INTERFACES = ("enp1s0f0np0", "enp1s0f1np1")
+SSH_TARGET_RE = re.compile(r"^[A-Za-z0-9._-]+@[A-Za-z0-9._-]+$")
+INTERFACE_RE = re.compile(r"^[A-Za-z0-9_.:-]+$")
+NAME_RE = re.compile(r"^[A-Za-z0-9_.-]+$")
+SECTION_RE = re.compile(r"^__RING_DOCTOR_([A-Z_]+)__$")
+UNAVAILABLE = "__UNAVAILABLE__"
+
+
+class ConfigurationError(ValueError):
+    """A ring-doctor input cannot identify a safe discovery operation."""
+
+
+@dataclasses.dataclass(frozen=True)
+class NodeSpec:
+    """One management SSH target and its optional discovery jump host."""
+
+    name: str
+    target: str
+    proxy_jump: str | None = None
+
+
+@dataclasses.dataclass(frozen=True)
+class InterfaceState:
+    """Observed IPv4 addresses and link state for one fabric interface."""
+
+    name: str
+    addresses: tuple[ipaddress.IPv4Interface, ...]
+    oper_state: str
+    mtu: int | None = None
+
+    def address_on(self, network: ipaddress.IPv4Network) -> ipaddress.IPv4Address | None:
+        for address in self.addresses:
+            if address.ip in network:
+                return address.ip
+        return None
+
+
+@dataclasses.dataclass(frozen=True)
+class Route:
+    """One IPv4 kernel route relevant to fabric reachability."""
+
+    destination: ipaddress.IPv4Network
+    gateway: ipaddress.IPv4Address | None
+    device: str | None
+    raw: str
+
+
+@dataclasses.dataclass(frozen=True)
+class CommandResult:
+    ok: bool
+    stdout: str = ""
+    stderr: str = ""
+    detail: str = ""
+
+
+class Runner(Protocol):
+    """An SSH command runner used by discovery, repair, and verification."""
+
+    def run(
+        self, target: str, command: str, proxy_jump: str | None = None
+    ) -> CommandResult:
+        ...
+
+
+class SshRunner:
+    """Run non-interactive SSH commands with an optional ProxyJump target."""
+
+    def __init__(self, timeout_seconds: int = 20, connect_timeout: int = 5) -> None:
+        self.timeout_seconds = timeout_seconds
+        self.connect_timeout = connect_timeout
+
+    def run(
+        self, target: str, command: str, proxy_jump: str | None = None
+    ) -> CommandResult:
+        argv = [
+            "ssh",
+            "-o",
+            f"ConnectTimeout={self.connect_timeout}",
+            "-o",
+            "BatchMode=yes",
+        ]
+        if proxy_jump:
+            argv.extend(("-J", proxy_jump))
+        argv.extend((target, command))
+        try:
+            completed = subprocess.run(
+                argv,
+                capture_output=True,
+                text=True,
+                timeout=self.timeout_seconds,
+                check=False,
+            )
+        except subprocess.TimeoutExpired:
+            return CommandResult(
+                False, detail=f"SSH timed out after {self.timeout_seconds} seconds"
+            )
+        except OSError as exc:
+            return CommandResult(False, detail=f"SSH could not run: {exc}")
+        detail = ""
+        if completed.returncode:
+            detail = (
+                f"SSH exited {completed.returncode}: "
+                f"{completed.stderr.strip()[:300]}"
+            )
+        return CommandResult(
+            completed.returncode == 0,
+            completed.stdout,
+            completed.stderr,
+            detail,
+        )
+
+
+@dataclasses.dataclass
+class NodeObservation:
+    """Discovery evidence for one configured node, including probe failures."""
+
+    spec: NodeSpec
+    reachable: bool
+    hostname: str | None = None
+    interfaces: dict[str, InterfaceState] = dataclasses.field(default_factory=dict)
+    routes: tuple[Route, ...] = ()
+    ip_forward: bool | None = None
+    forward_policy: str | None = None
+    docker_user_rules: tuple[str, ...] | None = None
+    error: str = ""
+    proxy_jump_used: str | None = None
+
+    @property
+    def label(self) -> str:
+        return self.hostname or self.spec.name
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "name": self.spec.name,
+            "target": self.spec.target,
+            "reachable": self.reachable,
+            "hostname": self.hostname,
+            "proxy_jump_used": self.proxy_jump_used,
+            "error": self.error,
+            "interfaces": {
+                name: {
+                    "addresses": [str(address) for address in state.addresses],
+                    "oper_state": state.oper_state,
+                    "mtu": state.mtu,
+                }
+                for name, state in sorted(self.interfaces.items())
+            },
+            "routes": [
+                {
+                    "destination": str(route.destination),
+                    "gateway": str(route.gateway) if route.gateway else None,
+                    "device": route.device,
+                    "raw": route.raw,
+                }
+                for route in self.routes
+            ],
+            "ip_forward": self.ip_forward,
+            "forward_policy": self.forward_policy,
+            "docker_user_rules": (
+                list(self.docker_user_rules)
+                if self.docker_user_rules is not None
+                else None
+            ),
+        }
+
+
+@dataclasses.dataclass(frozen=True)
+class Finding:
+    """One diagnosed condition and the observation that proves it."""
+
+    severity: str
+    code: str
+    node: str | None
+    message: str
+    evidence: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return dataclasses.asdict(self)
+
+
+@dataclasses.dataclass(frozen=True)
+class ProposedRoute:
+    """A route whose gateway is an address observed on an adjacent node."""
+
+    destination: ipaddress.IPv4Network
+    gateway: ipaddress.IPv4Address
+    device: str
+    path: tuple[str, ...]
+
+    def command(self, sudo: bool = True) -> str:
+        prefix = "sudo -n " if sudo else ""
+        return (
+            f"{prefix}ip route replace {self.destination} via {self.gateway} "
+            f"dev {self.device}"
+        )
+
+
+@dataclasses.dataclass
+class NodePlan:
+    """Idempotent route, forwarding, and firewall operations for one node."""
+
+    node: str
+    routes: list[ProposedRoute] = dataclasses.field(default_factory=list)
+    relay_directions: set[tuple[str, str]] = dataclasses.field(default_factory=set)
+
+    def commands(self, sudo: bool = True) -> list[str]:
+        prefix = "sudo -n " if sudo else ""
+        commands = [route.command(sudo=sudo) for route in self.routes]
+        if self.relay_directions:
+            commands.append(f"{prefix}sysctl -w net.ipv4.ip_forward=1")
+        for ingress, egress in sorted(self.relay_directions):
+            rule = f"-i {ingress} -o {egress} -j ACCEPT"
+            commands.append(
+                f"{prefix}iptables -C DOCKER-USER {rule} || "
+                f"{prefix}iptables -I DOCKER-USER 1 {rule}"
+            )
+        return commands
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "node": self.node,
+            "routes": [
+                {
+                    "destination": str(route.destination),
+                    "gateway": str(route.gateway),
+                    "device": route.device,
+                    "path": list(route.path),
+                    "command": route.command(),
+                }
+                for route in self.routes
+            ],
+            "relay_directions": [
+                {"in": ingress, "out": egress}
+                for ingress, egress in sorted(self.relay_directions)
+            ],
+            "commands": self.commands(),
+        }
+
+
+@dataclasses.dataclass
+class Topology:
+    """Adjacency and subnet ownership inferred only from reachable nodes."""
+
+    adjacency: dict[str, set[str]]
+    subnet_nodes: dict[ipaddress.IPv4Network, tuple[str, ...]]
+    cycle: tuple[str, ...]
+    valid_cycle: bool
+    reason: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "adjacency": {
+                node: sorted(neighbors)
+                for node, neighbors in sorted(self.adjacency.items())
+            },
+            "subnets": {
+                str(network): list(nodes)
+                for network, nodes in sorted(
+                    self.subnet_nodes.items(), key=lambda item: int(item[0].network_address)
+                )
+            },
+            "valid_cycle": self.valid_cycle,
+            "cycle": list(self.cycle),
+            "reason": self.reason,
+        }
+
+
+def _validate_ssh_target(value: str, field: str) -> str:
+    if not SSH_TARGET_RE.fullmatch(value):
+        raise ConfigurationError(f"{field} must have the form user@host")
+    return value
+
+
+def _validate_ssh_jump_chain(value: str, field: str) -> str:
+    """Validate a ProxyJump value, which may chain several hops.
+
+    A rank whose management interface is unavailable is still reachable by
+    hopping along the fabric cabling, so a jump specification is a comma
+    separated list of hops in the order ssh -J expects. Each hop is validated
+    on its own; an empty hop is rejected rather than silently dropped.
+    """
+    hops = value.split(",")
+    if not hops or any(not hop for hop in hops):
+        raise ConfigurationError(f"{field} contains an empty jump hop")
+    for index, hop in enumerate(hops):
+        _validate_ssh_target(hop, f"{field} hop {index + 1}")
+    return value
+
+
+def _validate_interface(value: str, field: str) -> str:
+    if not INTERFACE_RE.fullmatch(value):
+        raise ConfigurationError(f"{field} contains an unsupported interface name")
+    return value
+
+
+def _default_name(target: str) -> str:
+    return target.split("@", 1)[1]
+
+
+def parse_node_specs(document: Mapping[str, Any]) -> tuple[NodeSpec, ...]:
+    """Parse the JSON node list accepted by ``--config``."""
+    raw_nodes = document.get("nodes")
+    if not isinstance(raw_nodes, list) or not raw_nodes:
+        raise ConfigurationError("config.nodes must be a non-empty list")
+    specs: list[NodeSpec] = []
+    for index, raw in enumerate(raw_nodes):
+        where = f"config.nodes[{index}]"
+        if isinstance(raw, str):
+            target = _validate_ssh_target(raw, where)
+            specs.append(NodeSpec(_default_name(target), target))
+            continue
+        if not isinstance(raw, Mapping):
+            raise ConfigurationError(f"{where} must be a string or object")
+        unknown = set(raw) - {"name", "target", "proxy_jump"}
+        if unknown:
+            raise ConfigurationError(
+                f"{where} has unsupported keys: {', '.join(sorted(unknown))}"
+            )
+        target_value = raw.get("target")
+        if not isinstance(target_value, str):
+            raise ConfigurationError(f"{where}.target must be a string")
+        target = _validate_ssh_target(target_value, f"{where}.target")
+        name_value = raw.get("name", _default_name(target))
+        if not isinstance(name_value, str) or not NAME_RE.fullmatch(name_value):
+            raise ConfigurationError(f"{where}.name contains unsupported characters")
+        jump_value = raw.get("proxy_jump")
+        if jump_value is not None:
+            if not isinstance(jump_value, str):
+                raise ConfigurationError(f"{where}.proxy_jump must be a string")
+            jump_value = _validate_ssh_jump_chain(jump_value, f"{where}.proxy_jump")
+        specs.append(NodeSpec(name_value, target, jump_value))
+    _require_unique_specs(specs)
+    return tuple(specs)
+
+
+def _require_unique_specs(specs: Sequence[NodeSpec]) -> None:
+    names = [spec.name for spec in specs]
+    targets = [spec.target for spec in specs]
+    if len(names) != len(set(names)):
+        raise ConfigurationError("node names must be unique")
+    if len(targets) != len(set(targets)):
+        raise ConfigurationError("node SSH targets must be unique")
+
+
+def build_probe_command(interfaces: Sequence[str]) -> str:
+    """Build the read-only remote probe that emits sectioned evidence."""
+    for index, interface in enumerate(interfaces):
+        _validate_interface(interface, f"fabric_interfaces[{index}]")
+    names = " ".join(shlex.quote(interface) for interface in interfaces)
+    return f"""set +e
+printf '%s\\n' '__RING_DOCTOR_HOSTNAME__'
+hostname
+printf '%s\\n' '__RING_DOCTOR_ADDR__'
+ip -br -4 addr show
+printf '%s\\n' '__RING_DOCTOR_LINK__'
+ip -o link show
+printf '%s\\n' '__RING_DOCTOR_ROUTE__'
+ip -4 route show
+printf '%s\\n' '__RING_DOCTOR_FORWARD__'
+sysctl -n net.ipv4.ip_forward 2>/dev/null || printf '%s\\n' '{UNAVAILABLE}'
+printf '%s\\n' '__RING_DOCTOR_FORWARD_CHAIN__'
+sudo -n iptables -S FORWARD 2>/dev/null || printf '%s\\n' '{UNAVAILABLE}'
+printf '%s\\n' '__RING_DOCTOR_DOCKER_USER__'
+sudo -n iptables -S DOCKER-USER 2>/dev/null || printf '%s\\n' '{UNAVAILABLE}'
+printf '%s\\n' '__RING_DOCTOR_INTERFACES__'
+printf '%s\\n' {names}
+"""
+
+
+def _split_sections(text: str) -> dict[str, str]:
+    sections: dict[str, list[str]] = {}
+    active: str | None = None
+    for line in text.splitlines():
+        match = SECTION_RE.fullmatch(line.strip())
+        if match:
+            active = match.group(1)
+            sections.setdefault(active, [])
+        elif active is not None:
+            sections[active].append(line)
+    return {name: "\n".join(lines).strip() for name, lines in sections.items()}
+
+
+def parse_brief_addresses(
+    text: str, fabric_interfaces: Sequence[str] = FABRIC_INTERFACES
+) -> dict[str, InterfaceState]:
+    """Parse ``ip -br -4 addr`` output for the selected fabric interfaces."""
+    selected = set(fabric_interfaces)
+    states: dict[str, InterfaceState] = {}
+    for line in text.splitlines():
+        fields = line.split()
+        if len(fields) < 2 or fields[0] not in selected:
+            continue
+        addresses: list[ipaddress.IPv4Interface] = []
+        for field in fields[2:]:
+            try:
+                address = ipaddress.ip_interface(field)
+            except ValueError:
+                continue
+            if isinstance(address, ipaddress.IPv4Interface):
+                addresses.append(address)
+        states[fields[0]] = InterfaceState(
+            fields[0], tuple(addresses), fields[1].upper()
+        )
+    return states
+
+
+def parse_link_details(text: str) -> dict[str, tuple[str, int | None]]:
+    """Parse operational state and MTU from ``ip -o link show`` output."""
+    details: dict[str, tuple[str, int | None]] = {}
+    for line in text.splitlines():
+        match = re.match(r"^\d+:\s+([^:@]+)(?:@[^:]+)?:\s+.*$", line)
+        if not match:
+            continue
+        name = match.group(1)
+        state_match = re.search(r"\bstate\s+(\S+)", line)
+        mtu_match = re.search(r"\bmtu\s+(\d+)", line)
+        details[name] = (
+            state_match.group(1).upper() if state_match else "UNKNOWN",
+            int(mtu_match.group(1)) if mtu_match else None,
+        )
+    return details
+
+
+def parse_routes(text: str) -> tuple[Route, ...]:
+    """Parse IPv4 routes while retaining each source line as evidence."""
+    routes: list[Route] = []
+    for raw in text.splitlines():
+        fields = raw.split()
+        if not fields:
+            continue
+        destination_text = "0.0.0.0/0" if fields[0] == "default" else fields[0]
+        try:
+            destination = ipaddress.ip_network(destination_text, strict=False)
+        except ValueError:
+            continue
+        if not isinstance(destination, ipaddress.IPv4Network):
+            continue
+        gateway: ipaddress.IPv4Address | None = None
+        device: str | None = None
+        if "via" in fields:
+            try:
+                parsed_gateway = ipaddress.ip_address(fields[fields.index("via") + 1])
+                if isinstance(parsed_gateway, ipaddress.IPv4Address):
+                    gateway = parsed_gateway
+            except (ValueError, IndexError):
+                pass
+        if "dev" in fields:
+            try:
+                device = fields[fields.index("dev") + 1]
+            except IndexError:
+                pass
+        routes.append(Route(destination, gateway, device, raw))
+    return tuple(routes)
+
+
+def parse_probe_output(
+    spec: NodeSpec,
+    text: str,
+    interfaces: Sequence[str] = FABRIC_INTERFACES,
+    proxy_jump_used: str | None = None,
+) -> NodeObservation:
+    """Convert one successful probe record into typed discovery evidence."""
+    sections = _split_sections(text)
+    interface_states = parse_brief_addresses(sections.get("ADDR", ""), interfaces)
+    for name, (oper_state, mtu) in parse_link_details(
+        sections.get("LINK", "")
+    ).items():
+        if name in interface_states:
+            state = interface_states[name]
+            interface_states[name] = dataclasses.replace(
+                state, oper_state=oper_state, mtu=mtu
+            )
+    forward_text = sections.get("FORWARD", "")
+    ip_forward: bool | None = None
+    if forward_text.strip() in {"0", "1"}:
+        ip_forward = forward_text.strip() == "1"
+    chain_text = sections.get("FORWARD_CHAIN", "")
+    policy_match = re.search(r"^-P FORWARD\s+(\S+)", chain_text, re.MULTILINE)
+    forward_policy = policy_match.group(1).upper() if policy_match else None
+    docker_text = sections.get("DOCKER_USER", "")
+    docker_rules = None
+    if docker_text and UNAVAILABLE not in docker_text:
+        docker_rules = tuple(
+            line.strip() for line in docker_text.splitlines() if line.strip()
+        )
+    hostname = sections.get("HOSTNAME", "").splitlines()
+    return NodeObservation(
+        spec=spec,
+        reachable=True,
+        hostname=hostname[0].strip() if hostname and hostname[0].strip() else None,
+        interfaces=interface_states,
+        routes=parse_routes(sections.get("ROUTE", "")),
+        ip_forward=ip_forward,
+        forward_policy=forward_policy,
+        docker_user_rules=docker_rules,
+        proxy_jump_used=proxy_jump_used,
+    )
+
+
+def discover_nodes(
+    specs: Sequence[NodeSpec],
+    runner: Runner,
+    interfaces: Sequence[str] = FABRIC_INTERFACES,
+) -> dict[str, NodeObservation]:
+    """Probe nodes directly, then retry failures through discovered jump hosts."""
+    command = build_probe_command(interfaces)
+    observations: dict[str, NodeObservation] = {}
+    attempted: dict[str, list[str]] = {spec.name: [] for spec in specs}
+
+    def attempt(spec: NodeSpec, jump: str | None) -> bool:
+        label = jump or "direct"
+        if label in attempted[spec.name]:
+            return False
+        attempted[spec.name].append(label)
+        result = runner.run(spec.target, command, jump)
+        if result.ok:
+            observations[spec.name] = parse_probe_output(
+                spec, result.stdout, interfaces, jump
+            )
+            return True
+        observations[spec.name] = NodeObservation(
+            spec, False, error=result.detail or result.stderr.strip() or "SSH failed"
+        )
+        return False
+
+    for spec in specs:
+        attempt(spec, None)
+    for spec in specs:
+        if not observations[spec.name].reachable and spec.proxy_jump:
+            attempt(spec, spec.proxy_jump)
+
+    progress = True
+    while progress:
+        progress = False
+        jump_targets = [
+            observation.spec.target
+            for observation in observations.values()
+            if observation.reachable
+        ]
+        for spec in specs:
+            if observations[spec.name].reachable:
+                continue
+            for jump in jump_targets:
+                if jump == spec.target:
+                    continue
+                if attempt(spec, jump):
+                    progress = True
+                    break
+    for spec in specs:
+        observation = observations[spec.name]
+        if not observation.reachable:
+            observation.error = (
+                f"{observation.error}; attempted paths: "
+                f"{', '.join(attempted[spec.name])}"
+            )
+    return observations
+
+
+def _interface_networks(
+    observation: NodeObservation,
+) -> dict[ipaddress.IPv4Network, str]:
+    networks: dict[ipaddress.IPv4Network, str] = {}
+    for interface in observation.interfaces.values():
+        for address in interface.addresses:
+            networks[address.network] = interface.name
+    return networks
+
+
+def infer_adjacency(
+    observations: Mapping[str, NodeObservation],
+) -> tuple[dict[str, set[str]], dict[ipaddress.IPv4Network, tuple[str, ...]]]:
+    """Infer adjacency when two reachable nodes share an observed subnet."""
+    reachable = {
+        name: observation
+        for name, observation in observations.items()
+        if observation.reachable
+    }
+    subnet_members: dict[ipaddress.IPv4Network, list[str]] = {}
+    for name, observation in reachable.items():
+        for network in _interface_networks(observation):
+            subnet_members.setdefault(network, []).append(name)
+    adjacency = {name: set() for name in reachable}
+    subnet_nodes: dict[ipaddress.IPv4Network, tuple[str, ...]] = {}
+    for network, members in subnet_members.items():
+        unique = tuple(sorted(set(members)))
+        subnet_nodes[network] = unique
+        if len(unique) == 2:
+            left, right = unique
+            adjacency[left].add(right)
+            adjacency[right].add(left)
+    return adjacency, subnet_nodes
+
+
+def validate_cycle(
+    adjacency: Mapping[str, set[str]],
+) -> tuple[bool, tuple[str, ...], str]:
+    """Validate one connected simple cycle and return a deterministic order."""
+    if len(adjacency) < 3:
+        return False, (), "fewer than three nodes were available"
+    wrong_degree = sorted(node for node, neighbors in adjacency.items() if len(neighbors) != 2)
+    if wrong_degree:
+        return (
+            False,
+            (),
+            "cycle nodes must have two neighbors; invalid nodes: "
+            + ", ".join(wrong_degree),
+        )
+    start = min(adjacency)
+    cycle = [start]
+    previous: str | None = None
+    current = start
+    while True:
+        candidates = sorted(adjacency[current] - ({previous} if previous else set()))
+        if not candidates:
+            return False, (), "adjacency traversal ended before closing the cycle"
+        following = candidates[0]
+        if following == start:
+            break
+        if following in cycle:
+            return False, (), "adjacency contains a closed component below ring size"
+        cycle.append(following)
+        previous, current = current, following
+    if len(cycle) != len(adjacency):
+        return False, (), "adjacency contains more than one connected component"
+    return True, tuple(cycle), "single cycle"
+
+
+def infer_topology(observations: Mapping[str, NodeObservation]) -> Topology:
+    adjacency, subnet_nodes = infer_adjacency(observations)
+    invalid_nodes = []
+    for name, observation in observations.items():
+        if not observation.reachable:
+            continue
+        states = tuple(observation.interfaces.values())
+        if (
+            len(states) != 2
+            or any(len(state.addresses) != 1 for state in states)
+            or any(
+                address.network.prefixlen != 24
+                for state in states
+                for address in state.addresses
+            )
+        ):
+            invalid_nodes.append(name)
+    if invalid_nodes:
+        return Topology(
+            adjacency,
+            subnet_nodes,
+            (),
+            False,
+            "each reachable node must expose one /24 address on each of two "
+            "fabric interfaces; invalid nodes: " + ", ".join(sorted(invalid_nodes)),
+        )
+    invalid_subnets = [
+        network
+        for network, nodes in subnet_nodes.items()
+        if network.prefixlen != 24 or len(nodes) != 2
+    ]
+    if invalid_subnets:
+        details = ", ".join(
+            f"{network} ({len(subnet_nodes[network])} observed endpoints)"
+            for network in sorted(
+                invalid_subnets, key=lambda item: int(item.network_address)
+            )
+        )
+        return Topology(
+            adjacency,
+            subnet_nodes,
+            (),
+            False,
+            f"fabric subnets must be /24 links with two endpoints: {details}",
+        )
+    valid, cycle, reason = validate_cycle(adjacency)
+    return Topology(adjacency, subnet_nodes, cycle, valid, reason)
+
+
+def _shared_network(
+    left: str,
+    right: str,
+    topology: Topology,
+) -> ipaddress.IPv4Network | None:
+    matches = [
+        network
+        for network, nodes in topology.subnet_nodes.items()
+        if left in nodes and right in nodes
+    ]
+    return min(matches, key=lambda network: int(network.network_address)) if matches else None
+
+
+def _interface_for_network(
+    observation: NodeObservation, network: ipaddress.IPv4Network
+) -> str | None:
+    return _interface_networks(observation).get(network)
+
+
+def _address_for_network(
+    observation: NodeObservation, network: ipaddress.IPv4Network
+) -> ipaddress.IPv4Address | None:
+    for interface in observation.interfaces.values():
+        address = interface.address_on(network)
+        if address is not None:
+            return address
+    return None
+
+
+def _shortest_path(
+    adjacency: Mapping[str, set[str]], source: str, targets: set[str]
+) -> tuple[str, ...] | None:
+    queue: deque[tuple[str, ...]] = deque([(source,)])
+    visited = {source}
+    while queue:
+        path = queue.popleft()
+        if path[-1] in targets:
+            return path
+        for neighbor in sorted(adjacency.get(path[-1], set())):
+            if neighbor not in visited:
+                visited.add(neighbor)
+                queue.append(path + (neighbor,))
+    return None
+
+
+def select_route(
+    source: str,
+    destination: ipaddress.IPv4Network,
+    observations: Mapping[str, NodeObservation],
+    topology: Topology,
+) -> ProposedRoute | None:
+    """Choose a route through an observed neighbor address, or return unknown."""
+    owners = set(topology.subnet_nodes.get(destination, ()))
+    if not owners or source in owners:
+        return None
+    path = _shortest_path(topology.adjacency, source, owners)
+    if path is None or len(path) < 2:
+        return None
+    neighbor = path[1]
+    shared = _shared_network(source, neighbor, topology)
+    if shared is None:
+        return None
+    gateway = _address_for_network(observations[neighbor], shared)
+    device = _interface_for_network(observations[source], shared)
+    if gateway is None or device is None:
+        return None
+    return ProposedRoute(destination, gateway, device, path)
+
+
+def build_plans(
+    observations: Mapping[str, NodeObservation], topology: Topology
+) -> dict[str, NodePlan]:
+    """Build complete idempotent plans when the observed graph is a cycle."""
+    plans = {name: NodePlan(name) for name in topology.adjacency}
+    if not topology.valid_cycle:
+        return plans
+    networks = sorted(
+        topology.subnet_nodes, key=lambda network: int(network.network_address)
+    )
+    for source in sorted(topology.adjacency):
+        for network in networks:
+            route = select_route(source, network, observations, topology)
+            if route is None:
+                continue
+            plans[source].routes.append(route)
+            path = route.path
+            for index in range(1, len(path)):
+                relay = path[index]
+                incoming_network = _shared_network(path[index - 1], relay, topology)
+                if incoming_network is None:
+                    continue
+                ingress = _interface_for_network(observations[relay], incoming_network)
+                if index + 1 < len(path):
+                    outgoing_network = _shared_network(relay, path[index + 1], topology)
+                else:
+                    outgoing_network = network
+                if outgoing_network is None:
+                    continue
+                egress = _interface_for_network(observations[relay], outgoing_network)
+                if ingress and egress and ingress != egress:
+                    plans[relay].relay_directions.add((ingress, egress))
+    return plans
+
+
+def _route_covering(
+    routes: Sequence[Route], network: ipaddress.IPv4Network
+) -> list[Route]:
+    covering = [
+        route
+        for route in routes
+        if route.destination.prefixlen > 0 and network.subnet_of(route.destination)
+    ]
+    return sorted(covering, key=lambda route: route.destination.prefixlen, reverse=True)
+
+
+def _observed_gateway(
+    source: str,
+    route: Route,
+    observations: Mapping[str, NodeObservation],
+    topology: Topology,
+) -> bool:
+    if route.gateway is None or route.device is None:
+        return False
+    for neighbor in topology.adjacency.get(source, set()):
+        shared = _shared_network(source, neighbor, topology)
+        if shared is None:
+            continue
+        address = _address_for_network(observations[neighbor], shared)
+        device = _interface_for_network(observations[source], shared)
+        if route.gateway == address and route.device == device:
+            return True
+    return False
+
+
+def docker_user_accepts(
+    rules: Sequence[str] | None, ingress: str, egress: str
+) -> bool:
+    """Return whether an unrestricted ACCEPT covers one cross-interface flow."""
+    if rules is None:
+        return False
+    for rule in rules:
+        try:
+            fields = shlex.split(rule)
+        except ValueError:
+            continue
+        if len(fields) < 4 or fields[:2] != ["-A", "DOCKER-USER"]:
+            continue
+        constraints: dict[str, str] = {}
+        harmless = {"-A", "-i", "-o", "-j"}
+        index = 2
+        supported = True
+        while index < len(fields):
+            option = fields[index]
+            if option not in harmless or index + 1 >= len(fields):
+                supported = False
+                break
+            constraints[option] = fields[index + 1]
+            index += 2
+        if not supported or constraints.get("-j") != "ACCEPT":
+            continue
+        if constraints.get("-i", ingress) != ingress:
+            continue
+        if constraints.get("-o", egress) != egress:
+            continue
+        return True
+    return False
+
+
+def diagnose(
+    specs: Sequence[NodeSpec],
+    observations: Mapping[str, NodeObservation],
+    topology: Topology,
+    plans: Mapping[str, NodePlan],
+    interfaces: Sequence[str] = FABRIC_INTERFACES,
+) -> list[Finding]:
+    """Evaluate required ring invariants and retain evidence for every fault."""
+    findings: list[Finding] = []
+    for spec in specs:
+        observation = observations[spec.name]
+        if not observation.reachable:
+            findings.append(
+                Finding(
+                    "error",
+                    "node-unreachable",
+                    spec.name,
+                    "The node did not answer a non-interactive SSH probe. "
+                    "Hostname, fabric interface, route, IPv4 forwarding, "
+                    "FORWARD policy, and DOCKER-USER checks are unknown.",
+                    observation.error,
+                )
+            )
+            continue
+        for interface_name in interfaces:
+            state = observation.interfaces.get(interface_name)
+            if state is None:
+                findings.append(
+                    Finding(
+                        "error",
+                        "interface-unobserved",
+                        spec.name,
+                        f"Fabric interface {interface_name} was not observed.",
+                        "The ip -br -4 addr output contained no matching row.",
+                    )
+                )
+            elif state.oper_state != "UP":
+                findings.append(
+                    Finding(
+                        "error",
+                        "interface-down",
+                        spec.name,
+                        f"Fabric interface {interface_name} is not operationally up.",
+                        f"observed state={state.oper_state}",
+                    )
+                )
+    if not topology.valid_cycle:
+        findings.append(
+            Finding(
+                "error",
+                "topology-not-cycle",
+                None,
+                "The discovered fabric does not form one cycle.",
+                topology.reason,
+            )
+        )
+
+    for network, members in topology.subnet_nodes.items():
+        if len(members) != 2:
+            findings.append(
+                Finding(
+                    "warning",
+                    "subnet-endpoints-unknown",
+                    None,
+                    f"Fabric subnet {network} does not have two observed endpoints.",
+                    f"observed nodes={', '.join(members) if members else 'none'}",
+                )
+            )
+            continue
+        left, right = members
+        left_interface = _interface_for_network(observations[left], network)
+        right_interface = _interface_for_network(observations[right], network)
+        if not left_interface or not right_interface:
+            continue
+        left_mtu = observations[left].interfaces[left_interface].mtu
+        right_mtu = observations[right].interfaces[right_interface].mtu
+        if left_mtu is not None and right_mtu is not None and left_mtu != right_mtu:
+            findings.append(
+                Finding(
+                    "error",
+                    "link-mtu-mismatch",
+                    None,
+                    f"Fabric subnet {network} has mismatched endpoint MTUs.",
+                    f"{left}:{left_interface}={left_mtu}, "
+                    f"{right}:{right_interface}={right_mtu}",
+                )
+            )
+
+    if topology.valid_cycle:
+        for name, plan in plans.items():
+            observation = observations[name]
+            for proposed in plan.routes:
+                covering = _route_covering(observation.routes, proposed.destination)
+                if not covering:
+                    findings.append(
+                        Finding(
+                            "error",
+                            "route-missing",
+                            name,
+                            f"No kernel route covers fabric subnet {proposed.destination}.",
+                            "ip -4 route show returned no covering prefix",
+                        )
+                    )
+                elif not any(
+                    _observed_gateway(name, route, observations, topology)
+                    for route in covering
+                ):
+                    findings.append(
+                        Finding(
+                            "error",
+                            "route-next-hop-unobserved",
+                            name,
+                            f"The route to {proposed.destination} does not use an "
+                            "observed neighbor address and matching fabric interface.",
+                            "; ".join(route.raw for route in covering),
+                        )
+                    )
+            if not plan.relay_directions:
+                continue
+            if observation.ip_forward is False:
+                findings.append(
+                    Finding(
+                        "error",
+                        "ip-forward-disabled",
+                        name,
+                        "IPv4 forwarding is disabled on a node required to relay traffic.",
+                        "net.ipv4.ip_forward=0",
+                    )
+                )
+            elif observation.ip_forward is None:
+                findings.append(
+                    Finding(
+                        "warning",
+                        "ip-forward-unknown",
+                        name,
+                        "IPv4 forwarding could not be read on a required relay.",
+                        "The sysctl probe returned no boolean value.",
+                    )
+                )
+            if observation.forward_policy is None:
+                findings.append(
+                    Finding(
+                        "warning",
+                        "forward-policy-unknown",
+                        name,
+                        "The FORWARD chain policy could not be read.",
+                        "The iptables FORWARD probe returned no policy.",
+                    )
+                )
+            if observation.docker_user_rules is None:
+                findings.append(
+                    Finding(
+                        "warning",
+                        "docker-user-rules-unknown",
+                        name,
+                        "The DOCKER-USER rules could not be read.",
+                        "The iptables DOCKER-USER probe was unavailable.",
+                    )
+                )
+            if observation.forward_policy == "DROP":
+                for ingress, egress in sorted(plan.relay_directions):
+                    if not docker_user_accepts(
+                        observation.docker_user_rules, ingress, egress
+                    ):
+                        findings.append(
+                            Finding(
+                                "error",
+                                "docker-user-cross-accept-missing",
+                                name,
+                                "The FORWARD policy is DROP and no unrestricted "
+                                f"DOCKER-USER ACCEPT covers {ingress} to {egress}.",
+                                "Required relay direction: "
+                                f"-i {ingress} -o {egress}; observed rules: "
+                                + (
+                                    " | ".join(observation.docker_user_rules)
+                                    if observation.docker_user_rules
+                                    else "none"
+                                ),
+                            )
+                        )
+    return findings
+
+
+def _probe_by_name(
+    specs: Sequence[NodeSpec], runner: Runner, interfaces: Sequence[str]
+) -> tuple[dict[str, NodeObservation], Topology, dict[str, NodePlan], list[Finding]]:
+    observations = discover_nodes(specs, runner, interfaces)
+    topology = infer_topology(observations)
+    plans = build_plans(observations, topology)
+    findings = diagnose(specs, observations, topology, plans, interfaces)
+    return observations, topology, plans, findings
+
+
+def apply_plans(
+    observations: Mapping[str, NodeObservation],
+    plans: Mapping[str, NodePlan],
+    runner: Runner,
+) -> list[Finding]:
+    """Execute complete plans through the SSH paths proven by discovery."""
+    findings: list[Finding] = []
+    for name, plan in sorted(plans.items()):
+        commands = plan.commands()
+        if not commands:
+            continue
+        observation = observations[name]
+        result = runner.run(
+            observation.spec.target,
+            "set -e\n" + "\n".join(commands),
+            observation.proxy_jump_used,
+        )
+        if not result.ok:
+            findings.append(
+                Finding(
+                    "error",
+                    "apply-failed",
+                    name,
+                    "The idempotent repair plan did not complete.",
+                    result.detail or result.stderr.strip() or "remote command failed",
+                )
+            )
+    return findings
+
+
+def _unit_program(observation: NodeObservation, plan: NodePlan) -> str:
+    expected = {
+        name: sorted(str(address) for address in interface.addresses)
+        for name, interface in sorted(observation.interfaces.items())
+    }
+    route_argv = [
+        [
+            "ip",
+            "route",
+            "replace",
+            str(route.destination),
+            "via",
+            str(route.gateway),
+            "dev",
+            route.device,
+        ]
+        for route in plan.routes
+    ]
+    directions = [list(direction) for direction in sorted(plan.relay_directions)]
+    return f'''#!/usr/bin/env python3
+"""Reapply a recorded SparkRing fabric plan after exact address validation."""
+
+import ipaddress
+import json
+import subprocess
+import sys
+
+EXPECTED = {expected!r}
+ROUTES = {route_argv!r}
+RELAY_DIRECTIONS = {directions!r}
+
+
+def observed_addresses(interface):
+    result = subprocess.run(
+        ["ip", "-j", "-4", "addr", "show", "dev", interface],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    rows = json.loads(result.stdout)
+    addresses = []
+    for row in rows:
+        for item in row.get("addr_info", []):
+            if item.get("family") == "inet":
+                addresses.append(
+                    str(ipaddress.ip_interface(
+                        f"{{item['local']}}/{{item['prefixlen']}}"
+                    ))
+                )
+    return sorted(addresses)
+
+
+def main():
+    for interface, expected in EXPECTED.items():
+        try:
+            actual = observed_addresses(interface)
+        except (OSError, subprocess.SubprocessError, ValueError, json.JSONDecodeError) as exc:
+            print(f"ADDRESS CHECK FAILED {{interface}}: {{exc}}", file=sys.stderr)
+            return 1
+        if actual != expected:
+            print(
+                f"ADDRESS MISMATCH {{interface}}: expected={{expected}} actual={{actual}}",
+                file=sys.stderr,
+            )
+            return 1
+    for command in ROUTES:
+        subprocess.run(command, check=True)
+    if RELAY_DIRECTIONS:
+        subprocess.run(
+            ["sysctl", "-w", "net.ipv4.ip_forward=1"], check=True
+        )
+    for ingress, egress in RELAY_DIRECTIONS:
+        rule = ["-i", ingress, "-o", egress, "-j", "ACCEPT"]
+        check = subprocess.run(
+            ["iptables", "-C", "DOCKER-USER", *rule], check=False
+        )
+        if check.returncode:
+            subprocess.run(
+                ["iptables", "-I", "DOCKER-USER", "1", *rule], check=True
+            )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+'''
+
+
+def emit_units(
+    directory: Path,
+    observations: Mapping[str, NodeObservation],
+    plans: Mapping[str, NodePlan],
+) -> list[str]:
+    """Write one fail-closed systemd service and program per observed node."""
+    directory.mkdir(parents=True, exist_ok=True)
+    written: list[str] = []
+    for name, plan in sorted(plans.items()):
+        observation = observations[name]
+        slug = re.sub(r"[^A-Za-z0-9_.-]", "-", name)
+        program_path = (directory / f"ring-doctor-{slug}.py").resolve()
+        unit_path = directory / f"ring-doctor-{slug}.service"
+        program_path.write_text(_unit_program(observation, plan), encoding="utf-8")
+        os.chmod(program_path, 0o755)
+        unit = f"""[Unit]
+Description=Reapply verified SparkRing fabric plan for {name}
+Wants=network-online.target
+After=network-online.target docker.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/python3 {program_path}
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target
+"""
+        unit_path.write_text(unit, encoding="utf-8")
+        written.extend((str(program_path), str(unit_path.resolve())))
+    return written
+
+
+def verify_reachability(
+    specs: Sequence[NodeSpec],
+    observations: Mapping[str, NodeObservation],
+    runner: Runner,
+) -> dict[str, Any]:
+    """Ping every observed fabric address from every reachable node."""
+    matrix: dict[str, dict[str, bool | None]] = {}
+    probes: list[dict[str, Any]] = []
+    for source_spec in specs:
+        source = observations[source_spec.name]
+        matrix[source_spec.name] = {}
+        for destination_spec in specs:
+            destination = observations[destination_spec.name]
+            if source_spec.name == destination_spec.name:
+                matrix[source_spec.name][destination_spec.name] = (
+                    True if source.reachable else None
+                )
+                continue
+            if not source.reachable or not destination.reachable:
+                matrix[source_spec.name][destination_spec.name] = None
+                continue
+            addresses = sorted(
+                {
+                    str(address.ip)
+                    for interface in destination.interfaces.values()
+                    for address in interface.addresses
+                },
+                key=ipaddress.ip_address,
+            )
+            if not addresses:
+                matrix[source_spec.name][destination_spec.name] = None
+                continue
+            pair_ok = True
+            for address in addresses:
+                result = runner.run(
+                    source.spec.target,
+                    f"ping -n -c 1 -W 2 {address}",
+                    source.proxy_jump_used,
+                )
+                probes.append(
+                    {
+                        "source": source_spec.name,
+                        "destination": destination_spec.name,
+                        "address": address,
+                        "reachable": result.ok,
+                        "evidence": result.detail or result.stderr.strip(),
+                    }
+                )
+                pair_ok = pair_ok and result.ok
+            matrix[source_spec.name][destination_spec.name] = pair_ok
+    failed = any(value is False for row in matrix.values() for value in row.values())
+    unknown = any(value is None for row in matrix.values() for value in row.values())
+    return {"matrix": matrix, "probes": probes, "failed": failed, "unknown": unknown}
+
+
+def _render_matrix(matrix: Mapping[str, Mapping[str, bool | None]]) -> list[str]:
+    nodes = list(matrix)
+    width = max(7, *(len(node) for node in nodes))
+    lines = ["Reachability matrix:"]
+    lines.append(" " * (width + 1) + " ".join(f"{node:>{width}}" for node in nodes))
+    for source in nodes:
+        cells = []
+        for destination in nodes:
+            value = matrix[source][destination]
+            cells.append("PASS" if value is True else "FAIL" if value is False else "UNKNOWN")
+        lines.append(
+            f"{source:>{width}} " + " ".join(f"{cell:>{width}}" for cell in cells)
+        )
+    return lines
+
+
+def render_text(report: Mapping[str, Any]) -> str:
+    """Render the complete report for an operator without hidden context."""
+    lines = ["SparkRing fabric diagnosis"]
+    topology = report["topology"]
+    if topology["valid_cycle"]:
+        cycle = topology["cycle"]
+        lines.append("Ring cycle: " + " -> ".join(cycle + cycle[:1]))
+    else:
+        lines.append(f"Ring cycle: UNKNOWN ({topology['reason']})")
+    lines.append("Nodes:")
+    for name, node in report["nodes"].items():
+        status = "reachable" if node["reachable"] else "unreachable"
+        hostname = f" hostname={node['hostname']}" if node["hostname"] else ""
+        jump = (
+            f" proxy_jump={node['proxy_jump_used']}"
+            if node["proxy_jump_used"]
+            else ""
+        )
+        lines.append(f"  {name}: {status}{hostname}{jump}")
+    findings = report["findings"]
+    lines.append(f"Findings: {len(findings)}")
+    for finding in findings:
+        scope = f" {finding['node']}" if finding["node"] else ""
+        lines.append(
+            f"  [{finding['severity'].upper()}] {finding['code']}{scope}: "
+            f"{finding['message']}"
+        )
+        lines.append(f"    evidence: {finding['evidence']}")
+    lines.append("Repair plan (read-only output unless --apply is present):")
+    commands_printed = 0
+    for name, plan in report["plans"].items():
+        for command in plan["commands"]:
+            lines.append(f"  {name}: {command}")
+            commands_printed += 1
+    if not commands_printed:
+        lines.append("  No verified repair commands are available.")
+    if report.get("unit_files"):
+        lines.append("Generated systemd files:")
+        lines.extend(f"  {path}" for path in report["unit_files"])
+    apply_status = report["apply"]
+    if apply_status["requested"]:
+        outcome = "executed" if apply_status["executed"] else "withheld"
+        lines.append(f"Repair application: {outcome}")
+    if report.get("verification"):
+        lines.extend(_render_matrix(report["verification"]["matrix"]))
+    return "\n".join(lines)
+
+
+def _load_inputs(args: argparse.Namespace) -> tuple[tuple[NodeSpec, ...], tuple[str, ...], int]:
+    interfaces = tuple(args.interface or FABRIC_INTERFACES)
+    timeout = args.ssh_timeout
+    if args.config:
+        try:
+            document = json.loads(Path(args.config).read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            raise ConfigurationError(f"could not read --config JSON: {exc}") from exc
+        if not isinstance(document, Mapping):
+            raise ConfigurationError("config root must be a JSON object")
+        specs = parse_node_specs(document)
+        configured_interfaces = document.get("fabric_interfaces")
+        if configured_interfaces is not None:
+            if not isinstance(configured_interfaces, list) or len(configured_interfaces) != 2:
+                raise ConfigurationError("config.fabric_interfaces must contain two names")
+            checked_interfaces: list[str] = []
+            for index, value in enumerate(configured_interfaces):
+                if not isinstance(value, str):
+                    raise ConfigurationError(
+                        f"config.fabric_interfaces[{index}] must be a string"
+                    )
+                checked_interfaces.append(
+                    _validate_interface(
+                        value, f"config.fabric_interfaces[{index}]"
+                    )
+                )
+            interfaces = tuple(checked_interfaces)
+        configured_timeout = document.get("ssh_timeout_seconds")
+        if configured_timeout is not None:
+            if not isinstance(configured_timeout, int) or not 1 <= configured_timeout <= 3600:
+                raise ConfigurationError(
+                    "config.ssh_timeout_seconds must be an integer from 1 to 3600"
+                )
+            timeout = configured_timeout
+    else:
+        if not args.node:
+            raise ConfigurationError("provide --config or at least one --node user@host")
+        jumps: dict[str, str] = {}
+        for item in args.proxy_jump or []:
+            if "=" not in item:
+                raise ConfigurationError("--proxy-jump must have the form NODE=JUMP")
+            target, jump = item.split("=", 1)
+            jumps[_validate_ssh_target(target, "--proxy-jump NODE")] = (
+                _validate_ssh_jump_chain(jump, "--proxy-jump JUMP")
+            )
+        specs = tuple(
+            NodeSpec(
+                _default_name(_validate_ssh_target(target, "--node")),
+                target,
+                jumps.get(target),
+            )
+            for target in args.node
+        )
+        _require_unique_specs(specs)
+        unused = sorted(set(jumps) - {spec.target for spec in specs})
+        if unused:
+            raise ConfigurationError(
+                "--proxy-jump names targets absent from --node: " + ", ".join(unused)
+            )
+    if len(interfaces) != 2 or len(set(interfaces)) != 2:
+        raise ConfigurationError("exactly two distinct fabric interfaces are required")
+    for index, interface in enumerate(interfaces):
+        _validate_interface(interface, f"fabric_interfaces[{index}]")
+    if not isinstance(timeout, int) or not 1 <= timeout <= 3600:
+        raise ConfigurationError("--ssh-timeout must be an integer from 1 to 3600")
+    return specs, interfaces, timeout
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="ring-doctor",
+        description=(
+            "Discover and diagnose a four-node switchless SparkRing fabric. "
+            "The default operation is read-only and prints a repair plan."
+        ),
+    )
+    parser.add_argument("--config", help="JSON file containing node SSH targets")
+    parser.add_argument(
+        "--node", action="append", metavar="USER@HOST", help="seed SSH target; repeatable"
+    )
+    parser.add_argument(
+        "--proxy-jump",
+        action="append",
+        metavar="NODE=JUMP",
+        help="per-node ProxyJump assignment for --node inputs; repeatable",
+    )
+    parser.add_argument(
+        "--interface",
+        action="append",
+        metavar="NAME",
+        help="fabric interface name; specify exactly twice to override defaults",
+    )
+    parser.add_argument(
+        "--ssh-timeout", type=int, default=20, help="SSH command timeout in seconds"
+    )
+    parser.add_argument(
+        "--apply", action="store_true", help="execute the verified idempotent repair plan"
+    )
+    parser.add_argument(
+        "--emit-unit",
+        metavar="DIR",
+        help="write a fail-closed systemd service and program for each node",
+    )
+    parser.add_argument(
+        "--verify",
+        action="store_true",
+        help="ping every observed fabric address from every reachable node",
+    )
+    parser.add_argument(
+        "--json", action="store_true", help="emit the complete report as JSON"
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    try:
+        specs, interfaces, timeout = _load_inputs(args)
+    except ConfigurationError as exc:
+        print(f"INVALID RING DOCTOR INPUT: {exc}", file=sys.stderr)
+        return 2
+    runner = SshRunner(timeout_seconds=timeout)
+    observations, topology, plans, findings = _probe_by_name(
+        specs, runner, interfaces
+    )
+    apply_findings: list[Finding] = []
+    apply_executed = False
+    enough = len(specs) == 4 and all(
+        observation.reachable for observation in observations.values()
+    ) and topology.valid_cycle
+    if args.apply:
+        if enough:
+            apply_executed = True
+            apply_findings = apply_plans(observations, plans, runner)
+            observations, topology, plans, findings = _probe_by_name(
+                specs, runner, interfaces
+            )
+            enough = len(specs) == 4 and all(
+                observation.reachable for observation in observations.values()
+            ) and topology.valid_cycle
+        else:
+            apply_findings.append(
+                Finding(
+                    "error",
+                    "apply-withheld",
+                    None,
+                    "No repair was applied because the complete four-node cycle was not observed.",
+                    topology.reason,
+                )
+            )
+    unit_files: list[str] = []
+    if args.emit_unit:
+        if enough:
+            try:
+                unit_files = emit_units(Path(args.emit_unit), observations, plans)
+            except OSError as exc:
+                apply_findings.append(
+                    Finding(
+                        "error",
+                        "unit-write-failed",
+                        None,
+                        "The systemd files could not be written.",
+                        str(exc),
+                    )
+                )
+        else:
+            apply_findings.append(
+                Finding(
+                    "error",
+                    "unit-withheld",
+                    None,
+                    "No systemd files were written because the complete four-node cycle was not observed.",
+                    topology.reason,
+                )
+            )
+    findings.extend(apply_findings)
+    verification = (
+        verify_reachability(specs, observations, runner) if args.verify else None
+    )
+    report = {
+        "schema": "sparkring-ring-doctor/v1",
+        "nodes": {
+            name: observation.to_dict()
+            for name, observation in observations.items()
+        },
+        "topology": topology.to_dict(),
+        "findings": [finding.to_dict() for finding in findings],
+        "plans": {name: plan.to_dict() for name, plan in plans.items()},
+        "apply": {
+            "requested": args.apply,
+            "executed": apply_executed,
+            "failures": [
+                finding.to_dict()
+                for finding in apply_findings
+                if finding.code == "apply-failed"
+            ],
+        },
+        "unit_files": unit_files,
+        "verification": verification,
+        "discovery_sufficient": enough,
+    }
+    if args.json:
+        print(json.dumps(report, indent=2, sort_keys=True))
+    else:
+        print(render_text(report))
+    if not enough:
+        return 2
+    if findings:
+        return 1
+    if verification and (verification["failed"] or verification["unknown"]):
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/test_ring_doctor.py
+++ b/scripts/test_ring_doctor.py
@@ -1,0 +1,278 @@
+"""Offline unit tests for the SparkRing fabric doctor."""
+
+from __future__ import annotations
+
+import ipaddress
+import unittest
+
+from scripts.ring_doctor import (
+    FABRIC_INTERFACES,
+    CommandResult,
+    InterfaceState,
+    NodeObservation,
+    NodeSpec,
+    build_plans,
+    diagnose,
+    discover_nodes,
+    docker_user_accepts,
+    infer_adjacency,
+    infer_topology,
+    parse_brief_addresses,
+    select_route,
+    validate_cycle,
+)
+
+IF0, IF1 = FABRIC_INTERFACES
+
+
+def observation(
+    name: str,
+    addresses: str,
+    *,
+    hostname: str | None = None,
+    reachable: bool = True,
+    forward_policy: str | None = "DROP",
+    docker_rules: tuple[str, ...] | None = (),
+) -> NodeObservation:
+    interfaces = parse_brief_addresses(addresses)
+    interfaces = {
+        interface_name: InterfaceState(
+            state.name, state.addresses, state.oper_state, 9000
+        )
+        for interface_name, state in interfaces.items()
+    }
+    return NodeObservation(
+        NodeSpec(name, f"operator@{name}"),
+        reachable,
+        hostname=hostname,
+        interfaces=interfaces,
+        ip_forward=True if reachable else None,
+        forward_policy=forward_policy if reachable else None,
+        docker_user_rules=docker_rules if reachable else None,
+        error="SSH exited 255: connection timed out" if not reachable else "",
+    )
+
+
+def synthetic_cycle() -> dict[str, NodeObservation]:
+    return {
+        "a": observation(
+            "a",
+            f"{IF0} UP 10.0.1.1/24\n{IF1} UP 10.0.4.1/24",
+        ),
+        "b": observation(
+            "b",
+            f"{IF0} UP 10.0.2.1/24\n{IF1} UP 10.0.1.2/24",
+        ),
+        "c": observation(
+            "c",
+            f"{IF0} UP 10.0.3.1/24\n{IF1} UP 10.0.2.2/24",
+        ),
+        "d": observation(
+            "d",
+            f"{IF0} UP 10.0.4.2/24\n{IF1} UP 10.0.3.2/24",
+        ),
+    }
+
+
+def probe_output(hostname: str, addresses: str) -> str:
+    return f"""__RING_DOCTOR_HOSTNAME__
+{hostname}
+__RING_DOCTOR_ADDR__
+{addresses}
+__RING_DOCTOR_LINK__
+2: {IF0}: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 9000 state UP mode DEFAULT
+3: {IF1}: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 9000 state UP mode DEFAULT
+__RING_DOCTOR_ROUTE__
+__RING_DOCTOR_FORWARD__
+1
+__RING_DOCTOR_FORWARD_CHAIN__
+-P FORWARD DROP
+__RING_DOCTOR_DOCKER_USER__
+-N DOCKER-USER
+__RING_DOCTOR_INTERFACES__
+{IF0}
+{IF1}
+"""
+
+
+class FakeDiscoveryRunner:
+    def __init__(self, outputs: dict[str, str], down: set[str]) -> None:
+        self.outputs = outputs
+        self.down = down
+        self.calls: list[tuple[str, str | None]] = []
+
+    def run(
+        self, target: str, command: str, proxy_jump: str | None = None
+    ) -> CommandResult:
+        del command
+        self.calls.append((target, proxy_jump))
+        if target in self.down:
+            return CommandResult(False, detail="SSH exited 255: connection timed out")
+        return CommandResult(True, stdout=self.outputs[target])
+
+
+class AddressAndTopologyTests(unittest.TestCase):
+    def test_adjacency_inference_from_real_brief_address_fixture(self) -> None:
+        observations = {
+            "r0": observation(
+                "r0",
+                f"{IF0} UP 192.168.101.10/24\n"
+                f"{IF1} UP 192.168.200.12/24",
+                hostname="spark-edfd",
+            ),
+            "r1": observation(
+                "r1",
+                f"{IF0} UP 192.168.102.10/24\n"
+                f"{IF1} UP 192.168.101.11/24",
+                hostname="spark-ebb8",
+            ),
+            "r2": observation(
+                "r2",
+                f"{IF0} UP 192.168.103.11/24\n"
+                f"{IF1} UP 192.168.102.11/24",
+                hostname="spark-ebee",
+            ),
+            "r3": observation("r3", "", reachable=False),
+        }
+
+        adjacency, subnet_nodes = infer_adjacency(observations)
+
+        self.assertEqual(adjacency["r0"], {"r1"})
+        self.assertEqual(adjacency["r1"], {"r0", "r2"})
+        self.assertEqual(adjacency["r2"], {"r1"})
+        self.assertNotIn("r3", adjacency)
+        self.assertEqual(
+            subnet_nodes[ipaddress.ip_network("192.168.101.0/24")],
+            ("r0", "r1"),
+        )
+        self.assertEqual(
+            subnet_nodes[ipaddress.ip_network("192.168.200.0/24")], ("r0",)
+        )
+
+    def test_cycle_validation_accepts_cycle_and_rejects_path(self) -> None:
+        cycle_graph = {
+            "r0": {"r1", "r3"},
+            "r1": {"r0", "r2"},
+            "r2": {"r1", "r3"},
+            "r3": {"r0", "r2"},
+        }
+        valid, cycle, reason = validate_cycle(cycle_graph)
+        self.assertTrue(valid, reason)
+        self.assertEqual(set(cycle), set(cycle_graph))
+
+        path_graph = {
+            "r0": {"r1"},
+            "r1": {"r0", "r2"},
+            "r2": {"r1"},
+        }
+        valid, cycle, reason = validate_cycle(path_graph)
+        self.assertFalse(valid)
+        self.assertEqual(cycle, ())
+        self.assertIn("two neighbors", reason)
+
+
+class FirewallAndPlanningTests(unittest.TestCase):
+    def test_same_interface_accepts_do_not_cover_cross_interface_relay(self) -> None:
+        observations = synthetic_cycle()
+        same_interface_rules = (
+            f"-A DOCKER-USER -i {IF0} -o {IF0} -j ACCEPT",
+            f"-A DOCKER-USER -i {IF1} -o {IF1} -j ACCEPT",
+        )
+        for item in observations.values():
+            item.docker_user_rules = same_interface_rules
+        topology = infer_topology(observations)
+        plans = build_plans(observations, topology)
+
+        findings = diagnose(
+            [item.spec for item in observations.values()],
+            observations,
+            topology,
+            plans,
+        )
+
+        self.assertFalse(docker_user_accepts(same_interface_rules, IF0, IF1))
+        cross_findings = [
+            finding
+            for finding in findings
+            if finding.code == "docker-user-cross-accept-missing"
+        ]
+        self.assertTrue(cross_findings)
+        self.assertTrue(
+            any(IF0 in finding.message and IF1 in finding.message for finding in cross_findings)
+        )
+
+    def test_next_hops_are_addresses_observed_on_direct_neighbors(self) -> None:
+        observations = synthetic_cycle()
+        topology = infer_topology(observations)
+        destination = ipaddress.ip_network("10.0.2.0/24")
+
+        route = select_route("a", destination, observations, topology)
+
+        self.assertIsNotNone(route)
+        assert route is not None
+        self.assertEqual(route.gateway, ipaddress.ip_address("10.0.1.2"))
+        self.assertEqual(route.path[:2], ("a", "b"))
+        plans = build_plans(observations, topology)
+        for source, plan in plans.items():
+            neighbor_addresses = {
+                address.ip
+                for neighbor in topology.adjacency[source]
+                for interface in observations[neighbor].interfaces.values()
+                for address in interface.addresses
+                if any(
+                    address.ip in own_address.network
+                    for own_interface in observations[source].interfaces.values()
+                    for own_address in own_interface.addresses
+                )
+            }
+            for proposed in plan.routes:
+                self.assertIn(proposed.gateway, neighbor_addresses)
+
+
+class PartialDiscoveryTests(unittest.TestCase):
+    def test_one_unreachable_node_preserves_observations_and_unknown_checks(self) -> None:
+        specs = (
+            NodeSpec("r0", "operator@r0"),
+            NodeSpec("r1", "operator@r1"),
+            NodeSpec("r2", "operator@r2"),
+            NodeSpec("r3", "operator@r3"),
+        )
+        outputs = {
+            "operator@r0": probe_output(
+                "spark-edfd",
+                f"{IF0} UP 192.168.101.10/24\n"
+                f"{IF1} UP 192.168.200.12/24",
+            ),
+            "operator@r1": probe_output(
+                "spark-ebb8",
+                f"{IF0} UP 192.168.102.10/24\n"
+                f"{IF1} UP 192.168.101.11/24",
+            ),
+            "operator@r2": probe_output(
+                "spark-ebee",
+                f"{IF0} UP 192.168.103.11/24\n"
+                f"{IF1} UP 192.168.102.11/24",
+            ),
+        }
+        runner = FakeDiscoveryRunner(outputs, {"operator@r3"})
+
+        observations = discover_nodes(specs, runner)
+        topology = infer_topology(observations)
+        plans = build_plans(observations, topology)
+        findings = diagnose(specs, observations, topology, plans)
+
+        self.assertFalse(observations["r3"].reachable)
+        self.assertEqual(observations["r3"].interfaces, {})
+        self.assertIn("attempted paths", observations["r3"].error)
+        self.assertIn(("operator@r3", "operator@r0"), runner.calls)
+        self.assertFalse(topology.valid_cycle)
+        self.assertEqual(plans["r0"].routes, [])
+        self.assertIn("node-unreachable", {finding.code for finding in findings})
+        self.assertIn("topology-not-cycle", {finding.code for finding in findings})
+        self.assertIn(
+            "subnet-endpoints-unknown", {finding.code for finding in findings}
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Resulting behavior

Adds `scripts/ring_doctor.py`, a tool that discovers the four-node fabric over
management SSH, infers the ring topology from observed interface addresses,
validates that the observed adjacency forms the expected 4-cycle, and proposes
per-node route and boot-time address plans.

Default operation is read-only. Remote changes require `--apply`. Every route
next hop and every boot-time address guard comes from addresses observed
through SSH during the same invocation, so the tool never writes a value it
did not first read.

## Technical reason

Ring bring-up and repair currently depend on operator-held procedure. This
gives that procedure an executable form whose read-only mode can be inspected
before anything is changed.

## Review scope

This branch has not been reviewed and has never had CI run against it. It is
opened to make it reviewable and to get a CI result, not because it is ready
to merge. Two things a reviewer should weigh in particular:

- the `--apply` path, which is the only part that mutates a host, against the
  safety classes in `AGENTS.md`;
- whether `FABRIC_INTERFACES` being hardcoded to `enp1s0f0np0` and
  `enp1s0f1np1` is the right contract, or whether it should come from site
  configuration.

A follow-up will add management-interface assertions: that the management
interface is never a fabric interface, and that all four ranks are reachable
over one management network rather than a point-to-point pair.

## Validation

`scripts/test_ring_doctor.py`, 278 lines, offline with a stubbed runner. No
host is contacted by the suite.