### PR TITLE
Find the pinned checkpoint by its bytes rather than by a path

### DIFF
--- a/scripts/download_exl3_r7.py
+++ b/scripts/download_exl3_r7.py
@@ -43,6 +43,12 @@ PINNED_FILES = {
 }
 
 
+DEFAULT_SEARCH_ROOTS = ("/home", "/srv", "/models", "/data", "/mnt", "/var/tmp")
+SEARCH_MAX_DEPTH = 4
+INDEX_NAME = "model.safetensors.index.json"
+IDENTIFYING_FILES = ("config.json", INDEX_NAME)
+
+
 def sha256(path: Path) -> str:
     digest = hashlib.sha256()
     with path.open("rb") as stream:
@@ -156,11 +162,92 @@ def download(path: Path, api, snapshot_download) -> dict:
     return verify(path, remote_inventory)
 
 
+
+def identifies_checkpoint(path: Path) -> bool:
+    """Whether a directory holds the pinned checkpoint, judged by its bytes.
+
+    A directory is named for whatever produced it, so a name proves nothing.
+    This compares the size and SHA-256 of the files PINNED_FILES identifies and
+    counts the shards, which is what distinguishes this checkpoint from another
+    quantization of the same model.
+    """
+
+    for name in IDENTIFYING_FILES:
+        size, digest = PINNED_FILES[name]
+        candidate = path / name
+        try:
+            if not candidate.is_file() or candidate.stat().st_size != size:
+                return False
+            if sha256(candidate) != digest:
+                return False
+        except OSError:
+            return False
+    return len(list(path.glob("*.safetensors"))) == EXPECTED_SHARD_COUNT
+
+
+def candidate_directories(roots, max_depth: int = SEARCH_MAX_DEPTH):
+    """Yield directories beneath `roots` that carry a shard index.
+
+    Descent stops at `max_depth` and skips dotted directories, so a search over
+    a home directory does not walk caches unrelated to model storage.
+    """
+
+    for raw in roots:
+        root = Path(raw)
+        if not root.is_dir():
+            continue
+        base = len(root.parts)
+        for current, subdirectories, files in os.walk(root, onerror=lambda _: None):
+            here = Path(current)
+            if len(here.parts) - base >= max_depth:
+                subdirectories[:] = []
+            else:
+                subdirectories[:] = [d for d in subdirectories if not d.startswith(".")]
+            if INDEX_NAME in files:
+                yield here
+
+
+def locate(roots) -> dict:
+    """Report every directory beneath `roots` holding the pinned checkpoint."""
+
+    found = []
+    for directory in candidate_directories(roots):
+        resolved = str(directory.resolve())
+        if resolved in found:
+            continue
+        if identifies_checkpoint(directory):
+            found.append(resolved)
+    return {
+        "repository": REPOSITORY,
+        "revision": REVISION,
+        "searched_roots": [str(root) for root in roots],
+        "shard_count": EXPECTED_SHARD_COUNT,
+        "found": sorted(found),
+        "status": "pass" if found else "absent",
+    }
+
+
 def main() -> int:
     parser = argparse.ArgumentParser()
-    parser.add_argument("action", choices=("download", "verify"))
-    parser.add_argument("--model-path", type=Path, required=True)
+    parser.add_argument("action", choices=("download", "verify", "locate"))
+    parser.add_argument("--model-path", type=Path)
+    parser.add_argument(
+        "--search-root",
+        type=Path,
+        action="append",
+        dest="search_roots",
+        help=(
+            "directory to search for the pinned checkpoint; repeatable, and "
+            "defaults to " + ", ".join(DEFAULT_SEARCH_ROOTS)
+        ),
+    )
     args = parser.parse_args()
+    if args.action == "locate":
+        report = locate(args.search_roots or [Path(r) for r in DEFAULT_SEARCH_ROOTS])
+        print(json.dumps(report, sort_keys=True))
+        return 0 if report["found"] else 1
+    if args.model_path is None:
+        parser.error("--model-path is required for download and verify")
     try:
         from huggingface_hub import HfApi, snapshot_download
 

