### PR TITLE
Give the plugin an on-host integrity check and cover its refusal contract

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,8 +3,19 @@
 runtime/** text eol=lf
 runtime/exl3/patches/*.patch whitespace=-trailing-space
 
-# Runtime receipts hash these source files byte-for-byte before copying them.
-# Keep their checked-out bytes identical on Windows and POSIX hosts.
+# Runtime receipts hash these source files byte-for-byte before copying them,
+# and the plugin vendors byte-identical copies whose SHA-256 it records in
+# _vendor/MANIFEST.json for a pip-installed wheel to verify on the serving
+# host. Both comparisons are over raw bytes, so every one of these paths must
+# check out identically on Windows and POSIX hosts.
+spark_transport/integrations/vllm/*.py text eol=lf
+sparkring_plugin/src/sparkring/_vendor/*.py text eol=lf
+
+# Named individually as well as covered above: these are the sources the
+# runtime overlay receipts pin by preimage hash, and
+# runtime/exl3/test_public_exl3.py asserts each one appears here by name so a
+# later narrowing of the globs cannot silently unpin them.
 spark_transport/integrations/vllm/spark_glm52_mtp_index_reuse.py text eol=lf
 spark_transport/integrations/vllm/spark_true_adaptive_draft.py text eol=lf
 spark_transport/experiments/q2r_phase_timing/live_installer.py text eol=lf
+

--- a/docs/PLUGIN_LIVE_VALIDATION_20260820.md
+++ b/docs/PLUGIN_LIVE_VALIDATION_20260820.md
@@ -1,0 +1,90 @@
+# vLLM plugin four-Spark live validation, 2026-08-20
+
+Status: **live-validated** for eager transport admission at width 768 on
+four directly cabled DGX Sparks. This record covers the
+`sparkring_plugin` integration path only. It establishes that the
+pip-installed plugin reaches the SparkRing transport and serves; it
+establishes no numerical, performance, or profile claim.
+
+## Conditions
+
+| Item | Value |
+|---|---|
+| Hardware | Four directly cabled DGX Sparks, GB10 |
+| Container image | `sparkring/glm52-exl3-r7-3.5bpw:r34-sm121a-flat2-20260810` |
+| vLLM | `0.1.dev1+ge2666d9a6.d20260810` |
+| Plugin | Wheel built on aarch64 from this branch, `libspark_transport_capi_w4096.so` packaged as `_native/` payload |
+| Model | `facebook/opt-125m`, hidden width 768 |
+| Serving | TP4, four nodes, `--enforce-eager`, BF16, `--max-model-len 2048`, `--max-num-seqs 4` |
+| Transport | `VLLM_SPARK_TP4_MODE=shadow`, `VLLM_SPARK_TP4_EAGER_WIDTHS=768` |
+| Overlay | Neutralized: an empty file bind-mounted over `/opt/spark-vllm/sitecustomize.py` |
+
+The overlay is neutralized deliberately. The image bakes
+`sitecustomize.py`, and with a mode variable set both installers run, so
+a result from an unmodified image is not attributable to either path.
+
+## Measurement
+
+The plugin installed and patched the integration point on every rank:
+
+```
+installed Spark TP4 vLLM backend in shadow mode
+```
+
+Every rank opened both eager sessions the width-768 shapes require:
+
+```
+rank 0  Spark TP4 eager session ready for 12288 bytes (control ports 11100/11101)
+rank 0  Spark TP4 eager session ready for  6144 bytes (control ports 12130/12131)
+rank 1  Spark TP4 eager session ready for 12288 bytes (control ports 11100/11101)
+rank 1  Spark TP4 eager session ready for  6144 bytes (control ports 12130/12131)
+rank 2  Spark TP4 eager session ready for 12288 bytes (control ports 11100/11101)
+rank 2  Spark TP4 eager session ready for  6144 bytes (control ports 12130/12131)
+rank 3  Spark TP4 eager session ready for 12288 bytes (control ports 11100/11101)
+rank 3  Spark TP4 eager session ready for  6144 bytes (control ports 12130/12131)
+```
+
+Both payload sizes follow from the shapes: 6,144 bytes is four query rows
+of 768 BF16 elements, and 12,288 bytes is eight.
+
+`sparkring-preflight` passed every required check on a serving rank,
+including `hca-devices` resolving `rocep1s0f0` and `rocep1s0f1` at GID 3,
+`native-library` resolving the packaged payload, `vllm-compat` resolving
+against the deployed fork, and `vendor-integrity` matching all sixteen
+vendored modules against the manifest in the installed wheel.
+
+A greedy completion returned correct text:
+
+```
+prompt "The capital of France is" -> " the capital of the French Republic."
+system_fingerprint vllm-0.1.dev1+ge2666d9a6.d20260810-tp4-nohash
+```
+
+## Result
+
+The pip-installed plugin admits width-768 eager all-reduce through the
+SparkRing transport on four ranks and serves an OpenAI-compatible
+completion. Shadow mode reported no mismatch.
+
+## Limitations
+
+- One width, one model, one bounded request. No sustained load, no
+  concurrency sweep, and no performance number.
+- Shadow mode compares against the stock path; `custom` mode, in which
+  the transport carries the result, is unexercised here.
+- Graph capture is unexercised: the run is `--enforce-eager`.
+- The absence of a reported mismatch is not a numerical qualification.
+  A shadow window per the eager-width runbook remains outstanding.
+- The overlay was neutralized. Running both installers together is
+  unqualified, and section "Coexistence" in the plugin README states
+  what is known about it.
+
+## Conditions required for a profile claim
+
+1. A shadow-comparison window closed per
+   [eager width admission validation runbook](EAGER_WIDTH_VALIDATION_RUNBOOK.md)
+   at each width a profile admits.
+2. `custom` mode serving the same shapes with the transport carrying the
+   result, compared against the overlay path on the same model.
+3. A width the qualified profiles actually use. Width 768 is a
+   validation instrument, not a serving width.

--- a/docs/README.md
+++ b/docs/README.md
@@ -27,7 +27,8 @@ linked runbook. A document being listed here does not authorize remote action.
 | Subject | Canonical source |
 |---|---|
 | Public-lane definition and open blockers | [Public-functional lane definition](PUBLIC_FUNCTIONAL_TARGET.md) |
-| Public headless-startup ABI audit | [Public startup-shim audit](PUBLIC_STARTUP_SHIM_AUDIT.md) |
+| Public headless-startup ABI audit | [vLLM plugin live validation](PLUGIN_LIVE_VALIDATION_20260820.md) | Records the four-Spark run in which the pip-installed plugin admits width-768 eager all-reduce through the transport and serves a completion, with the overlay neutralized so the result is attributable to one installer; states the limitations and what a profile claim would still require. |
+| [Public startup-shim audit](PUBLIC_STARTUP_SHIM_AUDIT.md) |
 | Runtime input pins | [`runtime/runtime-lock.json`](../runtime/runtime-lock.json) |
 | Site-config schema | [`scripts/sparkring_site.py`](../scripts/sparkring_site.py) |
 | Repository prose standard | [Write Without Hidden Context](WRITING_STANDARD.md) |

--- a/sparkring_plugin/README.md
+++ b/sparkring_plugin/README.md
@@ -31,6 +31,102 @@ remain individually opt-in via their own `VLLM_SPARK_TP4_*_MODE`
 variables. Unsupported collectives fall back to the stock vLLM path and
 are counted by the collective audit.
 
+## Environment variables each installer acts on
+
+Two installers exist for these adapters. The container overlay is
+[`spark_transport/integrations/vllm/sitecustomize.py`](../spark_transport/integrations/vllm/sitecustomize.py),
+which CPython imports at interpreter startup when that directory is on
+`PYTHONPATH`. The plugin installer is `register()` in
+[`src/sparkring/plugin.py`](src/sparkring/plugin.py), which vLLM calls
+through the `vllm.general_plugins` entry point.
+
+They install different sets of hooks. `register()` gates on four
+variables — one per collective family — and on nothing else. The overlay
+gates on those four and on ten further startup hooks. A variable that
+only the overlay gates on is inert under the plugin: `register()` never
+reads it, no hook is installed, startup succeeds, and neither the plugin
+nor `sparkring-preflight` reports it. Exit 78 is the failure contract for
+a family that was enabled and could not install; it is not a check that
+every `VLLM_SPARK_*` or `SPARK_*` variable in the environment is one some
+installer reads. An overlay environment block ported to the plugin
+therefore loses the ten hooks below without an error, a warning, or a
+log line.
+
+### Acted on by both installers
+
+| Variable | Family it installs |
+|---|---|
+| `VLLM_SPARK_TP4_MODE` | Width-generic eager TP4 all-reduce |
+| `VLLM_SPARK_TP4_ALLGATHER_MODE` | Generic all-gather |
+| `VLLM_SPARK_TP4_VOCAB_MODE` | Vocabulary all-gather |
+| `VLLM_SPARK_TP4_DCP_MODE` | DCP query and attention combine |
+
+`VLLM_SPARK_TP4_MODE=disabled` installs nothing under either installer.
+Per-family tuning variables — control ports, shadow windows and
+promotion, admitted widths, query-row policy, combine tolerances,
+`SPARK_TP4_GRAPH_STATUS_PATH` — are read by the family modules
+themselves, not by either installer, and `tests/test_vendor_parity.py`
+keeps the vendored copies byte-identical to the overlay's sources, so
+those variables behave the same on both paths. One of them,
+`SPARK_TP4_GRAPH_STATUS_PATH`, reaches into overlay-only hooks; see
+note 2.
+
+### Acted on by the overlay only
+
+| Overlay gate | Hook it installs | Under the plugin |
+|---|---|---|
+| `VLLM_SPARK_NF3_STARTUP_PROFILE_MAX_TOKENS` non-empty | NF3 startup-profile cap around `GPUModelRunner.profile_run`, extended to `Worker._compile_or_warm_up_model_impl` when `VLLM_SPARK_NF3_SINGLE_COMPILE_RANGE=1` | inert |
+| `VLLM_SPARK_NF3_PROFILE` set to `reference-four-spark`, `reference-four-spark-adaptive-2-4`, or `reference-four-spark-adaptive-2-4-c8`, or `VLLM_SPARK_NF3_WORKSPACE_RESERVE_BYTES` non-empty | NF3 workspace reserve around `GPUModelRunner.capture_model` | inert |
+| `SPARK_ADAPTIVE_MTP_CONTROL=1` | adaptive-MTP controller runtime hooks | inert; note 2 |
+| `SPARK_GLM52_MTP_INDEX_REUSE=1` | GLM-5.2 MTP index reuse for the V2 speculator | inert |
+| `VLLM_SPARK_TRUE_ADAPTIVE_DRAFT=1` | true selected-depth drafting, which attests `VLLM_SPARK_MTP_TOKENS`, `VLLM_SPARK_MTP_ADAPTIVE_WINDOW`, and `VLLM_ADAPTIVE_SPEC_DEPTHS` | inert; note 2 |
+| `SPARK_Q2R_PROBE=1` | Q2R probe bridge on `Worker.initialize_from_config` | inert; note 2 |
+| `SPARK_TP4_FLIGHT_RECORDER=1` | B12X fused-indexer import hook | partial; note 1 |
+| `SPARK_CUDAGRAPH_REPLAY_TIMING=1` | CUDA-graph replay timing, armed through `SPARK_CUDAGRAPH_REPLAY_TIMING_ARM_PATH` | inert; note 2 |
+| `SPARK_TP4_DCP_COLLECTIVE_AUDIT=1` | DCP combine and reduce-scatter audit on `vllm.v1.attention.ops.common` | inert |
+| `VLLM_SPARK_TRACE_ALLREDUCE=1` | all-reduce shape tracer writing `VLLM_SPARK_TRACE_PATH` | inert |
+
+**Note 1 — the flight recorder is partial, not inert.**
+`spark_tp4_backend` and `spark_tp4_allgather_backend` read
+`SPARK_TP4_FLIGHT_RECORDER` themselves. With the all-reduce family
+installed, the recorder is activated when the first native backend is
+constructed, so the `op=AR` and `op=AG:*` trace lines are emitted under
+either installer. Only `install_b12x_import_hook()` is overlay-gated, so
+the `op=B12X` indexer lines are the part that disappears.
+
+**Note 2 — the graph-status snapshot reads four overlay gates.**
+With `SPARK_TP4_GRAPH_STATUS_PATH` set, the collective families start the
+low-rate status reporter on both paths. Its collector branches on
+`SPARK_CUDAGRAPH_REPLAY_TIMING`, `SPARK_Q2R_PROBE`,
+`VLLM_SPARK_TRUE_ADAPTIVE_DRAFT`, and `SPARK_ADAPTIVE_MTP_CONTROL`, so
+under the plugin those sections describe hooks that were never installed.
+`SPARK_ADAPTIVE_MTP_CONTROL=1` additionally makes the collector import
+`adaptive_mtp_controller.runtime_installer`, which the wheel does not
+vendor: where that package is not importable in the serving process, the
+collector raises on every poll, the reporter thread swallows the
+exception, and no status file is written at all.
+
+Four of the overlay-only modules ship in the wheel because they are in
+the import closure of the collective families —
+`spark_q2r_probe_bridge`, `spark_cudagraph_replay_timing`,
+`spark_tp4_flight_recorder`, and `spark_true_adaptive_draft` — and
+`register()` never calls their `install()`. Present is not installed. The
+remaining six hooks (both NF3 adapters, the adaptive-MTP controller, MTP
+index reuse, the DCP collective audit, and the shape tracer) are not in
+the wheel at all. The stock-path counting named above is
+`spark_collective_audit`, which is vendored and active under the plugin;
+it is a different module from the one `SPARK_TP4_DCP_COLLECTIVE_AUDIT`
+gates.
+
+Scope of this comparison: both installer files and the vendored modules
+were read in this checkout, and every gate listed above is the expression
+those files test. Whether an overlay-only hook would work if it were
+installed from the plugin was not tested, and none of this was exercised
+on a serving process. `VLLM_USE_V2_MODEL_RUNNER` is a vLLM variable that
+the overlay's NF3 cap requires to be exactly `0` or `1`; the plugin adds
+no check of its own, and what vLLM does with it is outside this
+comparison.
+
 ## Native library
 
 `spark_tp4_backend` loads `libspark_transport_capi.so` from

--- a/sparkring_plugin/README.md
+++ b/sparkring_plugin/README.md
@@ -172,3 +172,33 @@ cannot ship silently.
 CUDA-graph admission (open correctness gate; `--enforce-eager` only),
 expert-parallel all-to-all, non-BF16 collective dtypes, topologies beyond
 directly cabled two- and four-Spark rings, and any performance claim.
+
+## Coexistence with the container overlay
+
+Both integration paths install the same four collective families, and
+neither detects the other. The container image used by the qualified
+profiles bakes `sitecustomize.py` and puts its directory on
+`PYTHONPATH`, so installing this package into that image gives an
+interpreter two installers gated on the same variables.
+
+Observed on four Sparks with `VLLM_SPARK_TP4_MODE` set, image
+`sparkring/glm52-exl3-r7-3.5bpw:r34-sm121a-flat2-20260810`:
+
+- `sitecustomize` runs first, at interpreter start, and patches the
+  integration point before any entry point loads.
+- `register()` then runs and reports installing again.
+- `import spark_tp4_backend` resolves to this package's `_vendor` copy,
+  not the overlay's module, because `register()` inserts `_vendor` at
+  the front of `sys.path` while the overlay's directory sits later on
+  `PYTHONPATH`.
+
+The consequence is that the modules executing are this package's
+vendored copies while the deployed overlay files are shadowed, and a
+deployment pinned to specific overlay bytes no longer runs them. Neither
+path reports the substitution.
+
+Use one path per deployment. To exercise this package inside an image
+that carries the overlay, replace `sitecustomize.py` with an empty file
+for the run, which is what
+[the four-Spark live validation](../docs/PLUGIN_LIVE_VALIDATION_20260820.md)
+does.

--- a/sparkring_plugin/pyproject.toml
+++ b/sparkring_plugin/pyproject.toml
@@ -35,4 +35,4 @@ package-dir = { "" = "src" }
 where = ["src"]
 
 [tool.setuptools.package-data]
-sparkring = ["_vendor/*.py", "_native/*.so"]
+sparkring = ["_vendor/*.py", "_vendor/MANIFEST.json", "_native/*.so"]

--- a/sparkring_plugin/scripts/sync_vendor.py
+++ b/sparkring_plugin/scripts/sync_vendor.py
@@ -6,22 +6,42 @@ Run from anywhere inside the repository:
 
     python sparkring_plugin/scripts/sync_vendor.py
 
+Copying also rewrites src/sparkring/_vendor/MANIFEST.json, which records
+{"modules": {"<name>.py": "<sha256>"}} over the bytes written into the
+vendor directory. A pip-installed host has no source tree to compare
+against, so the manifest is what lets that host re-hash the modules it
+received and show they are the bytes this script produced.
+
 tests/test_vendor_parity.py fails whenever the vendored copies drift from
 the source tree, so forgetting to re-run this script cannot ship silently.
 """
 
 from __future__ import annotations
 
+import hashlib
+import json
 import pathlib
 import shutil
 import sys
 
-# Transitive import closure of spark_tp4_backend. Row policy enters
-# through spark_tp4_query_row_provider: a deployment may name an external
-# provider module in VLLM_SPARK_TP4_QUERY_ROW_PROVIDER, which is imported
-# lazily at resolution time and is deliberately not vendored — the wheel
-# is complete without any provider, and the preflight reports a configured
-# provider's importability as its own check.
+MANIFEST = "MANIFEST.json"
+
+# Transitive import closure of spark_tp4_backend, and the set MANIFEST.json
+# describes. Four import targets sit deliberately outside it, so the manifest
+# covers what the wheel ships rather than everything an enabled mode reaches:
+#
+#   - The external row-policy module a deployment may name in
+#     VLLM_SPARK_TP4_QUERY_ROW_PROVIDER. It is imported lazily at resolution
+#     time; the wheel is complete without any provider, and the preflight
+#     reports a configured provider's importability as its own check.
+#   - spark_transport/experiments/adaptive_mtp_controller, imported by
+#     spark_graph_status_reporter under SPARK_ADAPTIVE_MTP_CONTROL=1.
+#   - spark_transport/experiments/moe_round_floor and
+#     spark_transport/experiments/q2r_phase_timing, imported by
+#     spark_q2r_probe_bridge under SPARK_Q2R_PROBE=1.
+#
+# Those three experiment packages must reach sys.path from outside the wheel
+# whenever their gating variables are set.
 MODULES = (
     "spark_collective_audit",
     "spark_cudagraph_replay_timing",
@@ -51,13 +71,23 @@ def main() -> int:
         print(f"source tree not found: {source}", file=sys.stderr)
         return 1
     vendor.mkdir(parents=True, exist_ok=True)
+    digests: dict[str, str] = {}
     for name in MODULES:
         module = source / f"{name}.py"
         if not module.is_file():
             print(f"missing source module: {module}", file=sys.stderr)
             return 1
-        shutil.copyfile(module, vendor / f"{name}.py")
+        copy = vendor / f"{name}.py"
+        shutil.copyfile(module, copy)
+        # Hash the destination, not the source: the manifest is a claim
+        # about the bytes the wheel carries.
+        digests[copy.name] = hashlib.sha256(copy.read_bytes()).hexdigest()
         print(f"synced {name}.py")
+    document = json.dumps({"modules": digests}, sort_keys=True, indent=2)
+    # write_bytes, not write_text: the serialization must come out identical
+    # on every host, and text mode rewrites the line ending on Windows.
+    (vendor / MANIFEST).write_bytes((document + "\n").encode("utf-8"))
+    print(f"wrote {MANIFEST} over {len(digests)} modules")
     return 0
 
 

--- a/sparkring_plugin/src/sparkring/_vendor/MANIFEST.json
+++ b/sparkring_plugin/src/sparkring/_vendor/MANIFEST.json
@@ -1,0 +1,20 @@
+{
+  "modules": {
+    "spark_collective_audit.py": "8fa7aa9747845a84b40e8d3a0d72c39f8a562d6490764b777e5dcbe1cbe47721",
+    "spark_cudagraph_replay_timing.py": "c56ebcf03ca2527fcac50d85980ca211f0acbbf1bf38f9a351e48452a9462cda",
+    "spark_graph_status_reporter.py": "183add7a2e8403577175fff8df0c0ef4f1d6bf3cb163e9907b6b7c0b1031989c",
+    "spark_persistent_output_ring.py": "03220c78ed87651f93c3165f1eedb843ffcad6a116126e2a9b89beab299bd2f3",
+    "spark_q2r_probe_bridge.py": "8cc6cd2ecf0728be34d268e4ef319eba128df9ae167c571690d65be5d9d29686",
+    "spark_tp4_allgather_backend.py": "a8f7db5270cf8c84ec7616ea0640a6842d452d1e29aad8cf07b28b5acfba3496",
+    "spark_tp4_backend.py": "a1d0453612ca71467b596b7616ada0a29947422e51af0561a61f5d79c5c1c526",
+    "spark_tp4_dcp_backend.py": "39f60eded53e21044da7fe924f2068c2aaa50415459589edf24b6427aa8a1817",
+    "spark_tp4_flight_recorder.py": "1c060ef21d4243a7f9a2b053fbe1d55e11f3a00c244abed0d0bdff500f5b4360",
+    "spark_tp4_port_namespace.py": "274149fcbae08b0347dffb1e47973613778fbf78d6e56f0d15f061933b9670b9",
+    "spark_tp4_prefill_capacity_pool.py": "246437af7d7051e0b9fe4a83bcefa9dffefe5256440c13e86d259917e9a175d2",
+    "spark_tp4_query_contract.py": "978df868fd83a6a780111092e99de2a3f07a5df375cf52d4b2358ccf4dcd0c31",
+    "spark_tp4_query_row_provider.py": "09c9e7af5d14b5c6930e15c999ada2231d639eb59609d705aadecdd7497ddec7",
+    "spark_tp4_stock_timing.py": "85f3f2fe5392248afc7c0009844c1d3b7ea8583ecd2d9bd618f98e8b6225b7d8",
+    "spark_tp4_vocab_allgather_backend.py": "4f44ea1f142d649f1a531b8d2bd930a93ea1d9dd734b3eac525b319f75230fe9",
+    "spark_true_adaptive_draft.py": "57428eb85364e85875a1ee3c500483b22c660d2367962703c02532e220edfb02"
+  }
+}

--- a/sparkring_plugin/src/sparkring/preflight.py
+++ b/sparkring_plugin/src/sparkring/preflight.py
@@ -9,6 +9,7 @@ check (control-peer TCP reachability) is opt-in via ``--connect``.
 from __future__ import annotations
 
 import argparse
+import contextlib
 import hashlib
 import json
 import os
@@ -398,7 +399,15 @@ def main(argv: list[str] | None = None) -> int:
         help="enable the control-peer TCP reachability check",
     )
     arguments = parser.parse_args(argv)
-    checks = run_preflight(connect=arguments.connect)
+    # Collecting the checks imports vLLM, which writes progress lines to
+    # stdout. Under --json stdout carries one document and nothing else, so
+    # the checks run with stdout diverted to stderr; the diagnostics stay
+    # visible to a person and stay out of the parsed stream.
+    if arguments.as_json:
+        with contextlib.redirect_stdout(sys.stderr):
+            checks = run_preflight(connect=arguments.connect)
+    else:
+        checks = run_preflight(connect=arguments.connect)
     if arguments.as_json:
         print(json.dumps([asdict(check) for check in checks], indent=2))
     else:

--- a/sparkring_plugin/src/sparkring/preflight.py
+++ b/sparkring_plugin/src/sparkring/preflight.py
@@ -1,14 +1,15 @@
 """Read-only operator preflight for the SparkRing transport.
 
 Run on one rank before enabling any SparkRing mode. Validates
-configuration and host state without touching GPUs, RDMA queues, or the
-network; the single network-touching check (control-peer TCP
-reachability) is opt-in via ``--connect``.
+configuration, vendored-module integrity, and host state without
+touching GPUs, RDMA queues, or the network; the single network-touching
+check (control-peer TCP reachability) is opt-in via ``--connect``.
 """
 
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import os
 import socket
@@ -22,6 +23,8 @@ _SYSFS_INFINIBAND = "/sys/class/infiniband"
 _VALID_MODES = ("shadow", "custom", "disabled")
 _DEFAULT_CONTROL_PORTS = (11000, 11001)
 _CONNECT_TIMEOUT_SECONDS = 2.0
+_VENDOR_MANIFEST = os.path.join(_VENDOR, "MANIFEST.json")
+_HASH_CHUNK_BYTES = 1 << 20
 
 
 @dataclass(frozen=True)
@@ -44,6 +47,95 @@ def _vendored():
     return spark_tp4_port_namespace
 
 
+def _raised(name: str, context: str, error: Exception) -> Check:
+    """Turn an exception a handler does not model into a failed Check.
+
+    run_preflight is the sole producer of the report, so an exception
+    that escapes one handler erases every other result: --json then
+    prints no Check array at all. Every handler that calls into
+    configuration-derived or third-party code routes what it cannot
+    model here, naming the configuration it was resolving. Only
+    Exception is converted; a KeyboardInterrupt still ends the run.
+    """
+
+    return Check(
+        name, False, f"{context}: {type(error).__name__}: {error}", "required"
+    )
+
+
+def _sha256_file(path: str) -> str:
+    """Hash the file's bytes as written; no newline or encoding translation."""
+
+    digest = hashlib.sha256()
+    with open(path, "rb") as handle:
+        while True:
+            block = handle.read(_HASH_CHUNK_BYTES)
+            if not block:
+                break
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def _check_vendor_integrity() -> Check:
+    """Compare the vendored backend modules against their manifest.
+
+    scripts/sync_vendor.py writes MANIFEST.json beside the copies it
+    makes, as ``{"modules": {"<stem>.py": "<sha256 hex>"}}``, and every
+    entry is resolved relative to that file. A checkout that has not
+    generated a manifest reports info: absence is not evidence of
+    tampering. A manifest that is present is authoritative, so a listed
+    module that is missing, unreadable, or altered is a required
+    failure — the vendored copies are what every other check imports.
+    """
+
+    if not os.path.isfile(_VENDOR_MANIFEST):
+        return Check(
+            "vendor-integrity",
+            True,
+            f"no manifest at {_VENDOR_MANIFEST}",
+            "info",
+        )
+    try:
+        with open(_VENDOR_MANIFEST, "rb") as handle:
+            manifest = json.loads(handle.read())
+    except (OSError, ValueError) as error:
+        return _raised("vendor-integrity", _VENDOR_MANIFEST, error)
+    modules = manifest.get("modules") if isinstance(manifest, dict) else None
+    if not isinstance(modules, dict):
+        return Check(
+            "vendor-integrity",
+            False,
+            f"{_VENDOR_MANIFEST}: no 'modules' object",
+            "required",
+        )
+    root = os.path.dirname(_VENDOR_MANIFEST)
+    problems: list[str] = []
+    for name in sorted(modules):
+        path = os.path.join(root, name)
+        if not os.path.isfile(path):
+            problems.append(f"{name}: missing")
+            continue
+        try:
+            actual = _sha256_file(path)
+        except OSError as error:
+            problems.append(f"{name}: unreadable: {error}")
+            continue
+        if actual != modules[name]:
+            problems.append(
+                f"{name}: sha256 {actual} != manifest {modules[name]}"
+            )
+    if problems:
+        return Check(
+            "vendor-integrity", False, "; ".join(problems), "required"
+        )
+    return Check(
+        "vendor-integrity",
+        True,
+        f"{len(modules)} vendored modules match the manifest",
+        "required",
+    )
+
+
 def _check_query_row_provider(environ: Mapping[str, str]) -> Check:
     """Report the resolved query-row policy.
 
@@ -56,15 +148,26 @@ def _check_query_row_provider(environ: Mapping[str, str]) -> Check:
     if _VENDOR not in sys.path:
         sys.path.insert(0, _VENDOR)
     from spark_tp4_query_row_provider import (
+        PROVIDER_ENV,
         provider_module_name,
         resolve_query_rows,
     )
 
     module_name = provider_module_name(environ)
+    configured = (
+        f"{PROVIDER_ENV}={module_name}"
+        if module_name is not None
+        else f"{PROVIDER_ENV} unset"
+    )
     try:
         rows = resolve_query_rows(environ)
     except ValueError as error:
         return Check("query-row-provider", False, str(error), "required")
+    except Exception as error:
+        # A configured provider is third-party code, and the resolver
+        # models only its ValueError contract. Whatever else it raises
+        # at call time is this rank's diagnostic, not a crash.
+        return _raised("query-row-provider", configured, error)
     if module_name is None:
         return Check(
             "query-row-provider",
@@ -86,6 +189,8 @@ def _check_widths(environ: Mapping[str, str]) -> Check:
         widths = namespace.eager_allreduce_admitted_widths(environ)
     except ValueError as error:
         return Check("env-widths", False, str(error), "required")
+    except Exception as error:
+        return _raised("env-widths", "VLLM_SPARK_TP4_EAGER_WIDTHS", error)
     return Check(
         "env-widths",
         True,
@@ -116,6 +221,12 @@ def _check_port_namespace(environ: Mapping[str, str]) -> Check:
         reservations = namespace.validate_active_port_namespace(environ)
     except ValueError as error:
         return Check("port-namespace", False, str(error), "required")
+    except Exception as error:
+        # The reservation plan resolves the query-row policy, so a
+        # provider that raises anything but ValueError reaches here too.
+        return _raised(
+            "port-namespace", "active control-port reservations", error
+        )
     return Check(
         "port-namespace",
         True,
@@ -193,11 +304,15 @@ def _check_vllm_compat() -> Check:
         return Check(
             "vllm-compat", True, "compat module unavailable", "info"
         )
-    report = compat_report()
-    detail = (
-        f"vLLM {report['vllm_version']!r}: {report['detail']}"
-    )
-    return Check("vllm-compat", bool(report["ok"]), detail, "required")
+    try:
+        report = compat_report()
+        detail = (
+            f"vLLM {report['vllm_version']!r}: {report['detail']}"
+        )
+        passed = bool(report["ok"])
+    except Exception as error:
+        return _raised("vllm-compat", "sparkring._compat", error)
+    return Check("vllm-compat", passed, detail, "required")
 
 
 def _check_peers(
@@ -207,18 +322,23 @@ def _check_peers(
         return Check(
             "peer-reachability", True, "skipped (--connect)", "info"
         )
-    peers = [
-        (
-            environ.get(f"SPARK_TP4_PEER{index}"),
-            int(
-                environ.get(
-                    f"SPARK_TP4_CONTROL_PORT{index}",
-                    str(_DEFAULT_CONTROL_PORTS[index]),
-                )
-            ),
+    try:
+        peers = [
+            (
+                environ.get(f"SPARK_TP4_PEER{index}"),
+                int(
+                    environ.get(
+                        f"SPARK_TP4_CONTROL_PORT{index}",
+                        str(_DEFAULT_CONTROL_PORTS[index]),
+                    )
+                ),
+            )
+            for index in (0, 1)
+        ]
+    except Exception as error:
+        return _raised(
+            "peer-reachability", "SPARK_TP4_CONTROL_PORT0/1", error
         )
-        for index in (0, 1)
-    ]
     configured = [(p, port) for p, port in peers if p]
     if not configured:
         return Check(
@@ -254,6 +374,7 @@ def run_preflight(
 ) -> list[Check]:
     env = _environment(environ)
     return [
+        _check_vendor_integrity(),
         _check_query_row_provider(env),
         _check_widths(env),
         _check_mode(env),

--- a/sparkring_plugin/tests/test_preflight.py
+++ b/sparkring_plugin/tests/test_preflight.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import contextlib
 import hashlib
+import io
 import json
 import os
 import pathlib
@@ -436,3 +438,42 @@ class PreflightTest(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class JsonStreamIsolationTest(unittest.TestCase):
+    """--json emits one document on stdout and nothing else.
+
+    Collecting the checks imports vLLM, which writes progress lines to
+    stdout. A caller that parses stdout must not receive those lines.
+    """
+
+    def test_json_stdout_carries_only_the_document(self) -> None:
+        def noisy(*_args, **_kwargs):
+            print("INFO 00-00 00:00:00 [importing.py:53] Triton is installed")
+            return [preflight.Check("mode", True, "disabled", "info")]
+
+        with patch.object(preflight, "run_preflight", noisy):
+            stdout = io.StringIO()
+            stderr = io.StringIO()
+            with contextlib.redirect_stdout(stdout):
+                with contextlib.redirect_stderr(stderr):
+                    code = preflight.main(["--json"])
+
+        self.assertEqual(code, 0)
+        document = json.loads(stdout.getvalue())
+        self.assertEqual(document[0]["name"], "mode")
+        self.assertIn("Triton is installed", stderr.getvalue())
+
+    def test_text_mode_leaves_diagnostics_on_stdout(self) -> None:
+        def noisy(*_args, **_kwargs):
+            print("collector diagnostic")
+            return [preflight.Check("mode", True, "disabled", "info")]
+
+        with patch.object(preflight, "run_preflight", noisy):
+            stdout = io.StringIO()
+            with contextlib.redirect_stdout(stdout):
+                code = preflight.main([])
+
+        self.assertEqual(code, 0)
+        self.assertIn("collector diagnostic", stdout.getvalue())
+        self.assertIn("PASS mode", stdout.getvalue())

--- a/sparkring_plugin/tests/test_preflight.py
+++ b/sparkring_plugin/tests/test_preflight.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 import pathlib
+import socket
 import sys
 import types
 import unittest
@@ -186,6 +188,66 @@ class PreflightTest(unittest.TestCase):
             bad = _by_name(preflight.run_preflight({}))
         self.assertFalse(bad["vllm-compat"].passed)
 
+    def test_provider_raising_non_valueerror_stays_in_the_report(self) -> None:
+        def explode(environ):
+            raise RuntimeError("provider backend unavailable")
+
+        module = types.ModuleType("_preflight_rows_raise")
+        module.provider_query_rows = explode
+        sys.modules["_preflight_rows_raise"] = module
+        environ = {
+            "VLLM_SPARK_TP4_QUERY_ROW_PROVIDER": "_preflight_rows_raise",
+            "VLLM_SPARK_TP4_MODE": "custom",
+        }
+        try:
+            checks = _by_name(preflight.run_preflight(environ))
+        finally:
+            del sys.modules["_preflight_rows_raise"]
+        check = checks["query-row-provider"]
+        self.assertFalse(check.passed)
+        self.assertEqual(check.severity, "required")
+        self.assertIn("VLLM_SPARK_TP4_QUERY_ROW_PROVIDER", check.detail)
+        self.assertIn("_preflight_rows_raise", check.detail)
+        self.assertIn("RuntimeError", check.detail)
+        # The reservation plan resolves the same row policy, so it sees
+        # the same exception and must also report instead of aborting.
+        self.assertFalse(checks["port-namespace"].passed)
+        self.assertIn("RuntimeError", checks["port-namespace"].detail)
+        # Every later check still produced a result.
+        self.assertIn("peer-reachability", checks)
+
+    def test_main_json_survives_a_raising_provider(self) -> None:
+        import contextlib
+        import io
+
+        def explode(environ):
+            raise RuntimeError("provider backend unavailable")
+
+        module = types.ModuleType("_preflight_rows_raise_cli")
+        module.provider_query_rows = explode
+        sys.modules["_preflight_rows_raise_cli"] = module
+        environ = {
+            key: value
+            for key, value in os.environ.items()
+            if not key.startswith(("VLLM_SPARK", "SPARK_TP4"))
+        }
+        environ["VLLM_SPARK_TP4_QUERY_ROW_PROVIDER"] = (
+            "_preflight_rows_raise_cli"
+        )
+        environ["VLLM_SPARK_TP4_MODE"] = "custom"
+        stream = io.StringIO()
+        try:
+            with patch.dict(os.environ, environ, clear=True):
+                with contextlib.redirect_stdout(stream):
+                    code = preflight.main(["--json"])
+        finally:
+            del sys.modules["_preflight_rows_raise_cli"]
+        self.assertEqual(code, 1)  # query-row-provider fails
+        payload = json.loads(stream.getvalue())
+        names = {entry["name"] for entry in payload}
+        self.assertIn("query-row-provider", names)
+        self.assertIn("peer-reachability", names)
+
     def test_peer_check_skipped_by_default(self) -> None:
         checks = _by_name(
             preflight.run_preflight(
@@ -194,6 +256,162 @@ class PreflightTest(unittest.TestCase):
         )
         self.assertTrue(checks["peer-reachability"].passed)
         self.assertEqual(checks["peer-reachability"].severity, "info")
+
+    def test_peer_reachable_over_loopback(self) -> None:
+        listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        try:
+            listener.bind(("127.0.0.1", 0))
+            listener.listen(1)
+            port = listener.getsockname()[1]
+            checks = _by_name(
+                preflight.run_preflight(
+                    {
+                        "SPARK_TP4_PEER0": "127.0.0.1",
+                        "SPARK_TP4_CONTROL_PORT0": str(port),
+                    },
+                    connect=True,
+                )
+            )
+        finally:
+            listener.close()
+        check = checks["peer-reachability"]
+        self.assertTrue(check.passed)
+        self.assertEqual(check.severity, "required")
+        self.assertIn(f"127.0.0.1:{port}", check.detail)
+
+    def test_refused_peer_counts_as_routable(self) -> None:
+        probe = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        probe.bind(("127.0.0.1", 0))
+        port = probe.getsockname()[1]
+        probe.close()  # nothing listens on this port now
+        # How fast a host turns a closed port into a refusal is a host
+        # property: loopback RST is immediate on Linux and takes about
+        # two seconds on Windows. Raise the bound so this exercises the
+        # refusal branch rather than the timeout branch anywhere.
+        with patch.object(preflight, "_CONNECT_TIMEOUT_SECONDS", 10.0):
+            checks = _by_name(
+                preflight.run_preflight(
+                    {
+                        "SPARK_TP4_PEER0": "127.0.0.1",
+                        "SPARK_TP4_CONTROL_PORT0": str(port),
+                    },
+                    connect=True,
+                )
+            )
+        check = checks["peer-reachability"]
+        self.assertTrue(check.passed)
+        self.assertEqual(check.severity, "required")
+        self.assertIn(f"127.0.0.1:{port}", check.detail)
+
+    def test_unroutable_peer_is_a_required_failure(self) -> None:
+        class _UnroutableSocket:
+            """Every connect fails the way an absent route does.
+
+            Substituted for socket.socket because reaching a genuinely
+            unroutable address requires a host outside this checkout.
+            """
+
+            def __init__(self, family, kind):
+                pass
+
+            def settimeout(self, seconds):
+                pass
+
+            def connect(self, address):
+                raise OSError("network is unreachable")
+
+            def close(self):
+                pass
+
+        with patch.object(preflight.socket, "socket", _UnroutableSocket):
+            checks = _by_name(
+                preflight.run_preflight(
+                    {"SPARK_TP4_PEER0": "127.0.0.1"}, connect=True
+                )
+            )
+        check = checks["peer-reachability"]
+        self.assertFalse(check.passed)
+        self.assertEqual(check.severity, "required")
+        self.assertIn("127.0.0.1:11000", check.detail)
+        self.assertIn("network is unreachable", check.detail)
+
+    def test_non_integer_control_port_is_reported_not_raised(self) -> None:
+        checks = _by_name(
+            preflight.run_preflight(
+                {
+                    "SPARK_TP4_PEER0": "127.0.0.1",
+                    "SPARK_TP4_CONTROL_PORT0": "eleven-thousand",
+                },
+                connect=True,
+            )
+        )
+        check = checks["peer-reachability"]
+        self.assertFalse(check.passed)
+        self.assertEqual(check.severity, "required")
+        self.assertIn("SPARK_TP4_CONTROL_PORT0/1", check.detail)
+
+    def _write_vendor(self, root, contents):
+        """Write module files and return their true digests by name."""
+
+        modules = {}
+        for name, data in contents.items():
+            with open(os.path.join(root, name), "wb") as handle:
+                handle.write(data)
+            modules[name] = hashlib.sha256(data).hexdigest()
+        return modules
+
+    def _write_manifest(self, root, modules):
+        path = os.path.join(root, "MANIFEST.json")
+        with open(path, "wb") as handle:
+            handle.write(json.dumps({"modules": modules}).encode("utf-8"))
+        return path
+
+    def test_vendor_integrity_without_manifest_is_info_pass(self) -> None:
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as root:
+            absent = os.path.join(root, "MANIFEST.json")
+            with patch.object(preflight, "_VENDOR_MANIFEST", absent):
+                checks = _by_name(preflight.run_preflight({}))
+        check = checks["vendor-integrity"]
+        self.assertTrue(check.passed)
+        self.assertEqual(check.severity, "info")
+
+    def test_vendor_integrity_matches_recorded_digests(self) -> None:
+        import tempfile
+
+        # CRLF bytes: the digest covers the file as written, so a
+        # newline-translating read would compute a different hash.
+        contents = {
+            "spark_a.py": b"x = 1\r\ny = 2\r\n",
+            "spark_b.py": b"z = 3\n",
+        }
+        with tempfile.TemporaryDirectory() as root:
+            modules = self._write_vendor(root, contents)
+            manifest = self._write_manifest(root, modules)
+            with patch.object(preflight, "_VENDOR_MANIFEST", manifest):
+                checks = _by_name(preflight.run_preflight({}))
+        check = checks["vendor-integrity"]
+        self.assertTrue(check.passed)
+        self.assertEqual(check.severity, "required")
+        self.assertIn("2 vendored modules", check.detail)
+
+    def test_vendor_integrity_fails_on_altered_and_missing(self) -> None:
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as root:
+            modules = self._write_vendor(root, {"spark_a.py": b"x = 1\n"})
+            modules["spark_gone.py"] = "0" * 64
+            manifest = self._write_manifest(root, modules)
+            with open(os.path.join(root, "spark_a.py"), "wb") as handle:
+                handle.write(b"x = 2\n")  # altered after the manifest
+            with patch.object(preflight, "_VENDOR_MANIFEST", manifest):
+                checks = _by_name(preflight.run_preflight({}))
+        check = checks["vendor-integrity"]
+        self.assertFalse(check.passed)
+        self.assertEqual(check.severity, "required")
+        self.assertIn("spark_a.py: sha256", check.detail)
+        self.assertIn("spark_gone.py: missing", check.detail)
 
     def test_main_json_and_exit_codes(self) -> None:
         import contextlib

--- a/sparkring_plugin/tests/test_register_contract.py
+++ b/sparkring_plugin/tests/test_register_contract.py
@@ -1,0 +1,147 @@
+"""Fail-closed exit status of the ``vllm.general_plugins`` entry point.
+
+``register()`` ends the process with ``os._exit(78)`` when a
+``VLLM_SPARK_*`` mode is set and installation fails, so the contract
+cannot be observed in-process: ``os._exit`` would end the test runner
+with it. Each case therefore runs a child interpreter that imports
+``sparkring.plugin``, calls ``register()``, and reports its exit status.
+
+Precondition for the refusal cases: vLLM must not be importable. They
+pin the path where the compatibility gate finds no
+``CudaCommunicator.all_reduce`` and refuses, which is what makes an
+enabled mode fail on a host without the fork. With a real vLLM present
+the gate can pass and installation proceeds instead, so those cases
+skip.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import pathlib
+import subprocess
+import sys
+import tempfile
+import textwrap
+import unittest
+
+PLUGIN_ROOT = pathlib.Path(__file__).resolve().parent.parent
+SRC = PLUGIN_ROOT / "src"
+
+# The exit status register() uses for a fatal install failure with a
+# mode enabled. A half-installed transport must never carry collectives,
+# so the process ends before vLLM can serve traffic.
+FATAL_EXIT = 78
+
+_CHILD = textwrap.dedent(
+    """
+    from sparkring.plugin import register
+
+    register()
+    print("REGISTER-RETURNED")
+    """
+)
+
+
+def _vllm_importable() -> bool:
+    try:
+        return importlib.util.find_spec("vllm") is not None
+    except BaseException:
+        # A vLLM that is present but not resolvable is also not the
+        # absent-vLLM precondition the refusal cases need.
+        return True
+
+
+_absent_vllm_only = unittest.skipIf(
+    _vllm_importable(),
+    "vLLM is importable; the compatibility gate can pass instead of "
+    "refusing",
+)
+
+
+def _register(**mode_env: str) -> subprocess.CompletedProcess:
+    """Call register() in a child holding only the named mode variables.
+
+    The child inherits neither the parent's ``VLLM_SPARK*`` /
+    ``SPARK_TP4*`` settings nor its ``PYTHON*`` settings, and runs in an
+    empty directory, so its only import root is the checkout's ``src``.
+    """
+
+    environment = {
+        key: value
+        for key, value in os.environ.items()
+        if not key.startswith(("VLLM_SPARK", "SPARK_TP4", "PYTHON"))
+    }
+    environment["PYTHONPATH"] = str(SRC)
+    environment.update(mode_env)
+    with tempfile.TemporaryDirectory() as empty:
+        return subprocess.run(
+            [sys.executable, "-c", _CHILD],
+            capture_output=True,
+            text=True,
+            timeout=120,
+            env=environment,
+            cwd=empty,
+        )
+
+
+class RegisterExitContractTest(unittest.TestCase):
+    def _assert_fails_closed(
+        self, result: subprocess.CompletedProcess
+    ) -> None:
+        self.assertEqual(
+            result.returncode,
+            FATAL_EXIT,
+            f"expected exit {FATAL_EXIT}, got {result.returncode}\n"
+            f"stdout:\n{result.stdout[-2000:]}\n"
+            f"stderr:\n{result.stderr[-2000:]}",
+        )
+        self.assertNotIn("REGISTER-RETURNED", result.stdout)
+        self.assertIn(
+            "FATAL: SparkRing plugin installation failed", result.stderr
+        )
+        self.assertIn(
+            "terminating before vLLM can serve traffic", result.stderr
+        )
+        self.assertIn(
+            "SparkRing cannot locate the vLLM integration point",
+            result.stderr,
+        )
+        self.assertIn("CudaCommunicator.all_reduce", result.stderr)
+
+    def _assert_returns(
+        self, result: subprocess.CompletedProcess
+    ) -> None:
+        self.assertEqual(
+            result.returncode,
+            0,
+            f"expected exit 0, got {result.returncode}\n"
+            f"stderr:\n{result.stderr[-2000:]}",
+        )
+        self.assertIn("REGISTER-RETURNED", result.stdout)
+
+    @_absent_vllm_only
+    def test_shadow_mode_exits_fatal(self) -> None:
+        self._assert_fails_closed(_register(VLLM_SPARK_TP4_MODE="shadow"))
+
+    @_absent_vllm_only
+    def test_custom_mode_exits_fatal(self) -> None:
+        self._assert_fails_closed(_register(VLLM_SPARK_TP4_MODE="custom"))
+
+    @_absent_vllm_only
+    def test_family_mode_alone_exits_fatal(self) -> None:
+        """A family mode enables the plugin without the core mode, so it
+        must reach the same refusal rather than install partially."""
+        self._assert_fails_closed(
+            _register(VLLM_SPARK_TP4_DCP_MODE="custom")
+        )
+
+    def test_disabled_core_mode_returns(self) -> None:
+        self._assert_returns(_register(VLLM_SPARK_TP4_MODE="disabled"))
+
+    def test_no_mode_variable_returns(self) -> None:
+        self._assert_returns(_register())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/sparkring_plugin/tests/test_vendor_closure.py
+++ b/sparkring_plugin/tests/test_vendor_closure.py
@@ -1,0 +1,231 @@
+"""The vendor manifest must be a closed, dependency-free import set.
+
+``scripts/sync_vendor.py`` declares which flat modules the wheel ships,
+and the adapter imports its siblings by bare name. Two properties make
+that manifest checkable instead of asserted: every source-tree module a
+vendored module names is itself vendored, and every vendored module
+imports with nothing but the standard library on the path.
+"""
+
+from __future__ import annotations
+
+import ast
+import os
+import pathlib
+import subprocess
+import sys
+import textwrap
+import unittest
+
+PLUGIN_ROOT = pathlib.Path(__file__).resolve().parent.parent
+VENDOR = PLUGIN_ROOT / "src" / "sparkring" / "_vendor"
+REPO_ROOT = PLUGIN_ROOT.parent
+SOURCE = REPO_ROOT / "spark_transport" / "integrations" / "vllm"
+EXPERIMENTS = REPO_ROOT / "spark_transport" / "experiments"
+
+sys.path.insert(0, str(PLUGIN_ROOT / "scripts"))
+from sync_vendor import MODULES  # noqa: E402
+
+# Repository packages a vendored module names on purpose without
+# vendoring them. Each import is function-local and gated on its own
+# environment variable, so the wheel is complete without the package and
+# the adapter runs unchanged when it is absent.
+ALLOWED_EXPERIMENT_PACKAGES = {
+    # spark_graph_status_reporter reports the controller's installation
+    # snapshot only under SPARK_ADAPTIVE_MTP_CONTROL=1.
+    "adaptive_mtp_controller",
+    # spark_q2r_probe_bridge reads route-capture provenance and live
+    # capture control only inside its SPARK_Q2R_PROBE=1 install path.
+    "moe_round_floor",
+    # spark_q2r_probe_bridge installs phase timing from the same
+    # SPARK_Q2R_PROBE=1 path.
+    "q2r_phase_timing",
+}
+
+# The one seam that imports a name no static analysis can see:
+# spark_tp4_query_row_provider resolves the module named in
+# VLLM_SPARK_TP4_QUERY_ROW_PROVIDER at row-resolution time. No provider
+# is vendored — the wheel is complete without one, and
+# sparkring.preflight reports a configured provider's importability as
+# its own check. Any other module importing a computed name would be an
+# unaudited hole in the manifest.
+DYNAMIC_IMPORT_MODULES = {"spark_tp4_query_row_provider"}
+
+# Heavy dependencies the wheel must not need at import time. The probe
+# blocks them outright so the result does not depend on what the host
+# happens to have installed.
+DEFERRED_DEPENDENCIES = ("torch", "vllm")
+
+_IMPORT_PROBE = textwrap.dedent(
+    """
+    import importlib
+    import importlib.abc
+    import sys
+
+    vendor, names, blocked = sys.argv[1], sys.argv[2], sys.argv[3]
+
+
+    class _Absent(importlib.abc.MetaPathFinder):
+        def find_spec(self, fullname, path=None, target=None):
+            if fullname.split(".")[0] in blocked.split(","):
+                raise ModuleNotFoundError(
+                    f"{fullname} is absent in this probe"
+                )
+            return None
+
+
+    sys.meta_path.insert(0, _Absent())
+    # Keep the interpreter's own standard-library entries and nothing
+    # else: no repository source root, no site-packages. A bare-name
+    # import must therefore resolve inside the vendored directory.
+    roots = (sys.base_prefix, sys.prefix)
+    stdlib = [
+        entry for entry in sys.path
+        if entry and entry.startswith(roots)
+        and "site-packages" not in entry
+    ]
+    sys.path[:] = [vendor] + stdlib
+    for name in blocked.split(","):
+        try:
+            importlib.import_module(name)
+        except ModuleNotFoundError:
+            continue
+        raise AssertionError(f"{name} must be absent in this probe")
+    for name in names.split(","):
+        importlib.import_module(name)
+    print("VENDOR-IMPORT-OK")
+    """
+)
+
+
+def _import_call_target(node: ast.Call) -> tuple[bool, str | None]:
+    """Return (is an import call, constant module name or None)."""
+
+    function = node.func
+    if isinstance(function, ast.Name):
+        called = function.id
+    elif isinstance(function, ast.Attribute):
+        called = function.attr
+    else:
+        return False, None
+    if called not in ("import_module", "__import__"):
+        return False, None
+    first = node.args[0] if node.args else None
+    if isinstance(first, ast.Constant) and isinstance(first.value, str):
+        return True, first.value
+    return True, None
+
+
+def _static_import_targets(tree: ast.Module) -> set[str]:
+    """Every module name the source names as a constant, at any depth.
+
+    ``ast.walk`` reaches function-local imports as well as module-level
+    ones, which is what the closure claim needs: the adapter defers most
+    of its sibling imports into the call that uses them.
+    """
+
+    targets: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            targets.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom):
+            # Relative imports cannot name a flat source-tree module.
+            if node.level == 0 and node.module:
+                targets.add(node.module)
+        elif isinstance(node, ast.Call):
+            is_import, name = _import_call_target(node)
+            if is_import and name is not None:
+                targets.add(name)
+    return targets
+
+
+def _parse(name: str) -> ast.Module:
+    path = VENDOR / f"{name}.py"
+    return ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+
+
+@unittest.skipUnless(
+    SOURCE.is_dir(), "source tree not present (wheel-installed run)"
+)
+class VendorClosureTest(unittest.TestCase):
+    def test_manifest_covers_every_source_tree_import(self) -> None:
+        for name in MODULES:
+            for target in sorted(_static_import_targets(_parse(name))):
+                root = target.split(".")[0]
+                if (SOURCE / f"{root}.py").is_file():
+                    with self.subTest(module=name, imports=target):
+                        self.assertIn(
+                            root,
+                            MODULES,
+                            f"{name}.py imports {target}, which lives "
+                            "in spark_transport/integrations/vllm/ but "
+                            "is not vendored; add it to "
+                            "scripts/sync_vendor.py MODULES and re-run "
+                            "the script",
+                        )
+                elif (EXPERIMENTS / root).is_dir():
+                    with self.subTest(module=name, imports=target):
+                        self.assertIn(
+                            root,
+                            ALLOWED_EXPERIMENT_PACKAGES,
+                            f"{name}.py imports the experiment package "
+                            f"{root}, which the wheel does not ship; "
+                            "vendor it or record why it is an optional "
+                            "seam in ALLOWED_EXPERIMENT_PACKAGES",
+                        )
+
+    def test_only_the_row_policy_seam_imports_a_computed_name(self) -> None:
+        computed = set()
+        for name in MODULES:
+            for node in ast.walk(_parse(name)):
+                if not isinstance(node, ast.Call):
+                    continue
+                is_import, constant = _import_call_target(node)
+                if is_import and constant is None:
+                    computed.add(name)
+        self.assertEqual(
+            computed,
+            DYNAMIC_IMPORT_MODULES,
+            "a vendored module imports a name computed at runtime that "
+            "no static closure covers; document the seam in "
+            "DYNAMIC_IMPORT_MODULES or replace it with a constant",
+        )
+
+
+class VendorImportIsolationTest(unittest.TestCase):
+    def test_every_vendored_module_imports_without_heavy_deps(
+        self,
+    ) -> None:
+        """Deferred-import discipline: the wheel installs and imports on
+        a host with neither torch nor vLLM, so every heavy import must
+        sit inside the function that uses it."""
+
+        environment = {
+            key: value
+            for key, value in os.environ.items()
+            if not key.startswith(("VLLM_SPARK", "SPARK_TP4", "PYTHON"))
+        }
+        # -I -S: no user site, no site-packages, no script directory, and
+        # PYTHONPATH ignored, so the probe starts from the standard
+        # library alone.
+        result = subprocess.run(
+            [
+                sys.executable, "-I", "-S", "-c", _IMPORT_PROBE,
+                str(VENDOR), ",".join(MODULES),
+                ",".join(DEFERRED_DEPENDENCIES),
+            ],
+            capture_output=True,
+            text=True,
+            timeout=300,
+            env=environment,
+        )
+        self.assertEqual(
+            result.returncode,
+            0,
+            f"vendored import probe failed:\n{result.stderr[-4000:]}",
+        )
+        self.assertIn("VENDOR-IMPORT-OK", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/sparkring_plugin/tests/test_wheel.py
+++ b/sparkring_plugin/tests/test_wheel.py
@@ -2,16 +2,26 @@
 
 The rest of the suite imports from the source checkout, which cannot
 detect broken package data, missing vendored modules, or wrong
-entry-point metadata in the artifact a user would install. This test
-builds the wheel from the checkout, installs it into an isolated
-target directory, and — in a subprocess that sees only that
-directory — discovers the ``vllm.general_plugins`` entry point and
-verifies that mode-unset ``register()`` is a no-op that imports
-neither vLLM nor any adapter module.
+entry-point metadata in the artifact a user would install. This module
+builds the wheel once, installs it into an isolated target directory,
+and asserts three contracts in subprocesses that see only that
+directory: mode-unset ``register()`` imports neither vLLM nor any
+adapter module, the installed ``sparkring-preflight`` console script
+runs and prints the documented check records, and mode-set
+``register()`` exits 78 instead of returning to vLLM when installation
+cannot complete.
+
+The build passes ``--no-build-isolation`` because it must stay OFFLINE:
+PEP 517 isolation installs the ``setuptools>=68`` build requirement
+from a package index, which fails on a network-isolated host. That
+requirement must therefore be satisfied by the running interpreter, and
+the class is skipped when it is not.
 """
 
 from __future__ import annotations
 
+import importlib.metadata
+import json
 import os
 import pathlib
 import subprocess
@@ -22,87 +32,222 @@ import unittest
 
 PLUGIN_ROOT = pathlib.Path(__file__).resolve().parent.parent
 
+# Mirrors the [build-system] requires pin in pyproject.toml. Without
+# build isolation the backend is imported from this interpreter, so the
+# pin has to hold here instead of in a fetched build environment.
+_MINIMUM_SETUPTOOLS = 68
+
+# Field names of sparkring.preflight.Check, which --json emits per check.
+_CHECK_FIELDS = ("name", "passed", "detail", "severity")
+
+
+def _setuptools_shortfall() -> str | None:
+    """Describe why an isolation-free build cannot run here, or None."""
+
+    try:
+        version = importlib.metadata.version("setuptools")
+    except importlib.metadata.PackageNotFoundError:
+        return "setuptools is not installed"
+    major, _, _ = version.partition(".")
+    if not major.isdigit() or int(major) < _MINIMUM_SETUPTOOLS:
+        return f"setuptools {version} is installed"
+    return None
+
+
+def _run_pip(*arguments: str, what: str) -> None:
+    """Run one pip command, failing with the tail of its stderr."""
+
+    completed = subprocess.run(
+        [sys.executable, "-m", "pip", *arguments],
+        capture_output=True, text=True, timeout=600,
+    )
+    if completed.returncode != 0:
+        raise AssertionError(f"{what} failed:\n{completed.stderr[-2000:]}")
+
 
 class WheelContractTest(unittest.TestCase):
-    def test_wheel_installs_and_registers_as_a_noop(self) -> None:
-        with tempfile.TemporaryDirectory() as tmp:
-            wheel_dir = pathlib.Path(tmp) / "wheel"
-            target = pathlib.Path(tmp) / "site"
-            build = subprocess.run(
-                [
-                    sys.executable, "-m", "pip", "wheel", "--no-deps",
-                    "--wheel-dir", str(wheel_dir), str(PLUGIN_ROOT),
-                ],
-                capture_output=True, text=True, timeout=600,
-            )
-            self.assertEqual(
-                build.returncode, 0, f"wheel build failed:\n{build.stderr[-2000:]}"
-            )
-            wheels = list(wheel_dir.glob("sparkring-*.whl"))
-            self.assertEqual(len(wheels), 1, f"expected one wheel: {wheels}")
-            install = subprocess.run(
-                [
-                    sys.executable, "-m", "pip", "install", "--no-deps",
-                    "--target", str(target), str(wheels[0]),
-                ],
-                capture_output=True, text=True, timeout=600,
-            )
-            self.assertEqual(
-                install.returncode, 0,
-                f"wheel install failed:\n{install.stderr[-2000:]}",
-            )
+    tmp: pathlib.Path
+    target: pathlib.Path
 
-            probe = textwrap.dedent(
-                """
-                import importlib.metadata
-                import sys
-
-                entry_points = importlib.metadata.entry_points(
-                    group="vllm.general_plugins"
-                )
-                matches = [e for e in entry_points if e.name == "sparkring"]
-                assert len(matches) == 1, f"entry points: {entry_points}"
-                register = matches[0].load()
-                assert callable(register)
-
-                for name in ("VLLM_SPARK_TP4_MODE",):
-                    import os
-                    os.environ.pop(name, None)
-                register()
-
-                forbidden = [
-                    name for name in sys.modules
-                    if name == "vllm"
-                    or name.startswith("vllm.")
-                    or name.startswith("spark_tp4")
-                    or name.startswith("spark_collective")
-                ]
-                assert not forbidden, f"mode-unset register imported: {forbidden}"
-
-                scripts = importlib.metadata.entry_points(
-                    group="console_scripts"
-                )
-                assert any(e.name == "sparkring-preflight" for e in scripts)
-                print("WHEEL-CONTRACT-OK")
-                """
+    @classmethod
+    def setUpClass(cls) -> None:
+        shortfall = _setuptools_shortfall()
+        if shortfall is not None:
+            raise unittest.SkipTest(
+                "an offline wheel build needs setuptools>="
+                f"{_MINIMUM_SETUPTOOLS} importable in {sys.executable}; "
+                f"{shortfall}"
             )
-            probe_env = {
-                key: value
-                for key, value in os.environ.items()
-                if not key.startswith(("VLLM_SPARK", "SPARK_TP4", "PYTHON"))
-            }
-            probe_env["PYTHONPATH"] = str(target)
-            check = subprocess.run(
-                [sys.executable, "-c", probe],
-                capture_output=True, text=True, timeout=120,
-                env=probe_env,
-                cwd=tmp,
+        # One build and one install serve every test in this class; the
+        # build dominates the runtime of the module.
+        temporary = tempfile.TemporaryDirectory()
+        cls.addClassCleanup(temporary.cleanup)
+        cls.tmp = pathlib.Path(temporary.name)
+        cls.target = cls.tmp / "site"
+        wheel_dir = cls.tmp / "wheel"
+        # --no-index keeps the build from reaching a package index at
+        # all: pip fails locally instead of opening a connection.
+        _run_pip(
+            "wheel", "--no-deps", "--no-build-isolation", "--no-index",
+            "--wheel-dir", str(wheel_dir), str(PLUGIN_ROOT),
+            what="wheel build",
+        )
+        wheels = list(wheel_dir.glob("sparkring-*.whl"))
+        if len(wheels) != 1:
+            raise AssertionError(f"expected one wheel: {wheels}")
+        _run_pip(
+            "install", "--no-deps", "--no-index",
+            "--target", str(cls.target), str(wheels[0]),
+            what="wheel install",
+        )
+
+    def _probe_env(self) -> dict[str, str]:
+        """Environment in which only the install target is importable.
+
+        An inherited PYTHONPATH would let the source checkout satisfy
+        imports the artifact is supposed to satisfy, and an inherited
+        VLLM_SPARK*/SPARK_TP4* variable would change what the installed
+        code does.
+        """
+
+        environment = {
+            key: value
+            for key, value in os.environ.items()
+            if not key.startswith(("VLLM_SPARK", "SPARK_TP4", "PYTHON"))
+        }
+        environment["PYTHONPATH"] = str(self.target)
+        return environment
+
+    def _run_probe(self, source: str) -> subprocess.CompletedProcess:
+        return subprocess.run(
+            [sys.executable, "-c", textwrap.dedent(source)],
+            capture_output=True, text=True, timeout=120,
+            env=self._probe_env(), cwd=self.tmp,
+        )
+
+    def test_installed_register_without_mode_is_a_noop(self) -> None:
+        probe = """
+            import importlib.metadata
+            import sys
+
+            entry_points = importlib.metadata.entry_points(
+                group="vllm.general_plugins"
             )
