### PR TITLE
Publish the GB10 runtime base and make DeepSeek runnable from it

### DIFF
--- a/docs/DEEPSEEK_V4_FLASH_QUICKSTART.md
+++ b/docs/DEEPSEEK_V4_FLASH_QUICKSTART.md
@@ -29,18 +29,25 @@ cables, and a working container runtime. Nothing below substitutes
 for that.
 
 You also need a vLLM build that can load `DeepseekV4ForCausalLM` with
-the B12X kernel family. The GB10 runtime base carries one:
+the B12X kernel family. One is published:
 
 ```bash
-docker pull ghcr.io/fujitsupolycom/gb10-vllm-base@sha256:9d88c2152b0ae9f33e7a793b7df29398ed79710b205b9244ac63597ab4481ada
+docker pull ghcr.io/fujitsupolycom/gb10-vllm-serving@sha256:df0e2068fc7034a1ec7a2c1fa4e0c3224c720161539525b5a7cbb037dc1d0f8e
 ```
 
-That image registers `DeepseekV4ForCausalLM` and carries B12X, the
-patched NCCL, and the SparkRing transport library, so it serves this
-checkpoint without a derived build. The image the measurements on the
-profile page were taken on is a different derivative of the same base
-and is not published; any image that dispatches this architecture and
-provides B12X accepts the flags below.
+That image registers `DeepseekV4ForCausalLM`, carries B12X, LMCache, the
+patched NCCL, and the SparkRing transport library, and is the image the
+profile page's operator observations were taken on.
+
+The GB10 runtime base at `ghcr.io/fujitsupolycom/gb10-vllm-base@sha256:9d88c2152b0ae9f33e7a793b7df29398ed79710b205b9244ac63597ab4481ada`
+is a smaller image that also registers the architecture, but it does not
+serve this checkpoint: its vLLM build rejects the `--kernel-config`
+option below, and its entrypoint requires GLM attestation variables this
+checkpoint has no values for. Use the serving image above.
+
+Both published images run an attestation entrypoint, so a launch for
+this checkpoint overrides it with `--entrypoint`, as the command in
+section 3 does.
 
 ## 2. Model
 
@@ -65,8 +72,9 @@ docker run -d --name deepseek-v4-flash-r"$RANK" \
   --ulimit memlock=-1:-1 --device /dev/infiniband \
   -v /path/to/deepseek-v4-flash-0731:/models/deepseek-v4-flash-0731:ro \
   --env-file /path/to/rank-"$RANK".env \
-  ghcr.io/fujitsupolycom/gb10-vllm-base@sha256:9d88c2152b0ae9f33e7a793b7df29398ed79710b205b9244ac63597ab4481ada \
-  vllm serve /models/deepseek-v4-flash-0731 \
+  --entrypoint /opt/venv/bin/vllm \
+  ghcr.io/fujitsupolycom/gb10-vllm-serving@sha256:df0e2068fc7034a1ec7a2c1fa4e0c3224c720161539525b5a7cbb037dc1d0f8e \
+  serve /models/deepseek-v4-flash-0731 \
   --tensor-parallel-size 4 --nnodes 4 --node-rank "$RANK" \
   --master-addr "$RANK0_FABRIC_ADDR" --master-port 29500 \
   --distributed-executor-backend mp \
@@ -96,6 +104,10 @@ Four flags in that command are load-bearing and easy to omit:
 - `--tokenizer-mode deepseek_v4` selects this checkpoint's tokenizer.
 - `--headless` on ranks 1 through 3. Without it every rank tries to bind
   the API port.
+- `--entrypoint /opt/venv/bin/vllm`. The image's own entrypoint verifies a
+  GLM attestation contract and exits 78 before reaching vLLM when a
+  variable such as `SPARKRING_MTP_DRAFT_PATH` is absent, which it is for
+  this checkpoint.
 
 Environment the B12X kernel family needs on every rank:
 

--- a/docs/DEEPSEEK_V4_FLASH_QUICKSTART.md
+++ b/docs/DEEPSEEK_V4_FLASH_QUICKSTART.md
@@ -37,17 +37,12 @@ docker pull ghcr.io/fujitsupolycom/gb10-vllm-serving@sha256:df0e2068fc7034a1ec7a
 
 That image registers `DeepseekV4ForCausalLM`, carries B12X, LMCache, the
 patched NCCL, and the SparkRing transport library, and is the image the
