### PR TITLE
Close the SIRCL bundle over the query-row provider its modules import

### DIFF
--- a/scripts/prepare_exl3_r7_sircl_tiered.py
+++ b/scripts/prepare_exl3_r7_sircl_tiered.py
@@ -30,11 +30,21 @@ LIBRARY_CONTAINER = "/opt/sparkring/spark_transport/libspark_transport_capi.so"
 BACKEND_CONTAINER = "/opt/spark-vllm/spark_tp4_backend.py"
 PORT_NAMESPACE_CONTAINER = "/opt/spark-vllm/spark_tp4_port_namespace.py"
 CAPACITY_POOL_CONTAINER = "/opt/spark-vllm/spark_tp4_prefill_capacity_pool.py"
+QUERY_ROW_PROVIDER_CONTAINER = "/opt/spark-vllm/spark_tp4_query_row_provider.py"
 ARTIFACTS = {
     "transport_library": ("libspark_transport_capi.so", LIBRARY_CONTAINER),
     "backend": ("spark_tp4_backend.py", BACKEND_CONTAINER),
     "port_namespace": ("spark_tp4_port_namespace.py", PORT_NAMESPACE_CONTAINER),
     "capacity_pool": ("spark_tp4_prefill_capacity_pool.py", CAPACITY_POOL_CONTAINER),
+    # The backend and port namespace both import this module at their top
+    # level, so a bundle that stages them without it produces a worker that
+    # dies on import. The path is derived from the backend's directory
+    # rather than taken as an argument, because the two files are only
+    # correct together.
+    "query_row_provider": (
+        "spark_tp4_query_row_provider.py",
+        QUERY_ROW_PROVIDER_CONTAINER,
+    ),
 }
 ENVIRONMENT_DELTA = {
     "SPARK_TP4_CONTROL_PORT0": "11100",
@@ -250,6 +260,8 @@ def main() -> int:
                 "backend": args.backend.resolve(),
                 "port_namespace": args.port_namespace.resolve(),
                 "capacity_pool": args.capacity_pool.resolve(),
+                "query_row_provider": args.backend.resolve().parent
+                / "spark_tp4_query_row_provider.py",
             },
             bundle=args.bundle.resolve(),
         )

--- a/scripts/test_prepare_exl3_r7_sircl_tiered.py
+++ b/scripts/test_prepare_exl3_r7_sircl_tiered.py
@@ -88,6 +88,11 @@ def _write_inputs(tmp_path: Path) -> tuple[Path, dict[str, Path], str]:
         path = tmp_path / f"input-{filename}"
         path.write_bytes(f"public-{name}\n".encode())
         artifacts[name] = path
+    # The CLI derives the query-row provider as the backend's sibling
+    # rather than taking it as an argument, so the fixture places it there.
+    (tmp_path / "spark_tp4_query_row_provider.py").write_bytes(
+        b"public-query_row_provider\n"
+    )
     return base, artifacts, hashlib.sha256(base.read_bytes()).hexdigest()
 
 
@@ -128,6 +133,7 @@ def test_cli_builds_exclusive_hash_bound_bundle(tmp_path: Path) -> None:
     assert receipt["schema"] == "sparkring-r7-sircl-tiered-bundle/v1"
     assert receipt["rollback"]["sha256"] == base_sha
     assert receipt["policy"]["dual_port"] is False
+    assert (bundle / "spark_tp4_query_row_provider.py").is_file()
     assert receipt["policy"]["prefill_capacity_pool"] is False
     for name, (filename, _container) in sircl.ARTIFACTS.items():
         assert (bundle / filename).read_bytes() == artifacts[name].read_bytes()


### PR DESCRIPTION
`spark_tp4_backend.py:22` and `spark_tp4_port_namespace.py:17` both import `spark_tp4_query_row_provider` at module scope, but `prepare_exl3_r7_sircl_tiered.py` staged only backend / port-namespace / capacity-pool. A worker launched from the bundle dies at import:

```
ModuleNotFoundError: No module named 'spark_tp4_query_row_provider'
```

Observed on a real four-rank launch through `sparkring_generic_launcher.py` — every rank exited within 30 seconds. The gap stayed invisible because the deployment lineage the bundle derives from carried the module inside its image's `/opt/spark-vllm`.

The generator now stages the provider alongside the backend, mounts it at `/opt/spark-vllm/spark_tp4_query_row_provider.py`, and hash-binds it in the manifest like the other three. Its path is derived from the backend's directory rather than taken as a new argument — the files are only correct together, and the documented invocation does not change.

`scripts/test_prepare_exl3_r7_sircl_tiered.py`: 7 passed, including a new assertion that the bundle holds the provider. `scripts` + `runtime`: 2117 passed, 12 skipped.