### PR TITLE
Correct three claims that the repository's own records contradict

### DIFF
--- a/docs/DEEPSEEK_V4_FLASH_QUICKSTART.md
+++ b/docs/DEEPSEEK_V4_FLASH_QUICKSTART.md
@@ -168,15 +168,21 @@ start will miss that window, and a rank without a route to the registry
 cannot pull at all. Distribute first, verify every rank reports the same
 image ID, then launch.
 
-Four flags in that command are load-bearing and easy to omit:
+These flags in that command are easy to omit, and one is commonly
+misread as load-bearing:
 
-- `--kernel-config '{"enable_cutedsl_warmup": false}'` disables a CuteDSL
-  router-GEMM warmup pass. Against an uncorrected image that pass aborts
-  the worker before the engine starts, because it reaches the quack import
-  described in section 1. Against the corrected image a launch that omits
-  the flag reports `Skipping CuTeDSL warmup because no compile units were
-  requested` and serves, so the flag is not required; it is retained here
-  because the configuration these observations come from carries it.
+- `--kernel-config '{"enable_cutedsl_warmup": false}'` gates the CuteDSL
+  GEMM autotune section only. It does not gate
+  `_warmup_ll_bf16_router_gemm()`, which runs on any capability-90 or higher
+  device regardless of the flag, so it does not prevent the abort an
+  uncorrected image raises;
+  [`runtime/hotfixes/deployed-r34-20260810/README.md`](../runtime/hotfixes/deployed-r34-20260810/README.md)
+  records that call site and the version skew behind it. Section 1's
+  correction is what prevents the abort. A launch from the corrected image
+  that omits the flag reports `Skipping CuTeDSL warmup because no compile
+  units were requested` and serves. The flag is retained here because the
+  configuration these observations come from carries it, not because it is
+  load-bearing.
 - `--kv-cache-dtype fp8_ds_mla` declares the layout the engine allocates.
   `fp8` allocates identically but declares a generic geometry; the engine's
   own kernels never read the declaration, so both serve, and only

--- a/docs/EAGER_WIDTH_VALIDATION_RUNBOOK.md
+++ b/docs/EAGER_WIDTH_VALIDATION_RUNBOOK.md
@@ -86,8 +86,8 @@ not gate on, the numbers).
 
 Operator-launched from CodesPC; stack down, links idle. `spark_tp4_tensor_probe`
 from the `sparkring-native-full-20260812T0335Z` build on r0, fanned to
-r1/r2/r3. Control TCP over the direct links (192.168.101/102/103/200.x)
-because the 192.168.0.x network was unavailable; RDMA devices and GID
+r1/r2/r3. Control TCP over the direct links, one subnet per link, because
+the management network was unavailable; RDMA devices and GID
 indexes per the per-rank env of the deployed serving launch
 configuration (generation label `v23`, from the container name component
 `launch-tunable-v10-adaptive-closure-v23`): `rocep1s0f0/f1`, odd ranks

--- a/docs/EXL3_R7_QUICKSTART.md
+++ b/docs/EXL3_R7_QUICKSTART.md
@@ -349,8 +349,13 @@ These must match.
 - DCP and indexer collectives use the stock path. Only the
   qualified TP all-reduce and vocabulary families use the SparkRing native
   transport.
-- Fixed MTP5 is unsupported by this image. Q48 requires a Python
-  contract extension and a rebuilt native library.
+- Fixed MTP5 requires a Q48 Python contract extension and the matching
+  native library, which the deployed overlay set supplies rather than the
+  bare image. A four-rank launch at `num_speculative_tokens: 5` serves and
+  reports mean acceptance length between 4.38 and 5.52. Whether it decodes
+  faster than the fixed-MTP4 contract above is unmeasured: no matched
+  comparison between the two has been run, so this page continues to
+  specify MTP4.
 
 ## Input chain
 


### PR DESCRIPTION
Each of these is contradicted by something already in the repository or already observed on hardware.

## 1. Real site identity in a public runbook

`docs/EAGER_WIDTH_VALIDATION_RUNBOOK.md` named the four direct-link subnets and the management network by their real addresses. They are written as **ranges** rather than single addresses, so the release-safety gate's `192\.168\.[0-9]{1,3}\.[0-9]{1,3}` pattern never matched them — the gate was not at fault, the shape simply slipped it.

The record states the same fact without them: control TCP ran over the direct links, one subnet per link, because the management network was unavailable. Nothing evidential is lost — which link carried which address is not what the record establishes.

## 2. A flag described as preventing an abort

The DeepSeek quickstart listed `--kernel-config '{"enable_cutedsl_warmup": false}'` among **load-bearing** flags and said the pass it disables aborts the worker.

`runtime/hotfixes/deployed-r34-20260810/README.md` — already in the repo — records otherwise:

> The `kernel_warmup` patch … gates the CuTe-DSL GEMM autotune section on `kernel_config.enable_cutedsl_warmup` but the `_warmup_ll_bf16_router_gemm()` call site runs unconditionally on any capability-90+ device.

So the flag does not prevent the abort; the quack correction does. The bullet now says that, cites the hotfix record, and states why the flag is still carried (the observed configuration has it, not because it is required). The surrounding "Four flags … are load-bearing" count is corrected with it.

Worth noting: that hotfix README documents the same version skew — `AttributeError: module 'cutlass.cute.core' has no attribute 'ThrMma'`, dying in `determine_available_memory`, GLM never exercising the path — that #69 root-caused independently. The repo knew; the quickstart disagreed with it.

## 3. MTP5 described as unsupported

`docs/EXL3_R7_QUICKSTART.md` said fixed MTP5 is unsupported by the image. A four-rank launch at `num_speculative_tokens: 5` serves and reports mean acceptance length between **4.38 and 5.52**.

What the bare image lacks is the Q48 contract extension and its native library, which the deployed overlay set supplies. The limitation says that now, and states that **no matched comparison against fixed MTP4 has been run** — so the page keeps specifying MTP4 without claiming MTP5 is slower. It isn't known to be.

## Checks

`runtime` and `scripts`: 2117 passed, 12 skipped. `validate_publication_consistency.py`: PASS. The release-safety blocking pattern matches no tracked file.