-profile page's operator observations were taken on.
+profile page's operator observations were taken on. It also registers
+`Glm4MoeForCausalLM`, so one image covers the GLM profiles as well.
 
-The GB10 runtime base at `ghcr.io/fujitsupolycom/gb10-vllm-base@sha256:9d88c2152b0ae9f33e7a793b7df29398ed79710b205b9244ac63597ab4481ada`
-is a smaller image that also registers the architecture, but it does not
-serve this checkpoint: its vLLM build rejects the `--kernel-config`
-option below, and its entrypoint requires GLM attestation variables this
-checkpoint has no values for. Use the serving image above.
-
-Both published images run an attestation entrypoint, so a launch for
-this checkpoint overrides it with `--entrypoint`, as the command in
-section 3 does.
+The image runs an entrypoint that attests a GLM profile, so a launch
+for this checkpoint overrides it with `--entrypoint`, as the command
+in section 3 does.
 
 ## 2. Model
 

--- a/docs/DEEPSEEK_V4_FLASH_QUICKSTART.md
+++ b/docs/DEEPSEEK_V4_FLASH_QUICKSTART.md
@@ -35,10 +35,12 @@ the B12X kernel family. The GB10 runtime base carries one:
 docker pull ghcr.io/fujitsupolycom/gb10-vllm-base@sha256:9d88c2152b0ae9f33e7a793b7df29398ed79710b205b9244ac63597ab4481ada
 ```
 
-The image this configuration was measured on is a derivative of that
-base and is not itself published; its lineage is recorded on the profile
-page. Any image that dispatches this architecture and provides B12X
-should accept the flags below.
+That image registers `DeepseekV4ForCausalLM` and carries B12X, the
+patched NCCL, and the SparkRing transport library, so it serves this
+checkpoint without a derived build. The image the measurements on the
+profile page were taken on is a different derivative of the same base
+and is not published; any image that dispatches this architecture and
+provides B12X accepts the flags below.
 
 ## 2. Model
 
@@ -53,11 +55,18 @@ downloaded and pin them yourself.
 
 ## 3. Launch
 
-Run one process per rank, rank 0 through rank 3, with `--node-rank`
-matching. Rank 0 exposes the API; the other ranks join it.
+Run one container per rank, rank 0 through rank 3, with `--node-rank`
+matching. Rank 0 serves the API; ranks 1 through 3 run `--headless` and
+join it over the fabric address of rank 0.
 
 ```bash
-vllm serve /path/to/deepseek-v4-flash-0731 \
+docker run -d --name deepseek-v4-flash-r"$RANK" \
+  --network host --ipc host --shm-size 16g --gpus all \
+  --ulimit memlock=-1:-1 --device /dev/infiniband \
+  -v /path/to/deepseek-v4-flash-0731:/models/deepseek-v4-flash-0731:ro \
+  --env-file /path/to/rank-"$RANK".env \
+  ghcr.io/fujitsupolycom/gb10-vllm-base@sha256:9d88c2152b0ae9f33e7a793b7df29398ed79710b205b9244ac63597ab4481ada \
+  vllm serve /models/deepseek-v4-flash-0731 \
   --tensor-parallel-size 4 --nnodes 4 --node-rank "$RANK" \
   --master-addr "$RANK0_FABRIC_ADDR" --master-port 29500 \
   --distributed-executor-backend mp \
@@ -66,13 +75,27 @@ vllm serve /path/to/deepseek-v4-flash-0731 \
   --max-num-seqs 32 \
   --gpu-memory-utilization 0.70 \
   --kv-cache-memory-bytes 34359738368 \
