### PR TITLE
Scope the tiered graph transport's width claim to graph capture

### DIFF
--- a/spark_transport/TIERED_DEFERRED_GRAPH.md
+++ b/spark_transport/TIERED_DEFERRED_GRAPH.md
@@ -6,8 +6,15 @@ The sequential two-slot deferred-credit protocol plus the tiered 64-KiB graph
 kernel is **live-validated** in the operator-accepted four-Spark EXL3 3.5-bpw
 profile (R7). It serves TP4 BF16 all-reduce shapes from Q1 through Q40. The public
 source is hardware-specific: it assumes four ranks, two directly attached
-ConnectX-7 edges per rank, CUDA architecture SM121, and the GLM hidden width
-6,144.
+ConnectX-7 edges per rank, and CUDA architecture SM121.
+
+Hidden width is a qualification scope, not a source assumption. Eager
+admission is width-generic behind `VLLM_SPARK_TP4_EAGER_WIDTHS`, described in
+the [vLLM integration README](integrations/vllm/README.md); the
+DeepSeek-V4-Flash-0731 profile admits width 4096, and the shadow validation set
+exercises widths 512 through 2048. What is qualified only at the GLM hidden
+width of 6,144 is CUDA-graph capture: the graph paths in the accepted profiles
+capture that width alone, and any other width is research-only.
 
 The dual-port striped schedule and the prefill-capacity pool are
 **research-only** and default off. They are included because the vLLM adapter


### PR DESCRIPTION
## Resulting behavior

The transport's status section separates the hardware properties the public
source assumes from the width at which it is qualified.

## Technical reason

The section listed "the GLM hidden width 6,144" alongside four ranks, two
ConnectX-7 edges per rank, and SM121, as though all four were source-level
assumptions. Three are. Width is not.

Eager admission is width-generic behind `VLLM_SPARK_TP4_EAGER_WIDTHS`
(`spark_transport/integrations/vllm/README.md`). `docs/profiles/README.md`
states the same, the DeepSeek-V4-Flash-0731 profile admits width 4096 in the
operator deployment, and the shadow validation set exercises 512, 768, 1024,
and 2048.

Confirmed directly: a four-Spark deployment at width 768 opened eager sessions
on all four ranks through this transport and served a completion — recorded in
`docs/PLUGIN_LIVE_VALIDATION_20260820.md` on the plugin branch. A reader
following the text as written would conclude the source cannot carry that shape.

What is qualified at 6,144 alone is CUDA-graph capture: the graph paths in the
accepted profiles capture that width and no other, which
`docs/profiles/DEEPSEEK_V4_FLASH_0731.md` already states from the profile side.

## Compatibility

Documentation only. No source, admission bound, or qualification changes.

## Validation

Repo-relative Markdown link and anchor check, ruff, and the offline pytest
suites.