### PR TITLE
Remove four obstacles between a clean checkout and a four-rank launch

### DIFF
--- a/docs/PREREQUISITES.md
+++ b/docs/PREREQUISITES.md
@@ -47,6 +47,11 @@ connected. Do not add or assume those fabric paths.
 - Both 200 GbE ports detected and link-capable on every Spark.
 - A separate management connection on every Spark: wired LAN, Wi-Fi, USB
   Ethernet, or Tailscale.
+- Outbound HTTPS from every Spark to the source repository. The bootstrap
+  clones the tree on ranks 1 through 3 and fetches rank 0's exact commit, so
+  all four need to reach it, not only the controller. A deployment working
+  from a fork, a mirror, or an internal host sets
+  `SPARKRING_BOOTSTRAP_REPOSITORY` to that origin.
 - Adequate cooling and power for four sustained full-load systems.
 - About 450 GB of usable storage per rank for the checkpoint, MTP draft,
   images, caches, and working headroom.

--- a/scripts/acceptance_gate.py
+++ b/scripts/acceptance_gate.py
@@ -672,6 +672,7 @@ class GateContext:
                     "interface": str(port["interface"]),
                     "address": str(port["address"]),
                     "gid_index": int(port["roce_gid_index"]),
+                    "rdma_device": str(port["rdma_device"]),
                 }
             )
         return descriptors[0], descriptors[1]
@@ -1730,6 +1731,10 @@ def _qualifier_argv(ctx: GateContext, edge: dict) -> list[str]:
         str(dig(ctx.site, "topology.mtu")),
         "--gid-index",
         str(left["gid_index"]),
+        "--left-rdma-device",
+        left["rdma_device"],
+        "--right-rdma-device",
+        right["rdma_device"],
         "--strict-latency",
     ]
     probe = dig(ctx.gate, "fabric.probe_binary", None)

--- a/scripts/bootstrap_nf3.py
+++ b/scripts/bootstrap_nf3.py
@@ -27,6 +27,19 @@ from verify_ssh_mesh import Hop, image_fanout_hops, split_ssh_target
 ROOT = Path(__file__).resolve().parents[1]
 CONFIRMATION = "BOOTSTRAP-NF3-ALL-FOUR"
 PUBLIC_REPOSITORY = "https://github.com/FujitsuPolycom/sparkring.git"