-            self.assertEqual(
-                check.returncode, 0,
-                f"wheel probe failed:\n{check.stderr[-2000:]}",
+            matches = [e for e in entry_points if e.name == "sparkring"]
+            assert len(matches) == 1, f"entry points: {entry_points}"
+            register = matches[0].load()
+            assert callable(register)
+
+            for name in ("VLLM_SPARK_TP4_MODE",):
+                import os
+                os.environ.pop(name, None)
+            register()
+
+            forbidden = [
+                name for name in sys.modules
+                if name == "vllm"
+                or name.startswith("vllm.")
+                or name.startswith("spark_tp4")
+                or name.startswith("spark_collective")
+            ]
+            assert not forbidden, f"mode-unset register imported: {forbidden}"
+            print("WHEEL-CONTRACT-OK")
+            """
+        check = self._run_probe(probe)
+        self.assertEqual(
+            check.returncode, 0,
+            f"wheel probe failed:\n{check.stderr[-2000:]}",
+        )
+        self.assertIn("WHEEL-CONTRACT-OK", check.stdout)
+
+    def test_installed_preflight_script_reports_json_checks(self) -> None:
+        """The console script the wheel generates runs and reports checks.
+
+        ``pip install --target`` writes console scripts to ``bin``, named
+        with the platform's launcher suffix.
+        """
+
+        scripts = sorted((self.target / "bin").glob("sparkring-preflight*"))
+        self.assertEqual(len(scripts), 1, f"installed scripts: {scripts}")
+        run = subprocess.run(
+            [str(scripts[0]), "--json"],
+            capture_output=True, text=True, timeout=120,
+            env=self._probe_env(), cwd=self.tmp,
+        )
+        try:
+            checks = json.loads(run.stdout)
+        except json.JSONDecodeError as error:
+            self.fail(
+                f"--json output is not JSON ({error}); "
+                f"exit {run.returncode}, stdout {run.stdout[-2000:]!r}, "
+                f"stderr {run.stderr[-2000:]!r}"
             )
-            self.assertIn("WHEEL-CONTRACT-OK", check.stdout)
+        self.assertIsInstance(checks, list)
+        self.assertTrue(checks, "preflight reported no checks")
+        for check in checks:
+            self.assertEqual(set(check), set(_CHECK_FIELDS), f"shape: {check}")
+            self.assertIsInstance(check["name"], str)
+            self.assertIsInstance(check["passed"], bool)
+            self.assertIsInstance(check["detail"], str)
+            self.assertIn(check["severity"], ("required", "info"))
+
+        by_name = {check["name"]: check for check in checks}
+        self.assertIn("env-mode", by_name)
+        # A mode variable inherited from the caller would land here, so
+        # this also proves the probe environment is clean.
+        self.assertIn("mode unset", by_name["env-mode"]["detail"])
+        # main() returns 1 when a required check failed and 0 otherwise;
+        # which checks fail depends on the host, the relation does not.
+        required_failures = sorted(
+            check["name"] for check in checks
+            if check["severity"] == "required" and not check["passed"]
+        )
+        self.assertEqual(
+            run.returncode, 1 if required_failures else 0,
+            f"exit {run.returncode} with required failures "
+            f"{required_failures}",
+        )
+
+    def test_installed_register_with_mode_exits_78(self) -> None:
+        """A mode-set register() that cannot install must not return.
+
+        The refusal is only reachable where installation genuinely
+        fails. A host without a resolvable vLLM integration point
+        satisfies that condition, and the probe reports the integration
+        point before it enables the mode.
+        """
+
+        probe = """
+            import importlib.metadata
+            import os
+
+            from sparkring._compat import compat_report
+
+            if compat_report()["ok"]:
+                print("VLLM-INTEGRATION-PRESENT")
+                raise SystemExit(0)
+
+            os.environ["VLLM_SPARK_TP4_MODE"] = "shadow"
+            entry_points = importlib.metadata.entry_points(
+                group="vllm.general_plugins"
+            )
+            matches = [e for e in entry_points if e.name == "sparkring"]
+            assert len(matches) == 1, f"entry points: {entry_points}"
+            matches[0].load()()
+            print("REGISTER-RETURNED")
+            """
+        check = self._run_probe(probe)
+        if "VLLM-INTEGRATION-PRESENT" in check.stdout:
+            self.skipTest(
+                "this host resolves the vLLM integration point, so "
+                "mode-set register() is not forced to fail here"
+            )
+        self.assertEqual(
+            check.returncode, 78,
+            f"stdout {check.stdout[-2000:]!r}, "
+            f"stderr {check.stderr[-2000:]!r}",
+        )
+        self.assertIn("FATAL", check.stderr)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Resulting behavior

The vLLM plugin gains the offline evidence it lacks, and the bytes it ships
become verifiable from the host that installs it. Plugin suite goes from 29
tests to 48.

**Integrity.** `sync_vendor.py` writes `_vendor/MANIFEST.json` recording the
SHA-256 of every vendored module, and `sparkring-preflight` gains a
`vendor-integrity` check that verifies it. The runtime overlay proves per-file
integrity on a serving rank through `runtime/verify-runtime.py`; the plugin has
no equivalent, because `test_vendor_parity.py` compares against a source tree a
wheel does not carry and self-skips when it is absent — exactly the
pip-installed case. Without this, a live result cannot be attributed to a known
set of bytes.

**Byte stability.** `.gitattributes` pins the vendored modules and the sources
they copy to `eol=lf`. Both the parity test and the manifest compare raw bytes,
and a CRLF checkout makes a vendored copy differ from its source on Windows
while `git diff --no-index` reports nothing. That is the parity failure
`CONTRIBUTING.md` describes as a Windows artifact; pinning removes the
difference rather than tolerating it, and makes the manifest describe the same
bytes on every platform.

**Refusal contract.** `register()` exiting 78 with a mode set is what stops
vLLM serving with a half-installed transport, and it had no coverage because
`os._exit` cannot be observed in-process. A subprocess suite asserts exit 78
for a core mode, an invalid mode, and a family mode set alone; exit 0 for
`disabled` and for no mode; and that the diagnostic names the integration point
it could not resolve.

**Closure.** A test parses every vendored module with `ast` and requires each
intra-project import to be in `MODULES` or in a named allowlist of the four
deliberate external seams, so "authoritative closure manifest" is enforced
rather than asserted. A second test imports all sixteen modules with torch and
vLLM unreachable, pinning the deferred-import discipline that lets the wheel
install without them.

**Diagnostics.** A query-row provider raising anything other than `ValueError`
propagates out of `run_preflight`, so `--json` prints nothing — no partial
results, no `Check` array — for the failure most likely in the field. Every
check now returns a diagnostic. The `--connect` peer path, previously
uncovered, gains tests against a loopback listener and a closed port.

**Packaging.** `test_wheel.py` builds with `--no-build-isolation`, so the suite
stays inside the checkout and matches the OFFLINE class `AGENTS.md:88` assigns
it; PEP 517 isolation otherwise fetches `setuptools>=68` from an index. It also
exercises the installed console script and the mode-set refusal against the
built artifact rather than the checkout.

## Scope

The plugin remains `offline-validated`. None of this establishes that it forms
a ring, that vLLM invokes `register()` at the right point in every worker
process, or that it is numerically correct. Those require the live legs.

Separately verified while preparing this, and worth recording: upstream vLLM
`v0.27.1` declares `CudaCommunicator.all_reduce(self, input_)` with two
parameters and no decorators, which is what `_compat.py` requires. That is the
first check of the gate against a real vLLM rather than a synthetic module.

## Validation

`ruff` clean. `python -m pytest sparkring_plugin -q` → 48 passed.
`python -m pytest spark_transport sparkcache runtime scripts -q` → 3179 passed,
19 skipped.

The manifest was verified against the **committed blob bytes** rather than the
working copy. An earlier iteration hashed the Windows working tree and would
have mismatched all sixteen modules on a POSIX checkout; the committed state
matches on both.