### PR TITLE
Replace deployment fabric addresses in the ring-doctor fixtures

### DIFF
--- a/scripts/test_ring_doctor.py
+++ b/scripts/test_ring_doctor.py
@@ -116,20 +116,20 @@ class AddressAndTopologyTests(unittest.TestCase):
         observations = {
             "r0": observation(
                 "r0",
-                f"{IF0} UP 192.168.101.10/24\n"
-                f"{IF1} UP 192.168.200.12/24",
+                f"{IF0} UP 10.0.1.10/24\n"
+                f"{IF1} UP 10.0.4.12/24",
                 hostname="spark-edfd",
             ),
             "r1": observation(
                 "r1",
-                f"{IF0} UP 192.168.102.10/24\n"
-                f"{IF1} UP 192.168.101.11/24",
+                f"{IF0} UP 10.0.2.10/24\n"
+                f"{IF1} UP 10.0.1.11/24",
                 hostname="spark-ebb8",
             ),
             "r2": observation(
                 "r2",
-                f"{IF0} UP 192.168.103.11/24\n"
-                f"{IF1} UP 192.168.102.11/24",
+                f"{IF0} UP 10.0.3.11/24\n"
+                f"{IF1} UP 10.0.2.11/24",
                 hostname="spark-ebee",
             ),
             "r3": observation("r3", "", reachable=False),
@@ -142,11 +142,11 @@ class AddressAndTopologyTests(unittest.TestCase):
         self.assertEqual(adjacency["r2"], {"r1"})
         self.assertNotIn("r3", adjacency)
         self.assertEqual(
-            subnet_nodes[ipaddress.ip_network("192.168.101.0/24")],
+            subnet_nodes[ipaddress.ip_network("10.0.1.0/24")],
             ("r0", "r1"),
         )
         self.assertEqual(
-            subnet_nodes[ipaddress.ip_network("192.168.200.0/24")], ("r0",)
+            subnet_nodes[ipaddress.ip_network("10.0.4.0/24")], ("r0",)
         )
 
     def test_cycle_validation_accepts_cycle_and_rejects_path(self) -> None:
@@ -240,18 +240,18 @@ class PartialDiscoveryTests(unittest.TestCase):
         outputs = {
             "operator@r0": probe_output(
                 "spark-edfd",
-                f"{IF0} UP 192.168.101.10/24\n"
-                f"{IF1} UP 192.168.200.12/24",
+                f"{IF0} UP 10.0.1.10/24\n"
+                f"{IF1} UP 10.0.4.12/24",
             ),
             "operator@r1": probe_output(
                 "spark-ebb8",
-                f"{IF0} UP 192.168.102.10/24\n"
-                f"{IF1} UP 192.168.101.11/24",
+                f"{IF0} UP 10.0.2.10/24\n"
+                f"{IF1} UP 10.0.1.11/24",
             ),
             "operator@r2": probe_output(
                 "spark-ebee",
-                f"{IF0} UP 192.168.103.11/24\n"
-                f"{IF1} UP 192.168.102.11/24",
+                f"{IF0} UP 10.0.3.11/24\n"
+                f"{IF1} UP 10.0.2.11/24",
             ),
         }
         runner = FakeDiscoveryRunner(outputs, {"operator@r3"})


### PR DESCRIPTION
## Resulting behavior

`main` passes the blocking release-safety job.

## Technical reason

`scripts/test_ring_doctor.py` carries fourteen literals of the four-Spark
deployment's own per-link fabric addressing. The release-safety job treats that
RFC1918 shape as blocking, so the gate fails on `main` and on every branch taken
from it, including branches whose own diff contains no such literal.

At the last commit where the job passed, the pattern has zero matches across the
tracked tree; with these fixtures present it has fourteen, all in this one file.

Two problems are independent: a public repository should not carry the
deployment's addressing, and a red blocking gate on `main` obstructs unrelated
work while training reviewers to expect red.

## What changed

The fixtures address their links in `10.0.0.0/8`, matching the `synthetic_cycle`
fixture in the same file. The job's own comment classifies bare `10.x` as
illustrative rather than blocking, and `docs/SETUP.md` uses it for placeholder
examples.

Every adjacency, host octet, cage assignment, and subnet relationship the
assertions depend on is preserved; only the network prefix differs. The five
tests pass unchanged.

## Validation

All four blocking patterns return zero hits across the tracked tree, checked
with the job's own expressions. `ruff` clean.
`python -m pytest scripts -q` → 1515 passed, 9 skipped.