+# Follower ranks clone the source they build from. A deployment working from a
+# fork, a mirror, or an internal host serves that source elsewhere, and every
+# rank must agree on which. This environment variable names that origin; the
+# clone still verifies the checked-out commit, so a substituted origin cannot
+# change which bytes are built.
+BOOTSTRAP_REPOSITORY_ENV = "SPARKRING_BOOTSTRAP_REPOSITORY"
+
+
+def bootstrap_repository(environ=None) -> str:
+    """Return the repository URL follower ranks clone."""
+
+    source = os.environ if environ is None else environ
+    return str(source.get(BOOTSTRAP_REPOSITORY_ENV, "")).strip() or PUBLIC_REPOSITORY
 IMAGE_TRANSFER_HEADROOM_BYTES = 5 * 1024**3
 RECIPE_PATH = ROOT / "recipes/glm52-nf3-hybrid.json"
 PROFILES = {
@@ -419,20 +432,23 @@ def fanout_image_archive(
         )
 
 
-def checkout_command(commit: str, remote_root: str) -> str:
+def checkout_command(
+    commit: str, remote_root: str, repository_url: str | None = None
+) -> str:
     repository = f"{remote_root}/{commit}"
+    origin = repository_url or bootstrap_repository()
     return "\n".join(
         (
             "set -euo pipefail",
             f"mkdir -p -- {shlex.quote(remote_root)}",
             (
                 f"if [ ! -d {shlex.quote(repository + '/.git')} ]; then "
-                f"git clone --filter=blob:none {shlex.quote(PUBLIC_REPOSITORY)} "
+                f"git clone --filter=blob:none {shlex.quote(origin)} "
                 f"{shlex.quote(repository)}; fi"
             ),
             (
                 f"test \"$(git -C {shlex.quote(repository)} remote get-url origin)\" "
-                f"= {shlex.quote(PUBLIC_REPOSITORY)}"
+                f"= {shlex.quote(origin)}"
             ),
             (
                 f"git -C {shlex.quote(repository)} fetch --depth 1 origin "

--- a/scripts/config/exl3-r7-site.example.yaml
+++ b/scripts/config/exl3-r7-site.example.yaml
@@ -167,29 +167,12 @@ paths:
     jit_cache: 34359738368
     context_cache: 549755813888
 
-artifacts:
-  # Runtime files used by the default profile are baked into and attested in
-  # the image. Generated experiment bundles add their own host artifacts.
-  - name: transport_library
-    path: /opt/sparkring/lib/libspark_transport_capi.so
-    sha256: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-    executable: false
-  - name: nccl_library
-    path: /opt/sparkring/lib/libnccl.so.2
-    sha256: bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
-    executable: false
-  - name: tp4_graph_probe
-    path: /opt/sparkring/bin/spark_tp4_graph_probe
-    sha256: cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
-    executable: true
-  - name: tp4_vocab_graph_probe
-    path: /opt/sparkring/bin/spark_tp4_vocab_graph_probe
-    sha256: dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd
-    executable: true
-  - name: tp4_dcp_graph_probe
-    path: /opt/sparkring/bin/spark_tp4_dcp_graph_probe
-    sha256: eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee
-    executable: true
+# The runtime files this profile depends on are baked into the image and
+# verified from its in-image runtime manifest before vLLM starts, so there
+# is nothing on the host for preflight to hash. Host artifacts belong here
+# only when a deployment stages a file outside the image, and each entry
+# must name a path something actually writes.
+artifacts: []
 
 preflight:
   ssh_timeout_seconds: 45

--- a/scripts/config/site.example.yaml
+++ b/scripts/config/site.example.yaml
@@ -376,8 +376,8 @@ artifacts:
     sha256: bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
     executable: false
 
-  - name: tp4_graph_probe
-    path: /opt/sparkring/bin/spark_tp4_graph_probe
+  - name: tp4_graph_q1_probe
+    path: /opt/sparkring/bin/spark_tp4_graph_q1_probe
     sha256: cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
     executable: true
 

--- a/scripts/test_acceptance_gate.py
+++ b/scripts/test_acceptance_gate.py
@@ -15,6 +15,7 @@ obviously fake hex. No real site's identifiers appear in this tree.
 from __future__ import annotations
 
 import copy
+import argparse
 import json
 import sys
 import threading
@@ -1787,3 +1788,42 @@ def test_evidence_bundle_carries_a_manifest_and_a_review_warning(tmp_path):
     assert all(entry["sha256"] for entry in manifest["files"])
     assert "Review" in manifest["warning"]
     assert (out / "README.txt").is_file()
+
+
+def test_cable_qualifier_argv_carries_both_rdma_devices(tmp_path):
+    """The roce200 tier refuses to run without both RDMA device names.
+
+    `qualify_direct_cable.py` raises on a missing `--left-rdma-device` or
+    `--right-rdma-device` before it contacts a host, so an argv without them
+    fails stage 2 on a correct fabric and aborts every later stage. The
+    executor is stubbed everywhere else in this suite, which is why the argv
+    itself is asserted here.
+    """
+
+    site = normalised_site(tmp_path)
+    gate_config = gate_document(tmp_path)
+    gate_config.setdefault("fabric", {})["qualifier"] = (
+        "spark_transport/scripts/qualify_direct_cable.py"
+    )
+    ctx = gate.GateContext(
+        site=site,
+        gate=gate_config,
+        site_path=tmp_path / "site.yaml",
+        site_sha256="0" * 64,
+        gate_config_sha256="0" * 64,
+        repo_root=tmp_path,
+        lock={},
+        executor=None,
+        http=None,
+        bundle=gate.Bundle(None),
+        args=argparse.Namespace(),
+    )
+    edge = site["topology"]["edges"][0]
+
+    argv = gate._qualifier_argv(ctx, edge)
+
+    assert "--left-rdma-device" in argv
+    assert "--right-rdma-device" in argv
+    left, right = ctx.edge_endpoints(edge)
+    assert argv[argv.index("--left-rdma-device") + 1] == left["rdma_device"]
+    assert argv[argv.index("--right-rdma-device") + 1] == right["rdma_device"]

--- a/sparkring_plugin/README.md
+++ b/sparkring_plugin/README.md
@@ -16,8 +16,12 @@ fail-closed contract the container deployment enforced via
 
 ## Enabling (shadow-first)
 
+This package is not on a public index. Install it from a checkout of
+this repository; a wheel built that way carries no native library, so
+`SPARK_TP4_LIBRARY` must name one unless the build packaged it.
+
 ```bash
-pip install sparkring
+pip install ./sparkring_plugin
 export VLLM_SPARK_TP4_MODE=shadow          # or custom, after qualification
 export VLLM_SPARK_TP4_EAGER_WIDTHS=5120    # admitted eager hidden widths
 export SPARK_TP4_PEER0=... SPARK_TP4_PEER1=...        # ring control peers


### PR DESCRIPTION
## Resulting behavior

Four failures that stop an otherwise-correct deployment are removed. None had
an in-tree workaround.

### Bootstrap origin

`bootstrap_nf3.py` cloned a hardcoded repository URL on ranks 1 through 3 and
asserted `git remote get-url origin` matched it exactly, then fetched rank 0's
HEAD by commit. A deployment working from a fork, a mirror, or an internal host
was rejected on rank 1 — after all four machines were provisioned — and there
was no flag to override it. The first thing anyone does after hitting a
documentation bug is commit a fix, and that commit is unfetchable from the
hardcoded origin.

`SPARKRING_BOOTSTRAP_REPOSITORY` names the origin. The default is unchanged.
The clone still verifies the checked-out commit, so a substituted origin cannot
change which bytes are built.

`docs/PREREQUISITES.md` now records that all four ranks need outbound access to
the source repository. The bootstrap depends on it and no document said so.

### Site templates pinned artifacts nothing builds

`scripts/config/exl3-r7-site.example.yaml` pinned five host artifacts, and
`scripts/config/site.example.yaml` pinned `spark_tp4_graph_probe`.
`spark_transport/CMakeLists.txt` declares **zero** `install()` rules and has no
`spark_tp4_graph_probe` target — the nearest is `spark_tp4_graph_q1_probe`.
Preflight hashes those host paths at full scope, so the qualification step in
`docs/EXL3_R7_QUICKSTART.md` could not pass on a correct deployment.

The 3.5-bpw profile's runtime files are verified from the image's own manifest,
so its artifact list is empty with the reason stated. The default template names
a target that exists.

### Cable qualification could not run

`acceptance_gate.py` built edge descriptors without `rdma_device` and invoked
the qualifier without `--left-rdma-device` / `--right-rdma-device`.
`qualify_direct_cable.py` refuses the `roce200` tier without both and raises
before contacting a host, so stage 2 failed on a correct fabric and set
`aborted_after`, skipping stages 3 through 8.

The suite stubs the qualifier everywhere, which is why this survived. The new
test asserts the argv itself, and was run against the previous behavior to
confirm it fails there.

### Plugin installation named a package no index serves

The enabling command in `sparkring_plugin/README.md` was `pip install
sparkring`. It installs from a checkout, with a note that a wheel built that way
carries no native library unless the build packaged one.

## Compatibility

Default behavior is unchanged in every case. The bootstrap default origin, the
qualifier tier, and the plugin's runtime behavior are the same; what changes is
that correct deployments outside the maintainer's exact setup are no longer
rejected.

## Validation

`ruff` clean. `python -m pytest scripts -q` → 1516 passed, 9 skipped.
`python -m pytest sparkring_plugin -q` → 50 passed. Both site templates validate
through `scripts/sparkring_site.py`. Repo-relative Markdown link and anchor
check passes.