### PR TITLE
State the plugin contract without reference to how it was deployed before

### DIFF
--- a/sparkring_plugin/src/sparkring/__init__.py
+++ b/sparkring_plugin/src/sparkring/__init__.py
@@ -1,11 +1,11 @@
 """SparkRing: switchless direct-cable RDMA collectives (SIRCL) for vLLM.
 
 This package delivers the SparkRing vLLM adapter as a standard
-``vllm.general_plugins`` entry point, replacing the container-era
-``sitecustomize``/bind-mount deployment. The runtime modules under
-``sparkring/_vendor`` are byte-identical copies of
-``spark_transport/integrations/vllm`` in the SparkRing repository,
-enforced by ``tests/test_vendor_parity.py``.
+``vllm.general_plugins`` entry point, so a deployment reaches the transport
+by installing a wheel rather than by overlaying files onto a container
+image. The runtime modules under ``sparkring/_vendor`` are byte-identical
+copies of ``spark_transport/integrations/vllm`` in the SparkRing
+repository, enforced by ``tests/test_vendor_parity.py``.
 """
 
 from __future__ import annotations

--- a/sparkring_plugin/src/sparkring/plugin.py
+++ b/sparkring_plugin/src/sparkring/plugin.py
@@ -1,12 +1,17 @@
 """vLLM general-plugin entry point for the SparkRing SIRCL transport.
 
-Contract, carried over from the container ``sitecustomize`` deployment:
+Two properties define this entry point, and the tests under
+``sparkring_plugin/tests`` enforce both:
 
 - With no ``VLLM_SPARK_*`` mode variable set, ``register()`` does nothing.
   Installing the wheel must never change a serving process by itself.
 - When a mode is enabled and installation fails for any reason, the process
   exits with code 78 before vLLM can serve traffic. A partially installed
   transport must never carry collectives.
+
+``spark_transport/integrations/vllm/sitecustomize.py`` holds the same two
+properties for a deployment that overlays the integration onto a container
+image instead of installing this wheel.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
The package and entry-point docstrings in `sparkring_plugin` described the wheel by what it replaced rather than by what it is: a lifecycle label ("container-era") and the two guarantees presented as inherited from another deployment. A reader holding only the repository cannot resolve either reference, which is what the repository's prose standard forbids.

Both docstrings now state the guarantees directly, and name `spark_transport/integrations/vllm/sitecustomize.py` as the module holding the same guarantees for an overlay deployment. The relationship between the two integration paths becomes a statement about the present system rather than about a sequence of changes.

No behavior changes — docstrings only.

`python -m pytest sparkring_plugin/tests -q`: 50 passed.