### PR TITLE
Publish the runtime image without capture-host labels

### DIFF
--- a/docs/DEEPSEEK_V4_FLASH_QUICKSTART.md
+++ b/docs/DEEPSEEK_V4_FLASH_QUICKSTART.md
@@ -32,7 +32,7 @@ You also need a vLLM build that can load `DeepseekV4ForCausalLM` with
 the B12X kernel family. One is published:
 
 ```bash
-docker pull ghcr.io/fujitsupolycom/gb10-vllm-serving@sha256:df0e2068fc7034a1ec7a2c1fa4e0c3224c720161539525b5a7cbb037dc1d0f8e
+docker pull ghcr.io/fujitsupolycom/gb10-vllm-serving@sha256:35b29616dc05677b98f647282e81a99fbca1969791ccbfca711c11a44285385e
 ```
 
 That image registers `DeepseekV4ForCausalLM`, carries B12X, LMCache, the
@@ -68,7 +68,7 @@ docker run -d --name deepseek-v4-flash-r"$RANK" \
   -v /path/to/deepseek-v4-flash-0731:/models/deepseek-v4-flash-0731:ro \
   --env-file /path/to/rank-"$RANK".env \
   --entrypoint /opt/venv/bin/vllm \
-  ghcr.io/fujitsupolycom/gb10-vllm-serving@sha256:df0e2068fc7034a1ec7a2c1fa4e0c3224c720161539525b5a7cbb037dc1d0f8e \
+  ghcr.io/fujitsupolycom/gb10-vllm-serving@sha256:35b29616dc05677b98f647282e81a99fbca1969791ccbfca711c11a44285385e \
   serve /models/deepseek-v4-flash-0731 \
   --tensor-parallel-size 4 --nnodes 4 --node-rank "$RANK" \
   --master-addr "$RANK0_FABRIC_ADDR" --master-port 29500 \

--- a/runtime/exl3-r7/README.md
+++ b/runtime/exl3-r7/README.md
@@ -72,7 +72,7 @@ table describes what the builder accepts rather than asserting one lineage.
 A published image can serve as the parent rather than one built locally:
 
 ```bash
-docker pull ghcr.io/fujitsupolycom/gb10-vllm-serving@sha256:df0e2068fc7034a1ec7a2c1fa4e0c3224c720161539525b5a7cbb037dc1d0f8e
+docker pull ghcr.io/fujitsupolycom/gb10-vllm-serving@sha256:35b29616dc05677b98f647282e81a99fbca1969791ccbfca711c11a44285385e
 ```
 
 `scripts/pull_pinned_images.py` retrieves it along with every other image the

--- a/runtime/faststart-lock.json
+++ b/runtime/faststart-lock.json
@@ -21,8 +21,8 @@
   ],
   "serving_image": {
     "repository": "ghcr.io/fujitsupolycom/gb10-vllm-serving",
-    "manifest_digest": "sha256:df0e2068fc7034a1ec7a2c1fa4e0c3224c720161539525b5a7cbb037dc1d0f8e",
+    "manifest_digest": "sha256:35b29616dc05677b98f647282e81a99fbca1969791ccbfca711c11a44285385e",
     "platform": "linux/arm64",
-    "note": "The published GB10 runtime image. Carries the pinned vLLM, B12X, LMCache, the EXL3 quantization overlay, FlashInfer, DeepGEMM, the patched NCCL, and libspark_transport_capi.so with its probe binaries. Registers Glm4MoeForCausalLM and DeepseekV4ForCausalLM. Its entrypoint attests a GLM profile, so a launch for another checkpoint overrides it with --entrypoint."
+    "note": "The published GB10 runtime image. Carries the pinned vLLM, B12X, LMCache, the EXL3 quantization overlay, FlashInfer, DeepGEMM, the patched NCCL, and libspark_transport_capi.so with its probe binaries. Registers Glm4MoeForCausalLM and DeepseekV4ForCausalLM. Its entrypoint attests a GLM profile, so a launch for another checkpoint overrides it with --entrypoint. Its configuration carries only component-identity labels; container labels naming the machine that produced it are cleared."
   }
 }


### PR DESCRIPTION
Closes #64.

## Resulting behavior

The published runtime image is
`ghcr.io/fujitsupolycom/gb10-vllm-serving@sha256:35b29616dc05677b98f647282e81a99fbca1969791ccbfca711c11a44285385e`,
whose configuration carries component-identity labels only.

## What was wrong

Verified against the published image before changing it:

- **12** `com.docker.compose.*` labels, including
  `com.docker.compose.project.config_files` = `/home/tn/eldritch/compose.production-3.7rc.yaml`
- `docker history` shows a single layer commented `Imported from -`, confirming
  the image was produced by capturing a running container rather than by a build
- `com.docker.compose.image` names `sha256:37e966ff…`, a different image from the
  one published, so that field misleads anyone tracing provenance through it

A public artifact should not state a home-directory path and an internal compose
filename from the machine that produced it.

## What is kept

All **43** `local-inference.*` and `org.sparkring.*` labels — the vLLM, B12X,
torch, NCCL, and profile identities that make the image traceable. Those are the
useful provenance and are untouched.

## Digest change and cleanup

Clearing labels rewrites the image configuration, so the manifest digest changes.
The lock, the DeepSeek quickstart, and the 3.5-bpw builder documentation are
updated together; no reference to the previous digest remains in this repository.

The version carrying the host path was **deleted from the registry**, so it is
not pullable by digest either. One version remains under the package.

The push moved only the configuration blob — every layer already existed, so it
completed in three seconds.

## Outside this repository

`FujitsuPolycom/inference-runtime-profiles` pins the previous digest in its
`deepseek-v4-flash-0731-sparkring-runtime-2x-spark` profile and needs the same
update. That is the one edit #64 anticipated, and doing this now keeps it to one.

## Validation

`ruff` clean. `python -m pytest scripts runtime -q` → 1789 passed, 12 skipped.
`pull_pinned_images.py --plan` resolves the new digest. Repo-relative Markdown
link and anchor check passes.