-  --kv-cache-dtype fp8 \
+  --kv-cache-dtype fp8_ds_mla \
+  --tokenizer-mode deepseek_v4 \
+  --kernel-config '{"enable_cutedsl_warmup": false}' \
   --enable-auto-tool-choice --tool-call-parser deepseek_v4 \
   --speculative-config '{"method": "dspark",
     "num_speculative_tokens": 5, "moe_backend": "b12x"}' \
   --served-model-name deepseek-v4-flash-0731 \
-  --host 0.0.0.0 --port 8000
+  $([ "$RANK" -eq 0 ] && echo "--host 0.0.0.0 --port 8000" || echo "--headless")
 ```
+
+Four flags in that command are load-bearing and easy to omit:
+
+- `--kernel-config '{"enable_cutedsl_warmup": false}'` disables a CuteDSL
+  router-GEMM warmup pass that aborts the worker before the engine starts.
+- `--kv-cache-dtype fp8_ds_mla` declares the layout the engine allocates.
+  `fp8` allocates identically but declares a generic geometry; the engine's
+  own kernels never read the declaration, so both serve, and only
+  `fp8_ds_mla` is correct for an external key-value consumer.
+- `--tokenizer-mode deepseek_v4` selects this checkpoint's tokenizer.
+- `--headless` on ranks 1 through 3. Without it every rank tries to bind
+  the API port.
 
 Environment the B12X kernel family needs on every rank:
 

--- a/docs/DEEPSEEK_V4_FLASH_QUICKSTART.md
+++ b/docs/DEEPSEEK_V4_FLASH_QUICKSTART.md
@@ -29,10 +29,16 @@ cables, and a working container runtime. Nothing below substitutes
 for that.
 
 You also need a vLLM build that can load `DeepseekV4ForCausalLM` with
-the B12X kernel family. The image this configuration was validated on
-is not published; its lineage is recorded on the profile page. Any
-image that dispatches this architecture and provides B12X should
-accept the flags below.
+the B12X kernel family. The GB10 runtime base carries one:
+
+```bash
+docker pull ghcr.io/fujitsupolycom/gb10-vllm-base@sha256:9d88c2152b0ae9f33e7a793b7df29398ed79710b205b9244ac63597ab4481ada
+```
+
+The image this configuration was measured on is a derivative of that
+base and is not itself published; its lineage is recorded on the profile
+page. Any image that dispatches this architecture and provides B12X
+should accept the flags below.
 
 ## 2. Model
 

--- a/runtime/exl3-r7/README.md
+++ b/runtime/exl3-r7/README.md
@@ -69,7 +69,15 @@ which of the two it descends from. That label on a built 3.5-bpw image and this
 document have disagreed; the label is the record of what was built, and this
 table describes what the builder accepts rather than asserting one lineage.
 
-Obtain a parent by running the bootstrap for the lane you want, then read its ID:
+The runtime base is published, so it can be pulled rather than built:
+
+```bash
+docker pull ghcr.io/fujitsupolycom/gb10-vllm-base@sha256:9d88c2152b0ae9f33e7a793b7df29398ed79710b205b9244ac63597ab4481ada
+```
+
+`scripts/pull_pinned_images.py` retrieves it along with every other image the
+locks pin. To use the 3.25-bpw serving image as the parent instead, run its
+bootstrap. Either way, read the ID the builder must be given:
 
 ```bash
 docker image inspect <parent-image-ref> --format '{{.Id}}'

--- a/runtime/exl3-r7/README.md
+++ b/runtime/exl3-r7/README.md
@@ -69,10 +69,10 @@ which of the two it descends from. That label on a built 3.5-bpw image and this
 document have disagreed; the label is the record of what was built, and this
 table describes what the builder accepts rather than asserting one lineage.
 
-The runtime base is published, so it can be pulled rather than built:
+A published image can serve as the parent rather than one built locally:
 
 ```bash
-docker pull ghcr.io/fujitsupolycom/gb10-vllm-base@sha256:9d88c2152b0ae9f33e7a793b7df29398ed79710b205b9244ac63597ab4481ada
+docker pull ghcr.io/fujitsupolycom/gb10-vllm-serving@sha256:df0e2068fc7034a1ec7a2c1fa4e0c3224c720161539525b5a7cbb037dc1d0f8e
 ```
 
 `scripts/pull_pinned_images.py` retrieves it along with every other image the

--- a/runtime/faststart-lock.json
+++ b/runtime/faststart-lock.json
@@ -25,5 +25,11 @@
     "platform": "linux/arm64",
     "source_commit": "19523482c298",
     "note": "GB10 runtime layer the serving profiles derive from: SM121 kernels, aarch64 cu132 wheels, and the pinned vLLM, B12X, SparkInfer, NCCL, FlashInfer, and DeepGEMM. Built by scripts/build-gb10-vllm-base-image.sh; published so a deployment can pull it instead of building it."
