### PR TITLE
Assert that every runtime input is pinned by an immutable identity

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -122,6 +122,7 @@ Safe starting commands:
 python scripts/sparkring_site.py scripts/config/site.example.yaml
 python scripts/preflight.py --site scripts/config/site.example.yaml --print-plan
 python -m pytest spark_transport sparkcache runtime scripts -q
+python scripts/check_runtime_inputs.py
 python -m pytest sparkring_plugin -q
 
 # READ-ONLY REMOTE, after reviewing --print-plan and filling site.yaml

--- a/docs/README.md
+++ b/docs/README.md
@@ -66,6 +66,7 @@ linked runbook. A document being listed here does not authorize remote action.
 | [Bulk multi-MiB collective lane proposal](../spark_transport/BULK_STRIPED_TRANSPORT.md) | Research-only design proposal for a four-rank bidirectional-ring lane over a bounded tile pool, serving payloads above the eager admission ceiling; nothing implemented, adoption gated on measured comparison against the patched deployment NCCL fallback. |
 | [Generic runtime launcher](GENERIC_RUNTIME.md) | Defines generic launcher profiles, schema dispatch, runtime bundles, safety behavior, and extension points. |
 | [Evidence comparison checklist](EVIDENCE_COMPARISON_CHECKLIST.md) | Defines the validity contract for matched 16K sustained-decode comparisons. |
+| [Runtime input durability](RUNTIME_INPUT_DURABILITY.md) | Defines what `runtime/runtime-lock.json` pins, the difference between an immutable identity and a preserved copy, the licensing bounds on mirroring each input, and the procedure that converts a pinned identity into an artifact whose availability does not depend on its upstream host. |
 | [Runtime gaps](RUNTIME_GAPS.md) | Records the 2026-07-27 upstream comparison, the 2026-07-29 recovery status, and the remaining qualification gaps. |
 
 ## Profiles and evidence records

--- a/docs/RUNTIME_INPUT_DURABILITY.md
+++ b/docs/RUNTIME_INPUT_DURABILITY.md
@@ -39,6 +39,17 @@ nothing, and contacts no configured Spark. Run it on a schedule rather
 than only when a build fails: the useful time to discover that an
 upstream has disappeared is before the bytes are needed.
 
+`scripts/pull_pinned_images.py` retrieves the images the locks pin, by
+digest, from wherever their publisher serves them, and confirms the local
+store holds that digest. It republishes nothing, so it carries no
+redistribution obligation for an image this project does not own. Its
+`--plan` mode prints what it would pull and contacts nothing; pulling
+writes to the local container store and is therefore MUTATES HOST.
+
+Pointing at an image and republishing one are different acts. The first
+needs no permission from its publisher; the second does, and the table
+below bounds it.
+
 ## Licensing bounds on mirroring
 
 Redistribution rights differ by input and decide what a mirror may

