### PR TITLE
Pin the serving image to a digest the registry serves

### DIFF
--- a/docs/DEEPSEEK_V4_FLASH_QUICKSTART.md
+++ b/docs/DEEPSEEK_V4_FLASH_QUICKSTART.md
@@ -32,7 +32,7 @@ You also need a vLLM build that can load `DeepseekV4ForCausalLM` with
 the B12X kernel family. One is published:
 
 ```bash
-docker pull ghcr.io/fujitsupolycom/gb10-vllm-serving@sha256:df0e2068fc7034a1ec7a2c1fa4e0c3224c720161539525b5a7cbb037dc1d0f8e
+docker pull ghcr.io/fujitsupolycom/gb10-vllm-serving@sha256:6fc26fdad81a18f0fff67ce0a05f6d90165625ea2e1cac8a6f39bfb462017028
 ```
 
 That image registers `DeepseekV4ForCausalLM` and carries B12X, LMCache,
@@ -41,12 +41,14 @@ the patched NCCL, and the SparkRing transport library. It also registers
 
 What the image removes is the ARM64 CUDA build: the transport library,
 its probe binaries, the patched NCCL, and the forked vLLM all arrive
-prebuilt. What it does not carry is a `quack-kernels` compatible with
-its own `nvidia-cutlass-dsl`, so it requires the correction below before
-it serves this checkpoint. No bind mount and no file outside this
-repository is required.
+prebuilt. It also carries the `quack-kernels` correction described below,
+so no bind mount and no file outside this repository is required to serve
+this checkpoint from it.
 
-### Correcting the image
+`runtime/faststart-lock.json` owns this pin. The command above repeats it
+rather than establishing a second one.
+
+### What the correction is, and how to rebuild it
 
 `quack-kernels` 0.5.0 reaches the published image as a transitive
 dependency, so it escapes the two things `runtime/exl3-r7` applies to a
@@ -76,14 +78,15 @@ profiling:
   `map_dataclass_to_tuple` argument that `apache-tvm-ffi` 0.1.9 does not
   accept, raising `TypeError`.
 
-Build the corrected image on every rank, from a checkout of this
-repository:
+The published digest above is that correction already applied. To
+reproduce it, or to apply it to a different parent, build from a checkout
+of this repository:
 
 ```bash
 mkdir -p /var/tmp/sparkring-correction
 cp runtime/exl3-r7/bake_runtime_artifacts.py /var/tmp/sparkring-correction/
 cat > /var/tmp/sparkring-correction/Dockerfile <<'DOCKERFILE'
-FROM ghcr.io/fujitsupolycom/gb10-vllm-serving@sha256:df0e2068fc7034a1ec7a2c1fa4e0c3224c720161539525b5a7cbb037dc1d0f8e
+FROM ghcr.io/fujitsupolycom/gb10-vllm-serving@sha256:35b29616dc05677b98f647282e81a99fbca1969791ccbfca711c11a44285385e
 COPY bake_runtime_artifacts.py /tmp/bake_runtime_artifacts.py
 RUN /opt/venv/bin/pip install --no-cache-dir "apache-tvm-ffi==0.1.10" \
  && /opt/venv/bin/python /tmp/bake_runtime_artifacts.py quack \
@@ -101,8 +104,9 @@ bytes. A rank without a route to a package index needs the
 `--no-index --find-links` pointed at it; the wheel URL and its SHA-256
 are in `runtime/exl3-r7/requirements-tvm-ffi.txt`.
 
-Use `sparkring/gb10-vllm-serving:corrected` wherever the launch below
-names an image.
+A locally built image carries a different identity from the published
+digest, so a launch from one is evidence about that build rather than
+about the pin.
 
 ## 2. Model
 
@@ -128,7 +132,7 @@ docker run -d --name deepseek-v4-flash-r"$RANK" \
   -v /path/to/deepseek-v4-flash-0731:/models/deepseek-v4-flash-0731:ro \
   --env-file /path/to/rank-"$RANK".env \
   --entrypoint /opt/venv/bin/vllm \
-  sparkring/gb10-vllm-serving:corrected \
+  ghcr.io/fujitsupolycom/gb10-vllm-serving@sha256:6fc26fdad81a18f0fff67ce0a05f6d90165625ea2e1cac8a6f39bfb462017028 \
   serve /models/deepseek-v4-flash-0731 \
   --tensor-parallel-size 4 --nnodes 4 --node-rank "$RANK" \
   --master-addr "$RANK0_FABRIC_ADDR" --master-port 29500 \

--- a/runtime/exl3-r7/README.md
+++ b/runtime/exl3-r7/README.md
@@ -69,10 +69,12 @@ which of the two it descends from. That label on a built 3.5-bpw image and this
 document have disagreed; the label is the record of what was built, and this
 table describes what the builder accepts rather than asserting one lineage.
 
-A published image can serve as the parent rather than one built locally:
+A published image can serve as the parent rather than one built locally. The
+pin for it lives in `runtime/faststart-lock.json` under `serving_image`; this
+command repeats that digest rather than establishing a second pin:
 
 ```bash