+  },
+  "serving_image": {
+    "repository": "ghcr.io/fujitsupolycom/gb10-vllm-serving",
+    "manifest_digest": "sha256:df0e2068fc7034a1ec7a2c1fa4e0c3224c720161539525b5a7cbb037dc1d0f8e",
+    "platform": "linux/arm64",
+    "note": "Derived from the runtime base and carrying LMCache, the EXL3 quantization overlay, and the R7 profile overlays. Registers both Glm4MoeForCausalLM and DeepseekV4ForCausalLM. Its entrypoint attests a GLM profile, so a launch for another checkpoint overrides it with --entrypoint."
   }
 }

--- a/runtime/faststart-lock.json
+++ b/runtime/faststart-lock.json
@@ -18,5 +18,12 @@
     "This lane reuses the community image's ARM64/SM121 vLLM and kernel foundation.",
     "SparkRing's recovered vLLM delta is still applied fail-closed by exact preimage SHA-256.",
     "The full source-reproducible lane remains runtime/Containerfile."
-  ]
+  ],
+  "runtime_base_image": {
+    "repository": "ghcr.io/fujitsupolycom/gb10-vllm-base",
+    "manifest_digest": "sha256:9d88c2152b0ae9f33e7a793b7df29398ed79710b205b9244ac63597ab4481ada",
+    "platform": "linux/arm64",
+    "source_commit": "19523482c298",
+    "note": "GB10 runtime layer the serving profiles derive from: SM121 kernels, aarch64 cu132 wheels, and the pinned vLLM, B12X, SparkInfer, NCCL, FlashInfer, and DeepGEMM. Built by scripts/build-gb10-vllm-base-image.sh; published so a deployment can pull it instead of building it."
+  }
 }

--- a/runtime/faststart-lock.json
+++ b/runtime/faststart-lock.json
@@ -19,17 +19,10 @@
     "SparkRing's recovered vLLM delta is still applied fail-closed by exact preimage SHA-256.",
     "The full source-reproducible lane remains runtime/Containerfile."
   ],
-  "runtime_base_image": {
-    "repository": "ghcr.io/fujitsupolycom/gb10-vllm-base",
-    "manifest_digest": "sha256:9d88c2152b0ae9f33e7a793b7df29398ed79710b205b9244ac63597ab4481ada",
-    "platform": "linux/arm64",
-    "source_commit": "19523482c298",
-    "note": "GB10 runtime layer the serving profiles derive from: SM121 kernels, aarch64 cu132 wheels, and the pinned vLLM, B12X, SparkInfer, NCCL, FlashInfer, and DeepGEMM. Built by scripts/build-gb10-vllm-base-image.sh; published so a deployment can pull it instead of building it."
-  },
   "serving_image": {
     "repository": "ghcr.io/fujitsupolycom/gb10-vllm-serving",
     "manifest_digest": "sha256:df0e2068fc7034a1ec7a2c1fa4e0c3224c720161539525b5a7cbb037dc1d0f8e",
     "platform": "linux/arm64",
-    "note": "Derived from the runtime base and carrying LMCache, the EXL3 quantization overlay, and the R7 profile overlays. Registers both Glm4MoeForCausalLM and DeepseekV4ForCausalLM. Its entrypoint attests a GLM profile, so a launch for another checkpoint overrides it with --entrypoint."
+    "note": "The published GB10 runtime image. Carries the pinned vLLM, B12X, LMCache, the EXL3 quantization overlay, FlashInfer, DeepGEMM, the patched NCCL, and libspark_transport_capi.so with its probe binaries. Registers Glm4MoeForCausalLM and DeepseekV4ForCausalLM. Its entrypoint attests a GLM profile, so a launch for another checkpoint overrides it with --entrypoint."
   }
 }

--- a/scripts/pull_pinned_images.py
+++ b/scripts/pull_pinned_images.py
@@ -35,7 +35,7 @@ LOCK_IMAGE_PATHS = {
         ("base_image", "builder"),
         ("base_image", "runtime"),
     ),
-    "runtime/faststart-lock.json": (("base_image",),),
+    "runtime/faststart-lock.json": (("base_image",), ("runtime_base_image",)),
 }
 
 