--- a/scripts/test_download_exl3_r7.py
+++ b/scripts/test_download_exl3_r7.py
@@ -63,3 +63,70 @@ def test_verify_fails_when_revision_has_no_digest_for_a_runtime_shard(tmp_path, 
     monkeypatch.setattr(r7, "indexed_shards", lambda _: {"missing.safetensors"})
     with pytest.raises(RuntimeError, match="lacks LFS SHA-256 metadata"):
         r7.verify(tmp_path, {})
+
+
+def _plant_checkpoint(root, monkeypatch, *, shards=None, config=b"cfg", index=b"idx"):
+    """Create a directory the locator should accept, and pin it to those bytes."""
+    monkeypatch.setitem(r7.PINNED_FILES, "config.json", (len(config), _sha(config)))
+    monkeypatch.setitem(r7.PINNED_FILES, r7.INDEX_NAME, (len(index), _sha(index)))
+    monkeypatch.setattr(r7, "EXPECTED_SHARD_COUNT", 3)
+    root.mkdir(parents=True, exist_ok=True)
+    (root / "config.json").write_bytes(config)
+    (root / r7.INDEX_NAME).write_bytes(index)
+    for number in range(3 if shards is None else shards):
+        (root / f"shard-{number}.safetensors").write_bytes(b"")
+    return root
+
+
+def test_locate_finds_checkpoint_under_any_directory_name(tmp_path, monkeypatch):
+    """The directory is named for its repository, not for a mount point."""
+    planted = _plant_checkpoint(
+        tmp_path / "home" / "someone" / "models" / "GLM-5.2-EXL3-TR3v4-3.5bpw-MTP78",
+        monkeypatch,
+    )
+
+    report = r7.locate([tmp_path])
+
+    assert report["status"] == "pass"
+    assert report["found"] == [str(planted.resolve())]
+
+
+def test_locate_rejects_a_directory_whose_config_differs(tmp_path, monkeypatch):
+    """A different quantization of the same model must not be accepted."""
+    _plant_checkpoint(tmp_path / "models" / "other", monkeypatch)
+    (tmp_path / "models" / "other" / "config.json").write_bytes(b"different")
+
+    report = r7.locate([tmp_path])
+
+    assert report["status"] == "absent"
+    assert report["found"] == []
+
+
+def test_locate_rejects_a_partial_shard_set(tmp_path, monkeypatch):
+    _plant_checkpoint(tmp_path / "models" / "partial", monkeypatch, shards=2)
+
+    assert r7.locate([tmp_path])["status"] == "absent"
+
+
+def test_locate_reports_absent_for_a_missing_root(tmp_path):
+    report = r7.locate([tmp_path / "nowhere"])
+
+    assert report["status"] == "absent"
+    assert report["searched_roots"] == [str(tmp_path / "nowhere")]
+
+
+def test_candidate_directories_stops_at_the_depth_limit(tmp_path):
+    deep = tmp_path / "a" / "b" / "c" / "d" / "e"
+    deep.mkdir(parents=True)
+    (deep / r7.INDEX_NAME).write_bytes(b"idx")
+
+    assert list(r7.candidate_directories([tmp_path], max_depth=2)) == []
+    assert deep in list(r7.candidate_directories([tmp_path], max_depth=9))
+
+
+def test_candidate_directories_skips_dotted_directories(tmp_path):
+    hidden = tmp_path / ".cache" / "model"
+    hidden.mkdir(parents=True)
+    (hidden / r7.INDEX_NAME).write_bytes(b"idx")
+
+    assert list(r7.candidate_directories([tmp_path])) == []


### PR DESCRIPTION
Documentation and `scripts/config/exl3-r7-candidate.example.json` name `/var/tmp/sparkring-r7-model` as the checkpoint location, but the directory a download actually produces is named for its Hugging Face repository. A deployment can therefore hold the pinned checkpoint and offer no way to discover it — a search by path reports it absent.

That is not hypothetical. On the four-Spark stack the checkpoint sits at `/home/<user>/models/GLM-5.2-EXL3-TR3v4-3.5bpw-MTP78` on all four ranks, while `/var/tmp/sparkring-r7-model` held a different quantization of the same model. A path-shaped search concluded the checkpoint was missing.

## What this adds

`download_exl3_r7.py locate` searches by content:

- `config.json` and `model.safetensors.index.json` must match the size and SHA-256 already recorded in `PINNED_FILES`
- the directory must hold `EXPECTED_SHARD_COUNT` (157) shards

The directory's name plays no part in the answer, which is the point — the failure it prevents is a checkpoint stored under a name the search did not anticipate.

`--search-root` is repeatable and defaults to `/home`, `/srv`, `/models`, `/data`, `/mnt`, `/var/tmp`. Descent stops at four levels and skips dotted directories, keeping a search over a home directory away from caches unrelated to model storage.

Reports every match as JSON, exits non-zero when none is found, reaches no network — same offline safety class as `verify`.

## Verified against real hardware

```
$ python3 download_exl3_r7.py locate
{"found": ["/home/dooner/models/GLM-5.2-EXL3-TR3v4-3.5bpw-MTP78"],
 "revision": "9ab9579774cc432df91567a36f6e9e863e0d4c9f",
 "shard_count": 157, "status": "pass"}
real  0m2.850s
```

## Compatibility

`--model-path` becomes optional, required only by `download` and `verify`; both reject its absence with a parser error. No existing behavior changes.

`scripts/test_download_exl3_r7.py`: 11 passed (6 pre-existing, 5 new — covering an unexpected directory name, a differing `config.json`, a partial shard set, a missing root, the depth limit, and dotted-directory pruning).