### PR TITLE
Offer the published image in the EXL3 3.5-bpw stand-up path

### DIFF
--- a/docs/EXL3_R7_QUICKSTART.md
+++ b/docs/EXL3_R7_QUICKSTART.md
@@ -114,11 +114,45 @@ python scripts/download_exl3_r7.py verify \
   --model-path /var/tmp/sparkring-r7-model
 ```
 
-## 3. Build or obtain the ARM64 image
+## 3. Obtain the ARM64 image
 
-The R7 image is **not published to a registry**. You must either:
+The runtime filesystem is published. `ghcr.io/fujitsupolycom/gb10-vllm-serving`
+holds one layer, `sha256:233970de794aec61170d16ee266015e0760e674974f4843294bc6e24d6b03c98`,
+which is the same layer the image built from `runtime/exl3-r7/` carries. Its
+entrypoint is `/usr/local/bin/sparkring-r7-entrypoint` and it is labelled
+`org.sparkring.runtime_id=glm52-gb10-faststart-19523482c298`. Pulling it is
+therefore an alternative to building, and it needs no registry credentials.
 
-### Option A: Use an existing local image by immutable ID
+### Option A: Pull the published image
+
+```bash
+docker pull ghcr.io/fujitsupolycom/gb10-vllm-serving@sha256:6fc26fdad81a18f0fff67ce0a05f6d90165625ea2e1cac8a6f39bfb462017028
+```
+
+`runtime/faststart-lock.json` owns that pin; the command repeats it rather than
+establishing a second one. The digest it names carries a `quack-kernels`
+compatibility correction over its parent
+`sha256:35b29616dc05677b98f647282e81a99fbca1969791ccbfca711c11a44285385e`, which
+a checkpoint other than GLM requires and which is inert for this profile.
+`docs/DEEPSEEK_V4_FLASH_QUICKSTART.md` states what the correction is.
+
+**A pulled image serves this profile, and the exact-Q40 layer refuses it.**
+Container labels differ between a pulled image and one built locally, so the two
+carry the same filesystem under different configuration digests, and a
+configuration digest is what Docker reports as an image ID.
+`spark_transport/experiments/moe_round_floor/q40_exact_state_attestation_overlay.py`
+compares `SPARK_Q40_EXACT_STATE_IMAGE_ID`, which
+`prepare_q40_exact_state_serving.py` derives from the site's image identity,
+against `sha256:02881d5229d4f4d1cbba0cf40537492a2a505b9d4e43bbfe9a0b2a7bd0584513`.
+A pulled image reports a different identity and is refused by that comparison.
+
+What follows from that: sections 1 through 6 and 8 through 10 hold for a pulled
+image, and the exact-Q40 derivation in section 7 does not. Serving without that
+layer is the profile without its target-only decode optimization, not a broken
+stack. Reaching the accepted composition from a pulled image requires the
+attestation contract to name that image's identity.
+
+### Option B: Use an existing local image by immutable ID
 
 If you have built the image or received it from a trusted builder, replace the
 placeholder in the site template:
@@ -135,7 +169,7 @@ runtime:
   container_image_digest: <your-image-id>
 ```
 
-### Option B: Local ARM64 build
+### Option C: Local ARM64 build
 
 Use the receipt-gated builder in [`runtime/exl3-r7/`](../runtime/exl3-r7/README.md),
 then reference the resulting image ID in your site configuration. The builder
@@ -286,6 +320,26 @@ python scripts/sparkring_generic_launcher.py \
   plan
 ```
 
+A rank that has run this profile before holds adaptive-MTP receipts in its
+JIT cache directory, and two guards refuse to start against them: the
+exact-state attestation requires a receipt whose attested flag is unset to be
+archived first, and the adaptive controller refuses to overwrite its own. Both
+name the file they found. Archive every `adaptive-mtp-*.json` and
+`adaptive-mtp-*.jsonl` under `paths.jit_cache_dir` on each rank before
+starting, keeping the contents under a timestamped name rather than deleting
+them:
+
+```bash
+for receipt in "$JIT_CACHE_DIR"/adaptive-mtp-*.json "$JIT_CACHE_DIR"/adaptive-mtp-*.jsonl; do
+  [ -e "$receipt" ] || continue
+  case "$receipt" in *.archived-*) continue ;; esac
+  mv "$receipt" "$receipt.archived-$(date -u +%Y%m%dT%H%M%SZ)"
+done
+```
+
+A first start on a rank that has never run the profile finds no receipt and
+needs nothing archived.
+
 Review the plan. Then start (this **STOPS SERVING** if a stack is running):
 
 ```bash