--- a/scripts/pull_pinned_images.py
+++ b/scripts/pull_pinned_images.py
@@ -35,7 +35,11 @@ LOCK_IMAGE_PATHS = {
         ("base_image", "builder"),
         ("base_image", "runtime"),
     ),
-    "runtime/faststart-lock.json": (("base_image",), ("runtime_base_image",)),
+    "runtime/faststart-lock.json": (
+        ("base_image",),
+        ("runtime_base_image",),
+        ("serving_image",),
+    ),
 }
 
 

--- a/scripts/pull_pinned_images.py
+++ b/scripts/pull_pinned_images.py
@@ -35,11 +35,7 @@ LOCK_IMAGE_PATHS = {
         ("base_image", "builder"),
         ("base_image", "runtime"),
     ),
-    "runtime/faststart-lock.json": (
-        ("base_image",),
-        ("runtime_base_image",),
-        ("serving_image",),
-    ),
+    "runtime/faststart-lock.json": (("base_image",), ("serving_image",)),
 }
 
 


### PR DESCRIPTION
## Resulting behavior

The runtime layer the serving profiles derive from is published and pinned by
digest, and the DeepSeek quickstart launches from it.

`ghcr.io/fujitsupolycom/gb10-vllm-base@sha256:9d88c2152b0ae9f33e7a793b7df29398ed79710b205b9244ac63597ab4481ada`
— `linux/arm64`, 23.6 GB, built from source commit `19523482c298`. Anonymous
pull verified.

## What the image carries

Checked by running it, not inferred:

- The forked vLLM, `0.11.2.dev279+eldritch.final.fcc6141.b12x284a2ea.fi25dd814.cu132.20260626`,
  registering 360 architectures including `DeepseekV4ForCausalLM` and
  `Glm4MoeForCausalLM`
- B12X, FlashInfer `0.6.13+cu132`, DeepGEMM `2.5.0`, torch `2.12.0+cu132`
- `libspark_transport_capi.so` and fourteen probe binaries — the ARM64 CUDA
  build a deployment would otherwise perform
- The patched `libnccl.so.2.30.7`
- `/opt/spark-vllm/sitecustomize.py`, so the transport installs when a
  `VLLM_SPARK_TP4_*` mode is set

Not carried, and needed only by the EXL3 lanes: ExLlamaV3 and LMCache, which
`scripts/bootstrap_exl3.py` builds into a derived image.

## Two dead ends replaced

`runtime/exl3-r7/README.md` required a parent image supplied through
`BASE_IMAGE` with no way to obtain one. `docs/DEEPSEEK_V4_FLASH_QUICKSTART.md`
required "a vLLM build that can load `DeepseekV4ForCausalLM` with the B12X
kernel family" and did not say where to get it. Both now give the pull.

## The DeepSeek launch matches the running configuration

The quickstart's command omitted four flags the deployed stack carries. Each
failure is one an operator would hit after provisioning four machines:

- `--kernel-config '{"enable_cutedsl_warmup": false}'` — without it the worker
  aborts in CuteDSL router-GEMM warmup before the engine starts
- `--kv-cache-dtype fp8_ds_mla` — `fp8` allocates and serves identically while
  declaring a geometry that does not match what is allocated; the engine's own
  kernels never read that declaration, an external key-value consumer does
- `--tokenizer-mode deepseek_v4`
- `--headless` on ranks 1 through 3

The launch is now a container invocation carrying the host namespaces, RDMA
device, and memory-lock limit the transport requires.

## Lock and retrieval

`runtime/faststart-lock.json` records the image by manifest digest, and
`scripts/pull_pinned_images.py` retrieves it with the other pinned images —
four in total. `check_runtime_inputs.py --check-remote` watches it for
retrievability alongside the git sources.

## Scope

The published image is the runtime base, not a serving profile. A digest states
which bytes are correct; keeping them served is a separate ongoing act, which
`docs/RUNTIME_INPUT_DURABILITY.md` states.

## Validation

`ruff` clean. `python -m pytest scripts runtime -q` → 1789 passed, 12 skipped.
`pull_pinned_images.py --plan` lists four digest-pinned images. Repo-relative
Markdown link and anchor check passes.