### PR TITLE
Observe attested-descriptor release without probing a recycled number

### DIFF
--- a/sparkcache/native/tests/test_snapshot_ring_contract.py
+++ b/sparkcache/native/tests/test_snapshot_ring_contract.py
@@ -5,6 +5,7 @@ import gc
 import hashlib
 import importlib.util
 import os
+import weakref
 from pathlib import Path
 
 import pytest
@@ -21,6 +22,13 @@ SPEC = importlib.util.spec_from_file_location(
 assert SPEC is not None and SPEC.loader is not None
 native = importlib.util.module_from_spec(SPEC)
 SPEC.loader.exec_module(native)
+
+
+def _fd_identity(fd: int) -> tuple[int, int]:
+    """Return the device and inode a descriptor currently refers to."""
+
+    status = os.fstat(fd)
+    return (status.st_dev, status.st_ino)
 
 
 def test_snapshot_ctypes_sizes_are_fixed() -> None:
@@ -216,12 +224,28 @@ def test_attested_fd_lifetime_matches_library_object(
         expected_sha256=expected,
         cdll_factory=lambda _path, mode: FakeLibrary(),
     )
-    retained_fd = library._spark_cache_snapshot_attested_file.fileno()
+    owner = library._spark_cache_snapshot_attested_file
+    retained_fd = owner.fileno()
+    attested_identity = _fd_identity(retained_fd)
     assert os.fstat(retained_fd).st_size == len(payload)
+
+    # Observe finalization through a weak reference rather than by probing the
+    # descriptor number. File descriptors are recycled integers: anything else
+    # in the process opening a file between the close and the probe makes the
+    # same number valid again, so a bare fstat cannot distinguish "still ours"
+    # from "reissued to another file".
+    finalized: list[bool] = []
+    weakref.finalize(owner, finalized.append, True)
+    del owner
     del library
     gc.collect()
-    with pytest.raises(OSError):
-        os.fstat(retained_fd)
+
+    assert finalized == [True]
+    try:
+        reused_identity = _fd_identity(retained_fd)
+    except OSError:
+        return
+    assert reused_identity != attested_identity
 
 
 def test_secure_loader_fails_closed_without_linux_procfs(


### PR DESCRIPTION
## Resulting behavior

`test_attested_fd_lifetime_matches_library_object` proves the retained file
object was finalized when the library object was released, using a
weak-reference finalizer, instead of asserting that `os.fstat` on the
descriptor number raises.

## Technical reason

File descriptors are recycled integers. Anything else in the process that opens
a file between the close and the probe makes the same number valid again, so the
previous assertion could not distinguish a descriptor that stayed open from one
reissued to an unrelated file.

It failed intermittently in the blocking `tests (offline pytest)` job. Most
recently, run 32320995161 failed with `DID NOT RAISE <class 'OSError'>` while
run 32321006203 on the identical commit `391f58d` passed — on a
documentation-only change that touches no code the test exercises.

This matters beyond the annoyance. `ci.yml` argues of the release-safety gate
that "a gate that is red by default trains people to ignore it." A blocking
suite that fails at random teaches the same reflex, and the cost is paid the
one time the failure is genuine.

## What is still tested

The invariant is unchanged: `_dlopen_attested` keeps the attested inode open
for exactly the library object's lifetime, which the loader's own comment calls
the observable ownership boundary. The test now checks that boundary directly
rather than through a side effect another thread can invalidate. It also
tolerates descriptor reuse: if the number is still valid after release, the
device and inode it refers to must differ from the attested ones.

## Compatibility

Test-only. No library or loader behavior changes.

## Validation

ruff, `python -m pytest sparkcache -q` at 403 passed, and twenty consecutive
runs of the affected test with zero failures.