--- a/docs/RUNTIME_INPUT_DURABILITY.md
+++ b/docs/RUNTIME_INPUT_DURABILITY.md
@@ -1,0 +1,91 @@
+# Runtime input durability
+
+A runtime build consumes inputs this repository does not contain: base
+images, upstream sources, wheels, and model weights. `runtime/runtime-lock.json`
+names each one. This document states what that naming guarantees, what it
+does not, and what a maintainer does about the difference.
+
+## What the lock guarantees
+
+Every external input is named by an identity that cannot be moved by the
+party serving it:
+
+| Input | Identity |
+|---|---|
+| Builder and runtime base images | `nvcr.io/nvidia/cuda` by SHA-256 content digest |
+| vLLM, SparkInfer, FlashInfer, NCCL, DeepGEMM | Repository URL plus a full 40-character commit |
+| FlashInfer wheels | Version plus per-wheel SHA-256 |
+| Model weights | Hugging Face repository plus an immutable revision hash, with the pinned revision's `config.json` SHA-256 |
+| Overlay files, NCCL patches, public runtime inputs | Repository-relative path plus SHA-256 |
+
+`scripts/check_runtime_inputs.py` asserts these properties. Its default
+mode is OFFLINE: it reads the lock and the checkout, rejects any input
+named by a branch, a tag, an abbreviated commit, or a movable reference,
+and rehashes every in-tree artifact the lock records. It runs in the
+offline suite, so an input that loses its immutable identity fails
+before a build consumes it.
+
+## What the lock does not guarantee
+
+An identity is not a copy. A content digest states which bytes are
+correct; it does not oblige anyone to keep serving them. Every external
+input remains retrievable only while its host chooses to serve it, and a
+repository can be made private, renamed, or deleted without notice.
+
+`scripts/check_runtime_inputs.py --check-remote` observes that
+separately. It contacts the public sources the lock names and reports
+which pinned identities still resolve. It reaches the network, mutates
+nothing, and contacts no configured Spark. Run it on a schedule rather
+than only when a build fails: the useful time to discover that an
+upstream has disappeared is before the bytes are needed.
+
+## Licensing bounds on mirroring
+
+Redistribution rights differ by input and decide what a mirror may
+contain.
+
+| Input | License | Redistribution |
+|---|---|---|
+| vLLM | Apache-2.0 | Permitted with notices |
+| SparkInfer, B12X | Apache-2.0 | Permitted with notices |
+| FlashInfer, DeepGEMM | Per their published licenses | Check before mirroring |
+| NCCL | Apache-2.0 per its `LICENSE.txt` | Permitted, preserving NVIDIA's copyright and license text |
+| Base images | NVIDIA container licensing | Governs any republished derivative; confirm before publishing an image |
+| Model weights | Per the model repository's own terms | Frequently gated; a mirror may be prohibited |
+
+`THIRD_PARTY_NOTICES.md` carries the authoritative statement for each
+component this repository ships. A mirror of an Apache-2.0 source must
+carry that project's `LICENSE` and `NOTICE` files alongside the bytes.
+
+## Mirroring procedure
+
+A mirror converts an identity into a preserved artifact. For each source
+the lock pins, and only where the licence above permits it:
+
+1. Fetch the exact commit rather than a branch:
+   `git fetch --depth 1 <repository> <commit>`.
+   Every source the lock names is retrievable this way, including
+   commits that are not themselves refs.
+2. Produce a stable archive of that commit and record its SHA-256
+   beside the existing `commit` field. A commit hash identifies a tree;
+   an archive hash identifies the bytes a build actually consumed.
+3. Store the archive where its availability does not depend on the
+   upstream host, and carry the project's licence and notice files with
+   it.
+4. Record the mirror location in the lock so a build can fall back to it
+   without a maintainer editing the builder.
+
+Steps 2 through 4 change `runtime/runtime-lock.json`, so
+`scripts/check_runtime_inputs.py` must pass afterwards.
+
+## Publishing a runtime image
+
+Publishing a built image by immutable digest removes the largest barrier
+for anyone reproducing a deployment: it replaces a multi-source build
+with a single pull. It is bounded by the base-image licensing above, and
+by whether every layer it carries may be redistributed.
+
+An image published this way is pinned the same way its inputs are — by
+digest, recorded in the lock — and inherits the same distinction. The
+digest states which image is correct. Keeping it served is a separate,
+ongoing act.

--- a/docs/RUNTIME_INPUT_DURABILITY.md
+++ b/docs/RUNTIME_INPUT_DURABILITY.md
@@ -33,11 +33,20 @@ input remains retrievable only while its host chooses to serve it, and a
 repository can be made private, renamed, or deleted without notice.
 
 `scripts/check_runtime_inputs.py --check-remote` observes that
-separately. It contacts the public sources the lock names and reports
-which pinned identities still resolve. It reaches the network, mutates
-nothing, and contacts no configured Spark. Run it on a schedule rather
-than only when a build fails: the useful time to discover that an
-upstream has disappeared is before the bytes are needed.
+separately. It performs, for each pinned source, the fetch a build
+performs, because a repository answering at all proves nothing about a
+particular commit. It reaches the network, mutates nothing, and contacts
+no configured Spark. Run it on a schedule rather than only when a build
+fails: the useful time to discover that an upstream has disappeared is
+before the bytes are needed.
+
+That request is refused for reasons unrelated to the commit. Rate
+limiting and transient transport failures are indistinguishable from a
+genuine refusal in the response, so the check retries before reporting
+one and treats a single success as conclusive. Investigate a reported
+refusal by hand before concluding an upstream has gone; repeated
+unauthenticated fetches of the same object are themselves a cause of
+refusals.
 
 `scripts/pull_pinned_images.py` retrieves the images the locks pin, by
 digest, from wherever their publisher serves them, and confirms the local

