### PR TITLE
Name the shared runtime base for what it is

### DIFF
--- a/runtime/test_faststart.py
+++ b/runtime/test_faststart.py
@@ -161,7 +161,7 @@ def test_nvfp4_rope8_layer_preserves_nf3_and_restores_only_mla():
 
 def test_nvfp4_rope8_builder_reuses_pinned_nf3_and_faststart_layers():
     text = (
-        ROOT / "scripts/build-nf3-nvfp4-rope8-image.sh"
+        ROOT / "scripts/build-gb10-vllm-base-image.sh"
     ).read_text(encoding="utf-8")
     assert 'bash "${ROOT}/scripts/build-nf3-image.sh"' in text
     assert "NF3_IMAGE_ID=" in text

--- a/runtime/test_nf3_nvfp4_receipt.py
+++ b/runtime/test_nf3_nvfp4_receipt.py
@@ -54,7 +54,7 @@ def test_receipt_is_deterministic_and_names_final_and_parent_images(tmp_path):
     verifier = _verifier(tmp_path / "verification.json")
     installed_receipt = _installed_receipt(tmp_path / "installed.json")
     arguments = {
-        "image": "sparkring/glm52-nf3-nvfp4-rope8:test",
+        "image": "sparkring/gb10-vllm-base:test",
         "image_id": "sha256:" + "1" * 64,
         "nf3_image_id": "sha256:" + "2" * 64,
         "mla_image_id": "sha256:" + "3" * 64,
@@ -135,7 +135,7 @@ def test_receipt_rejects_untrusted_installed_file_receipt(tmp_path):
 
 def test_builder_writes_receipt_for_reused_and_new_images():
     text = (
-        ROOT / "scripts/build-nf3-nvfp4-rope8-image.sh"
+        ROOT / "scripts/build-gb10-vllm-base-image.sh"
     ).read_text(encoding="utf-8")
     assert "write_final_receipt()" in text
     assert text.count('write_final_receipt "') == 2
@@ -227,7 +227,7 @@ def test_final_layer_binds_installed_receipt_digest_and_reverifies():
 
 def test_builder_generates_receipt_from_candidate_then_builds_final_layer():
     text = (
-        ROOT / "scripts/build-nf3-nvfp4-rope8-image.sh"
+        ROOT / "scripts/build-gb10-vllm-base-image.sh"
     ).read_text(encoding="utf-8")
     assert 'CANDIDATE_IMAGE="${OUTPUT_IMAGE}-candidate"' in text
     assert "write-nf3-installed-receipt.py" in text

--- a/scripts/bootstrap_exl3.py
+++ b/scripts/bootstrap_exl3.py
@@ -237,7 +237,7 @@ def main(argv: list[str] | None = None) -> int:
     commit = git_value("rev-parse", "HEAD")
     dirty = git_value("status", "--porcelain")
     image = f"sparkring/glm52-exl3-tr3-3.25bpw:{commit[:12]}"
-    base_image = f"sparkring/glm52-nf3-nvfp4-rope8:{commit[:12]}"
+    base_image = f"sparkring/gb10-vllm-base:{commit[:12]}"
     plan = {
         "schema": "sparkring-exl3-bootstrap-plan/v1",
         "runs_on": "rank0",
@@ -297,7 +297,7 @@ def main(argv: list[str] | None = None) -> int:
 
     environment = os.environ.copy()
     environment["OUTPUT_IMAGE"] = base_image
-    run(["bash", str(ROOT / "scripts/build-nf3-nvfp4-rope8-image.sh")], cwd=ROOT, env=environment)
+    run(["bash", str(ROOT / "scripts/build-gb10-vllm-base-image.sh")], cwd=ROOT, env=environment)
     base_id = image_id(base_image)
     Path(args.model_host_path).parent.mkdir(parents=True, exist_ok=True)
     run(container_download_command(base_image, args.model_host_path), cwd=ROOT)

--- a/scripts/bootstrap_nf3.py
+++ b/scripts/bootstrap_nf3.py
@@ -49,8 +49,8 @@ PROFILES = {
         "build_step": "build faststart plus thin NF3 image once on rank0",
     },
     "nvfp4-rope8": {
-        "image_prefix": "sparkring/glm52-nf3-nvfp4-rope8",
-        "build_script": "scripts/build-nf3-nvfp4-rope8-image.sh",
+        "image_prefix": "sparkring/gb10-vllm-base",
+        "build_script": "scripts/build-gb10-vllm-base-image.sh",
         "build_step": (
             "build the thin NVFP4-latent/FP8-RoPE compatibility layer"
         ),

--- a/scripts/build-gb10-vllm-base-image.sh
+++ b/scripts/build-gb10-vllm-base-image.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
 ENGINE="${CONTAINER_ENGINE:-docker}"
 CACHE_ROOT="${SPARKRING_BOOTSTRAP_CACHE:-${HOME}/.cache/sparkring/nf3-bootstrap}"
-OUTPUT_IMAGE="${OUTPUT_IMAGE:-sparkring/glm52-nf3-nvfp4-rope8:local}"
+OUTPUT_IMAGE="${OUTPUT_IMAGE:-sparkring/gb10-vllm-base:local}"
 CANDIDATE_IMAGE="${OUTPUT_IMAGE}-candidate"
 
 fatal() {

--- a/scripts/sparkring_launcher.py
+++ b/scripts/sparkring_launcher.py
@@ -318,7 +318,7 @@ def _validate_pinned_model_launch(
 
     candidate_1m = (
         config.environment.get("VLLM_SPARK_RUNTIME_ID")
-        == "glm52-nf3-nvfp4-rope8-1m-candidate"
+        == "gb10-vllm-base-1m-candidate"
     )
     kv_profile = config.environment.get("VLLM_SPARK_KV_PROFILE")
     kv_contracts = {
@@ -542,7 +542,7 @@ def _validate_pinned_model_launch(
         expected_environment.update(
             {
                 "HYBRID_B12X_MAX_TOKENS": "3072",
-                "VLLM_SPARK_RUNTIME_ID": "glm52-nf3-nvfp4-rope8-1m-candidate",
+                "VLLM_SPARK_RUNTIME_ID": "gb10-vllm-base-1m-candidate",
             }
         )
         if site.serving.max_model_len != 1_048_576:
@@ -603,7 +603,7 @@ def start_actions(site: SiteConfig, config: LaunchConfig) -> list[RemoteAction]:
         )
         candidate_1m = (
             config.environment.get("VLLM_SPARK_RUNTIME_ID")
-            == "glm52-nf3-nvfp4-rope8-1m-candidate"
+            == "gb10-vllm-base-1m-candidate"
         )
         argv = [
             config.engine,

--- a/scripts/test_bootstrap_nf3.py
+++ b/scripts/test_bootstrap_nf3.py
@@ -55,7 +55,7 @@ def test_plan_selects_nvfp4_rope8_without_changing_model_downloads():
     assert result.returncode == 0, result.stderr
     plan = json.loads(result.stdout)
     assert plan["profile"] == "nvfp4-rope8"
-    assert plan["image"].startswith("sparkring/glm52-nf3-nvfp4-rope8:")
+    assert plan["image"].startswith("sparkring/gb10-vllm-base:")
     assert plan["model_path"].endswith(
         "GLM-5.2-MXFP8-NVFP4-NF3-Hybrid"
     )

--- a/scripts/test_sparkring_launcher.py
+++ b/scripts/test_sparkring_launcher.py
@@ -212,7 +212,7 @@ def test_nf3_nvfp4_1m_candidate_contract_is_accepted(tmp_path):
             "VLLM_SPARK_MAX_NUM_BATCHED_TOKENS": "3072",
             "VLLM_SPARK_NF3_PROFILE": "reference-four-spark-adaptive-2-4-c8",
             "VLLM_SPARK_RUNTIME_ID": (
-                "glm52-nf3-nvfp4-rope8-1m-candidate"
+                "gb10-vllm-base-1m-candidate"
             ),
         }
     )


### PR DESCRIPTION
## Resulting behavior

The runtime base image three profiles build on is `sparkring/gb10-vllm-base`.

## Technical reason

It was `glm52-nf3-nvfp4-rope8`, after the first profile that needed it. The
3.25-bpw lane, the 3.5-bpw R7 lane, and DeepSeek-V4-Flash all descend from that
image, so the name states a lineage none of them share and implies a model
relationship that does not hold. Nothing in the image is NF3-specific: its OCI
labels record CUDA 13.2.1, torch 2.12.0+cu132, the vLLM fork, B12X, SparkInfer,
NCCL, FlashInfer, and DeepGEMM.

`AGENTS.md` forbids exactly this — a lifecycle label serving as a technical
identity — and the rule applies to artifact names, not only to prose.

`gb10-vllm-base` states the two facts a reader needs. The image targets GB10:
SM121 kernels, aarch64 and cu132 wheels, and it does not run elsewhere. And it
is a base, not a serving profile; every deployment builds a derived image on
top of it.

`scripts/build-nf3-nvfp4-rope8-image.sh` becomes
`scripts/build-gb10-vllm-base-image.sh` for the same reason.

## What keeps the former name

`docs/configurations/glm52-nf3-live-1m-20260731.json` and
`docs/NF3_NVFP4_PUBLIC_VALIDATION.md` record runs that used an image with that
name. Changing them would describe those runs as something they were not.

## Compatibility

An image tagged `glm52-nf3-nvfp4-rope8` is not found under `gb10-vllm-base`.
`scripts/bootstrap_exl3.py` and `scripts/bootstrap_nf3.py` build the base
themselves, so a run produces a correctly tagged image; an operator holding an
image built earlier can retag it. Receipts pin image IDs rather than names and
are unaffected.

## Validation

`ruff` clean. `python -m pytest scripts runtime -q` → 1788 passed, 12 skipped.
Repo-relative Markdown link and anchor check at 407 links across 90 files.