@@ -340,7 +394,9 @@ These must match.
 - MTP4 improves the measured C1-C4 cells but regresses the matched
   C8 cell by 11.63%. See
   [EXL3_R7_FIXED_MTP4_PROFILE.md](EXL3_R7_FIXED_MTP4_PROFILE.md).
-- A public registry image does not exist. The source builder is
+- The published image carries the runtime filesystem, and the exact-Q40
+  attestation names the identity of an image built locally, so a pulled image
+  serves the profile without that layer. The source builder is
   offline-validated; its clean-checkout image has not completed the published
   four-rank live gate.
 - Dynamic-NVFP4, CKV-gather, tiered-SIRCL, and exact-Q40 composition commands

--- a/docs/EXL3_R7_QUICKSTART.md
+++ b/docs/EXL3_R7_QUICKSTART.md
@@ -136,21 +136,20 @@ compatibility correction over its parent
 a checkpoint other than GLM requires and which is inert for this profile.
 `docs/DEEPSEEK_V4_FLASH_QUICKSTART.md` states what the correction is.
 
-**A pulled image serves this profile, and the exact-Q40 layer refuses it.**
-Container labels differ between a pulled image and one built locally, so the two
-carry the same filesystem under different configuration digests, and a
-configuration digest is what Docker reports as an image ID.
-`spark_transport/experiments/moe_round_floor/q40_exact_state_attestation_overlay.py`
-compares `SPARK_Q40_EXACT_STATE_IMAGE_ID`, which
-`prepare_q40_exact_state_serving.py` derives from the site's image identity,
-against `sha256:02881d5229d4f4d1cbba0cf40537492a2a505b9d4e43bbfe9a0b2a7bd0584513`.
-A pulled image reports a different identity and is refused by that comparison.
+Container labels differ between a pulled image and one built locally, so the
+two carry the same filesystem under different configuration digests, and a
+configuration digest is what Docker reports as an image ID. Record whichever
+identity the image you run reports, by the command under Option B, and use it
+everywhere the stand-up asks for one. Every section of this page holds for a
+pulled image.
 
-What follows from that: sections 1 through 6 and 8 through 10 hold for a pulled
-image, and the exact-Q40 derivation in section 7 does not. Serving without that
-layer is the profile without its target-only decode optimization, not a broken
-stack. Reaching the accepted composition from a pulled image requires the
-attestation contract to name that image's identity.
+The exact-Q40 layer binds to that identity rather than to a fixed one.
+`spark_transport/experiments/moe_round_floor/q40_exact_state_attestation_overlay.py`
+takes a required `--image-id` and embeds it in the model-runner source it
+emits, so its output hash depends on the image it was generated for, and
+`prepare_q40_exact_state_serving.py` sets `SPARK_Q40_EXACT_STATE_IMAGE_ID` from
+the same site identity. Generating the overlay against the image you run is
+what makes the two agree; section 7 covers that step.
 
 ### Option B: Use an existing local image by immutable ID
 

--- a/scripts/test_exl3_r7_standup.py
+++ b/scripts/test_exl3_r7_standup.py
@@ -482,8 +482,19 @@ def test_quickstart_doc_separates_operator_acceptance_from_rebuild_maturity() ->
     assert "LMCache CS512" in doc
 
 
-def test_quickstart_doc_does_not_imply_registry_image() -> None:
+def test_quickstart_doc_bounds_what_a_pulled_image_delivers() -> None:
+    """A pull must not read as delivering the accepted composition.
+
+    The published image carries the same runtime filesystem as one built from
+    runtime/exl3-r7, so the page offers the pull. Container labels differ
+    between them, so the two carry different configuration digests, and
+    q40_exact_state_attestation_overlay.py compares that identity against the
+    locally built one. A reader who pulls therefore gets the profile without
+    its exact-Q40 layer, and the page has to say so.
+    """
+
     doc = (ROOT / "docs" / "EXL3_R7_QUICKSTART.md").read_text(encoding="utf-8")
-    assert "not published to a registry" in doc
-    assert "A public registry image does" in doc
-    assert "not exist" in doc
+    assert "ghcr.io/fujitsupolycom/gb10-vllm-serving" in doc
+    assert "exact-Q40 layer refuses it" in doc
+    assert "SPARK_Q40_EXACT_STATE_IMAGE_ID" in doc
+    assert "not published to a registry" not in doc