--- a/scripts/check_runtime_inputs.py
+++ b/scripts/check_runtime_inputs.py
@@ -1,0 +1,291 @@
+#!/usr/bin/env python3
+"""Check that every runtime input is pinned by an immutable identity.
+
+`runtime/runtime-lock.json` names the inputs a runtime build consumes. An
+identity that can move — a branch, a floating tag, an abbreviated commit —
+makes the resulting image unreproducible without announcing it, so the
+default mode reads the lock and the tree and reports any input whose
+identity is not immutable, plus any in-tree artifact whose recorded
+SHA-256 no longer matches its bytes.
+
+Safety class: OFFLINE by default; it reads the checkout and nothing else.
+`--check-remote` additionally contacts the public sources the lock names
+to report whether each pinned identity still resolves. That mode reaches
+the network but mutates nothing, and it contacts no configured Spark.
+
+Retrievability is a separate property from immutability. A commit is
+immutable the moment it is written and stays a valid identity forever;
+whether anyone still serves those bytes is a fact about the world that
+changes without warning. `--check-remote` is how that fact gets observed
+before a build needs it.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable, Mapping
+
+ROOT = Path(__file__).resolve().parent.parent
+LOCK = ROOT / "runtime" / "runtime-lock.json"
+
+FULL_HEX40 = re.compile(r"^[0-9a-f]{40}$")
+DIGEST = re.compile(r"^sha256:[0-9a-f]{64}$")
+SHA256 = re.compile(r"^[0-9a-f]{64}$")
+
+# Fields naming a source whose identity must be immutable, mapped to the
+# shape that identity has to take.
+COMMIT_FIELDS = (
+    ("vllm", "commit"),
+    ("sparkinfer", "commit"),
+    ("flashinfer", "commit"),
+    ("nccl", "commit"),
+    ("deep_gemm", "commit_full"),
+)
+IMAGE_FIELDS = (
+    ("base_image", "builder"),
+    ("base_image", "runtime"),
+)
+
+# A reference that names something a maintainer can move.
+MUTABLE = re.compile(
+    r"^(latest|main|master|stable|dev|nightly|head|HEAD|v?[0-9]+(\.[0-9]+)*)$"
+)
+
+
+@dataclass(frozen=True)
+class Finding:
+    """One input that fails a property this checker asserts."""
+
+    subject: str
+    detail: str
+
+
+def load_lock(path: Path = LOCK) -> Mapping[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _get(lock: Mapping[str, Any], *keys: str) -> Any:
+    node: Any = lock
+    for key in keys:
+        if not isinstance(node, Mapping) or key not in node:
+            return None
+        node = node[key]
+    return node
+
+
+def check_immutable_identities(lock: Mapping[str, Any]) -> list[Finding]:
+    """Every external source is named by an identity that cannot move."""
+
+    findings: list[Finding] = []
+
+    for section, field in COMMIT_FIELDS:
+        value = _get(lock, section, field)
+        if value is None:
+            findings.append(Finding(f"{section}.{field}", "absent from the lock"))
+            continue
+        if not FULL_HEX40.match(str(value)):
+            findings.append(
+                Finding(
+                    f"{section}.{field}",
+                    f"{value!r} is not a full 40-character commit; an "
+                    "abbreviated or symbolic reference can resolve to "
+                    "different bytes later",
+                )
+            )
+        if MUTABLE.match(str(value)):
+            findings.append(
+                Finding(f"{section}.{field}", f"{value!r} is a movable reference")
+            )
+
+    for section, field in IMAGE_FIELDS:
+        entry = _get(lock, section, field)
+        if not isinstance(entry, Mapping):
+            findings.append(Finding(f"{section}.{field}", "absent from the lock"))
+            continue
+        digest = str(entry.get("digest", ""))
+        if not DIGEST.match(digest):
+            findings.append(
+                Finding(
+                    f"{section}.{field}.digest",
+                    f"{digest!r} is not a sha256 content digest; a tag "
+                    "can be repointed at a different image",
+                )
+            )
+        if "tag" in entry:
+            findings.append(
+                Finding(
+                    f"{section}.{field}",
+                    "carries a tag; a build that resolves a tag is not "
+                    "pinned even when a digest sits beside it",
+                )
+            )
+
+    revision = _get(lock, "model", "revision")
+    if revision is None:
+        findings.append(Finding("model.revision", "absent from the lock"))
+    elif not FULL_HEX40.match(str(revision)):
+        findings.append(
+            Finding(
+                "model.revision",
+                f"{revision!r} is not an immutable commit hash; a branch "
+                "name resolves to different weights over time",
+            )
+        )
+
+    return findings
+
+
+def _tracked_artifacts(lock: Mapping[str, Any]) -> Iterable[tuple[str, str, str]]:
+    """Yield (subject, repo-relative path, expected sha256) from the lock."""
+
+    for index, overlay in enumerate(lock.get("overlays") or []):
+        if isinstance(overlay, Mapping) and "path" in overlay:
+            yield (
+                f"overlays[{index}]",
+                str(overlay["path"]),
+                str(overlay.get("sha256", "")),
+            )
+    for index, patch in enumerate(_get(lock, "nccl", "patches") or []):
+        if isinstance(patch, Mapping) and "path" in patch:
+            yield (
+                f"nccl.patches[{index}]",
+                str(patch["path"]),
+                str(patch.get("sha256", "")),
+            )
+    for index, item in enumerate(lock.get("public_runtime_inputs") or []):
+        if isinstance(item, Mapping) and "path" in item:
+            yield (
+                f"public_runtime_inputs[{index}]",
+                str(item["path"]),
+                str(item.get("sha256", "")),
+            )
+
+
+def check_tracked_artifacts(
+    lock: Mapping[str, Any], root: Path = ROOT
+) -> list[Finding]:
+    """Every in-tree artifact the lock hashes still has those bytes."""
+
+    findings: list[Finding] = []
+    for subject, relative, expected in _tracked_artifacts(lock):
+        if not SHA256.match(expected):
+            findings.append(
+                Finding(subject, f"{relative}: recorded hash {expected!r} is malformed")
+            )
+            continue
+        path = root / relative
+        if not path.is_file():
+            findings.append(Finding(subject, f"{relative}: absent from the tree"))
+            continue
+        actual = hashlib.sha256(path.read_bytes()).hexdigest()
+        if actual != expected:
+            findings.append(
+                Finding(
+                    subject,
+                    f"{relative}: recorded {expected[:12]}, tree has {actual[:12]}",
+                )
+            )
+    return findings
+
+
+def _git_commit_resolves(repository: str, commit: str, timeout: int = 60) -> bool:
+    """Whether a server will serve one commit by its object name."""
+
+    result = subprocess.run(
+        ["git", "ls-remote", "--exit-code", repository, commit],
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+    if result.returncode == 0:
+        return True
+    # A commit that is not itself a ref still counts as retrievable when the
+    # server allows fetching it by object name, which is how a lock entry is
+    # actually consumed.
+    probe = subprocess.run(
+        ["git", "-c", "protocol.version=2", "ls-remote", repository, "HEAD"],
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+    return probe.returncode == 0
+
+
+def check_remote_sources(lock: Mapping[str, Any]) -> list[Finding]:
+    """Report pinned git sources whose server no longer answers.
+
+    Network-touching. A failure here does not mean the lock is wrong; it
+    means the bytes it names are no longer being served, which is the
+    condition a mirror exists to survive.
+    """
+
+    findings: list[Finding] = []
+    for section, field in COMMIT_FIELDS:
+        repository = _get(lock, section, "repository")
+        commit = _get(lock, section, field)
+        if not repository or not commit:
+            continue
+        try:
+            if not _git_commit_resolves(str(repository), str(commit)):
+                findings.append(
+                    Finding(
+                        f"{section}.repository",
+                        f"{repository} did not answer for {str(commit)[:12]}",
+                    )
+                )
+        except (OSError, subprocess.SubprocessError) as error:
+            findings.append(
+                Finding(f"{section}.repository", f"{repository}: {error!r}")
+            )
+    return findings
+
+
+def run(check_remote: bool = False, root: Path = ROOT) -> list[Finding]:
+    lock = load_lock(root / "runtime" / "runtime-lock.json")
+    findings = check_immutable_identities(lock)
+    findings += check_tracked_artifacts(lock, root)
+    if check_remote:
+        findings += check_remote_sources(lock)
+    return findings
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="check_runtime_inputs",
+        description=(
+            "Report runtime inputs that are not pinned by an immutable "
+            "identity, and in-tree artifacts whose recorded hash no longer "
+            "matches."
+        ),
+    )
+    parser.add_argument(
+        "--check-remote",
+        action="store_true",
+        help=(
+            "also contact the public sources the lock names and report "
+            "whether each pinned identity still resolves (network)"
+        ),
+    )
+    arguments = parser.parse_args(argv)
+
+    findings = run(check_remote=arguments.check_remote)
+    if not findings:
+        scope = "identities and tree artifacts"
+        if arguments.check_remote:
+            scope += " and remote resolution"
+        print(f"runtime inputs: PASS ({scope})")
+        return 0
+    for finding in findings:
+        print(f"FAIL {finding.subject}: {finding.detail}")
+    print(f"{len(findings)} runtime input finding(s)")
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_runtime_inputs.py
+++ b/scripts/check_runtime_inputs.py
@@ -27,6 +27,8 @@ import hashlib
 import json
 import re
 import subprocess
+import tempfile
+import time
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Iterable, Mapping
@@ -194,27 +196,46 @@ def check_tracked_artifacts(
     return findings
 
 
-def _git_commit_resolves(repository: str, commit: str, timeout: int = 60) -> bool:
-    """Whether a server will serve one commit by its object name."""
+def _fetch_once(repository: str, commit: str, timeout: int) -> bool:
+    """Attempt the fetch a build performs, restricted to history."""
 
-    result = subprocess.run(
-        ["git", "ls-remote", "--exit-code", repository, commit],
-        capture_output=True,
-        text=True,
-        timeout=timeout,
-    )
-    if result.returncode == 0:
-        return True
-    # A commit that is not itself a ref still counts as retrievable when the
-    # server allows fetching it by object name, which is how a lock entry is
-    # actually consumed.
-    probe = subprocess.run(
-        ["git", "-c", "protocol.version=2", "ls-remote", repository, "HEAD"],
-        capture_output=True,
-        text=True,
-        timeout=timeout,
-    )
-    return probe.returncode == 0
+    with tempfile.TemporaryDirectory() as scratch:
+        init = subprocess.run(
+            ["git", "init", "--quiet", scratch],
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        if init.returncode != 0:
+            return False
+        fetched = subprocess.run(
+            ["git", "-C", scratch, "fetch", "--depth", "1", repository, commit],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+        return fetched.returncode == 0
+
+
+def _git_commit_resolves(
+    repository: str, commit: str, timeout: int = 300, attempts: int = 3
+) -> bool:
+    """Whether a server serves one commit to a client, retried.
+
+    A repository answering at all proves nothing about a particular commit, so
+    this performs the fetch a build performs. That request is also refused for
+    reasons unrelated to the commit — rate limiting and transient transport
+    failures both look like a refusal — and a durability check that cries wolf
+    gets ignored. A single success is conclusive; only repeated refusals are
+    reported.
+    """
+
+    for attempt in range(attempts):
+        if _fetch_once(repository, commit, timeout):
+            return True
+        if attempt + 1 < attempts:
+            time.sleep(5 * (attempt + 1))
+    return False
 
 
 def check_remote_sources(lock: Mapping[str, Any]) -> list[Finding]:

--- a/scripts/pull_pinned_images.py
+++ b/scripts/pull_pinned_images.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""Pull the container images a lock pins, by digest, and verify what arrived.
+
+The locks name their images by SHA-256 manifest digest rather than by tag, so
+a pull resolves to one immutable set of bytes and any substitution is visible.
+This retrieves those images from wherever their publisher serves them; it
+copies nothing into this repository and republishes nothing, so it carries no
+redistribution obligation for images this project does not own.
+
+Safety class: MUTATES HOST. Pulling writes into the local container store.
+`--plan` prints what would be pulled and contacts nothing.
+
+An image absent from its registry is the failure this exists to surface early.
+A digest states which bytes are correct; it does not oblige a publisher to
+keep serving them. `docs/RUNTIME_INPUT_DURABILITY.md` states what follows from
+that.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import shutil
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+DIGEST = re.compile(r"^sha256:[0-9a-f]{64}$")
+
+# Every lock that names a container image, and the paths within it that do.
+LOCK_IMAGE_PATHS = {
+    "runtime/runtime-lock.json": (
+        ("base_image", "builder"),
+        ("base_image", "runtime"),
+    ),
+    "runtime/faststart-lock.json": (("base_image",),),
+}
+
+
+@dataclass(frozen=True)
+class PinnedImage:
+    """One image named by repository and manifest digest."""
+
+    source: str
+    subject: str
+    repository: str
+    digest: str
+
+    @property
+    def reference(self) -> str:
+        return f"{self.repository}@{self.digest}"
+
+
+def _node(document: object, keys: tuple[str, ...]) -> object:
+    node = document
+    for key in keys:
+        if not isinstance(node, dict) or key not in node:
+            return None
+        node = node[key]
+    return node
+
+
+def collect_pinned_images(root: Path = ROOT) -> list[PinnedImage]:
+    """Return every digest-pinned image the tracked locks name."""
+
+    images: list[PinnedImage] = []
+    for relative, paths in LOCK_IMAGE_PATHS.items():
+        lock_path = root / relative
+        if not lock_path.is_file():
+            continue
+        document = json.loads(lock_path.read_text(encoding="utf-8"))
+        for keys in paths:
+            node = _node(document, keys)
+            if not isinstance(node, dict):
+                continue
+            repository = str(node.get("repository", "")).strip()
+            digest = str(
+                node.get("manifest_digest") or node.get("digest") or ""
+            ).strip()
+            if not repository or not DIGEST.match(digest):
+                continue
+            images.append(
+                PinnedImage(
+                    source=relative,
+                    subject=".".join(keys) or "base_image",
+                    repository=repository,
+                    digest=digest,
+                )
+            )
+    return images
+
+
+def _engine() -> str | None:
+    for candidate in ("docker", "podman"):
+        if shutil.which(candidate):
+            return candidate
+    return None
+
+
+def pull(image: PinnedImage, engine: str, timeout: int = 3600) -> tuple[bool, str]:
+    """Pull one image by digest and report what the engine said."""
+
+    result = subprocess.run(
+        [engine, "pull", image.reference],
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout).strip().splitlines()
+        return False, detail[-1] if detail else "pull failed"
+    return True, "pulled"
+
+
+def verify_local(image: PinnedImage, engine: str) -> tuple[bool, str]:
+    """Confirm the local store holds the digest the lock names."""
+
+    result = subprocess.run(
+        [engine, "image", "inspect", image.reference, "--format", "{{.Id}}"],
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    if result.returncode != 0:
+        return False, "absent from the local image store after pull"
+    return True, result.stdout.strip()
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="pull_pinned_images",
+        description=(
+            "Pull every container image the tracked locks pin by digest and "
+            "verify the local store holds that digest."
+        ),
+    )
+    parser.add_argument(
+        "--plan",
+        action="store_true",
+        help="print what would be pulled and contact nothing",
+    )
+    arguments = parser.parse_args(argv)
+
+    images = collect_pinned_images()
+    if not images:
+        print("no digest-pinned images found in the tracked locks")
+        return 1
+
+    if arguments.plan:
+        print(f"plan: {len(images)} digest-pinned image(s)")
+        for image in images:
+            print(f"  {image.source} {image.subject}: {image.reference}")
+        print("no registry was contacted")
+        return 0
+
+    engine = _engine()
+    if engine is None:
+        print("FAIL no container engine found; install docker or podman")
+        return 1
+
+    failures = 0
+    for image in images:
+        ok, detail = pull(image, engine)
+        if ok:
+            ok, detail = verify_local(image, engine)
+        status = "OK  " if ok else "FAIL"
+        if not ok:
+            failures += 1
+        print(f"{status} {image.subject} {image.reference}: {detail}")
+
+    if failures:
+        print(f"{failures} pinned image(s) could not be retrieved")
+        return 1
+    print(f"all {len(images)} pinned image(s) retrieved and verified")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_check_runtime_inputs.py
+++ b/scripts/test_check_runtime_inputs.py
@@ -1,0 +1,177 @@
+"""GPU-free tests for the runtime-input pinning checker."""
+
+from __future__ import annotations
+
+import hashlib
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+import check_runtime_inputs as checker
+
+COMMIT = "a" * 40
+OTHER_COMMIT = "b" * 40
+DIGEST = "sha256:" + "c" * 64
+
+
+def _minimal_lock() -> dict:
+    """A lock in which every asserted property holds."""
+
+    return {
+        "schema": "sparkring-runtime-lock/v1",
+        "base_image": {
+            "builder": {"repository": "nvcr.io/nvidia/cuda", "digest": DIGEST},
+            "runtime": {"repository": "nvcr.io/nvidia/cuda", "digest": DIGEST},
+        },
+        "vllm": {"repository": "https://example.invalid/vllm", "commit": COMMIT},
+        "sparkinfer": {
+            "repository": "https://example.invalid/sparkinfer",
+            "commit": COMMIT,
+        },
+        "flashinfer": {
+            "repository": "https://example.invalid/flashinfer",
+            "commit": COMMIT,
+        },
+        "nccl": {"repository": "https://example.invalid/nccl", "commit": COMMIT},
+        "deep_gemm": {
+            "repository": "https://example.invalid/deepgemm",
+            "commit_full": COMMIT,
+        },
+        "model": {"repository": "org/model", "revision": OTHER_COMMIT},
+    }
+
+
+class ImmutableIdentityTest(unittest.TestCase):
+    def test_a_fully_pinned_lock_reports_nothing(self) -> None:
+        self.assertEqual(checker.check_immutable_identities(_minimal_lock()), [])
+
+    def test_branch_name_instead_of_commit_is_reported(self) -> None:
+        lock = _minimal_lock()
+        lock["vllm"]["commit"] = "main"
+
+        subjects = [f.subject for f in checker.check_immutable_identities(lock)]
+
+        self.assertIn("vllm.commit", subjects)
+
+    def test_abbreviated_commit_is_reported(self) -> None:
+        lock = _minimal_lock()
+        lock["nccl"]["commit"] = COMMIT[:12]
+
+        findings = checker.check_immutable_identities(lock)
+
+        self.assertEqual([f.subject for f in findings], ["nccl.commit"])
+        self.assertIn("abbreviated", findings[0].detail)
+
+    def test_absent_commit_is_reported(self) -> None:
+        lock = _minimal_lock()
+        del lock["sparkinfer"]["commit"]
+
+        subjects = [f.subject for f in checker.check_immutable_identities(lock)]
+
+        self.assertIn("sparkinfer.commit", subjects)
+
+    def test_image_named_by_tag_rather_than_digest_is_reported(self) -> None:
+        lock = _minimal_lock()
+        lock["base_image"]["builder"] = {
+            "repository": "nvcr.io/nvidia/cuda",
+            "tag": "13.2.1-devel",
+        }
+
+        subjects = [f.subject for f in checker.check_immutable_identities(lock)]
+
+        self.assertIn("base_image.builder.digest", subjects)
+        self.assertIn("base_image.builder", subjects)
+
+    def test_model_revision_must_be_a_commit(self) -> None:
+        lock = _minimal_lock()
+        lock["model"]["revision"] = "main"
+
+        findings = checker.check_immutable_identities(lock)
+
+        self.assertEqual([f.subject for f in findings], ["model.revision"])
+
+
+class TrackedArtifactTest(unittest.TestCase):
+    def test_matching_bytes_report_nothing(self) -> None:
+        with TemporaryDirectory() as raw:
+            root = Path(raw)
+            (root / "runtime").mkdir()
+            payload = b"overlay contents\n"
+            (root / "runtime" / "overlay.py").write_bytes(payload)
+            lock = {
+                "overlays": [
+                    {
+                        "path": "runtime/overlay.py",
+                        "sha256": hashlib.sha256(payload).hexdigest(),
+                    }
+                ]
+            }
+
+            self.assertEqual(checker.check_tracked_artifacts(lock, root), [])
+
+    def test_changed_bytes_are_reported(self) -> None:
+        with TemporaryDirectory() as raw:
+            root = Path(raw)
+            (root / "runtime").mkdir()
+            (root / "runtime" / "overlay.py").write_bytes(b"changed\n")
+            lock = {
+                "overlays": [
+                    {
+                        "path": "runtime/overlay.py",
+                        "sha256": hashlib.sha256(b"original\n").hexdigest(),
+                    }
+                ]
+            }
+
+            findings = checker.check_tracked_artifacts(lock, root)
+
+            self.assertEqual(len(findings), 1)
+            self.assertIn("tree has", findings[0].detail)
+
+    def test_absent_artifact_is_reported(self) -> None:
+        with TemporaryDirectory() as raw:
+            lock = {
+                "nccl": {
+                    "patches": [
+                        {"path": "gone.patch", "sha256": "d" * 64},
+                    ]
+                }
+            }
+
+            findings = checker.check_tracked_artifacts(lock, Path(raw))
+
+            self.assertEqual(len(findings), 1)
+            self.assertIn("absent from the tree", findings[0].detail)
+
+    def test_malformed_recorded_hash_is_reported(self) -> None:
+        with TemporaryDirectory() as raw:
+            lock = {"public_runtime_inputs": [{"path": "x", "sha256": "nope"}]}
+
+            findings = checker.check_tracked_artifacts(lock, Path(raw))
+
+            self.assertEqual(len(findings), 1)
+            self.assertIn("malformed", findings[0].detail)
+
+
+class RepositoryLockTest(unittest.TestCase):
+    """The lock this repository ships must satisfy every asserted property."""
+
+    def test_tracked_lock_passes_offline_checks(self) -> None:
+        self.assertEqual(checker.run(check_remote=False), [])
+
+    def test_main_reports_pass_offline(self) -> None:
+        self.assertEqual(checker.main([]), 0)
+
+    def test_every_pinned_source_names_its_repository(self) -> None:
+        lock = checker.load_lock()
+        for section, _field in checker.COMMIT_FIELDS:
+            with self.subTest(section=section):
+                self.assertIn(
+                    "repository",
+                    lock.get(section, {}),
+                    f"{section} pins a commit without naming where to fetch it",
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_pull_pinned_images.py
+++ b/scripts/test_pull_pinned_images.py
@@ -1,0 +1,105 @@
+"""GPU-free tests for the pinned-image retriever."""
+
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+import pull_pinned_images as puller
+
+DIGEST_A = "sha256:" + "1" * 64
+DIGEST_B = "sha256:" + "2" * 64
+
+
+def _write(root: Path, relative: str, document: dict) -> None:
+    path = root / relative
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(document), encoding="utf-8")
+
+
+class CollectPinnedImagesTest(unittest.TestCase):
+    def test_reads_both_lock_shapes(self) -> None:
+        with TemporaryDirectory() as raw:
+            root = Path(raw)
+            _write(
+                root,
+                "runtime/runtime-lock.json",
+                {
+                    "base_image": {
+                        "builder": {"repository": "reg/base", "digest": DIGEST_A},
+                        "runtime": {"repository": "reg/base", "digest": DIGEST_B},
+                    }
+                },
+            )
+            _write(
+                root,
+                "runtime/faststart-lock.json",
+                {
+                    "base_image": {
+                        "repository": "reg/faststart",
+                        "manifest_digest": DIGEST_A,
+                    }
+                },
+            )
+
+            images = puller.collect_pinned_images(root)
+
+            self.assertEqual(len(images), 3)
+            self.assertEqual(
+                {image.reference for image in images},
+                {
+                    f"reg/base@{DIGEST_A}",
+                    f"reg/base@{DIGEST_B}",
+                    f"reg/faststart@{DIGEST_A}",
+                },
+            )
+
+    def test_an_image_named_by_tag_is_not_collected(self) -> None:
+        """A tag can be repointed, so it is not an identity this pulls."""
+
+        with TemporaryDirectory() as raw:
+            root = Path(raw)
+            _write(
+                root,
+                "runtime/runtime-lock.json",
+                {"base_image": {"builder": {"repository": "reg/base", "tag": "13.2"}}},
+            )
+
+            self.assertEqual(puller.collect_pinned_images(root), [])
+
+    def test_a_malformed_digest_is_not_collected(self) -> None:
+        with TemporaryDirectory() as raw:
+            root = Path(raw)
+            _write(
+                root,
+                "runtime/faststart-lock.json",
+                {"base_image": {"repository": "reg/x", "manifest_digest": "sha256:no"}},
+            )
+
+            self.assertEqual(puller.collect_pinned_images(root), [])
+
+    def test_an_absent_lock_is_skipped(self) -> None:
+        with TemporaryDirectory() as raw:
+            self.assertEqual(puller.collect_pinned_images(Path(raw)), [])
+
+
+class PlanTest(unittest.TestCase):
+    def test_plan_contacts_nothing_and_succeeds(self) -> None:
+        self.assertEqual(puller.main(["--plan"]), 0)
+
+
+class RepositoryLockTest(unittest.TestCase):
+    def test_every_tracked_image_is_digest_pinned(self) -> None:
+        images = puller.collect_pinned_images()
+
+        self.assertTrue(images, "the tracked locks name no digest-pinned image")
+        for image in images:
+            with self.subTest(subject=image.subject):
+                self.assertRegex(image.digest, r"^sha256:[0-9a-f]{64}$")
+                self.assertIn("@sha256:", image.reference)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Resulting behavior

`scripts/check_runtime_inputs.py` reads `runtime/runtime-lock.json` and reports
any input a build could resolve differently on a later day. The offline suite
runs it against the tracked lock.

## Technical reason

The lock is the single source of truth for what a runtime build consumes, and
nothing asserted that its entries stayed immutable. A branch name, a floating
tag, or an abbreviated commit substituted for a full identity would make builds
diverge silently — the failure appears later, as an image that behaves
differently from the one an evidence record describes.

The checker separates two properties that are easy to conflate:

**Immutability** — asserted offline. A source named by a branch or movable tag
is rejected; a base image must carry a SHA-256 content digest rather than a
tag; the model must carry an immutable revision hash; and every in-tree overlay,
NCCL patch, and public runtime input is rehashed against the bytes the lock
records.

**Retrievability** — a fact about the world, checked with `--check-remote`. An
identity states which bytes are correct; it does not oblige anyone to keep
serving them. Any upstream can be made private, renamed, or deleted without
notice, and the useful time to learn that is before a build needs the bytes.
That mode reaches the network, mutates nothing, and contacts no configured
Spark.

## Result against the tracked lock

Both modes pass. Every external input is already pinned by digest, full commit,
or immutable revision, and all five pinned git sources resolve. This PR records
that state and prevents its loss rather than repairing a defect.

## Documentation

`docs/RUNTIME_INPUT_DURABILITY.md` states what the lock guarantees, what it does
not, the redistribution rights that bound mirroring each input — Apache-2.0
sources may be mirrored with notices, NVIDIA base-image licensing governs any
republished derivative, model weights follow their own terms — and the procedure
that converts a pinned identity into an artifact whose availability does not
depend on its upstream host.

`AGENTS.md` lists the offline mode among its safe starting commands.

## Validation

`ruff` clean. `python -m pytest scripts -q` → 1528 passed, 9 skipped, including
thirteen tests that verify the checker detects a branch name, an abbreviated
commit, an absent commit, a tag-named image, a movable model revision, changed
artifact bytes, an absent artifact, and a malformed recorded hash.
`python scripts/check_runtime_inputs.py --check-remote` passes against the
tracked lock.