-docker pull ghcr.io/fujitsupolycom/gb10-vllm-serving@sha256:df0e2068fc7034a1ec7a2c1fa4e0c3224c720161539525b5a7cbb037dc1d0f8e
+docker pull ghcr.io/fujitsupolycom/gb10-vllm-serving@sha256:6fc26fdad81a18f0fff67ce0a05f6d90165625ea2e1cac8a6f39bfb462017028
 ```
 
 `scripts/pull_pinned_images.py` retrieves it along with every other image the

--- a/runtime/faststart-lock.json
+++ b/runtime/faststart-lock.json
@@ -21,8 +21,15 @@
   ],
   "serving_image": {
     "repository": "ghcr.io/fujitsupolycom/gb10-vllm-serving",
-    "manifest_digest": "sha256:df0e2068fc7034a1ec7a2c1fa4e0c3224c720161539525b5a7cbb037dc1d0f8e",
+    "manifest_digest": "sha256:6fc26fdad81a18f0fff67ce0a05f6d90165625ea2e1cac8a6f39bfb462017028",
+    "tag_for_humans": "quack-corrected",
     "platform": "linux/arm64",
-    "note": "The published GB10 runtime image. Carries the pinned vLLM, B12X, LMCache, the EXL3 quantization overlay, FlashInfer, DeepGEMM, the patched NCCL, and libspark_transport_capi.so with its probe binaries. Registers Glm4MoeForCausalLM and DeepseekV4ForCausalLM. Its entrypoint attests a GLM profile, so a launch for another checkpoint overrides it with --entrypoint."
+    "parent_manifest_digest": "sha256:35b29616dc05677b98f647282e81a99fbca1969791ccbfca711c11a44285385e",
+    "notes": [
+      "The published GB10 runtime image. Carries the pinned vLLM, B12X, LMCache, the EXL3 quantization overlay, FlashInfer, DeepGEMM, the patched NCCL, and libspark_transport_capi.so with its probe binaries. Registers Glm4MoeForCausalLM and DeepseekV4ForCausalLM.",
+      "Its entrypoint attests a GLM profile, so a launch for another checkpoint overrides it with --entrypoint.",
+      "It is built from parent_manifest_digest by installing apache-tvm-ffi 0.1.10 and running runtime/exl3-r7/bake_runtime_artifacts.py over /opt/venv/lib/python3.12/site-packages/quack. That rewrites the cute.core.ThrMma and cute.core.ThrCopy annotations the image's cutlass no longer exports. Without the rewrite a worker raises AttributeError on cutlass.cute.core.ThrMma while determining available memory for a checkpoint other than GLM; GLM serving does not reach that call site, so the parent serves GLM and this digest serves both.",
+      "Serving evidence for DeepSeek-V4-Flash-0731 is one four-rank launch on which three ranks ran this image's content and the fourth, which has no route to a registry, ran an image built locally and never compared against this digest. A four-rank launch from a registry pull of this digest is untested."
+    ]
   }
 }

--- a/runtime/test_faststart.py
+++ b/runtime/test_faststart.py
@@ -23,6 +23,23 @@ def test_faststart_lock_pins_arm64_base_and_model():
     assert re.fullmatch(r"[0-9a-f]{64}", model["config_sha256"])
 
 
+def test_faststart_lock_pins_the_published_serving_image():
+    serving = LOCK["serving_image"]
+    assert serving["repository"] == "ghcr.io/fujitsupolycom/gb10-vllm-serving"
+    assert serving["platform"] == "linux/arm64"
+    for field in ("manifest_digest", "parent_manifest_digest"):
+        assert re.fullmatch(r"sha256:[0-9a-f]{64}", serving[field])
+    assert serving["manifest_digest"] != serving["parent_manifest_digest"]
+
+
+def test_exl3_r7_builder_documents_the_locked_serving_image_digest():
+    """The builder's parent-image command repeats the lock, never a second pin."""
+
+    serving = LOCK["serving_image"]
+    text = (RUNTIME / "exl3-r7/README.md").read_text(encoding="utf-8")
+    assert f'{serving["repository"]}@{serving["manifest_digest"]}' in text
+
+
 def test_faststart_model_pin_matches_full_runtime_lock():
     full = json.loads((RUNTIME / "runtime-lock.json").read_text(encoding="utf-8"))
     assert LOCK["model"]["repository"] == full["model"]["repository"]


### PR DESCRIPTION
`ghcr.io/fujitsupolycom/gb10-vllm-serving@sha256:df0e2068…` returns **HTTP 404** with `MANIFEST_UNKNOWN`. Three documents and `runtime/faststart-lock.json` named it, so a reader following the DeepSeek quickstart failed at its very first command.

Verified against the GHCR API with an anonymous pull token, not inferred:

| digest | HTTP |
|---|---|
| `sha256:df0e2068…` | **404** `MANIFEST_UNKNOWN` |
| `sha256:35b29616…` (`r34-20260810`) | 200 |
| `sha256:6fc26fda…` (`quack-corrected`) | 200 |

The package publishes exactly two tags. 404 is distinguishable from rate limiting here because the two sibling digests returned 200 on the same token in the same second.

## What changes

The lock, `runtime/exl3-r7/README.md`, and the quickstart all name `sha256:6fc26fda…`. That image is built from `sha256:35b29616…` by installing `apache-tvm-ffi==0.1.10` and running `runtime/exl3-r7/bake_runtime_artifacts.py` over the image's `quack` package, rewriting the `cutlass.cute.core.ThrMma` / `ThrCopy` annotations that cutlass-dsl 4.6.0 defines in `cutlass.cute.atom` instead.

Because that digest **already carries** the correction, the quickstart now explains what the correction is and how to reproduce it, rather than requiring a build before a launch. The rebuild recipe starts `FROM` the parent digest, which is the one lacking it.

The lock records the parent under a field `pull_pinned_images.py` does not read, so the lineage is stated without adding a second 14 GB pull for one shared layer.

## What this deliberately does not claim

The serving evidence for DeepSeek-V4-Flash-0731 is **one** four-rank launch on which three ranks ran this image's content and the fourth — which has no route to any registry — ran a locally built image never compared against this digest. **A four-rank launch from a registry pull of this digest is untested**, and the lock says so in as many words. This is a pin to a retrievable artifact, not a promotion.

## Keeping it checkable

Two tests in `runtime/test_faststart.py`: the lock must pin the repository by a well-formed arm64 digest distinct from its parent, and the builder README's pull command must quote the lock's digest rather than establish a second pin.

`runtime` and `scripts`: 1977 passed, 12 skipped. `validate_publication_consistency.py`: PASS.

Supersedes #67, which moved the same pin to `sha256:35b29616…` for the same underlying reason — that image's configuration carries only component-identity labels, and `sha256:6fc26fda…` inherits them.