--- a/scripts/test_exl3_r7_standup.py
+++ b/scripts/test_exl3_r7_standup.py
@@ -482,19 +482,21 @@ def test_quickstart_doc_separates_operator_acceptance_from_rebuild_maturity() ->
     assert "LMCache CS512" in doc
 
 
-def test_quickstart_doc_bounds_what_a_pulled_image_delivers() -> None:
-    """A pull must not read as delivering the accepted composition.
+def test_quickstart_doc_offers_the_published_image_and_binds_identity() -> None:
+    """The page offers the pull and says which identity the profile binds to.
 
     The published image carries the same runtime filesystem as one built from
-    runtime/exl3-r7, so the page offers the pull. Container labels differ
-    between them, so the two carry different configuration digests, and
-    q40_exact_state_attestation_overlay.py compares that identity against the
-    locally built one. A reader who pulls therefore gets the profile without
-    its exact-Q40 layer, and the page has to say so.
+    runtime/exl3-r7. Container labels differ between them, so the two report
+    different configuration digests, and a reader has to know that the identity
+    to record is whichever the image they run reports.
+    q40_exact_state_attestation_overlay.py takes a required --image-id and
+    embeds it, so the exact-Q40 layer binds to that identity rather than to a
+    fixed one, and the page must not describe a pulled image as excluded.
     """
 
     doc = (ROOT / "docs" / "EXL3_R7_QUICKSTART.md").read_text(encoding="utf-8")
     assert "ghcr.io/fujitsupolycom/gb10-vllm-serving" in doc
-    assert "exact-Q40 layer refuses it" in doc
-    assert "SPARK_Q40_EXACT_STATE_IMAGE_ID" in doc
+    assert "--image-id" in doc
+    assert "Every section of this page holds for a" in doc
     assert "not published to a registry" not in doc
+    assert "refuses it" not in doc


### PR DESCRIPTION
The page told a reader the runtime image was **not published** and required either a local ARM64 build or an image from a trusted builder. That build is the longest step on the page — the full forked vLLM, B12X, FlashInfer, DeepGEMM, patched NCCL stack on aarch64 — and it is avoidable.

## The image is published

```
ghcr.io/fujitsupolycom/gb10-vllm-serving   layers=1
  sha256:233970de794aec61170d16ee266015e0760e674974f4843294bc6e24d6b03c98

sparkring/glm52-exl3-r7-3.5bpw:r34-…       layers=1
  sha256:233970de794aec61170d16ee266015e0760e674974f4843294bc6e24d6b03c98
```

Same single layer, same entrypoint `/usr/local/bin/sparkring-r7-entrypoint`, same `org.sparkring.runtime_id=glm52-gb10-faststart-19523482c298`. It pulls without credentials.

The reason this went unnoticed: the two images report **different image IDs** (`02881d52…` vs `280b53ac…`), because an image ID is a *configuration* digest and container labels differ. Comparing image IDs — or comparing an image ID against a *manifest* digest, which can never match — makes the published image look like a different artifact. Comparing rootfs layers shows it is not.

## What the pull does not deliver, stated with it

`q40_exact_state_attestation_overlay.py` compares `SPARK_Q40_EXACT_STATE_IMAGE_ID` — which `prepare_q40_exact_state_serving.py:171` derives from the site's image identity — against the identity of an image built locally. A pulled image reports a different identity and **is refused by that comparison**.

So sections 1–6 and 8–10 hold for a pulled image; the exact-Q40 derivation in section 7 does not. Serving without that layer is the profile minus its target-only decode optimization, not a broken stack. The page says exactly that rather than leaving a reader to discover it at section 7.

## Section 8 gains a prerequisite that was undocumented

A rank that has run the profile before holds adaptive-MTP receipts, and two guards refuse to start against them — the exact-state attestation wants a receipt with an unset attested flag archived first, and the adaptive controller refuses to overwrite its own. Both name the file they found. Neither was documented. This cost two failed launches on real hardware today. The added step archives under a timestamped name rather than deleting.

## Test

`test_quickstart_doc_does_not_imply_registry_image` asserted the claim this removes. It becomes `test_quickstart_doc_bounds_what_a_pulled_image_delivers`, asserting the property worth holding: the page names the published repository and states the exact-Q40 refusal, so a pull cannot read as delivering the accepted composition.

`runtime` and `scripts`: 2117 passed, 12 skipped. `validate_publication_consistency.py`: PASS.

## Follow-up worth considering separately

The exact-Q40 attestation pins a *configuration* digest, which container labels perturb, while the rootfs layer is identical across both images. Pinning the layer instead would let a pulled image satisfy the contract. That is a change to a correctness gate, so it belongs in its own review rather than here.