### PR TITLE
Use a documentation address for the management interface in ring-doctor tests

### DIFF
--- a/scripts/test_ring_doctor.py
+++ b/scripts/test_ring_doctor.py
@@ -303,7 +303,7 @@ WIFI = "wlP9s9"
 ADDRESSED_WIFI_LISTING = f"""lo UNKNOWN 127.0.0.1/8
 {IF0} UP 10.0.1.10/24
 {IF1} UP 10.0.4.12/24
-{WIFI} UP 192.168.7.21/24"""
+{WIFI} UP 192.0.2.21/24"""
 
 FABRIC_ONLY_LISTING = f"""lo UNKNOWN 127.0.0.1/8
 {IF0} UP 10.0.2.10/24
@@ -522,7 +522,7 @@ class LaunchEndpointTests(unittest.TestCase):
         self.assertEqual(len(runner.calls), len(specs))
         self.assertEqual(
             observations["r0"].host_interfaces[WIFI].addresses[0],
-            ipaddress.ip_interface("192.168.7.21/24"),
+            ipaddress.ip_interface("192.0.2.21/24"),
         )
         self.assertFalse(observations["r3"].rendezvous_route.routable)
         launch_findings = {
@@ -553,7 +553,7 @@ HEALTHY_RING = {
     "r0": (
         ("spark-edfd", (WIFI, IF0)),
         f"lo UNKNOWN 127.0.0.1/8\n{IF0} UP 10.0.1.10/24\n{IF1} UP 10.0.4.12/24\n"
-        f"{WIFI} UP 192.168.7.21/24",
+        f"{WIFI} UP 192.0.2.21/24",
         f"10.0.2.0/24 via 10.0.1.11 dev {IF0}\n10.0.3.0/24 via 10.0.4.13 dev {IF1}",
         f"local {RENDEZVOUS} dev lo src {RENDEZVOUS} uid 1000",
     ),


### PR DESCRIPTION
`main` currently fails the **release-safety (BLOCKING)** gate, so every open PR inherits the failure regardless of its own content.

The gate blocks the shape `192.168.x.y` in tracked content because this repository is public and that shape is a real site address. `scripts/test_ring_doctor.py` used `192.168.7.21` as the management interface's address in three fixtures:

```
scripts/test_ring_doctor.py:306  {WIFI} UP 192.168.7.21/24
scripts/test_ring_doctor.py:525  ipaddress.ip_interface("192.168.7.21/24")
scripts/test_ring_doctor.py:556  f"{WIFI} UP 192.168.7.21/24"
```

They now use `192.0.2.21`, from the RFC 5737 documentation range the gate's own message recommends. The address is arbitrary in these tests — it stands for an interface on a network that is not the fabric, and nothing asserts a particular value beyond what the fixture supplies. Every other address in the file already uses the permitted `10.0.x` range.

Verified with the gate's own blocking pattern across all tracked files:

```
$ git ls-files -z | xargs -0 grep -lE "192\.168\.[0-9]{1,3}\.[0-9]{1,3}" \
    | grep -vE "docs/RELEASE_SAFETY.md|.github/workflows/ci.yml"
(no output)
```

`scripts/test_ring_doctor.py`: 18 passed.

This should be merged before #74 and #75, which are otherwise green and blocked only by this.