### PR TITLE
Make the exact-Q40 overlay inputs reproducible from a clean checkout

### DIFF
--- a/docs/EXL3_R7_OPERATOR_REPRODUCTION.md
+++ b/docs/EXL3_R7_OPERATOR_REPRODUCTION.md
@@ -193,6 +193,16 @@ in [`TIERED_DEFERRED_GRAPH.md`](../spark_transport/TIERED_DEFERRED_GRAPH.md).
 
 Generate the EXL3 insertion-only state from the prepared vLLM result tree:
 
+Both generators verify their input hashes, and the tree
+`prepare_context.py` produces does not hold either input: `exl3.py` needs
+the W4A16 scratch reservation and `model_runner.py` needs the routed-expert
+capturer. Apply both first; the producer refuses to write when a hash does
+not match and reports an already-prepared tree without rewriting it:
+
+```bash
+python spark_transport/experiments/moe_round_floor/prepare_q40_overlay_inputs.py   .sparkring/r7-prepared-sources/vllm
+```
+
 ```bash
 q40=.sparkring/exl3-r7/q40-exact
 mkdir -p "$q40"

--- a/runtime/exl3-r7/test-fixtures/README.md
+++ b/runtime/exl3-r7/test-fixtures/README.md
@@ -1,9 +1,14 @@
 # R7 overlay source fixtures
 
-These files are test-only snapshots from the Apache-2.0-licensed vLLM result
-tree produced by [`runtime/exl3-r7/pins.json`](../pins.json). They let offline
-CI verify the target-only exact-Q40 overlay without fetching source trees or
-depending on an operator's ignored `.sparkring` build directory.
+These files are test-only snapshots of the Apache-2.0-licensed vLLM result
+tree that [`runtime/exl3-r7/pins.json`](../pins.json) names, after
+`spark_transport/experiments/moe_round_floor/prepare_q40_overlay_inputs.py`
+has applied the two exact-Q40 input edits: the W4A16 scratch reservation in
+`exl3.py` and the routed-expert capturer from `q40_v2_route_capture.patch`
+in `model_runner.py`. The pinned tree alone does not carry either file at
+these hashes. The snapshots let offline CI verify the target-only exact-Q40
+overlay without fetching source trees or depending on an operator's ignored
+`.sparkring` build directory.
 
 | File | SHA-256 | Role |
 |---|---|---|

--- a/spark_transport/experiments/moe_round_floor/prepare_q40_overlay_inputs.py
+++ b/spark_transport/experiments/moe_round_floor/prepare_q40_overlay_inputs.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+"""Bring a prepared vLLM tree to the inputs the exact-Q40 overlays require.
+
+`runtime/exl3-r7/prepare_context.py` materializes the tree `pins.json`
+names. Two of that tree's files are not what
+`q40_exact_state_overlay.py` and `q40_exact_state_attestation_overlay.py`
+accept, and both generators reject an unexpected input rather than
+transform it. This applies the two differences, each bound to the SHA-256
+of what it reads and what it writes:
+
+- `exl3.py` reserves W4A16 scratch for every row count. The pinned tree
+  returns a single unit below 129 rows, which holds for the cooperative
+  K6 small-M kernel and not for the generic scheduler other
+  architectures use.
+- `model_runner.py` and `scheduler.py` gain the routed-expert capturer
+  that the attestation overlay anchors on, from
+  `q40_v2_route_capture.patch`.
+
+The results are the two files
+`runtime/exl3-r7/test-fixtures/` records, so offline tests and a build
+consume identical bytes.
+
+Safety class: MUTATES the tree named on the command line. It contacts no
+network and no configured Spark, and it refuses to write anything when a
+SHA-256 does not match.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import subprocess
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+ROUTE_CAPTURE_PATCH = HERE / "q40_v2_route_capture.patch"
+ROUTE_CAPTURE_PATCH_SHA256 = (
+    "0b6f25459a84e52a1bc096c32ab27593ec42b059beaceb8a11b9b9a5e5543ff1"
+)
+
+EXL3_RELATIVE = "vllm/model_executor/layers/quantization/exl3.py"
+MODEL_RUNNER_RELATIVE = "vllm/v1/worker/gpu/model_runner.py"
+
+EXL3_INPUT_SHA256 = (
+    "42c0e9150a065c48e3780eebc8b3c89ea410d82610e2c14bc97546dee6866214"
+)
+EXL3_OUTPUT_SHA256 = (
+    "8e0051faf9b8bac9eefd6f38a5f0133a30bca4c0b5ab41962537e2f13cf968f4"
+)
+MODEL_RUNNER_INPUT_SHA256 = (
+    "e8f13cbabadc6c591bc644874abbfcca5a0c935396993e1046ace173f227b0d0"
+)
+MODEL_RUNNER_OUTPUT_SHA256 = (
+    "992486a1a70fd0cb54c54cf3f70af0f09b4bcc6ae3bbf433e66b1296415015b4"
+)
+
+SCRATCH_BEFORE = (
+    b"    if rows <= 128:\n"
+    b"        # The cooperative K6 small-M kernel does not consume W4A16 scratch.\n"
+    b"        return 1\n"
+)
+SCRATCH_AFTER = (
+    b"    # SM120 uses a cooperative K6 small-M kernel that ignores this buffer.\n"
+    b"    # Other architectures use the generic W4A16 scheduler even at small M,\n"
+    b"    # so reserve the conservative M48/M64 capacity for every row count.\n"
+)
+
+
+class OverlayInputError(RuntimeError):
+    """A tree did not hold the bytes an exact-Q40 overlay input requires."""
+
+
+def sha256_bytes(payload: bytes) -> str:
+    return hashlib.sha256(payload).hexdigest()
+
+
+def apply_scratch_reservation(tree: Path) -> str:
+    """Reserve W4A16 scratch for every row count, bound to both hashes."""
+
+    path = tree / EXL3_RELATIVE
+    payload = path.read_bytes()
+    observed = sha256_bytes(payload)
+    if observed == EXL3_OUTPUT_SHA256:
+        return "already applied"
+    if observed != EXL3_INPUT_SHA256:
+        raise OverlayInputError(
+            f"{EXL3_RELATIVE}: expected {EXL3_INPUT_SHA256}, read {observed}"
+        )
+    count = payload.count(SCRATCH_BEFORE)
+    if count != 1:
+        raise OverlayInputError(
+            f"{EXL3_RELATIVE}: found {count} scratch-reservation preimages, wanted 1"
+        )
+    updated = payload.replace(SCRATCH_BEFORE, SCRATCH_AFTER)
+    produced = sha256_bytes(updated)
+    if produced != EXL3_OUTPUT_SHA256:
+        raise OverlayInputError(
+            f"{EXL3_RELATIVE}: produced {produced}, expected {EXL3_OUTPUT_SHA256}"
+        )
+    path.write_bytes(updated)
+    return "applied"
+
+
+def apply_route_capture(tree: Path) -> str:
+    """Add the routed-expert capturer, bound to the model-runner hashes."""
+
+    path = tree / MODEL_RUNNER_RELATIVE
+    observed = sha256_bytes(path.read_bytes())
+    if observed == MODEL_RUNNER_OUTPUT_SHA256:
+        return "already applied"
+    if observed != MODEL_RUNNER_INPUT_SHA256:
+        raise OverlayInputError(
+            f"{MODEL_RUNNER_RELATIVE}: expected {MODEL_RUNNER_INPUT_SHA256}, "
+            f"read {observed}"
+        )
+    if not ROUTE_CAPTURE_PATCH.is_file():
+        raise OverlayInputError(f"{ROUTE_CAPTURE_PATCH} is absent")
+    patch_hash = sha256_bytes(ROUTE_CAPTURE_PATCH.read_bytes())
+    if patch_hash != ROUTE_CAPTURE_PATCH_SHA256:
+        raise OverlayInputError(
+            f"{ROUTE_CAPTURE_PATCH.name}: expected "
+            f"{ROUTE_CAPTURE_PATCH_SHA256}, read {patch_hash}"
+        )
+    result = subprocess.run(
+        ["git", "apply", str(ROUTE_CAPTURE_PATCH)],
+        cwd=tree,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout).strip().splitlines()
+        raise OverlayInputError(
+            "route-capture patch did not apply: "
+            + (detail[-1] if detail else "no detail")
+        )
+    produced = sha256_bytes(path.read_bytes())
+    if produced != MODEL_RUNNER_OUTPUT_SHA256:
+        raise OverlayInputError(
+            f"{MODEL_RUNNER_RELATIVE}: produced {produced}, expected "
+            f"{MODEL_RUNNER_OUTPUT_SHA256}"
+        )
+    return "applied"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="prepare_q40_overlay_inputs",
+        description=(
+            "Bring a prepared vLLM tree to the inputs the exact-Q40 overlays "
+            "accept, refusing to write when a SHA-256 does not match."
+        ),
+    )
+    parser.add_argument(
+        "tree",
+        type=Path,
+        help="the vLLM tree prepare_context.py produced, containing vllm/",
+    )
+    arguments = parser.parse_args(argv)
+    tree = arguments.tree.resolve()
+    if not (tree / EXL3_RELATIVE).is_file():
+        print(f"FAIL {tree} does not hold {EXL3_RELATIVE}")
+        return 1
+    try:
+        scratch = apply_scratch_reservation(tree)
+        capture = apply_route_capture(tree)
+    except OverlayInputError as error:
+        print(f"FAIL {error}")
+        return 1
+    print(f"OK  {EXL3_RELATIVE}: scratch reservation {scratch}")
+    print(f"OK  {MODEL_RUNNER_RELATIVE}: route capture {capture}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/spark_transport/experiments/moe_round_floor/q40_v2_route_capture.patch
+++ b/spark_transport/experiments/moe_round_floor/q40_v2_route_capture.patch
@@ -1,0 +1,379 @@
+diff --git a/vllm/v1/core/sched/scheduler.py b/vllm/v1/core/sched/scheduler.py
+index 208b5a679..ab5605a4d 100644
+--- a/vllm/v1/core/sched/scheduler.py
++++ b/vllm/v1/core/sched/scheduler.py
+@@ -1,6 +1,9 @@
+ # SPDX-License-Identifier: Apache-2.0
+ # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
++import hashlib
+ import itertools
++import json
++import os
+ import time
+ from collections import defaultdict, deque
+ from collections.abc import Iterable
+@@ -340,16 +343,59 @@ class Scheduler(SchedulerInterface):
+             vllm_config.model_config.enable_return_routed_experts
+         )
+ 
+-        if self.enable_return_routed_experts:
+-            assert self.dcp_world_size == 1 and self.pcp_world_size == 1, (
+-                "enable_return_routed_experts does not support context parallelism "
+-                "(dcp_world_size > 1 or pcp_world_size > 1)"
+-            )
++        # This opt-in captures the exact worker-returned Q40 target route
++        # tensor before the normal per-request slot-buffer association.  It is
++        # intentionally separate from the public routed-experts response ABI:
++        # DCP4 has a different physical KV-slot layout, but the raw route tensor
++        # is already complete and rank-replicated.  The trace-only path avoids
++        # claiming that DCP slot association has been validated.
++        self._q40_route_trace_path = os.getenv("SPARK_Q40_ROUTE_CAPTURE_PATH")
++        self._q40_route_trace_only = bool(self._q40_route_trace_path)
++        self._q40_route_capture_count = 0
++        self._q40_route_capture_limit = int(
++            os.getenv("SPARK_Q40_ROUTE_CAPTURE_LIMIT", "64")
++        )
++        if self._q40_route_capture_limit <= 0:
++            raise ValueError("SPARK_Q40_ROUTE_CAPTURE_LIMIT must be positive")
++        self._q40_route_capture_salt = os.getenv(
++            "SPARK_Q40_ROUTE_CAPTURE_SALT", ""
++        )
++        self._q40_route_provenance: dict[str, Any] | None = None
++        if self._q40_route_trace_only:
++            if not self._q40_route_capture_salt:
++                raise ValueError("SPARK_Q40_ROUTE_CAPTURE_SALT is required")
++            try:
++                provenance = json.loads(
++                    os.environ["SPARK_Q40_ROUTE_PROVENANCE_JSON"]
++                )
++            except KeyError as error:
++                raise ValueError(
++                    "SPARK_Q40_ROUTE_PROVENANCE_JSON is required"
++                ) from error
++            except json.JSONDecodeError as error:
++                raise ValueError(
++                    "SPARK_Q40_ROUTE_PROVENANCE_JSON is invalid"
++                ) from error
++            if not isinstance(provenance, dict):
++                raise ValueError(
++                    "SPARK_Q40_ROUTE_PROVENANCE_JSON must be an object"
++                )
++            self._q40_route_provenance = provenance
++            if self.dcp_world_size != 4 or self.pcp_world_size != 1:
++                raise ValueError(
++                    "Q40 route-only capture requires DCP4 and PCP1"
++                )
+ 
+-            self.routed_experts_mgr = RoutedExpertsManager(
+-                vllm_config=vllm_config,
+-                kv_cache_config=kv_cache_config,
+-            )
++        if self.enable_return_routed_experts:
++            if not self._q40_route_trace_only:
++                assert self.dcp_world_size == 1 and self.pcp_world_size == 1, (
++                    "enable_return_routed_experts does not support context "
++                    "parallelism (dcp_world_size > 1 or pcp_world_size > 1)"
++                )
++                self.routed_experts_mgr = RoutedExpertsManager(
++                    vllm_config=vllm_config,
++                    kv_cache_config=kv_cache_config,
++                )
+             # Block-ID snapshot taken at schedule time (before forward),
+             # so update_from_output can read slot data even if a later
+             # schedule() frees the blocks (async scheduling race).
+@@ -361,6 +407,105 @@ class Scheduler(SchedulerInterface):
+         # async KV loads). Their remaining-block reservation gates async loads.
+         self._inflight_prefills: set[Request] = set()
+ 
++    def _capture_q40_route_step(
++        self,
++        scheduler_output: SchedulerOutput,
++        model_runner_output: ModelRunnerOutput,
++    ) -> None:
++        """Append one provenance-complete C8/fixed-MTP4 Q40 route record."""
++
++        if (
++            not self._q40_route_trace_only
++            or self._q40_route_capture_count >= self._q40_route_capture_limit
++        ):
++            return
++        routed = model_runner_output.routed_experts
++        if routed is None:
++            raise RuntimeError("Q40 route-only capture received no route tensor")
++        counts = scheduler_output.num_scheduled_tokens
++        if len(counts) != 8 or any(value != 5 for value in counts.values()):
++            return
++        request_order = model_runner_output.req_ids
++        if len(request_order) != 8 or set(request_order) != set(counts):
++            raise RuntimeError("Q40 route request ordering is inconsistent")
++        data = routed.routing_data
++        if data.ndim != 3 or data.shape[0] != 40 or data.shape[2] != 8:
++            raise RuntimeError(
++                f"Q40 route tensor has unsupported shape {data.shape}"
++            )
++        # GLM-5.2 exposes 78 target layers; layers 0..2 are dense and the
++        # routed-MoE tensor occupies source layer IDs 3..77.
++        if data.shape[1] != 78:
++            raise RuntimeError(
++                f"Q40 route tensor must cover 78 model layers, got {data.shape[1]}"
++            )
++        routed_data = data[:, 3:78, :]
++        if routed_data.min() < 0 or routed_data.max() >= 256:
++            raise RuntimeError("Q40 route tensor contains an invalid expert ID")
++
++        request_digest = hashlib.sha256(
++            (
++                self._q40_route_capture_salt
++                + "\0"
++                + "\0".join(request_order)
++            ).encode("utf-8")
++        ).hexdigest()
++        record = {
++            "schema": "glm52-target-expert-routes/v1",
++            "request_key": request_digest,
++            "round": self._q40_route_capture_count,
++            "width": 40,
++            "phase": "target",
++            "capture_slot": self._q40_route_capture_count,
++            "route_source": {
++                "kind": "captured-real-model-routes",
++                "capture_schema": "sparkring-q40-target-router-capture/v1",
++                "capture_point": (
++                    "scheduler raw worker-returned route tensor before "
++                    "per-request KV-slot association"
++                ),
++            },
++            "row_layout": {
++                "schema": "glm52-fixed-mtp4-c8-route-rows/v1",
++                "requests": 8,
++                "rows_per_request": 5,
++                "total_rows": 40,
++                "row_order": "request-major verification rows",
++            },
++            "provenance": self._q40_route_provenance,
++            "capture_metadata": {
++                "scheduled_tokens_by_request_in_model_order": [
++                    counts[request_id] for request_id in request_order
++                ],
++                "source_model_layers": [3, 77],
++                "captured_at_unix_ns": time.time_ns(),
++            },
++            "layers": [
++                {
++                    "layer": layer,
++                    "positions": [
++                        {"expert_ids": routed_data[row, layer, :].tolist()}
++                        for row in range(40)
++                    ],
++                }
++                for layer in range(75)
++            ],
++        }
++        path = os.fspath(self._q40_route_trace_path)
++        with open(path, "a", encoding="utf-8", newline="\n") as stream:
++            stream.write(
++                json.dumps(record, sort_keys=True, separators=(",", ":"))
++            )
++            stream.write("\n")
++        self._q40_route_capture_count += 1
++        if self._q40_route_capture_count in (1, self._q40_route_capture_limit):
++            logger.warning(
++                "Q40 route-only capture wrote %d/%d records to %s",
++                self._q40_route_capture_count,
++                self._q40_route_capture_limit,
++                path,
++            )
++
+     def _mamba_block_aligned_split(
+         self,
+         request: Request,
+@@ -1292,7 +1437,7 @@ class Scheduler(SchedulerInterface):
+         # have not yet been consumed by update_from_output (async
+         # scheduling may call _update_after_schedule again before the
+         # prior update_from_output runs).
+-        if self.enable_return_routed_experts:
++        if self.enable_return_routed_experts and not self._q40_route_trace_only:
+             gid = self.routed_experts_mgr.attn_gid
+             self._re_block_ids.update(
+                 {
+@@ -1656,17 +1801,24 @@ class Scheduler(SchedulerInterface):
+         routing_offsets: dict[str, int] = {}
+         if model_runner_output.routed_experts is not None:
+             re = model_runner_output.routed_experts
+-            self.routed_experts_mgr.store_batch(re.routing_data, re.slot_mapping)
+-            routing_data = re.routing_data.astype(
+-                self.routed_experts_mgr.routed_experts_by_slot.dtype,
+-                copy=False,
+-            )
+-            # Build offset map using model runner's request order
+-            # (input_batch ordering), NOT scheduler dict order.
+-            offset = 0
+-            for rid in model_runner_output.req_ids:
+-                routing_offsets[rid] = offset
+-                offset += num_scheduled_tokens[rid]
++            if self._q40_route_trace_only:
++                self._capture_q40_route_step(
++                    scheduler_output, model_runner_output
++                )
++            else:
++                self.routed_experts_mgr.store_batch(
++                    re.routing_data, re.slot_mapping
++                )
++                routing_data = re.routing_data.astype(
++                    self.routed_experts_mgr.routed_experts_by_slot.dtype,
++                    copy=False,
++                )
++                # Build offset map using model runner's request order
++                # (input_batch ordering), NOT scheduler dict order.
++                offset = 0
++                for rid in model_runner_output.req_ids:
++                    routing_offsets[rid] = offset
++                    offset += num_scheduled_tokens[rid]
+ 
+         # NOTE(woosuk): As len(num_scheduled_tokens) can be up to 1K or more,
+         # the below loop can be a performance bottleneck. We should do our best
+diff --git a/vllm/v1/worker/gpu/model_runner.py b/vllm/v1/worker/gpu/model_runner.py
+index cbeba2b88..a30354fb4 100644
+--- a/vllm/v1/worker/gpu/model_runner.py
++++ b/vllm/v1/worker/gpu/model_runner.py
+@@ -19,6 +19,7 @@ instead of embedding feature-specific logic directly.
+ 
+ import functools
+ import gc
++import os
+ import sys
+ import time
+ from collections.abc import Callable
+@@ -44,6 +45,9 @@ from vllm.distributed.parallel_state import (
+ )
+ from vllm.forward_context import BatchDescriptor, set_forward_context
+ from vllm.logger import init_logger
++from vllm.model_executor.layers.fused_moe.routed_experts_capturer import (
++    RoutedExpertsCapturer,
++)
+ from vllm.model_executor.layers.mamba.ops.ssu_dispatch import (
+     initialize_mamba_ssu_backend,
+ )
+@@ -62,7 +66,7 @@ from vllm.v1.kv_cache_interface import (
+     get_kv_cache_cp_shard_count,
+ )
+ from vllm.v1.kv_cache_spec_registry import KVCacheSpecRegistry
+-from vllm.v1.outputs import DraftTokenIds, ModelRunnerOutput
++from vllm.v1.outputs import DraftTokenIds, ModelRunnerOutput, RoutedExpertsLists
+ from vllm.v1.utils import record_function_or_nullcontext
+ from vllm.v1.worker.cp_utils import check_attention_cp_compatibility
+ from vllm.v1.worker.gpu.async_utils import AsyncOutput, AsyncPoolingOutput
+@@ -346,6 +350,11 @@ class GPUModelRunner(LoRAModelRunnerMixin):
+         # Expert parallelism load balancer.
+         self.eplb = EPLBController(self.parallel_config, self.device)
+ 
++        # The Q40 research trace is independent from vLLM's public
++        # return-routed-experts ABI.  The latter remains unsupported by model
++        # runner V2 because its KV-slot association has not been implemented.
++        self.q40_route_capture_initialized = False
++
+     def update_max_model_len(self, max_model_len: int) -> None:
+         self.max_model_len = max_model_len
+         self.req_states.max_model_len = max_model_len
+@@ -450,6 +459,9 @@ class GPUModelRunner(LoRAModelRunnerMixin):
+         )
+         self.eplb.maybe_start_async_loop(eplb_models_added)
+ 
++        if os.getenv("SPARK_Q40_ROUTE_CAPTURE_PATH"):
++            self._init_q40_route_capturer()
++
+         if not self.is_first_pp_rank:
+             # For non-first PP ranks, create intermediate tensors sized
+             # for the max capture size so they can be sliced per batch.
+@@ -464,6 +476,73 @@ class GPUModelRunner(LoRAModelRunnerMixin):
+     def get_model(self) -> nn.Module:
+         return self.model
+ 
++    def _init_q40_route_capturer(self) -> None:
++        """Bind a trace-only target-router capturer to model runner V2."""
++
++        if self.q40_route_capture_initialized:
++            return
++        self.q40_route_capturer = RoutedExpertsCapturer(
++            max_num_batched_tokens=self.max_num_tokens,
++            vllm_config=self.vllm_config,
++        )
++
++        from vllm.model_executor.layers.fused_moe.layer import MoERunner
++        from vllm.model_executor.layers.fused_moe.router.base_router import (
++            BaseRouter,
++        )
++
++        bound_layer_ids: list[int] = []
++        for module in self.model.modules():
++            if isinstance(module, MoERunner) and isinstance(module.router, BaseRouter):
++                layer_id = module.layer_id
++
++                def _capture_fn(
++                    topk_ids,
++                    _layer_id=layer_id,
++                    _capturer=self.q40_route_capturer,
++                ):
++                    _capturer.capture(_layer_id, topk_ids)
++
++                module.router.set_capture_fn(_capture_fn)
++                bound_layer_ids.append(layer_id)
++        expected_layer_ids = list(range(3, 78))
++        if sorted(bound_layer_ids) != expected_layer_ids:
++            raise RuntimeError(
++                "Q40 route trace requires target MoE layer IDs 3..77; "
++                f"found {sorted(bound_layer_ids)}"
++            )
++        self.q40_route_capture_initialized = True
++        logger.warning(
++            "Q40 trace-only routed-expert capture bound to %d target layers",
++            len(bound_layer_ids),
++        )
++
++    def _get_q40_route_capture(
++        self, input_batch: InputBatch
++    ) -> RoutedExpertsLists | None:
++        """Synchronously snapshot the small active route slice for tracing."""
++
++        if not self.q40_route_capture_initialized:
++            return None
++        if (
++            input_batch.num_reqs != 8
++            or input_batch.num_tokens != 40
++            or not np.all(input_batch.num_scheduled_tokens == 5)
++        ):
++            return None
++        num_tokens = input_batch.num_tokens
++        route_data = (
++            self.q40_route_capturer.get_device_buffer()[:num_tokens]
++            .to("cpu")
++            .numpy()
++            .copy()
++        )
++        # The trace-only scheduler consumes raw route rows before physical
++        # KV-slot association.  A deterministic sentinel array satisfies the
++        # shared transport type without claiming that V2 slot mapping exists.
++        slot_mapping = np.full((num_tokens,), -1, dtype=np.int64)
++        return RoutedExpertsLists(route_data, slot_mapping)
++
+     def get_draft_model(self) -> nn.Module | None:
+         speculator = self.speculator
+         if not isinstance(speculator, DraftModelSpeculator):
+@@ -1568,6 +1647,8 @@ class GPUModelRunner(LoRAModelRunnerMixin):
+         skip_attn_for_dummy_run: bool = False,
+         is_profile: bool = False,
+     ) -> ModelRunnerOutput | IntermediateTensors | None:
++        if self.q40_route_capture_initialized:
++            self.q40_route_capturer.clear_buffer()
+         if not dummy_run:
+             with record_function_or_nullcontext("vllm:v2/target/update_batch"):
+                 # Update the request states.
+@@ -1972,6 +2053,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
+             req_id_to_index={req_id: i for i, req_id in enumerate(input_batch.req_ids)},
+             sampled_token_ids=None,  # type: ignore
+             prompt_logprobs_dict=prompt_logprobs_dict,  # type: ignore[arg-type]
++            routed_experts=self._get_q40_route_capture(input_batch),
+         )
+         copy_draft_with_output = (
+             self.num_speculative_steps > 0
+

--- a/spark_transport/experiments/moe_round_floor/test_prepare_q40_overlay_inputs.py
+++ b/spark_transport/experiments/moe_round_floor/test_prepare_q40_overlay_inputs.py
@@ -1,0 +1,117 @@
+"""Offline tests for the exact-Q40 overlay input producer."""
+
+from __future__ import annotations
+
+import hashlib
+import shutil
+import unittest
+from pathlib import Path
+
+from spark_transport.experiments.moe_round_floor import (
+    prepare_q40_overlay_inputs as producer,
+)
+
+REPO = Path(__file__).resolve().parents[3]
+FIXTURES = REPO / "runtime" / "exl3-r7" / "test-fixtures" / "vllm"
+EXL3_FIXTURE = FIXTURES / "model_executor/layers/quantization/exl3.py.fixture"
+MODEL_RUNNER_FIXTURE = FIXTURES / "v1/worker/gpu/model_runner.py.fixture"
+
+
+def sha256_file(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+class ConstantsMatchFixturesTest(unittest.TestCase):
+    """The producer must target exactly what the overlays accept."""
+
+    def test_exl3_output_hash_is_the_tracked_fixture(self) -> None:
+        self.assertEqual(sha256_file(EXL3_FIXTURE), producer.EXL3_OUTPUT_SHA256)
+
+    def test_model_runner_output_hash_is_the_tracked_fixture(self) -> None:
+        self.assertEqual(
+            sha256_file(MODEL_RUNNER_FIXTURE), producer.MODEL_RUNNER_OUTPUT_SHA256
+        )
+
+    def test_the_patch_matches_its_pinned_hash(self) -> None:
+        self.assertEqual(
+            sha256_file(producer.ROUTE_CAPTURE_PATCH),
+            producer.ROUTE_CAPTURE_PATCH_SHA256,
+        )
+
+    def test_the_overlays_accept_what_this_produces(self) -> None:
+        """The generators' declared inputs are this producer's outputs."""
+        from spark_transport.experiments.moe_round_floor import (
+            q40_exact_state_attestation_overlay as attestation,
+            q40_exact_state_overlay as exl3_overlay,
+        )
+
+        self.assertEqual(exl3_overlay.INPUT_SHA256, producer.EXL3_OUTPUT_SHA256)
+        self.assertEqual(
+            attestation.INPUT_SHA256, producer.MODEL_RUNNER_OUTPUT_SHA256
+        )
+
+
+class ScratchReservationTest(unittest.TestCase):
+    def _tree(self, root: Path, payload: bytes) -> Path:
+        path = root / producer.EXL3_RELATIVE
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(payload)
+        return root
+
+    def test_refuses_an_unexpected_input(self) -> None:
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as raw:
+            tree = self._tree(Path(raw), b"unrelated source\n")
+            with self.assertRaises(producer.OverlayInputError) as caught:
+                producer.apply_scratch_reservation(tree)
+            self.assertIn("expected", str(caught.exception))
+
+    def test_reports_an_already_applied_tree_without_rewriting(self) -> None:
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as raw:
+            tree = self._tree(Path(raw), EXL3_FIXTURE.read_bytes())
+            self.assertEqual(
+                producer.apply_scratch_reservation(tree), "already applied"
+            )
+            self.assertEqual(
+                sha256_file(tree / producer.EXL3_RELATIVE),
+                producer.EXL3_OUTPUT_SHA256,
+            )
+
+
+class RouteCaptureTest(unittest.TestCase):
+    def test_refuses_an_unexpected_model_runner(self) -> None:
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as raw:
+            tree = Path(raw)
+            path = tree / producer.MODEL_RUNNER_RELATIVE
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_bytes(b"unrelated source\n")
+            with self.assertRaises(producer.OverlayInputError) as caught:
+                producer.apply_route_capture(tree)
+            self.assertIn("expected", str(caught.exception))
+
+    def test_reports_an_already_applied_tree(self) -> None:
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as raw:
+            tree = Path(raw)
+            path = tree / producer.MODEL_RUNNER_RELATIVE
+            path.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copyfile(MODEL_RUNNER_FIXTURE, path)
+            self.assertEqual(producer.apply_route_capture(tree), "already applied")
+
+
+class CommandLineTest(unittest.TestCase):
+    def test_reports_a_tree_without_the_expected_layout(self) -> None:
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as raw:
+            self.assertEqual(producer.main([raw]), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Section 6 of the R7 reproduction guide failed closed from a clean checkout: both exact-Q40 overlay generators verify their input hashes, and the vLLM tree `prepare_context.py` produces holds **neither input**.

```
tree exl3.py          42c0e915…   generator wants 8e0051fa…
tree model_runner.py  e8f13cba…   generator wants 992486a1…
```

The expected inputs existed in exactly two places: the tracked test fixtures (whose README attributed them to the pinned tree alone — false), and inside the built image. The steps producing them were never published.

## What was missing, found and verified

- **`model_runner.py`**: a 379-line patch adding the routed-expert capturer (`SPARK_Q40_ROUTE_CAPTURE_PATH`, `RoutedExpertsCapturer`, `_init_q40_route_capturer`, `_get_q40_route_capture`, `routed_experts` plumbing across `scheduler.py` and `model_runner.py`). It sat untracked in one local checkout. Applying it to the pinned tree yields `992486a1…` **byte-exact**. Now tracked as `q40_v2_route_capture.patch`, pinned by its own SHA-256. It carries no site identity.
- **`exl3.py`**: a 3-line W4A16 scratch-reservation edit (drop the `rows <= 128` early-exit) with no producer anywhere. Reconstructed as a preimage-counted byte replacement in the `bake_runtime_artifacts.py` style.

## The producer

`prepare_q40_overlay_inputs.py` applies both, each bound to the SHA-256 of what it reads and writes. It refuses on any mismatch and reports an already-prepared tree without rewriting.

## Verified end to end on hardware, not inferred

On a rank-0 **clone of this repository at `origin/main`** — the stranger path:

```
prepare_context.py            → result_tree 4d006a43…  (matches pins.json)
prepare_q40_overlay_inputs.py → exl3 8e0051fa… ✓   model_runner 992486a1… ✓
q40_exact_state_overlay.py            → exit 0, output 8fad5330… ✓ documented value
q40_exact_state_attestation_overlay.py → exit 0, output 0e2e0150… ✓ documented value
```

The full chain now reproduces the operator image's attested artifacts from public sources.

## Also

- `runtime/exl3-r7/test-fixtures/README.md` states the fixtures' real provenance.
- The reproduction guide runs the producer before the generators.
- Tests assert the closure: producer outputs ≡ tracked fixtures ≡ generators' declared inputs; the patch matches its pinned hash; unexpected inputs are refused.

`runtime`, `scripts`, `spark_transport`: 3134 passed, 18 skipped. Publication consistency: PASS.

Note: this publishes the route-capture implementation from the vLLM fork (Apache-2.0 per the fixtures README's licensing statement).