### PR TITLE
Add a measure-and-tune harness for the mixed-bitrate Trellis MoE kernel

### DIFF
--- a/scripts/bench/mixed_trellis_roofline.py
+++ b/scripts/bench/mixed_trellis_roofline.py
@@ -1,0 +1,2429 @@
+#!/usr/bin/env python3
+"""Measure and tune the mixed-bitrate Trellis MoE kernel at one GB10 geometry.
+
+WHAT IS MEASURED
+
+    One call of the fused mixed-bitrate Trellis mixture-of-experts kernel
+    exposed by `b12x.moe._shared.kernels.w4a16.mixed_trellis`, driven the
+    way the vLLM EXL3 quantization backend drives it: two expert tiers at
+    different Trellis bit widths behind a single grid, routed by a top-k
+    identifier tensor, with the rotations and packed weights the companion
+    `prepare` module produces.
+
+    The default geometry is a four-Spark GB10 deployment at tensor
+    parallel 4: hidden size 6144, per-rank expert intermediate width 512,
+    192 experts at 3 bits and 64 experts at 4 bits, top-k 8, route block
+    size 8, 48 streaming multiprocessors. Token counts 40, 128, and 512
+    span the deployed decode capacity to a prefill-sized batch.
+
+    Weights are synthesized by `prepare_trellis256_moe_weights` with
+    `w13=None` and `w2=None`. No checkpoint is loaded, so the numbers
+    describe the kernel at a geometry, not a particular model's values.
+
+TWO MODES
+
+    `measure` runs one configuration across the requested token counts and
+    reports elapsed time, a dense-equivalent arithmetic rate, and an
+    achieved weight-stream rate over compressed bytes.
+
+    `tune` holds the geometry fixed, sweeps `force_tile_config` and
+    `moe_block_size`, and ranks every configuration against the deployed
+    one. A configuration that fails to compile or produces a non-finite
+    result is recorded as a skip carrying its exception type; it does not
+    end the sweep.
+
+DENSE-EQUIVALENT ARITHMETIC
+
+    A gated mixture-of-experts token routed to one expert passes through
+    three matrix products: gate and up, each hidden_size to
+    intermediate_size, and down, intermediate_size to hidden_size. With two
+    flops per inner-product term,
+
+        dense_equivalent_flop
+            = 2 * (size_m * top_k)
+              * (2 * hidden_size * intermediate_size
+                 + intermediate_size * hidden_size)
+            = 6 * size_m * top_k * hidden_size * intermediate_size
+
+    The count is labelled dense-equivalent because it is the arithmetic a
+    dense BF16 GEMM would perform for the same routed work. It is directly
+    comparable with a dense GEMM rate such as the one
+    `scripts/bench/gb10_gemm_roofline.py` reports. It is not a count of the
+    operations this kernel issues: the kernel also decodes Trellis codes
+    and applies rotations, and it performs no arithmetic for experts no
+    token selected.
+
+COMPRESSED WEIGHT TRAFFIC
+
+    Each expert holds gate, up, and down weights, so 3 * hidden_size *
+    intermediate_size coefficients, stored at its tier's bit width:
+
+        expert_compressed_bytes = 3 * hidden_size * intermediate_size
+                                  * tier_bits / 8
+        weight_stream_bytes     = that, summed over the experts the routing
+                                  selected, per tier
+
+    The reported GB/s divides that by elapsed time. It assumes each
+    selected expert's compressed weight is read once per call; a kernel
+    that re-reads an expert across m-blocks moves more, so the figure is a
+    lower bound on traffic and therefore a lower bound on the achieved
+    rate. Whether the kernel is traffic-bound or decode-bound decides
+    whether the 3-bit and 4-bit tier mix affects elapsed time at all, so
+    the tier split of the traffic is reported alongside it.
+
+WEIGHT-POOL CYCLING
+
+    Compressed expert weights for this geometry are on the order of a
+    gigabyte, which is small enough that repeated calls on one weight set
+    can be served from cache and report a rate no deployment reaches.
+    Several independent weight sets are therefore prepared and one is used
+    per timed call, round-robin. `--pool-size` sets the count; the
+    predicted device memory cost is computed, reported, and refused when it
+    exceeds a stated fraction of device memory.
+
+METHOD
+
+    Each timed call is bracketed by its own pair of CUDA events. The device
+    is synchronized after the warmup calls and again after the timed loop,
+    and event times are read only after that second synchronization.
+    Warmup absorbs the kernel's compilation, which the first call to a
+    configuration pays. Input activations, routing tensors, tier maps,
+    launch descriptors, and device buffers are allocated before the loop.
+
+    The reported statistic is the median with its interquartile range plus
+    the observed minimum and maximum.
+
+API DISCOVERY
+
+    The kernel entry points are resolved by introspection at run time, and
+    every signature this harness relies on is checked before a call is made
+    and recorded in the report. A signature that does not match is a stated
+    refusal naming what was found. Argument order is never assumed
+    silently: `run_mixed_trellis` is called positionally only after its
+    first ten parameter names are confirmed in the expected order.
+
+    The resolved `__file__` of the kernel module is compared against the
+    path the report names. Import hooks can bind a different implementation
+    to the same module name, and a measurement that names one module while
+    timing another is not a measurement of either.
+
+Safety class: OFFLINE. It runs entirely on the machine that invokes it: it
+contacts no configured Spark, starts and stops no service, installs
+nothing, and writes only the JSON path the caller names. Two qualifications
+that OFFLINE does not otherwise imply. It allocates device memory for the
+duration of the run, roughly a gigabyte per weight set at the default
+geometry, so it must not be pointed at a GPU that is serving: GB10 memory
+is unified. It also runs `nvidia-smi` locally to record clock and power
+state, which queries the driver and mutates nothing.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib
+import inspect
+import json
+import os
+import platform
+import shutil
+import statistics
+import subprocess
+import sys
+from dataclasses import dataclass, replace
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, Callable, Iterable, Sequence
+
+SCHEMA = "gb10-mixed-trellis-roofline/v1"
+
+EXIT_OK = 0
+# The measurement could not be taken because the environment cannot support
+# it. That is distinct from a measurement that ran and produced numbers.
+EXIT_UNAVAILABLE = 2
+
+KERNEL_MODULE = "b12x.moe._shared.kernels.w4a16.mixed_trellis"
+PREPARE_MODULE = "b12x.moe._shared.kernels.w4a16.prepare"
+HOST_MODULE = "b12x.moe._shared.kernels.w4a16.host"
+KERNEL_MODULE_PATH = (
+    "/opt/venv/lib/python3.12/site-packages/b12x/moe/_shared/kernels/w4a16/"
+    "mixed_trellis.py"
+)
+
+FLOP_FORMULA = (
+    "dense_equivalent_flop = 2 * (size_m * top_k) * (2 * hidden_size * "
+    "intermediate_size + intermediate_size * hidden_size) = 6 * size_m * "
+    "top_k * hidden_size * intermediate_size"
+)
+FLOP_NOTE = (
+    "dense-equivalent: the arithmetic a dense BF16 GEMM would perform for the "
+    "same routed work, comparable with a dense GEMM rate. Not a count of the "
+    "operations this kernel issues; it also decodes Trellis codes and applies "
+    "rotations, and does no arithmetic for unselected experts."
+)
+WEIGHT_BYTES_FORMULA = (
+    "weight_stream_bytes = sum over selected experts of ceil(3 * hidden_size "
+    "* intermediate_size * tier_bits / 8)"
+)
+WEIGHT_BYTES_NOTE = (
+    "compressed bytes at each tier's Trellis bit width, counted once per "
+    "expert the routing selected. A kernel that re-reads an expert across "
+    "m-blocks moves more, so this is a lower bound on traffic and the rate "
+    "derived from it is a lower bound on the achieved rate."
+)
+
+# Weight coefficients an expert holds: gate and up, each hidden_size by
+# intermediate_size, plus down, intermediate_size by hidden_size.
+PROJECTIONS_PER_EXPERT = 3
+
+# Matrix products a routed token passes through: gate, up, and down.
+MATMULS_PER_ROUTED_TOKEN = 3
+
+NVIDIA_SMI_FIELDS = (
+    "name",
+    "clocks.sm",
+    "clocks.max.sm",
+    "clocks.applications.graphics",
+    "clocks_throttle_reasons.active",
+    "persistence_mode",
+    "power.draw",
+    "power.limit",
+    "temperature.gpu",
+)
+
+# What nvidia-smi prints for a field the driver does not answer for.
+UNREPORTED = ("", "N/A", "[N/A]", "[Not Supported]", "[Unknown Error]")
+
+
+class MeasurementUnavailable(RuntimeError):
+    """The environment cannot support the measurement, so none was taken."""
+
+
+# --------------------------------------------------------------------------
+# Geometry and configuration. Pure; exercised without a GPU.
+# --------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Geometry:
+    """The kernel's problem size, independent of how it is tiled."""
+
+    hidden_size: int = 6144
+    intermediate_size: int = 512
+    tier0_num_experts: int = 192
+    tier1_num_experts: int = 64
+    tier0_bits: int = 3
+    tier1_bits: int = 4
+    top_k: int = 8
+    sms: int = 48
+
+    @property
+    def total_experts(self) -> int:
+        return self.tier0_num_experts + self.tier1_num_experts
+
+    def as_dict(self) -> dict[str, int]:
+        return {
+            "hidden_size": self.hidden_size,
+            "intermediate_size": self.intermediate_size,
+            "tier0_num_experts": self.tier0_num_experts,
+            "tier1_num_experts": self.tier1_num_experts,
+            "tier0_bits": self.tier0_bits,
+            "tier1_bits": self.tier1_bits,
+            "top_k": self.top_k,
+            "total_experts": self.total_experts,
+            "sms": self.sms,
+        }
+
+
+DEPLOYED_GEOMETRY = Geometry()
+
+# The four-tuple is (fc1_tile_k, fc1_tile_n, fc2_tile_k, fc2_tile_n). The vLLM
+# EXL3 backend selects it from hidden_size alone: a hidden size divisible by
+# 512 gives (128, 128, 32, 512), one divisible by 256 gives (128, 128, 64,
+# 256), and any other gives (128, 128, 128, 128). Hidden size 6144 is
+# divisible by 512, so the deployed value is the first of those.
+DEPLOYED_TILE_CONFIG: tuple[int, int, int, int] = (128, 128, 32, 512)
+DEPLOYED_MOE_BLOCK_SIZE = 8
+
+# The tile geometry the single-bitrate rank-sliced path uses. The backend
+# documents it as losing partial reductions at large prefill token counts, so
+# it is swept only as a labelled control, never as a recommendation.
+FC1_CONTROL_TILE_CONFIG: tuple[int, int, int, int] = (64, 256, 64, 256)
+
+DEPLOYED_SIZES_M: tuple[int, ...] = (40, 128, 512)
+# Token capacity the deployed decode path plans for.
+DECODE_SIZE_M = 40
+
+# The FC1 half of the tile config is held at (128, 128) by default: the mixed
+# three-and-four-bit megakernel requires a 128-wide FC1 K tile. The FC2 half is
+# the swept axis, because the 512-wide FC2 tile is the deployed choice and the
+# claim behind it, that it removes a second persistent wave, is a claim about
+# wave quantization against the device's 48 streaming multiprocessors.
+DEFAULT_FC1_K_VALUES: tuple[int, ...] = (128,)
+DEFAULT_FC1_N_VALUES: tuple[int, ...] = (128,)
+DEFAULT_FC2_K_VALUES: tuple[int, ...] = (32, 64, 128)
+DEFAULT_FC2_N_VALUES: tuple[int, ...] = (128, 256, 512)
+DEFAULT_MOE_BLOCK_SIZES: tuple[int, ...] = (8, 16)
+DEFAULT_CONFIGURATION_CAP = 32
+
+ROLE_BASELINE = "baseline"
+ROLE_CANDIDATE = "candidate"
+ROLE_CONTROL = "control"
+
+CONTROL_NOTE = (
+    "labelled control: a 64-wide FC1 K tile is documented in the vLLM EXL3 "
+    "backend as losing partial reductions at large token counts, so it is "
+    "measured for reference and not offered as a candidate"
+)
+
+
+@dataclass(frozen=True)
+class Configuration:
+    """One tiling of the kernel at a fixed geometry."""
+
+    tile_config: tuple[int, int, int, int]
+    moe_block_size: int
+    role: str = ROLE_CANDIDATE
+
+    @property
+    def name(self) -> str:
+        tiles = "x".join(str(value) for value in self.tile_config)
+        return f"tile{tiles}_block{self.moe_block_size}"
+
+    @property
+    def fc1_tile_n(self) -> int:
+        """The FC1 output tile width the weight preparation must agree with."""
+
+        return self.tile_config[1]
+
+    @property
+    def fc2_tile_n(self) -> int:
+        """The FC2 output tile width the weight preparation must agree with."""
+
+        return self.tile_config[3]
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "tile_config": list(self.tile_config),
+            "moe_block_size": self.moe_block_size,
+            "role": self.role,
+            "fc1_tile_n": self.fc1_tile_n,
+            "fc2_tile_n": self.fc2_tile_n,
+        }
+
+
+DEPLOYED_CONFIGURATION = Configuration(
+    DEPLOYED_TILE_CONFIG, DEPLOYED_MOE_BLOCK_SIZE, ROLE_BASELINE
+)
+
+
+def enumerate_configurations(
+    *,
+    baseline: Configuration = DEPLOYED_CONFIGURATION,
+    fc1_k_values: Sequence[int] = DEFAULT_FC1_K_VALUES,
+    fc1_n_values: Sequence[int] = DEFAULT_FC1_N_VALUES,
+    fc2_k_values: Sequence[int] = DEFAULT_FC2_K_VALUES,
+    fc2_n_values: Sequence[int] = DEFAULT_FC2_N_VALUES,
+    moe_block_sizes: Sequence[int] = DEFAULT_MOE_BLOCK_SIZES,
+    controls: Sequence[tuple[int, int, int, int]] = (),
+    cap: int = DEFAULT_CONFIGURATION_CAP,
+) -> tuple[list[Configuration], dict[str, Any]]:
+    """The sweep space, baseline first, deduplicated and capped.
+
+    Configurations are grouped by tile config so that one prepared weight
+    pool serves every route block size measured against it. The baseline
+    survives the cap unconditionally: a ranking with no baseline states
+    nothing.
+    """
+
+    if cap < 1:
+        raise ValueError(f"the configuration cap must be at least 1; got {cap}")
+
+    grouped: dict[tuple[int, int, int, int], list[Configuration]] = {
+        baseline.tile_config: [baseline]
+    }
+    order: list[tuple[int, int, int, int]] = [baseline.tile_config]
+    seen = {(baseline.tile_config, baseline.moe_block_size)}
+
+    def add(tile: tuple[int, int, int, int], block: int, role: str) -> None:
+        key = (tile, block)
+        if key in seen:
+            return
+        seen.add(key)
+        if tile not in grouped:
+            grouped[tile] = []
+            order.append(tile)
+        grouped[tile].append(Configuration(tile, block, role))
+
+    for fc1_k in fc1_k_values:
+        for fc1_n in fc1_n_values:
+            for fc2_k in fc2_k_values:
+                for fc2_n in fc2_n_values:
+                    for block in moe_block_sizes:
+                        add((fc1_k, fc1_n, fc2_k, fc2_n), block, ROLE_CANDIDATE)
+    for control in controls:
+        tile = (control[0], control[1], control[2], control[3])
+        for block in moe_block_sizes:
+            add(tile, block, ROLE_CONTROL)
+
+    enumerated = [configuration for tile in order for configuration in grouped[tile]]
+    kept = enumerated[:cap]
+    return kept, {
+        "enumerated": len(enumerated),
+        "cap": cap,
+        "measured": len(kept),
+        "dropped": len(enumerated) - len(kept),
+        "truncated": len(enumerated) > cap,
+    }
+
+
+def tile_config_groups(
+    configurations: Sequence[Configuration],
+) -> list[tuple[tuple[int, int, int, int], list[Configuration]]]:
+    """Configurations grouped by tile config, in first-appearance order."""
+
+    groups: dict[tuple[int, int, int, int], list[Configuration]] = {}
+    order: list[tuple[int, int, int, int]] = []
+    for configuration in configurations:
+        if configuration.tile_config not in groups:
+            groups[configuration.tile_config] = []
+            order.append(configuration.tile_config)
+        groups[configuration.tile_config].append(configuration)
+    return [(tile, groups[tile]) for tile in order]
+
+
+# --------------------------------------------------------------------------
+# Arithmetic. Pure; exercised without a GPU.
+# --------------------------------------------------------------------------
+
+
+def dense_equivalent_flop(geometry: Geometry, size_m: int) -> int:
+    """Flops a dense BF16 GEMM would perform for the same routed work."""
+
+    if size_m < 1:
+        raise ValueError(f"size_m must be at least 1; got {size_m}")
+    routed_tokens = size_m * geometry.top_k
+    return (
+        2
+        * routed_tokens
+        * MATMULS_PER_ROUTED_TOKEN
+        * geometry.hidden_size
+        * geometry.intermediate_size
+    )
+
+
+def expert_compressed_bytes(geometry: Geometry, bits: int) -> int:
+    """Compressed bytes one expert's gate, up, and down weights occupy."""
+
+    if bits < 1:
+        raise ValueError(f"a tier bit width must be at least 1; got {bits}")
+    coefficients = (
+        PROJECTIONS_PER_EXPERT * geometry.hidden_size * geometry.intermediate_size
+    )
+    return (coefficients * bits + 7) // 8
+
+
+def weight_stream_bytes(
+    geometry: Geometry, *, tier0_experts: int, tier1_experts: int
+) -> int:
+    """Compressed bytes for the experts a routing selected, both tiers."""
+
+    for count, limit, label in (
+        (tier0_experts, geometry.tier0_num_experts, "tier0"),
+        (tier1_experts, geometry.tier1_num_experts, "tier1"),
+    ):
+        if not 0 <= count <= limit:
+            raise ValueError(
+                f"{label} selected expert count {count} lies outside [0, {limit}]"
+            )
+    return tier0_experts * expert_compressed_bytes(
+        geometry, geometry.tier0_bits
+    ) + tier1_experts * expert_compressed_bytes(geometry, geometry.tier1_bits)
+
+
+def resident_weight_bytes(geometry: Geometry) -> int:
+    """Compressed bytes one complete prepared weight set occupies."""
+
+    return weight_stream_bytes(
+        geometry,
+        tier0_experts=geometry.tier0_num_experts,
+        tier1_experts=geometry.tier1_num_experts,
+    )
+
+
+def weight_pool_bytes(geometry: Geometry, pool_size: int) -> int:
+    """Compressed bytes a weight pool of `pool_size` sets occupies.
+
+    Packed expert weights only. Rotations, launch descriptors, and the
+    kernel's device buffers are additional and are not counted here.
+    """
+
+    if pool_size < 1:
+        raise ValueError(f"the weight pool must hold at least 1 set; got {pool_size}")
+    return pool_size * resident_weight_bytes(geometry)
+
+
+def count_selected_experts(
+    route_ids: Iterable[int], tier0_num_experts: int, total_experts: int
+) -> tuple[int, int]:
+    """Distinct experts a routing selects, split at the tier boundary.
+
+    Expert identifiers below `tier0_num_experts` belong to tier 0 and the
+    rest to tier 1, which is the assignment this harness gives its
+    synthetic tiers.
+    """
+
+    distinct = set()
+    for identifier in route_ids:
+        value = int(identifier)
+        if not 0 <= value < total_experts:
+            raise ValueError(
+                f"route identifier {value} lies outside [0, {total_experts})"
+            )
+        distinct.add(value)
+    tier0 = sum(1 for value in distinct if value < tier0_num_experts)
+    return tier0, len(distinct) - tier0
+
+
+def tflops(flop: int, milliseconds: float) -> float:
+    """Achieved rate in TFLOP/s for `flop` completed in `milliseconds`."""
+
+    if milliseconds <= 0:
+        raise ValueError(f"elapsed time must be positive; got {milliseconds}")
+    return flop / (milliseconds * 1e-3) / 1e12
+
+
+def gigabytes_per_second(byte_count: int, milliseconds: float) -> float:
+    """Achieved traffic rate in GB/s, 10^9 bytes per second."""
+
+    if milliseconds <= 0:
+        raise ValueError(f"elapsed time must be positive; got {milliseconds}")
+    return byte_count / (milliseconds * 1e-3) / 1e9
+
+
+def route_slot_plan(
+    api: Any, geometry: Geometry, *, size_m: int, moe_block_size: int
+) -> dict[str, int]:
+    """Packed route slots and the m-block count the compiler is given.
+
+    `max_m_blocks` is ceil(route_slots / moe_block_size), which is how the
+    vLLM EXL3 backend derives it from `max_packed_route_slots`.
+    """
+
+    if moe_block_size < 1:
+        raise ValueError(f"moe_block_size must be at least 1; got {moe_block_size}")
+    route_slots = int(
+        api.max_packed_route_slots(
+            size_m * geometry.top_k, moe_block_size, geometry.total_experts
+        )
+    )
+    if route_slots < 1:
+        raise MeasurementUnavailable(
+            f"max_packed_route_slots returned {route_slots} for size_m="
+            f"{size_m}, block={moe_block_size}, experts="
+            f"{geometry.total_experts}; a launch cannot be planned from it"
+        )
+    return {
+        "route_slots": route_slots,
+        "max_m_blocks": (route_slots + moe_block_size - 1) // moe_block_size,
+    }
+
+
+# --------------------------------------------------------------------------
+# Distribution. Pure; exercised without a GPU.
+# --------------------------------------------------------------------------
+
+
+def percentile(values: Sequence[float], fraction: float) -> float:
+    """Linear-interpolated percentile over `values`, which need not be sorted."""
+
+    if not values:
+        raise ValueError("percentile of an empty sample")
+    if not 0.0 <= fraction <= 1.0:
+        raise ValueError(f"fraction must lie in [0, 1]; got {fraction}")
+    ordered = sorted(float(value) for value in values)
+    index = (len(ordered) - 1) * fraction
+    lower = int(index)
+    upper = min(lower + 1, len(ordered) - 1)
+    weight = index - lower
+    return ordered[lower] * (1.0 - weight) + ordered[upper] * weight
+
+
+def summarize(samples_ms: Sequence[float]) -> dict[str, float]:
+    """Median, interquartile range, and observed extremes of a timing sample."""
+
+    if not samples_ms:
+        raise ValueError("cannot summarize an empty timing sample")
+    ordered = sorted(float(sample) for sample in samples_ms)
+    p25 = percentile(ordered, 0.25)
+    p75 = percentile(ordered, 0.75)
+    return {
+        "samples": len(ordered),
+        "min_ms": ordered[0],
+        "p25_ms": p25,
+        "median_ms": statistics.median(ordered),
+        "p75_ms": p75,
+        "max_ms": ordered[-1],
+        "iqr_ms": p75 - p25,
+    }
+
+
+def size_result(
+    *,
+    geometry: Geometry,
+    size_m: int,
+    configuration: Configuration,
+    samples_ms: Sequence[float],
+    selected_tier0: int,
+    selected_tier1: int,
+    plan: dict[str, int],
+) -> dict[str, Any]:
+    """One token count's timing distribution and the rates implied by it."""
+
+    timing = summarize(samples_ms)
+    flop = dense_equivalent_flop(geometry, size_m)
+    traffic = weight_stream_bytes(
+        geometry, tier0_experts=selected_tier0, tier1_experts=selected_tier1
+    )
+    tier0_traffic = selected_tier0 * expert_compressed_bytes(
+        geometry, geometry.tier0_bits
+    )
+    return {
+        "size_m": size_m,
+        "configuration": configuration.as_dict(),
+        "routing": {
+            "route_slots_planned": plan["route_slots"],
+            "max_m_blocks": plan["max_m_blocks"],
+            "selected_tier0_experts": selected_tier0,
+            "selected_tier1_experts": selected_tier1,
+            "selected_experts": selected_tier0 + selected_tier1,
+            "route_slots_drawn": size_m * geometry.top_k,
+        },
+        "dense_equivalent_flop": flop,
+        "weight_stream_bytes": traffic,
+        "weight_stream_bytes_tier0": tier0_traffic,
+        "weight_stream_bytes_tier1": traffic - tier0_traffic,
+        "timing": timing,
+        "rate": {
+            "dense_equivalent_tflops_at_median": tflops(flop, timing["median_ms"]),
+            "dense_equivalent_tflops_at_min": tflops(flop, timing["min_ms"]),
+            "weight_stream_gigabytes_per_second_at_median": gigabytes_per_second(
+                traffic, timing["median_ms"]
+            ),
+            "weight_stream_gigabytes_per_second_at_min": gigabytes_per_second(
+                traffic, timing["min_ms"]
+            ),
+        },
+    }
+
+
+def measured_entry(result: dict[str, Any]) -> dict[str, Any]:
+    """A sweep entry for a configuration that produced timings."""
+
+    return {"status": "measured", **result}
+
+
+def skipped_entry(
+    configuration: Configuration, error: BaseException, stage: str
+) -> dict[str, Any]:
+    """A sweep entry for a configuration that could not be measured.
+
+    The exception type is recorded rather than raised: an invalid tile
+    config is a fact about that configuration, not a reason to abandon the
+    remaining ones.
+    """
+
+    return {
+        "status": "skipped",
+        "configuration": configuration.as_dict(),
+        "stage": stage,
+        "exception_type": type(error).__name__,
+        "reason": str(error) or repr(error),
+    }
+
+
+def rank_configurations(entries: Sequence[dict[str, Any]]) -> dict[str, Any]:
+    """Rank measured configurations by median against the baseline entry."""
+
+    measured = [entry for entry in entries if entry["status"] == "measured"]
+    baseline = next(
+        (
+            entry
+            for entry in measured
+            if entry["configuration"]["role"] == ROLE_BASELINE
+        ),
+        None,
+    )
+    if baseline is None:
+        raise ValueError(
+            "the ranking needs a measured baseline configuration to compare against"
+        )
+    baseline_median = baseline["timing"]["median_ms"]
+    ranked = []
+    for entry in sorted(measured, key=lambda item: item["timing"]["median_ms"]):
+        ranked.append(
+            {
+                "name": entry["configuration"]["name"],
+                "tile_config": entry["configuration"]["tile_config"],
+                "moe_block_size": entry["configuration"]["moe_block_size"],
+                "role": entry["configuration"]["role"],
+                "median_ms": entry["timing"]["median_ms"],
+                "iqr_ms": entry["timing"]["iqr_ms"],
+                "speedup_over_baseline": baseline_median / entry["timing"]["median_ms"],
+            }
+        )
+    candidates = [row for row in ranked if row["role"] != ROLE_BASELINE]
+    faster = [row for row in candidates if row["speedup_over_baseline"] > 1.0]
+    best = max(candidates, key=lambda row: row["speedup_over_baseline"], default=None)
+    if best is None:
+        verdict = (
+            "only the baseline was measured, so the sweep states nothing about "
+            "alternatives"
+        )
+    elif not faster:
+        verdict = (
+            "no swept configuration beat the baseline; the fastest alternative "
+            f"({best['name']}) reached {best['speedup_over_baseline']:.3f} "
+            "times the baseline rate"
+        )
+    else:
+        verdict = (
+            f"{len(faster)} configuration(s) beat the baseline; the fastest "
+            f"({best['name']}) reached {best['speedup_over_baseline']:.3f} "
+            "times the baseline rate"
+        )
+    return {
+        "baseline": {
+            "name": baseline["configuration"]["name"],
+            "median_ms": baseline_median,
+            "iqr_ms": baseline["timing"]["iqr_ms"],
+        },
+        "ordered": ranked,
+        "faster_than_baseline": len(faster),
+        "skipped": sum(1 for entry in entries if entry["status"] == "skipped"),
+        "verdict": verdict,
+    }
+
+
+# --------------------------------------------------------------------------
+# Signature discovery. Pure over the recorded signature; exercised without a
+# GPU or the kernel package.
+# --------------------------------------------------------------------------
+
+
+def signature_record(function: Any, name: str) -> dict[str, Any]:
+    """Positional and keyword parameters of `function`, as a record."""
+
+    try:
+        signature = inspect.signature(function)
+    except (TypeError, ValueError) as error:
+        raise MeasurementUnavailable(
+            f"the signature of {name} could not be read, so no call to it can "
+            f"be checked before it is made: {error!r}"
+        ) from error
+    positional: list[str] = []
+    keywords: list[str] = []
+    var_positional = False
+    var_keyword = False
+    for parameter in signature.parameters.values():
+        if parameter.kind in (
+            inspect.Parameter.POSITIONAL_ONLY,
+            inspect.Parameter.POSITIONAL_OR_KEYWORD,
+        ):
+            positional.append(parameter.name)
+            if parameter.kind is inspect.Parameter.POSITIONAL_OR_KEYWORD:
+                keywords.append(parameter.name)
+        elif parameter.kind is inspect.Parameter.KEYWORD_ONLY:
+            keywords.append(parameter.name)
+        elif parameter.kind is inspect.Parameter.VAR_POSITIONAL:
+            var_positional = True
+        elif parameter.kind is inspect.Parameter.VAR_KEYWORD:
+            var_keyword = True
+    return {
+        "name": name,
+        "text": f"{name}{signature}",
+        "positional": positional,
+        "keywords": keywords,
+        "var_positional": var_positional,
+        "var_keyword": var_keyword,
+    }
+
+
+def require_positional_order(record: dict[str, Any], expected: Sequence[str]) -> None:
+    """Refuse unless the leading positional parameters are exactly `expected`."""
+
+    found = list(record["positional"])
+    if found[: len(expected)] != list(expected):
+        raise MeasurementUnavailable(
+            f"{record['name']} does not take the positional parameters this "
+            f"harness would pass. Expected the first {len(expected)} to be "
+            f"{list(expected)}; found {record['text']}. Argument order is not "
+            "guessed: correct the harness against the resolved implementation "
+            "before measuring."
+        )
+
+
+def require_positional_count(record: dict[str, Any], count: int) -> None:
+    """Refuse unless at least `count` positional parameters are accepted."""
+
+    if record["var_positional"]:
+        return
+    if len(record["positional"]) < count:
+        raise MeasurementUnavailable(
+            f"{record['name']} accepts {len(record['positional'])} positional "
+            f"parameter(s) where this harness passes {count}; found "
+            f"{record['text']}"
+        )
+
+
+def require_keywords(record: dict[str, Any], expected: Sequence[str]) -> None:
+    """Refuse unless every keyword this harness passes is accepted by name."""
+
+    if record["var_keyword"]:
+        return
+    missing = [name for name in expected if name not in record["keywords"]]
+    if missing:
+        raise MeasurementUnavailable(
+            f"{record['name']} does not accept the keyword argument(s) "
+            f"{missing} this harness passes; found {record['text']}"
+        )
+
+
+def module_path_record(
+    module: Any,
+    expected_path: str,
+    *,
+    realpath: Callable[[str], str] = os.path.realpath,
+) -> dict[str, Any]:
+    """Compare a module's resolved file against the path the report names."""
+
+    resolved = getattr(module, "__file__", None)
+    if resolved is None:
+        return {
+            "expected": expected_path,
+            "resolved": None,
+            "resolved_realpath": None,
+            "matches": False,
+            "reason": (
+                "the imported module has no __file__, so the implementation "
+                "being timed cannot be identified"
+            ),
+        }
+    resolved = str(resolved)
+    candidates = {resolved.replace("\\", "/"), realpath(resolved).replace("\\", "/")}
+    expected = {
+        expected_path.replace("\\", "/"),
+        realpath(expected_path).replace("\\", "/"),
+    }
+    matches = bool(candidates & expected)
+    return {
+        "expected": expected_path,
+        "resolved": resolved,
+        "resolved_realpath": realpath(resolved),
+        "matches": matches,
+        "reason": (
+            ""
+            if matches
+            else (
+                "the module bound to this name resolves to a different file "
+                "than the report names. An import hook can rebind a module "
+                "path, and a measurement that names one implementation while "
+                "timing another states nothing about either."
+            )
+        ),
+    }
+
+
+EXPECTED_RUN_POSITIONAL = (
+    "x",
+    "tier0",
+    "tier1",
+    "topk_weights",
+    "topk_ids",
+    "global_to_combined",
+    "descriptor_map",
+    "rotations",
+    "launch",
+    "buffers",
+)
+EXPECTED_COMPILE_KEYWORDS = (
+    "size_m",
+    "hidden_size",
+    "intermediate_size",
+    "tier0_num_experts",
+    "tier1_num_experts",
+    "top_k",
+    "max_m_blocks",
+    "sms",
+    "max_shared_mem",
+    "force_tile_config",
+    "tier0_bits",
+    "tier1_bits",
+    "trellis_codebook",
+    "moe_block_size",
+    "rotation_input_dtype",
+    "route_ids_dtype",
+)
+EXPECTED_BUFFERS_KEYWORDS = ("device", "sms")
+EXPECTED_PREPARE_KEYWORDS = (
+    "w13",
+    "w2",
+    "hidden_size",
+    "intermediate_size",
+    "num_experts",
+    "activation",
+    "fc1_tile_n",
+    "fc2_tile_n",
+    "device",
+    "seed",
+    "params_dtype",
+    "trellis_bits",
+    "codebook",
+    "tile_config",
+)
+# The rotations a tier carries, paired as (field of MixedTrellisRotations,
+# attribute of a prepared tier).
+ROTATION_FIELDS = (
+    ("intermediate", "intermediate_rotations"),
+    ("gate_suh", "gate_suh"),
+    ("up_suh", "up_suh"),
+    ("down_svh", "down_svh"),
+)
+
+
+def _attribute(module: Any, module_name: str, attribute: str) -> Any:
+    value = getattr(module, attribute, None)
+    if value is None:
+        exported = sorted(name for name in dir(module) if not name.startswith("_"))[:40]
+        raise MeasurementUnavailable(
+            f"{module_name} does not provide {attribute!r}, which this harness "
+            f"calls. It exposes {exported}"
+        )
+    return value
+
+
+def resolve_api(
+    kernel_module: Any, prepare_module: Any, host_module: Any
+) -> tuple[Any, dict[str, Any]]:
+    """Bind the kernel entry points and check every signature relied on.
+
+    Nothing is called before its signature is confirmed, and the confirmed
+    signatures travel with the report so a reader can see what was bound.
+    """
+
+    build_tiered_maps = _attribute(kernel_module, KERNEL_MODULE, "build_tiered_maps")
+    compile_mixed_trellis = _attribute(
+        kernel_module, KERNEL_MODULE, "compile_mixed_trellis"
+    )
+    make_buffers = _attribute(
+        kernel_module, KERNEL_MODULE, "make_mixed_trellis_buffers"
+    )
+    run_mixed_trellis = _attribute(kernel_module, KERNEL_MODULE, "run_mixed_trellis")
+    prepare_weights = _attribute(
+        prepare_module, PREPARE_MODULE, "prepare_trellis256_moe_weights"
+    )
+    max_packed_route_slots = _attribute(
+        host_module, HOST_MODULE, "max_packed_route_slots"
+    )
+    rotations_class = _attribute(
+        kernel_module, KERNEL_MODULE, "MixedTrellisRotations"
+    )
+    combine_rotations = getattr(kernel_module, "combine_trellis_rotations", None)
+
+    records = {
+        "build_tiered_maps": signature_record(build_tiered_maps, "build_tiered_maps"),
+        "compile_mixed_trellis": signature_record(
+            compile_mixed_trellis, "compile_mixed_trellis"
+        ),
+        "make_mixed_trellis_buffers": signature_record(
+            make_buffers, "make_mixed_trellis_buffers"
+        ),
+        "run_mixed_trellis": signature_record(run_mixed_trellis, "run_mixed_trellis"),
+        "prepare_trellis256_moe_weights": signature_record(
+            prepare_weights, "prepare_trellis256_moe_weights"
+        ),
+        "max_packed_route_slots": signature_record(
+            max_packed_route_slots, "max_packed_route_slots"
+        ),
+    }
+    if combine_rotations is not None:
+        records["combine_trellis_rotations"] = signature_record(
+            combine_rotations, "combine_trellis_rotations"
+        )
+
+    # `build_tiered_maps` is passed the tier-0 and tier-1 expert identifier
+    # sequences positionally and the device by keyword, and returns the pair
+    # (global_to_combined, descriptor_map) in that order.
+    require_positional_count(records["build_tiered_maps"], 2)
+    require_keywords(records["build_tiered_maps"], ("device",))
+    require_keywords(records["compile_mixed_trellis"], EXPECTED_COMPILE_KEYWORDS)
+    require_positional_count(records["make_mixed_trellis_buffers"], 1)
+    require_keywords(records["make_mixed_trellis_buffers"], EXPECTED_BUFFERS_KEYWORDS)
+    require_positional_order(records["run_mixed_trellis"], EXPECTED_RUN_POSITIONAL)
+    require_keywords(
+        records["prepare_trellis256_moe_weights"], EXPECTED_PREPARE_KEYWORDS
+    )
+    # max_packed_route_slots(route_slot_count, block_size, num_experts).
+    require_positional_count(records["max_packed_route_slots"], 3)
+
+    api = SimpleNamespace(
+        build_tiered_maps=build_tiered_maps,
+        compile_mixed_trellis=compile_mixed_trellis,
+        make_mixed_trellis_buffers=make_buffers,
+        run_mixed_trellis=run_mixed_trellis,
+        prepare_weights=prepare_weights,
+        max_packed_route_slots=max_packed_route_slots,
+        combine_rotations=combine_rotations,
+        rotations_class=rotations_class,
+    )
+    discovery = {
+        "kernel_module": KERNEL_MODULE,
+        "prepare_module": PREPARE_MODULE,
+        "host_module": HOST_MODULE,
+        "signatures": records,
+        "rotations_source": (
+            "combine_trellis_rotations"
+            if combine_rotations is not None
+            else "MixedTrellisRotations built from concatenated tier rotations"
+        ),
+    }
+    return api, discovery
+
+
+# --------------------------------------------------------------------------
+# Conditions that make a result reproducible and interpretable.
+# --------------------------------------------------------------------------
+
+
+def read_clock_state(
+    device_index: int = 0,
+    *,
+    which: Callable[[str], str | None] = shutil.which,
+    runner: Callable[..., Any] = subprocess.run,
+) -> dict[str, Any]:
+    """Clock, throttle, and power state from nvidia-smi, or why it is absent.
+
+    A result whose clock state is unknown is still a result; a result that
+    silently omits it is not, so every failure path returns a stated reason.
+    """
+
+    binary = which("nvidia-smi")
+    if binary is None:
+        return {"read": False, "reason": "nvidia-smi is not on PATH"}
+    command = [
+        binary,
+        "--query-gpu=" + ",".join(NVIDIA_SMI_FIELDS),
+        "--format=csv,noheader,nounits",
+        "-i",
+        str(device_index),
+    ]
+    try:
+        result = runner(command, capture_output=True, text=True, timeout=30)
+    except (OSError, subprocess.SubprocessError) as error:
+        return {"read": False, "reason": f"nvidia-smi could not be run: {error!r}"}
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout or "").strip().splitlines()
+        return {
+            "read": False,
+            "reason": detail[-1] if detail else "nvidia-smi exited non-zero",
+        }
+    rows = (result.stdout or "").strip().splitlines()
+    if not rows:
+        return {"read": False, "reason": "nvidia-smi returned no rows"}
+    values = [value.strip() for value in rows[0].split(",")]
+    if len(values) != len(NVIDIA_SMI_FIELDS):
+        return {
+            "read": False,
+            "reason": (
+                f"nvidia-smi returned {len(values)} fields where "
+                f"{len(NVIDIA_SMI_FIELDS)} were requested"
+            ),
+        }
+    fields = dict(zip(NVIDIA_SMI_FIELDS, values))
+    applied = fields["clocks.applications.graphics"]
+    pinned = applied not in UNREPORTED
+    return {
+        "read": True,
+        "fields": fields,
+        "application_clocks_pinned": pinned,
+        "lock_note": (
+            f"application clocks pinned at {applied} MHz"
+            if pinned
+            else (
+                "application clocks are not pinned; the driver is free to "
+                "move the SM clock during the run, so compare the before and "
+                "after readings"
+            )
+        ),
+    }
+
+
+def describe_environment(torch_module: Any, device_index: int) -> dict[str, Any]:
+    """Torch, CUDA, and device facts a reader needs to interpret the numbers."""
+
+    properties = torch_module.cuda.get_device_properties(device_index)
+    capability = tuple(torch_module.cuda.get_device_capability(device_index))
+    return {
+        "torch_version": str(torch_module.__version__),
+        "torch_cuda_version": str(torch_module.version.cuda),
+        "device_index": device_index,
+        "device_name": torch_module.cuda.get_device_name(device_index),
+        "compute_capability": list(capability),
+        "multi_processor_count": int(getattr(properties, "multi_processor_count", 0)),
+        "shared_memory_per_block_optin": int(
+            getattr(properties, "shared_memory_per_block_optin", 0)
+        ),
+        "total_memory_bytes": int(getattr(properties, "total_memory", 0)),
+        "platform": platform.platform(),
+        "python_version": platform.python_version(),
+    }
+
+
+# --------------------------------------------------------------------------
+# Device path.
+# --------------------------------------------------------------------------
+
+
+def import_torch() -> Any:
+    """Import Torch, or state that the measurement cannot be taken."""
+
+    try:
+        import torch
+    except ImportError as error:
+        raise MeasurementUnavailable(
+            f"torch is not importable, so no kernel can be launched: {error}"
+        ) from error
+    return torch
+
+
+def import_kernel_modules(
+    *,
+    kernel_name: str = KERNEL_MODULE,
+    prepare_name: str = PREPARE_MODULE,
+    host_name: str = HOST_MODULE,
+    importer: Callable[[str], Any] = importlib.import_module,
+) -> tuple[Any, Any, Any]:
+    """Import the kernel, weight preparation, and host planning modules."""
+
+    modules = []
+    for name in (kernel_name, prepare_name, host_name):
+        try:
+            modules.append(importer(name))
+        except Exception as error:  # noqa: BLE001 - the reason is reported
+            raise MeasurementUnavailable(
+                f"{name} is not importable, so the mixed-bitrate Trellis "
+                f"kernel cannot be measured: {type(error).__name__}: {error}"
+            ) from error
+    return modules[0], modules[1], modules[2]
+
+
+def require_cuda_device(torch_module: Any, device_index: int) -> None:
+    """Refuse, with a reason, unless the named CUDA device exists."""
+
+    cuda = getattr(torch_module, "cuda", None)
+    if cuda is None or not cuda.is_available():
+        raise MeasurementUnavailable(
+            "no CUDA device is visible to torch. This measures a compiled "
+            "GB10 kernel and has no CPU fallback, because there is no CPU "
+            "implementation of it to time. Run it on the GB10 host, inside "
+            "the serving runtime image, with the device visible to the "
+            "container."
+        )
+    count = int(cuda.device_count())
+    if not 0 <= device_index < count:
+        raise MeasurementUnavailable(
+            f"--device {device_index} does not exist; torch sees {count} CUDA "
+            "device(s)"
+        )
+
+
+def require_pool_fits(
+    geometry: Geometry, pool_size: int, total_memory_bytes: int, fraction: float
+) -> dict[str, Any]:
+    """Refuse a weight pool that would claim too much of device memory."""
+
+    predicted = weight_pool_bytes(geometry, pool_size)
+    limit = int(total_memory_bytes * fraction)
+    if total_memory_bytes and predicted > limit:
+        raise MeasurementUnavailable(
+            f"a weight pool of {pool_size} set(s) needs about "
+            f"{predicted / (1 << 30):.1f} GiB of packed expert weights, above "
+            f"the {fraction:.0%} of the device's "
+            f"{total_memory_bytes / (1 << 30):.1f} GiB this harness will "
+            "claim. Lower --pool-size, raise --max-pool-fraction, or run on a "
+            "device with more memory. GB10 memory is unified, so a pool that "
+            "fills it starves the host as well."
+        )
+    return {
+        "pool_size": pool_size,
+        "bytes_per_set": resident_weight_bytes(geometry),
+        "predicted_bytes": predicted,
+        "fraction_of_device_memory": (
+            predicted / total_memory_bytes if total_memory_bytes else None
+        ),
+        "note": (
+            "packed expert weights only; rotations, launch descriptors, and "
+            "kernel buffers are additional"
+        ),
+    }
+
+
+def build_routing(
+    torch_module: Any,
+    geometry: Geometry,
+    *,
+    size_m: int,
+    device: Any,
+    seed: int,
+) -> tuple[Any, Any, tuple[int, int]]:
+    """Deterministic top-k routing over every expert, and what it selects.
+
+    Each token draws `top_k` distinct experts uniformly, which is the
+    routing shape the kernel is given. A deployed router's distribution is
+    skewed, so a measured elapsed time under this routing describes the
+    geometry rather than a particular model's routing behaviour.
+    """
+
+    generator = torch_module.Generator(device="cpu")
+    generator.manual_seed(seed)
+    scores = torch_module.rand(
+        size_m,
+        geometry.total_experts,
+        generator=generator,
+        dtype=torch_module.float32,
+    )
+    _, ids = torch_module.topk(scores, geometry.top_k, dim=1)
+    weights = torch_module.rand(
+        size_m, geometry.top_k, generator=generator, dtype=torch_module.float32
+    )
+    weights = weights / weights.sum(dim=1, keepdim=True)
+    selected = count_selected_experts(
+        ids.reshape(-1).tolist(), geometry.tier0_num_experts, geometry.total_experts
+    )
+    return (
+        ids.to(device=device, dtype=torch_module.int32).contiguous(),
+        weights.to(device=device).contiguous(),
+        selected,
+    )
+
+
+def build_rotations(torch_module: Any, api: Any, tiers: Sequence[Any]) -> Any:
+    """Rotations covering both tiers, in combined expert order."""
+
+    if api.combine_rotations is not None:
+        return api.combine_rotations(*tiers)
+    fields = {}
+    for field, attribute in ROTATION_FIELDS:
+        parts = []
+        for tier in tiers:
+            value = getattr(tier, attribute, None)
+            if value is None:
+                raise MeasurementUnavailable(
+                    f"a prepared tier does not carry {attribute!r}, so the "
+                    "rotations this kernel needs cannot be assembled, and the "
+                    "module exposes no combine_trellis_rotations to assemble "
+                    "them"
+                )
+            parts.append(value)
+        fields[field] = torch_module.cat(parts, dim=0).contiguous()
+    return api.rotations_class(**fields)
+
+
+def prepare_weight_pool(
+    torch_module: Any,
+    api: Any,
+    geometry: Geometry,
+    *,
+    tile_config: tuple[int, int, int, int],
+    device: Any,
+    pool_size: int,
+    seed: int,
+    params_dtype: Any,
+    activation: str,
+) -> list[tuple[Any, Any, Any]]:
+    """Independent prepared weight sets, one per timed call in the cycle.
+
+    Weight preparation is told the same FC1 and FC2 output tile widths the
+    launch is compiled with: the vLLM EXL3 backend passes
+    `fc1_tile_n=tile_config[1]` and `fc2_tile_n=tile_config[3]`, so packed
+    weights belong to a tile config and a pool cannot be shared across
+    them.
+    """
+
+    pool = []
+    for index in range(pool_size):
+        tiers = []
+        for tier, (experts, bits) in enumerate(
+            (
+                (geometry.tier0_num_experts, geometry.tier0_bits),
+                (geometry.tier1_num_experts, geometry.tier1_bits),
+            )
+        ):
+            tiers.append(
+                api.prepare_weights(
+                    w13=None,
+                    w2=None,
+                    hidden_size=geometry.hidden_size,
+                    intermediate_size=geometry.intermediate_size,
+                    num_experts=experts,
+                    activation=activation,
+                    fc1_tile_n=tile_config[1],
+                    fc2_tile_n=tile_config[3],
+                    device=device,
+                    seed=seed + 1000 * index + tier,
+                    params_dtype=params_dtype,
+                    trellis_bits=bits,
+                    codebook="mcg",
+                    tile_config=tile_config,
+                )
+            )
+        pool.append((tiers[0], tiers[1], build_rotations(torch_module, api, tiers)))
+    return pool
+
+
+def compile_launch(
+    api: Any,
+    geometry: Geometry,
+    configuration: Configuration,
+    *,
+    size_m: int,
+    device: Any,
+    max_shared_mem: int,
+    rotation_input_dtype: str,
+    route_ids_dtype: Any,
+) -> tuple[Any, Any, dict[str, int]]:
+    """Compile one launch and allocate its device buffers."""
+
+    plan = route_slot_plan(
+        api, geometry, size_m=size_m, moe_block_size=configuration.moe_block_size
+    )
+    launch = api.compile_mixed_trellis(
+        size_m=size_m,
+        hidden_size=geometry.hidden_size,
+        intermediate_size=geometry.intermediate_size,
+        tier0_num_experts=geometry.tier0_num_experts,
+        tier1_num_experts=geometry.tier1_num_experts,
+        tier0_bits=geometry.tier0_bits,
+        tier1_bits=geometry.tier1_bits,
+        top_k=geometry.top_k,
+        max_m_blocks=plan["max_m_blocks"],
+        moe_block_size=configuration.moe_block_size,
+        sms=geometry.sms,
+        max_shared_mem=max_shared_mem,
+        force_tile_config=configuration.tile_config,
+        trellis_codebook="mcg",
+        rotation_input_dtype=rotation_input_dtype,
+        route_ids_dtype=route_ids_dtype,
+    )
+    buffers = api.make_mixed_trellis_buffers(launch, device=device, sms=geometry.sms)
+    return launch, buffers, plan
+
+
+def time_calls(
+    torch_module: Any,
+    api: Any,
+    *,
+    x: Any,
+    topk_weights: Any,
+    topk_ids: Any,
+    global_to_combined: Any,
+    descriptor_map: Any,
+    pool: Sequence[tuple[Any, Any, Any]],
+    launch: Any,
+    buffers: Any,
+    device: Any,
+    warmup: int,
+    iterations: int,
+    label: str,
+) -> list[float]:
+    """Elapsed milliseconds per timed call, cycling the weight pool.
+
+    Every reusable tensor is allocated by the caller. The kernel returns
+    its output, so that allocation stays inside the loop; only the most
+    recent output is retained, and it is checked for a finite, non-zero
+    result after the loop.
+    """
+
+    def call(entry: tuple[Any, Any, Any]) -> Any:
+        tier0, tier1, rotations = entry
+        return api.run_mixed_trellis(
+            x,
+            tier0,
+            tier1,
+            topk_weights,
+            topk_ids,
+            global_to_combined,
+            descriptor_map,
+            rotations,
+            launch,
+            buffers,
+        )
+
+    # Warmup absorbs the kernel's compilation, which the first call to a
+    # configuration pays, and touches every weight set in the pool.
+    for index in range(warmup):
+        call(pool[index % len(pool)])
+    torch_module.cuda.synchronize(device)
+
+    starts = [torch_module.cuda.Event(enable_timing=True) for _ in range(iterations)]
+    ends = [torch_module.cuda.Event(enable_timing=True) for _ in range(iterations)]
+    output = None
+    for index, (start, end) in enumerate(zip(starts, ends)):
+        entry = pool[index % len(pool)]
+        start.record()
+        output = call(entry)
+        end.record()
+    torch_module.cuda.synchronize(device)
+
+    if output is None:
+        raise MeasurementUnavailable(
+            f"{label} ran no timed call, so there is nothing to report"
+        )
+    if not bool(torch_module.isfinite(output).all().item()):
+        raise MeasurementUnavailable(
+            f"{label} produced non-finite output, so its timing is not a "
+            "measurement of a completed kernel"
+        )
+    if not bool((output != 0).any().item()):
+        raise MeasurementUnavailable(
+            f"{label} produced an all-zero output, so its timing is not a "
+            "measurement of completed work"
+        )
+    return [float(start.elapsed_time(end)) for start, end in zip(starts, ends)]
+
+
+def measure_size(
+    torch_module: Any,
+    api: Any,
+    geometry: Geometry,
+    configuration: Configuration,
+    *,
+    size_m: int,
+    device: Any,
+    pool: Sequence[tuple[Any, Any, Any]],
+    maps: tuple[Any, Any],
+    max_shared_mem: int,
+    dtype_name: str,
+    seed: int,
+    warmup: int,
+    iterations: int,
+) -> dict[str, Any]:
+    """Compile, drive, and summarize one token count of one configuration."""
+
+    torch_dtype = (
+        torch_module.bfloat16 if dtype_name == "bf16" else torch_module.float16
+    )
+    topk_ids, topk_weights, selected = build_routing(
+        torch_module, geometry, size_m=size_m, device=device, seed=seed
+    )
+    x = torch_module.randn(
+        size_m, geometry.hidden_size, device=device, dtype=torch_module.float32
+    )
+    x = (x * 1.0e-2).to(torch_dtype).contiguous()
+    launch, buffers, plan = compile_launch(
+        api,
+        geometry,
+        configuration,
+        size_m=size_m,
+        device=device,
+        max_shared_mem=max_shared_mem,
+        rotation_input_dtype=dtype_name,
+        route_ids_dtype=topk_ids.dtype,
+    )
+    samples = time_calls(
+        torch_module,
+        api,
+        x=x,
+        topk_weights=topk_weights,
+        topk_ids=topk_ids,
+        global_to_combined=maps[0],
+        descriptor_map=maps[1],
+        pool=pool,
+        launch=launch,
+        buffers=buffers,
+        device=device,
+        warmup=warmup,
+        iterations=iterations,
+        label=f"{configuration.name} at size_m={size_m}",
+    )
+    result = size_result(
+        geometry=geometry,
+        size_m=size_m,
+        configuration=configuration,
+        samples_ms=samples,
+        selected_tier0=selected[0],
+        selected_tier1=selected[1],
+        plan=plan,
+    )
+    del launch, buffers, x, topk_ids, topk_weights
+    torch_module.cuda.empty_cache()
+    return result
+
+
+def build_tier_maps(
+    torch_module: Any, api: Any, geometry: Geometry, device: Any
+) -> tuple[tuple[Any, Any], dict[str, Any]]:
+    """Expert identifier maps for the two tiers, and how they were accepted.
+
+    Expert identifiers 0 to tier0_num_experts-1 are assigned to tier 0 and
+    the rest to tier 1. Which identifier sits in which tier is a property
+    of a checkpoint's bitrate assignment; the kernel's cost depends on the
+    tier sizes and the routing, so the assignment is stated here rather
+    than recovered from a checkpoint.
+
+    `build_tiered_maps` is passed the two identifier sequences positionally
+    and the device by keyword. The container type its implementation
+    accepts is not part of the documented interface, so a list of integers
+    is tried first and a 64-bit integer tensor second; whichever form was
+    accepted is recorded.
+    """
+
+    tier0_ids = list(range(geometry.tier0_num_experts))
+    tier1_ids = list(range(geometry.tier0_num_experts, geometry.total_experts))
+    attempts: list[str] = []
+    forms = (
+        ("list[int]", tier0_ids, tier1_ids),
+        (
+            "torch.int64 tensor",
+            torch_module.tensor(tier0_ids, dtype=torch_module.int64, device=device),
+            torch_module.tensor(tier1_ids, dtype=torch_module.int64, device=device),
+        ),
+    )
+    for form, first, second in forms:
+        try:
+            maps = api.build_tiered_maps(first, second, device=device)
+        except Exception as error:  # noqa: BLE001 - the reason is reported
+            attempts.append(f"{form}: {type(error).__name__}: {error}")
+            continue
+        if not isinstance(maps, tuple) or len(maps) != 2:
+            raise MeasurementUnavailable(
+                f"build_tiered_maps returned {type(maps).__name__} where the "
+                "pair (global_to_combined, descriptor_map) was expected"
+            )
+        return (maps[0], maps[1]), {
+            "identifier_form_accepted": form,
+            "rejected_forms": attempts,
+            "tier0_identifiers": [tier0_ids[0], tier0_ids[-1]],
+            "tier1_identifiers": [tier1_ids[0], tier1_ids[-1]],
+        }
+    raise MeasurementUnavailable(
+        "build_tiered_maps rejected every expert identifier container this "
+        "harness knows how to pass: " + "; ".join(attempts)
+    )
+
+
+# --------------------------------------------------------------------------
+# Drivers.
+# --------------------------------------------------------------------------
+
+
+def open_device(
+    torch_module: Any, arguments: argparse.Namespace
+) -> tuple[Any, dict[str, Any]]:
+    """Claim the named CUDA device and describe it."""
+
+    require_cuda_device(torch_module, arguments.device)
+    device = torch_module.device("cuda", arguments.device)
+    torch_module.cuda.set_device(device)
+    return device, describe_environment(torch_module, arguments.device)
+
+
+def run_measure(
+    torch_module: Any,
+    api: Any,
+    *,
+    geometry: Geometry,
+    configuration: Configuration,
+    sizes: Sequence[int],
+    device: Any,
+    environment: dict[str, Any],
+    discovery: dict[str, Any],
+    module_record: dict[str, Any],
+    arguments: argparse.Namespace,
+) -> dict[str, Any]:
+    """Time one configuration across every requested token count."""
+
+    pool_record = require_pool_fits(
+        geometry,
+        arguments.pool_size,
+        environment["total_memory_bytes"],
+        arguments.max_pool_fraction,
+    )
+    clocks_before = read_clock_state(arguments.device)
+    maps, map_record = build_tier_maps(torch_module, api, geometry, device)
+    torch_dtype = (
+        torch_module.bfloat16 if arguments.dtype == "bf16" else torch_module.float16
+    )
+    pool = prepare_weight_pool(
+        torch_module,
+        api,
+        geometry,
+        tile_config=configuration.tile_config,
+        device=device,
+        pool_size=arguments.pool_size,
+        seed=arguments.seed,
+        params_dtype=torch_dtype,
+        activation=arguments.activation,
+    )
+    results = [
+        measure_size(
+            torch_module,
+            api,
+            geometry,
+            configuration,
+            size_m=size_m,
+            device=device,
+            pool=pool,
+            maps=maps,
+            max_shared_mem=environment["shared_memory_per_block_optin"],
+            dtype_name=arguments.dtype,
+            seed=arguments.seed,
+            warmup=arguments.warmup,
+            iterations=arguments.iterations,
+        )
+        for size_m in sizes
+    ]
+    del pool
+    torch_module.cuda.empty_cache()
+    clocks_after = read_clock_state(arguments.device)
+    return build_report(
+        mode="measure",
+        geometry=geometry,
+        environment=environment,
+        module_record=module_record,
+        discovery=discovery,
+        map_record=map_record,
+        pool_record=pool_record,
+        clocks_before=clocks_before,
+        clocks_after=clocks_after,
+        arguments=arguments,
+        sizes=results,
+        baseline=configuration,
+    )
+
+
+def run_tune(
+    torch_module: Any,
+    api: Any,
+    *,
+    geometry: Geometry,
+    configurations: Sequence[Configuration],
+    enumeration: dict[str, Any],
+    size_m: int,
+    device: Any,
+    environment: dict[str, Any],
+    discovery: dict[str, Any],
+    module_record: dict[str, Any],
+    arguments: argparse.Namespace,
+) -> dict[str, Any]:
+    """Time every configuration at one token count and rank the results.
+
+    A candidate that fails at any stage is recorded as a skip carrying its
+    exception type. The baseline is the only configuration whose failure
+    ends the run, because a ranking with no baseline states nothing.
+    """
+
+    pool_record = require_pool_fits(
+        geometry,
+        arguments.pool_size,
+        environment["total_memory_bytes"],
+        arguments.max_pool_fraction,
+    )
+    clocks_before = read_clock_state(arguments.device)
+    maps, map_record = build_tier_maps(torch_module, api, geometry, device)
+    torch_dtype = (
+        torch_module.bfloat16 if arguments.dtype == "bf16" else torch_module.float16
+    )
+    entries: list[dict[str, Any]] = []
+    for tile_config, group in tile_config_groups(configurations):
+        try:
+            pool = prepare_weight_pool(
+                torch_module,
+                api,
+                geometry,
+                tile_config=tile_config,
+                device=device,
+                pool_size=arguments.pool_size,
+                seed=arguments.seed,
+                params_dtype=torch_dtype,
+                activation=arguments.activation,
+            )
+        except Exception as error:  # noqa: BLE001 - recorded as a skip
+            if any(item.role == ROLE_BASELINE for item in group):
+                raise MeasurementUnavailable(
+                    "weight preparation failed for the baseline tile config "
+                    f"{tile_config}: {type(error).__name__}: {error}"
+                ) from error
+            entries.extend(
+                skipped_entry(item, error, "prepare_weights") for item in group
+            )
+            torch_module.cuda.empty_cache()
+            continue
+        for configuration in group:
+            try:
+                entries.append(
+                    measured_entry(
+                        measure_size(
+                            torch_module,
+                            api,
+                            geometry,
+                            configuration,
+                            size_m=size_m,
+                            device=device,
+                            pool=pool,
+                            maps=maps,
+                            max_shared_mem=environment[
+                                "shared_memory_per_block_optin"
+                            ],
+                            dtype_name=arguments.dtype,
+                            seed=arguments.seed,
+                            warmup=arguments.warmup,
+                            iterations=arguments.iterations,
+                        )
+                    )
+                )
+            except Exception as error:  # noqa: BLE001 - recorded as a skip
+                if configuration.role == ROLE_BASELINE:
+                    raise MeasurementUnavailable(
+                        f"the baseline configuration {configuration.name} "
+                        "could not be measured, so no ranking can be stated "
+                        f"against it: {type(error).__name__}: {error}"
+                    ) from error
+                entries.append(skipped_entry(configuration, error, "measure"))
+                torch_module.cuda.empty_cache()
+        del pool
+        torch_module.cuda.empty_cache()
+    clocks_after = read_clock_state(arguments.device)
+    return build_report(
+        mode="tune",
+        geometry=geometry,
+        environment=environment,
+        module_record=module_record,
+        discovery=discovery,
+        map_record=map_record,
+        pool_record=pool_record,
+        clocks_before=clocks_before,
+        clocks_after=clocks_after,
+        arguments=arguments,
+        configurations=entries,
+        enumeration=enumeration,
+        ranking=rank_configurations(entries),
+        tuned_size_m=size_m,
+        baseline=next(
+            (item for item in configurations if item.role == ROLE_BASELINE),
+            DEPLOYED_CONFIGURATION,
+        ),
+    )
+
+
+# --------------------------------------------------------------------------
+# Report assembly and rendering. Pure; exercised without a GPU.
+# --------------------------------------------------------------------------
+
+
+def build_report(
+    *,
+    mode: str,
+    geometry: Geometry,
+    environment: dict[str, Any],
+    module_record: dict[str, Any],
+    discovery: dict[str, Any],
+    map_record: dict[str, Any],
+    pool_record: dict[str, Any],
+    clocks_before: dict[str, Any],
+    clocks_after: dict[str, Any],
+    arguments: Any,
+    sizes: Sequence[dict[str, Any]] = (),
+    configurations: Sequence[dict[str, Any]] = (),
+    enumeration: dict[str, Any] | None = None,
+    ranking: dict[str, Any] | None = None,
+    tuned_size_m: int | None = None,
+    baseline: Configuration = DEPLOYED_CONFIGURATION,
+) -> dict[str, Any]:
+    """Assemble the machine-readable document."""
+
+    report: dict[str, Any] = {
+        "schema": SCHEMA,
+        "mode": mode,
+        "measurement": {
+            "operation": (
+                "one call of the fused mixed-bitrate Trellis mixture-of-"
+                "experts kernel over two expert tiers behind a single grid"
+            ),
+            "weights": (
+                "synthesized by prepare_trellis256_moe_weights with w13=None "
+                "and w2=None; no checkpoint is loaded, so the result "
+                "describes the kernel at a geometry and not a model's values"
+            ),
+            "flop_formula": FLOP_FORMULA,
+            "flop_note": FLOP_NOTE,
+            "weight_bytes_formula": WEIGHT_BYTES_FORMULA,
+            "weight_bytes_note": WEIGHT_BYTES_NOTE,
+            "timing": (
+                "one CUDA event pair per call; the device is synchronized "
+                "after warmup and after the timed loop, and event times are "
+                "read only after that second synchronization"
+            ),
+            "statistic": (
+                "median with interquartile range, plus observed min and max"
+            ),
+            "warmup_calls": arguments.warmup,
+            "timed_calls": arguments.iterations,
+            "weight_pool": pool_record,
+            "weight_pool_note": (
+                "one prepared weight set per timed call, round-robin, so "
+                "weights stream rather than remaining resident in cache "
+                "across calls"
+            ),
+            "activation": arguments.activation,
+            "rotation_input_dtype": arguments.dtype,
+            "route_ids_dtype": "torch.int32",
+            "routing": (
+                "each token draws top_k distinct experts uniformly from a "
+                "seeded generator; a deployed router's distribution is skewed, "
+                "so elapsed time here describes the geometry rather than a "
+                "model's routing behaviour"
+            ),
+            "seed": arguments.seed,
+            "single_process": True,
+            "distributed": False,
+        },
+        "geometry": geometry.as_dict(),
+        "module": module_record,
+        "api_discovery": discovery,
+        "tier_maps": map_record,
+        "environment": environment,
+        "clocks": {"before": clocks_before, "after": clocks_after},
+    }
+    if mode == "measure":
+        report["configuration"] = baseline.as_dict() if not sizes else sizes[0][
+            "configuration"
+        ]
+        report["sizes"] = list(sizes)
+    else:
+        report["tuned_size_m"] = tuned_size_m
+        report["baseline_configuration"] = baseline.as_dict()
+        report["enumeration"] = dict(enumeration or {})
+        report["configurations"] = list(configurations)
+        report["ranking"] = dict(ranking or {})
+    return report
+
+
+def _clock_line(label: str, state: dict[str, Any]) -> list[str]:
+    if not state.get("read"):
+        return [f"  {label:<22}NOT READ ({state.get('reason', 'no reason given')})"]
+    fields = state["fields"]
+    return [
+        f"  {label:<22}sm {fields['clocks.sm']} MHz of max "
+        f"{fields['clocks.max.sm']} MHz, {fields['power.draw']} W of "
+        f"{fields['power.limit']} W, {fields['temperature.gpu']} C, "
+        f"throttle: {fields['clocks_throttle_reasons.active']}"
+    ]
+
+
+def _condition_lines(report: dict[str, Any]) -> list[str]:
+    environment = report["environment"]
+    measurement = report["measurement"]
+    geometry = report["geometry"]
+    module = report["module"]
+    capability = "".join(str(part) for part in environment["compute_capability"])
+    pool = measurement["weight_pool"]
+    lines = [
+        "CONDITIONS",
+        f"  {'torch':<22}{environment['torch_version']} "
+        f"(CUDA {environment['torch_cuda_version']})",
+        f"  {'device':<22}{environment['device_name']} "
+        f"(index {environment['device_index']}, SM{capability}, "
+        f"{environment['multi_processor_count']} SMs)",
+        f"  {'kernel module':<22}{module['resolved']}",
+        f"  {'module path check':<22}"
+        + ("matches the expected path" if module["matches"] else "MISMATCH"),
+        f"  {'rotations from':<22}{report['api_discovery']['rotations_source']}",
+        f"  {'tier ids passed as':<22}"
+        f"{report['tier_maps']['identifier_form_accepted']}",
+        f"  {'geometry':<22}hidden {geometry['hidden_size']}, intermediate "
+        f"{geometry['intermediate_size']}, experts "
+        f"{geometry['tier0_num_experts']}@{geometry['tier0_bits']}b + "
+        f"{geometry['tier1_num_experts']}@{geometry['tier1_bits']}b, top_k "
+        f"{geometry['top_k']}",
+        f"  {'warmup calls':<22}{measurement['warmup_calls']}",
+        f"  {'timed calls':<22}{measurement['timed_calls']}",
+        f"  {'weight pool':<22}{pool['pool_size']} set(s), "
+        f"{pool['predicted_bytes'] / (1 << 30):.2f} GiB of packed expert weights",
+        f"  {'activation':<22}{measurement['activation']}",
+        f"  {'timing':<22}{measurement['timing']}",
+        f"  {'platform':<22}{environment['platform']}",
+    ]
+    lines += _clock_line("clocks before", report["clocks"]["before"])
+    lines += _clock_line("clocks after", report["clocks"]["after"])
+    before = report["clocks"]["before"]
+    if before.get("read"):
+        lines.append(f"  {'clock lock':<22}{before['lock_note']}")
+    return lines
+
+
+def _arithmetic_lines(report: dict[str, Any]) -> list[str]:
+    measurement = report["measurement"]
+    return [
+        "",
+        "ARITHMETIC",
+        f"  {measurement['flop_formula']}",
+        f"  {measurement['flop_note']}",
+        f"  {measurement['weight_bytes_formula']}",
+        f"  {measurement['weight_bytes_note']}",
+    ]
+
+
+def render_text(report: dict[str, Any]) -> str:
+    """Render the report for a person reading a terminal."""
+
+    if report["mode"] == "measure":
+        return _render_measure(report)
+    return _render_tune(report)
+
+
+def _render_measure(report: dict[str, Any]) -> str:
+    configuration = report["configuration"]
+    lines = [
+        "Mixed-bitrate Trellis MoE kernel rate, single GPU, single process",
+        f"schema: {report['schema']}  mode: {report['mode']}",
+        "",
+    ]
+    lines += _condition_lines(report)
+    lines.append(
+        f"  {'tile config':<22}{tuple(configuration['tile_config'])}, "
+        f"moe_block_size {configuration['moe_block_size']}"
+    )
+    lines += _arithmetic_lines(report)
+    lines += [
+        "",
+        "TOKEN COUNTS",
+        f"  {'size_m':>7}{'median ms':>12}{'IQR ms':>10}{'min ms':>10}"
+        f"{'max ms':>10}{'TFLOP/s med':>13}{'GB/s med':>11}{'experts':>9}"
+        f"{'m_blocks':>10}",
+    ]
+    for entry in report["sizes"]:
+        timing = entry["timing"]
+        rate = entry["rate"]
+        lines.append(
+            f"  {entry['size_m']:>7}{timing['median_ms']:>12.4f}"
+            f"{timing['iqr_ms']:>10.4f}{timing['min_ms']:>10.4f}"
+            f"{timing['max_ms']:>10.4f}"
+            f"{rate['dense_equivalent_tflops_at_median']:>13.2f}"
+            f"{rate['weight_stream_gigabytes_per_second_at_median']:>11.1f}"
+            f"{entry['routing']['selected_experts']:>9}"
+            f"{entry['routing']['max_m_blocks']:>10}"
+        )
+    lines += [
+        "",
+        "HOW TO READ THIS",
+        "  TFLOP/s is dense-equivalent: it counts the arithmetic a dense BF16",
+        "  GEMM would perform for the same routed work, so it can be read",
+        "  against a dense GEMM rate at the same hidden and intermediate",
+        "  sizes. It is not this kernel's operation count.",
+        "  GB/s counts compressed weight bytes for the experts the routing",
+        "  selected, once each. If that rate approaches the device's memory",
+        "  bandwidth the kernel is weight-traffic bound and the tier bit mix",
+        "  moves elapsed time; if it sits far below, decode and launch",
+        "  behaviour bound it and the mix does not.",
+        "  Both rates are lower bounds to the extent the kernel re-reads",
+        "  weights across m-blocks, which this harness does not observe.",
+    ]
+    return "\n".join(lines) + "\n"
+
+
+def _render_tune(report: dict[str, Any]) -> str:
+    ranking = report["ranking"]
+    enumeration = report["enumeration"]
+    lines = [
+        "Mixed-bitrate Trellis MoE kernel tiling sweep, single GPU, single process",
+        f"schema: {report['schema']}  mode: {report['mode']}  "
+        f"size_m: {report['tuned_size_m']}",
+        "",
+    ]
+    lines += _condition_lines(report)
+    baseline = report["baseline_configuration"]
+    lines += [
+        f"  {'baseline':<22}{tuple(baseline['tile_config'])}, moe_block_size "
+        f"{baseline['moe_block_size']}",
+        f"  {'configurations':<22}{enumeration.get('measured', 0)} measured of "
+        f"{enumeration.get('enumerated', 0)} enumerated, cap "
+        f"{enumeration.get('cap', 0)}",
+    ]
+    if enumeration.get("truncated"):
+        lines.append(
+            f"  {'cap note':<22}{enumeration['dropped']} configuration(s) were "
+            "not measured because the cap was reached"
+        )
+    lines += _arithmetic_lines(report)
+    lines += [
+        "",
+        "RANKING BY MEDIAN",
+        f"  {'rank':>5}  {'configuration':<28}{'role':<10}{'median ms':>12}"
+        f"{'IQR ms':>10}{'speedup':>10}",
+    ]
+    for index, row in enumerate(ranking.get("ordered", []), start=1):
+        lines.append(
+            f"  {index:>5}  {row['name']:<28}{row['role']:<10}"
+            f"{row['median_ms']:>12.4f}{row['iqr_ms']:>10.4f}"
+            f"{row['speedup_over_baseline']:>10.3f}"
+        )
+    skipped = [
+        entry for entry in report["configurations"] if entry["status"] == "skipped"
+    ]
+    if skipped:
+        lines += ["", "SKIPPED"]
+        for entry in skipped:
+            lines.append(
+                f"  {entry['configuration']['name']:<28}{entry['stage']:<18}"
+                f"{entry['exception_type']}: {entry['reason'][:90]}"
+            )
+    if any(
+        entry["configuration"]["role"] == ROLE_CONTROL
+        for entry in report["configurations"]
+    ):
+        lines += ["", "CONTROL", f"  {CONTROL_NOTE}"]
+    lines += [
+        "",
+        "VERDICT",
+        f"  {ranking.get('verdict', 'no ranking was produced')}",
+        "  speedup is the baseline median divided by the row's median, so a",
+        "  value above 1.000 is faster than the deployed configuration. Read",
+        "  it against the interquartile range in the same row: a speedup",
+        "  smaller than the spread is not a difference this run resolved.",
+    ]
+    return "\n".join(lines) + "\n"
+
+
+def emit_json(report: dict[str, Any], destination: str) -> None:
+    """Write the report as JSON to a path, or to stdout for `-`."""
+
+    rendered = json.dumps(report, indent=2, sort_keys=True, default=str)
+    if destination == "-":
+        print(rendered)
+        return
+    Path(destination).write_text(rendered + "\n", encoding="utf-8")
+
+
+def render_configuration_table(
+    configurations: Sequence[Configuration],
+    enumeration: dict[str, Any],
+    geometry: Geometry,
+    size_m: int,
+) -> str:
+    """The sweep space and its arithmetic, without touching a device."""
+
+    lines = [
+        f"{'configuration':<28}{'role':<10}{'fc1_tile':>12}{'fc2_tile':>12}"
+        f"{'block':>7}"
+    ]
+    for configuration in configurations:
+        tile = configuration.tile_config
+        fc1 = f"{tile[0]}x{tile[1]}"
+        fc2 = f"{tile[2]}x{tile[3]}"
+        lines.append(
+            f"{configuration.name:<28}{configuration.role:<10}{fc1:>12}"
+            f"{fc2:>12}{configuration.moe_block_size:>7}"
+        )
+    lines += [
+        "",
+        f"{enumeration['measured']} of {enumeration['enumerated']} enumerated "
+        f"configuration(s), cap {enumeration['cap']}",
+        "",
+        f"at size_m={size_m}: dense_equivalent_flop = "
+        f"{dense_equivalent_flop(geometry, size_m)}",
+        f"one prepared weight set holds {resident_weight_bytes(geometry)} "
+        "compressed bytes of expert weights",
+        "",
+        FLOP_FORMULA,
+        WEIGHT_BYTES_FORMULA,
+    ]
+    return "\n".join(lines) + "\n"
+
+
+# --------------------------------------------------------------------------
+# Command line.
+# --------------------------------------------------------------------------
+
+
+def _int_list(text: str) -> tuple[int, ...]:
+    try:
+        values = tuple(int(part) for part in text.replace(",", " ").split())
+    except ValueError as error:
+        raise argparse.ArgumentTypeError(str(error)) from error
+    if not values:
+        raise argparse.ArgumentTypeError("expected at least one integer")
+    if any(value < 1 for value in values):
+        raise argparse.ArgumentTypeError("every value must be at least 1")
+    return values
+
+
+def _tile_config(text: str) -> tuple[int, int, int, int]:
+    values = _int_list(text)
+    if len(values) != 4:
+        raise argparse.ArgumentTypeError(
+            "a tile config is four integers: fc1_tile_k, fc1_tile_n, "
+            "fc2_tile_k, fc2_tile_n"
+        )
+    return (values[0], values[1], values[2], values[3])
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="mixed_trellis_roofline",
+        description=(
+            "Measure the fused mixed-bitrate Trellis MoE kernel at a GB10 "
+            "deployment geometry, and sweep its tiling for a configuration "
+            "faster than the deployed one."
+        ),
+    )
+    parser.add_argument(
+        "mode",
+        choices=("measure", "tune"),
+        help=(
+            "measure: time the deployed configuration across token counts. "
+            "tune: sweep force_tile_config and moe_block_size at one token "
+            "count and rank against the deployed configuration."
+        ),
+    )
+    parser.add_argument("--device", type=int, default=0, help="CUDA device index")
+    parser.add_argument(
+        "--warmup",
+        type=int,
+        default=20,
+        help=(
+            "untimed calls per configuration before measuring, absorbing the "
+            "kernel's compilation (default: 20)"
+        ),
+    )
+    parser.add_argument(
+        "--iterations",
+        type=int,
+        default=100,
+        help="timed calls per configuration (default: 100)",
+    )
+    parser.add_argument(
+        "--pool-size",
+        type=int,
+        default=3,
+        help=(
+            "prepared weight sets cycled one per timed call, so weights stream "
+            "cold. Each set holds every expert's packed weights: about 0.91 "
+            "GiB at the default geometry, so the default of 3 costs about 2.7 "
+            "GiB of device memory (default: 3)"
+        ),
+    )
+    parser.add_argument(
+        "--max-pool-fraction",
+        type=float,
+        default=0.25,
+        help=(
+            "refuse a weight pool larger than this fraction of device memory "
+            "(default: 0.25)"
+        ),
+    )
+    parser.add_argument(
+        "--dtype",
+        choices=("bf16", "fp16"),
+        default="bf16",
+        help="activation and rotation input dtype (default: bf16)",
+    )
+    parser.add_argument(
+        "--activation",
+        default="silu",
+        help="gated MoE activation passed to weight preparation (default: silu)",
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=20260820,
+        help="seed for the synthetic weights and the routing (default: 20260820)",
+    )
+    parser.add_argument(
+        "--sizes",
+        type=_int_list,
+        default=DEPLOYED_SIZES_M,
+        help=(
+            "token counts to measure in measure mode (default: "
+            f"{' '.join(str(value) for value in DEPLOYED_SIZES_M)})"
+        ),
+    )
+    parser.add_argument(
+        "--size-m",
+        type=int,
+        default=DECODE_SIZE_M,
+        help=(
+            "token count the sweep holds fixed in tune mode, the deployed "
+            f"decode capacity (default: {DECODE_SIZE_M})"
+        ),
+    )
+    parser.add_argument(
+        "--hidden-size", type=int, default=DEPLOYED_GEOMETRY.hidden_size
+    )
+    parser.add_argument(
+        "--intermediate-size", type=int, default=DEPLOYED_GEOMETRY.intermediate_size
+    )
+    parser.add_argument(
+        "--tier0-experts", type=int, default=DEPLOYED_GEOMETRY.tier0_num_experts
+    )
+    parser.add_argument(
+        "--tier1-experts", type=int, default=DEPLOYED_GEOMETRY.tier1_num_experts
+    )
+    parser.add_argument("--tier0-bits", type=int, default=DEPLOYED_GEOMETRY.tier0_bits)
+    parser.add_argument("--tier1-bits", type=int, default=DEPLOYED_GEOMETRY.tier1_bits)
+    parser.add_argument("--top-k", type=int, default=DEPLOYED_GEOMETRY.top_k)
+    parser.add_argument(
+        "--sms",
+        type=int,
+        default=DEPLOYED_GEOMETRY.sms,
+        help="streaming multiprocessor count the launch is planned for",
+    )
+    parser.add_argument(
+        "--baseline-tile-config",
+        type=_tile_config,
+        default=DEPLOYED_TILE_CONFIG,
+        help=(
+            "tile config the sweep ranks against, four integers: fc1_tile_k "
+            "fc1_tile_n fc2_tile_k fc2_tile_n. The vLLM EXL3 backend selects "
+            "it from hidden_size, which at 6144 gives '128 128 32 512' "
+            "(default: 128 128 32 512)"
+        ),
+    )
+    parser.add_argument(
+        "--baseline-moe-block-size",
+        type=int,
+        default=DEPLOYED_MOE_BLOCK_SIZE,
+        help=(
+            "route block size the sweep ranks against (default: "
+            f"{DEPLOYED_MOE_BLOCK_SIZE})"
+        ),
+    )
+    parser.add_argument(
+        "--fc1-tile-k",
+        type=_int_list,
+        default=DEFAULT_FC1_K_VALUES,
+        help=(
+            "FC1 K tile widths to sweep. The mixed three-and-four-bit "
+            "megakernel needs a 128-wide FC1 K tile, so widening this is "
+            "opt-in (default: 128)"
+        ),
+    )
+    parser.add_argument(
+        "--fc1-tile-n",
+        type=_int_list,
+        default=DEFAULT_FC1_N_VALUES,
+        help="FC1 output tile widths to sweep (default: 128)",
+    )
+    parser.add_argument(
+        "--fc2-tile-k",
+        type=_int_list,
+        default=DEFAULT_FC2_K_VALUES,
+        help="FC2 K tile widths to sweep (default: 32 64 128)",
+    )
+    parser.add_argument(
+        "--fc2-tile-n",
+        type=_int_list,
+        default=DEFAULT_FC2_N_VALUES,
+        help=(
+            "FC2 output tile widths to sweep. The deployed 512 is chosen to "
+            "remove a second persistent wave, which is a claim about wave "
+            "quantization against the device's SM count (default: 128 256 512)"
+        ),
+    )
+    parser.add_argument(
+        "--moe-block-sizes",
+        type=_int_list,
+        default=DEFAULT_MOE_BLOCK_SIZES,
+        help="route block sizes to sweep (default: 8 16)",
+    )
+    parser.add_argument(
+        "--include-fc1-control",
+        action="store_true",
+        help=(
+            "also measure the 64x256 FC1 geometry the single-bitrate path "
+            "uses, labelled a control because it is documented as losing "
+            "partial reductions at large token counts"
+        ),
+    )
+    parser.add_argument(
+        "--max-configurations",
+        type=int,
+        default=DEFAULT_CONFIGURATION_CAP,
+        help=(
+            "cap on configurations measured in one sweep; the baseline is "
+            f"always among them (default: {DEFAULT_CONFIGURATION_CAP})"
+        ),
+    )
+    parser.add_argument(
+        "--module",
+        default=KERNEL_MODULE,
+        help=f"kernel module to import (default: {KERNEL_MODULE})",
+    )
+    parser.add_argument(
+        "--module-path",
+        default=KERNEL_MODULE_PATH,
+        help=(
+            "file the kernel module must resolve to; a mismatch is refused "
+            "because an import hook can bind another implementation to the "
+            "same name"
+        ),
+    )
+    parser.add_argument(
+        "--json",
+        metavar="PATH",
+        help="also write the report as JSON to PATH, or to stdout for '-'",
+    )
+    parser.add_argument(
+        "--list-configurations",
+        action="store_true",
+        help="print the sweep space with its arithmetic and measure nothing",
+    )
+    return parser
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = build_parser()
+    arguments = parser.parse_args(argv)
+    if arguments.warmup < 1:
+        parser.error(
+            "--warmup must be at least 1; this kernel is compiled, so the "
+            "first call to a configuration is not a steady state"
+        )
+    if arguments.iterations < 4:
+        parser.error("--iterations must be at least 4 for an interquartile range")
+    if arguments.pool_size < 1:
+        parser.error("--pool-size must be at least 1")
+    if not 0.0 < arguments.max_pool_fraction <= 1.0:
+        parser.error("--max-pool-fraction must lie in (0, 1]")
+    if arguments.max_configurations < 1:
+        parser.error("--max-configurations must be at least 1")
+    if arguments.size_m < 1:
+        parser.error("--size-m must be at least 1")
+    return arguments
+
+
+def geometry_from_arguments(arguments: argparse.Namespace) -> Geometry:
+    """The problem size the run measures, from defaults and overrides."""
+
+    return replace(
+        DEPLOYED_GEOMETRY,
+        hidden_size=arguments.hidden_size,
+        intermediate_size=arguments.intermediate_size,
+        tier0_num_experts=arguments.tier0_experts,
+        tier1_num_experts=arguments.tier1_experts,
+        tier0_bits=arguments.tier0_bits,
+        tier1_bits=arguments.tier1_bits,
+        top_k=arguments.top_k,
+        sms=arguments.sms,
+    )
+
+
+def baseline_from_arguments(arguments: argparse.Namespace) -> Configuration:
+    """The configuration a sweep ranks against and measure mode times."""
+
+    return Configuration(
+        _tile_config_tuple(arguments.baseline_tile_config),
+        arguments.baseline_moe_block_size,
+        ROLE_BASELINE,
+    )
+
+
+def _tile_config_tuple(values: Sequence[int]) -> tuple[int, int, int, int]:
+    if len(values) != 4:
+        raise ValueError(
+            f"a tile config is four integers; got {len(values)}: {list(values)}"
+        )
+    return (values[0], values[1], values[2], values[3])
+
+
+def configurations_from_arguments(
+    arguments: argparse.Namespace,
+) -> tuple[list[Configuration], dict[str, Any]]:
+    """The sweep space the command line asks for."""
+
+    return enumerate_configurations(
+        baseline=baseline_from_arguments(arguments),
+        fc1_k_values=arguments.fc1_tile_k,
+        fc1_n_values=arguments.fc1_tile_n,
+        fc2_k_values=arguments.fc2_tile_k,
+        fc2_n_values=arguments.fc2_tile_n,
+        moe_block_sizes=arguments.moe_block_sizes,
+        controls=(FC1_CONTROL_TILE_CONFIG,) if arguments.include_fc1_control else (),
+        cap=arguments.max_configurations,
+    )
+
+
+def main(
+    argv: Sequence[str] | None = None,
+    *,
+    load_torch: Callable[[], Any] = import_torch,
+    load_kernel: Callable[..., tuple[Any, Any, Any]] = import_kernel_modules,
+) -> int:
+    arguments = parse_args(argv)
+    geometry = geometry_from_arguments(arguments)
+
+    if arguments.list_configurations:
+        configurations, enumeration = configurations_from_arguments(arguments)
+        print(
+            render_configuration_table(
+                configurations, enumeration, geometry, arguments.size_m
+            ),
+            end="",
+        )
+        return EXIT_OK
+
+    try:
+        torch_module = load_torch()
+        device, environment = open_device(torch_module, arguments)
+        kernel_module, prepare_module, host_module = load_kernel(
+            kernel_name=arguments.module
+        )
+        module_record = module_path_record(kernel_module, arguments.module_path)
+        if not module_record["matches"]:
+            raise MeasurementUnavailable(
+                f"{arguments.module} resolves to {module_record['resolved']} "
+                f"where {module_record['expected']} was expected. "
+                f"{module_record['reason']} Pass --module-path to name the "
+                "path this run should measure."
+            )
+        api, discovery = resolve_api(kernel_module, prepare_module, host_module)
+        if arguments.mode == "measure":
+            report = run_measure(
+                torch_module,
+                api,
+                geometry=geometry,
+                configuration=baseline_from_arguments(arguments),
+                sizes=arguments.sizes,
+                device=device,
+                environment=environment,
+                discovery=discovery,
+                module_record=module_record,
+                arguments=arguments,
+            )
+        else:
+            configurations, enumeration = configurations_from_arguments(arguments)
+            report = run_tune(
+                torch_module,
+                api,
+                geometry=geometry,
+                configurations=configurations,
+                enumeration=enumeration,
+                size_m=arguments.size_m,
+                device=device,
+                environment=environment,
+                discovery=discovery,
+                module_record=module_record,
+                arguments=arguments,
+            )
+    except MeasurementUnavailable as error:
+        print(f"FAIL no measurement taken: {error}", file=sys.stderr)
+        return EXIT_UNAVAILABLE
+
+    print(render_text(report), end="")
+    if arguments.json:
+        emit_json(report, arguments.json)
+    return EXIT_OK
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/bench/test_mixed_trellis_roofline.py
+++ b/scripts/bench/test_mixed_trellis_roofline.py
@@ -1,0 +1,1615 @@
+"""GPU-free tests for the mixed-bitrate Trellis MoE measurement and sweep.
+
+Everything here runs on a machine with no CUDA device and without the b12x
+kernel package installed. Covered: the flop and compressed-byte arithmetic,
+the timing statistics, sweep enumeration and its cap, the skip path that
+keeps a failing configuration from ending a sweep, signature discovery and
+its refusals, the module-path check, report shape and rendering, argument
+parsing, and the refusal that fires when no device is visible.
+
+The timed loop is driven here against a stand-in for Torch, which fixes the
+loop's structure - warmup count, pool cycling, one event pair per call, and
+the output checks - without asserting anything about kernel performance.
+Timing the kernel itself is a manual gate on a GB10 host.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from dataclasses import dataclass
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from types import SimpleNamespace
+
+import mixed_trellis_roofline as bench
+
+GEOMETRY = bench.DEPLOYED_GEOMETRY
+
+
+def _samples(count: int = 8, base: float = 1.0) -> list[float]:
+    """A timing sample with a known median and a known interquartile range."""
+
+    return [base + index for index in range(count)]
+
+
+def _plan(route_slots: int = 320, max_m_blocks: int = 40) -> dict[str, int]:
+    return {"route_slots": route_slots, "max_m_blocks": max_m_blocks}
+
+
+def _size_result(
+    size_m: int = 40,
+    configuration: bench.Configuration = bench.DEPLOYED_CONFIGURATION,
+    samples: list[float] | None = None,
+) -> dict:
+    return bench.size_result(
+        geometry=GEOMETRY,
+        size_m=size_m,
+        configuration=configuration,
+        samples_ms=samples or _samples(),
+        selected_tier0=190,
+        selected_tier1=60,
+        plan=_plan(),
+    )
+
+
+def _arguments(*extra: str) -> object:
+    return bench.parse_args(["measure", *extra])
+
+
+def _environment() -> dict:
+    return {
+        "torch_version": "2.11.0",
+        "torch_cuda_version": "13.2",
+        "device_index": 0,
+        "device_name": "NVIDIA GB10",
+        "compute_capability": [12, 1],
+        "multi_processor_count": 48,
+        "shared_memory_per_block_optin": 232448,
+        "total_memory_bytes": 128 * 1024**3,
+        "platform": "Linux-aarch64",
+        "python_version": "3.12.10",
+    }
+
+
+def _module_record() -> dict:
+    return {
+        "expected": bench.KERNEL_MODULE_PATH,
+        "resolved": bench.KERNEL_MODULE_PATH,
+        "resolved_realpath": bench.KERNEL_MODULE_PATH,
+        "matches": True,
+        "reason": "",
+    }
+
+
+def _discovery() -> dict:
+    return {
+        "kernel_module": bench.KERNEL_MODULE,
+        "prepare_module": bench.PREPARE_MODULE,
+        "host_module": bench.HOST_MODULE,
+        "signatures": {},
+        "rotations_source": "combine_trellis_rotations",
+    }
+
+
+def _map_record() -> dict:
+    return {
+        "identifier_form_accepted": "list[int]",
+        "rejected_forms": [],
+        "tier0_identifiers": [0, 191],
+        "tier1_identifiers": [192, 255],
+    }
+
+
+def _pool_record(pool_size: int = 3) -> dict:
+    return {
+        "pool_size": pool_size,
+        "bytes_per_set": bench.resident_weight_bytes(GEOMETRY),
+        "predicted_bytes": bench.weight_pool_bytes(GEOMETRY, pool_size),
+        "fraction_of_device_memory": 0.02,
+        "note": "packed expert weights only",
+    }
+
+
+def _measure_report(sizes=None) -> dict:
+    if sizes is None:
+        sizes = [_size_result(size_m) for size_m in bench.DEPLOYED_SIZES_M]
+    return bench.build_report(
+        mode="measure",
+        geometry=GEOMETRY,
+        environment=_environment(),
+        module_record=_module_record(),
+        discovery=_discovery(),
+        map_record=_map_record(),
+        pool_record=_pool_record(),
+        clocks_before={"read": False, "reason": "nvidia-smi is not on PATH"},
+        clocks_after={"read": False, "reason": "nvidia-smi is not on PATH"},
+        arguments=_arguments(),
+        sizes=sizes,
+    )
+
+
+def _sweep_entries() -> list[dict]:
+    baseline = bench.DEPLOYED_CONFIGURATION
+    faster = bench.Configuration((128, 128, 64, 256), 8)
+    slower = bench.Configuration((128, 128, 128, 128), 16)
+    broken = bench.Configuration((128, 128, 32, 128), 16)
+    return [
+        bench.measured_entry(_size_result(configuration=baseline, samples=[2.0] * 8)),
+        bench.measured_entry(_size_result(configuration=faster, samples=[1.0] * 8)),
+        bench.measured_entry(_size_result(configuration=slower, samples=[4.0] * 8)),
+        bench.skipped_entry(broken, ValueError("unsupported tile config"), "measure"),
+    ]
+
+
+def _tune_report(entries=None, enumeration=None) -> dict:
+    entries = _sweep_entries() if entries is None else entries
+    if enumeration is None:
+        enumeration = {
+            "enumerated": 5,
+            "cap": 4,
+            "measured": 4,
+            "dropped": 1,
+            "truncated": True,
+        }
+    return bench.build_report(
+        mode="tune",
+        geometry=GEOMETRY,
+        environment=_environment(),
+        module_record=_module_record(),
+        discovery=_discovery(),
+        map_record=_map_record(),
+        pool_record=_pool_record(),
+        clocks_before={"read": False, "reason": "nvidia-smi is not on PATH"},
+        clocks_after={"read": False, "reason": "nvidia-smi is not on PATH"},
+        arguments=_arguments(),
+        configurations=entries,
+        enumeration=enumeration,
+        ranking=bench.rank_configurations(entries),
+        tuned_size_m=40,
+    )
+
+
+class DenseEquivalentFlopTest(unittest.TestCase):
+    def test_a_routed_token_costs_gate_and_up_and_down(self) -> None:
+        expected = (
+            2
+            * (40 * GEOMETRY.top_k)
+            * (
+                2 * GEOMETRY.hidden_size * GEOMETRY.intermediate_size
+                + GEOMETRY.intermediate_size * GEOMETRY.hidden_size
+            )
+        )
+
+        self.assertEqual(bench.dense_equivalent_flop(GEOMETRY, 40), expected)
+
+    def test_the_closed_form_matches_the_expanded_form(self) -> None:
+        self.assertEqual(
+            bench.dense_equivalent_flop(GEOMETRY, 128),
+            6
+            * 128
+            * GEOMETRY.top_k
+            * GEOMETRY.hidden_size
+            * GEOMETRY.intermediate_size,
+        )
+
+    def test_flop_scales_linearly_with_the_token_count(self) -> None:
+        self.assertEqual(
+            bench.dense_equivalent_flop(GEOMETRY, 512),
+            4 * bench.dense_equivalent_flop(GEOMETRY, 128),
+        )
+
+    def test_flop_scales_linearly_with_top_k(self) -> None:
+        wider = bench.Geometry(top_k=GEOMETRY.top_k * 2)
+
+        self.assertEqual(
+            bench.dense_equivalent_flop(wider, 40),
+            2 * bench.dense_equivalent_flop(GEOMETRY, 40),
+        )
+
+    def test_a_token_count_below_one_is_rejected(self) -> None:
+        with self.assertRaises(ValueError):
+            bench.dense_equivalent_flop(GEOMETRY, 0)
+
+
+class CompressedByteTest(unittest.TestCase):
+    def test_an_expert_holds_three_projections_at_its_tier_bit_width(self) -> None:
+        coefficients = 3 * GEOMETRY.hidden_size * GEOMETRY.intermediate_size
+
+        self.assertEqual(
+            bench.expert_compressed_bytes(GEOMETRY, 3), coefficients * 3 // 8
+        )
+        self.assertEqual(
+            bench.expert_compressed_bytes(GEOMETRY, 4), coefficients * 4 // 8
+        )
+
+    def test_a_four_bit_expert_costs_a_third_more_than_a_three_bit_expert(
+        self,
+    ) -> None:
+        self.assertAlmostEqual(
+            bench.expert_compressed_bytes(GEOMETRY, 4)
+            / bench.expert_compressed_bytes(GEOMETRY, 3),
+            4 / 3,
+        )
+
+    def test_weight_stream_bytes_sums_both_tiers_at_their_own_widths(self) -> None:
+        expected = 10 * bench.expert_compressed_bytes(
+            GEOMETRY, 3
+        ) + 5 * bench.expert_compressed_bytes(GEOMETRY, 4)
+
+        self.assertEqual(
+            bench.weight_stream_bytes(GEOMETRY, tier0_experts=10, tier1_experts=5),
+            expected,
+        )
+
+    def test_selecting_no_expert_streams_no_weight(self) -> None:
+        self.assertEqual(
+            bench.weight_stream_bytes(GEOMETRY, tier0_experts=0, tier1_experts=0), 0
+        )
+
+    def test_a_selected_count_above_the_tier_size_is_rejected(self) -> None:
+        with self.assertRaises(ValueError):
+            bench.weight_stream_bytes(
+                GEOMETRY, tier0_experts=GEOMETRY.tier0_num_experts + 1, tier1_experts=0
+            )
+
+    def test_a_resident_set_covers_every_expert_in_both_tiers(self) -> None:
+        self.assertEqual(
+            bench.resident_weight_bytes(GEOMETRY),
+            bench.weight_stream_bytes(
+                GEOMETRY,
+                tier0_experts=GEOMETRY.tier0_num_experts,
+                tier1_experts=GEOMETRY.tier1_num_experts,
+            ),
+        )
+
+    def test_the_deployed_geometry_costs_under_a_gibibyte_per_weight_set(self) -> None:
+        self.assertLess(bench.resident_weight_bytes(GEOMETRY), 1 << 30)
+
+    def test_a_weight_pool_costs_its_size_times_one_set(self) -> None:
+        self.assertEqual(
+            bench.weight_pool_bytes(GEOMETRY, 4),
+            4 * bench.resident_weight_bytes(GEOMETRY),
+        )
+
+    def test_an_empty_weight_pool_is_rejected(self) -> None:
+        with self.assertRaises(ValueError):
+            bench.weight_pool_bytes(GEOMETRY, 0)
+
+
+class SelectedExpertTest(unittest.TestCase):
+    def test_identifiers_split_at_the_tier_boundary(self) -> None:
+        self.assertEqual(bench.count_selected_experts([0, 191, 192, 255], 192, 256), (2, 2))
+
+    def test_repeated_identifiers_are_counted_once(self) -> None:
+        self.assertEqual(bench.count_selected_experts([5, 5, 5, 200, 200], 192, 256), (1, 1))
+
+    def test_an_identifier_outside_the_expert_range_is_rejected(self) -> None:
+        with self.assertRaises(ValueError):
+            bench.count_selected_experts([256], 192, 256)
+
+
+class RoutePlanTest(unittest.TestCase):
+    def test_max_m_blocks_is_the_ceiling_of_slots_over_the_block_size(self) -> None:
+        api = SimpleNamespace(max_packed_route_slots=lambda *_args: 321)
+
+        plan = bench.route_slot_plan(api, GEOMETRY, size_m=40, moe_block_size=8)
+
+        self.assertEqual(plan["route_slots"], 321)
+        self.assertEqual(plan["max_m_blocks"], 41)
+
+    def test_the_slot_count_is_asked_for_the_drawn_slots_and_expert_total(
+        self,
+    ) -> None:
+        seen = []
+
+        def slots(drawn, block, experts):
+            seen.append((drawn, block, experts))
+            return 320
+
+        bench.route_slot_plan(
+            SimpleNamespace(max_packed_route_slots=slots),
+            GEOMETRY,
+            size_m=40,
+            moe_block_size=8,
+        )
+
+        self.assertEqual(seen, [(40 * GEOMETRY.top_k, 8, GEOMETRY.total_experts)])
+
+    def test_a_non_positive_slot_count_is_refused_with_a_reason(self) -> None:
+        api = SimpleNamespace(max_packed_route_slots=lambda *_args: 0)
+
+        with self.assertRaises(bench.MeasurementUnavailable) as raised:
+            bench.route_slot_plan(api, GEOMETRY, size_m=40, moe_block_size=8)
+
+        self.assertIn("max_packed_route_slots", str(raised.exception))
+
+
+class DistributionTest(unittest.TestCase):
+    def test_percentile_interpolates_between_neighbours(self) -> None:
+        self.assertAlmostEqual(bench.percentile([0.0, 10.0], 0.5), 5.0)
+        self.assertAlmostEqual(bench.percentile([0.0, 10.0], 0.25), 2.5)
+
+    def test_percentile_ignores_input_order(self) -> None:
+        self.assertAlmostEqual(bench.percentile([3.0, 1.0, 2.0], 0.5), 2.0)
+
+    def test_percentile_rejects_an_empty_sample_and_a_bad_fraction(self) -> None:
+        with self.assertRaises(ValueError):
+            bench.percentile([], 0.5)
+        with self.assertRaises(ValueError):
+            bench.percentile([1.0], 1.5)
+
+    def test_summarize_reports_median_iqr_and_extremes(self) -> None:
+        summary = bench.summarize([1.0, 2.0, 3.0, 4.0, 5.0])
+
+        self.assertEqual(summary["samples"], 5)
+        self.assertAlmostEqual(summary["min_ms"], 1.0)
+        self.assertAlmostEqual(summary["max_ms"], 5.0)
+        self.assertAlmostEqual(summary["median_ms"], 3.0)
+        self.assertAlmostEqual(summary["iqr_ms"], 2.0)
+
+    def test_summarize_rejects_an_empty_sample(self) -> None:
+        with self.assertRaises(ValueError):
+            bench.summarize([])
+
+    def test_rate_conversions(self) -> None:
+        # 1e12 flop in 1 ms is 1000 TFLOP/s; 1e9 bytes in 1000 ms is 1 GB/s.
+        self.assertAlmostEqual(bench.tflops(10**12, 1.0), 1000.0)
+        self.assertAlmostEqual(bench.gigabytes_per_second(10**9, 1000.0), 1.0)
+
+    def test_a_non_positive_elapsed_time_is_rejected(self) -> None:
+        with self.assertRaises(ValueError):
+            bench.tflops(10**12, 0.0)
+        with self.assertRaises(ValueError):
+            bench.gigabytes_per_second(10**9, -1.0)
+
+
+class SizeResultTest(unittest.TestCase):
+    def test_the_median_rate_is_the_flop_count_over_the_median_time(self) -> None:
+        result = bench.size_result(
+            geometry=GEOMETRY,
+            size_m=40,
+            configuration=bench.DEPLOYED_CONFIGURATION,
+            samples_ms=[1.0, 2.0, 3.0],
+            selected_tier0=100,
+            selected_tier1=50,
+            plan=_plan(),
+        )
+
+        self.assertAlmostEqual(
+            result["rate"]["dense_equivalent_tflops_at_median"],
+            bench.dense_equivalent_flop(GEOMETRY, 40) / (2.0 * 1e-3) / 1e12,
+        )
+
+    def test_the_weight_rate_uses_compressed_bytes_of_selected_experts(self) -> None:
+        result = _size_result()
+        expected = bench.weight_stream_bytes(
+            GEOMETRY, tier0_experts=190, tier1_experts=60
+        )
+
+        self.assertEqual(result["weight_stream_bytes"], expected)
+        self.assertAlmostEqual(
+            result["rate"]["weight_stream_gigabytes_per_second_at_median"],
+            expected / (result["timing"]["median_ms"] * 1e-3) / 1e9,
+        )
+
+    def test_the_tier_split_of_the_traffic_is_reported(self) -> None:
+        result = _size_result()
+
+        self.assertEqual(
+            result["weight_stream_bytes_tier0"] + result["weight_stream_bytes_tier1"],
+            result["weight_stream_bytes"],
+        )
+        self.assertEqual(
+            result["weight_stream_bytes_tier0"],
+            190 * bench.expert_compressed_bytes(GEOMETRY, GEOMETRY.tier0_bits),
+        )
+
+    def test_the_result_carries_the_routing_and_launch_plan(self) -> None:
+        result = _size_result()
+
+        self.assertEqual(result["routing"]["max_m_blocks"], 40)
+        self.assertEqual(result["routing"]["route_slots_drawn"], 40 * GEOMETRY.top_k)
+        self.assertEqual(result["routing"]["selected_experts"], 250)
+
+    def test_the_minimum_time_gives_the_highest_reported_rate(self) -> None:
+        result = _size_result()
+
+        self.assertGreater(
+            result["rate"]["dense_equivalent_tflops_at_min"],
+            result["rate"]["dense_equivalent_tflops_at_median"],
+        )
+
+
+class SweepEnumerationTest(unittest.TestCase):
+    def test_the_default_space_holds_fc1_at_128_and_sweeps_fc2(self) -> None:
+        configurations, _ = bench.enumerate_configurations()
+
+        self.assertEqual({item.tile_config[:2] for item in configurations}, {(128, 128)})
+        self.assertEqual(
+            {item.tile_config[2] for item in configurations}, {32, 64, 128}
+        )
+        self.assertEqual(
+            {item.tile_config[3] for item in configurations}, {128, 256, 512}
+        )
+        self.assertEqual({item.moe_block_size for item in configurations}, {8, 16})
+
+    def test_the_default_space_contains_all_three_backend_branches(self) -> None:
+        configurations, _ = bench.enumerate_configurations()
+        tiles = {item.tile_config for item in configurations}
+
+        for branch in ((128, 128, 32, 512), (128, 128, 64, 256), (128, 128, 128, 128)):
+            self.assertIn(branch, tiles)
+
+    def test_the_baseline_comes_first_and_is_labelled(self) -> None:
+        configurations, _ = bench.enumerate_configurations()
+
+        self.assertEqual(configurations[0], bench.DEPLOYED_CONFIGURATION)
+        self.assertEqual(configurations[0].role, bench.ROLE_BASELINE)
+        self.assertEqual(configurations[0].tile_config, (128, 128, 32, 512))
+        self.assertEqual(configurations[0].moe_block_size, 8)
+
+    def test_the_baseline_is_not_enumerated_twice_as_a_candidate(self) -> None:
+        configurations, enumeration = bench.enumerate_configurations()
+        keys = [(item.tile_config, item.moe_block_size) for item in configurations]
+
+        self.assertEqual(len(keys), len(set(keys)))
+        self.assertEqual(enumeration["enumerated"], len(configurations))
+        self.assertEqual(
+            sum(1 for item in configurations if item.role == bench.ROLE_BASELINE), 1
+        )
+
+    def test_configurations_are_grouped_by_tile_config(self) -> None:
+        configurations, _ = bench.enumerate_configurations()
+        groups = bench.tile_config_groups(configurations)
+
+        self.assertEqual(len(groups), len({item.tile_config for item in configurations}))
+        self.assertEqual(groups[0][0], bench.DEPLOYED_TILE_CONFIG)
+        for tile, group in groups:
+            self.assertTrue(all(item.tile_config == tile for item in group))
+
+    def test_the_cap_truncates_and_records_what_was_dropped(self) -> None:
+        configurations, enumeration = bench.enumerate_configurations(cap=5)
+
+        self.assertEqual(len(configurations), 5)
+        self.assertEqual(enumeration["measured"], 5)
+        self.assertEqual(enumeration["enumerated"], 18)
+        self.assertEqual(enumeration["dropped"], 13)
+        self.assertTrue(enumeration["truncated"])
+
+    def test_the_baseline_survives_the_tightest_cap(self) -> None:
+        configurations, enumeration = bench.enumerate_configurations(cap=1)
+
+        self.assertEqual(configurations, [bench.DEPLOYED_CONFIGURATION])
+        self.assertTrue(enumeration["truncated"])
+
+    def test_an_untruncated_sweep_reports_nothing_dropped(self) -> None:
+        _, enumeration = bench.enumerate_configurations(cap=1000)
+
+        self.assertFalse(enumeration["truncated"])
+        self.assertEqual(enumeration["dropped"], 0)
+
+    def test_a_control_tile_is_enumerated_and_labelled_a_control(self) -> None:
+        configurations, _ = bench.enumerate_configurations(
+            controls=(bench.FC1_CONTROL_TILE_CONFIG,)
+        )
+        controls = [
+            item for item in configurations if item.role == bench.ROLE_CONTROL
+        ]
+
+        self.assertTrue(controls)
+        self.assertEqual({item.tile_config for item in controls}, {(64, 256, 64, 256)})
+
+    def test_a_cap_below_one_is_rejected(self) -> None:
+        with self.assertRaises(ValueError):
+            bench.enumerate_configurations(cap=0)
+
+    def test_a_configuration_names_the_tile_widths_weight_preparation_needs(
+        self,
+    ) -> None:
+        configuration = bench.Configuration((128, 128, 32, 512), 8)
+
+        self.assertEqual(configuration.fc1_tile_n, 128)
+        self.assertEqual(configuration.fc2_tile_n, 512)
+        self.assertEqual(configuration.name, "tile128x128x32x512_block8")
+
+
+class SkipAndRankingTest(unittest.TestCase):
+    def test_a_failed_configuration_is_recorded_with_its_exception_type(self) -> None:
+        entry = bench.skipped_entry(
+            bench.Configuration((128, 128, 32, 128), 16),
+            RuntimeError("shared memory request exceeds the device limit"),
+            "compile",
+        )
+
+        self.assertEqual(entry["status"], "skipped")
+        self.assertEqual(entry["exception_type"], "RuntimeError")
+        self.assertEqual(entry["stage"], "compile")
+        self.assertIn("shared memory", entry["reason"])
+        self.assertEqual(entry["configuration"]["moe_block_size"], 16)
+
+    def test_an_exception_with_no_message_still_records_a_reason(self) -> None:
+        entry = bench.skipped_entry(
+            bench.DEPLOYED_CONFIGURATION, ValueError(), "measure"
+        )
+
+        self.assertTrue(entry["reason"])
+
+    def test_ranking_orders_by_median_and_leaves_skips_out_of_the_order(self) -> None:
+        ranking = bench.rank_configurations(_sweep_entries())
+
+        self.assertEqual(len(ranking["ordered"]), 3)
+        self.assertEqual(ranking["skipped"], 1)
+        self.assertEqual(
+            [row["median_ms"] for row in ranking["ordered"]], [1.0, 2.0, 4.0]
+        )
+
+    def test_speedup_is_the_baseline_median_over_the_row_median(self) -> None:
+        ranking = bench.rank_configurations(_sweep_entries())
+        rows = {row["name"]: row for row in ranking["ordered"]}
+
+        self.assertAlmostEqual(
+            rows["tile128x128x64x256_block8"]["speedup_over_baseline"], 2.0
+        )
+        self.assertAlmostEqual(
+            rows["tile128x128x128x128_block16"]["speedup_over_baseline"], 0.5
+        )
+        self.assertAlmostEqual(ranking["baseline"]["median_ms"], 2.0)
+
+    def test_a_faster_configuration_is_named_in_the_verdict(self) -> None:
+        ranking = bench.rank_configurations(_sweep_entries())
+
+        self.assertEqual(ranking["faster_than_baseline"], 1)
+        self.assertIn("tile128x128x64x256_block8", ranking["verdict"])
+
+    def test_the_verdict_states_plainly_when_nothing_beat_the_baseline(self) -> None:
+        entries = [
+            bench.measured_entry(
+                _size_result(
+                    configuration=bench.DEPLOYED_CONFIGURATION, samples=[1.0] * 8
+                )
+            ),
+            bench.measured_entry(
+                _size_result(
+                    configuration=bench.Configuration((128, 128, 64, 256), 8),
+                    samples=[3.0] * 8,
+                )
+            ),
+        ]
+
+        ranking = bench.rank_configurations(entries)
+
+        self.assertEqual(ranking["faster_than_baseline"], 0)
+        self.assertIn("no swept configuration beat the baseline", ranking["verdict"])
+
+    def test_a_baseline_measured_alone_states_nothing_about_alternatives(self) -> None:
+        entries = [
+            bench.measured_entry(
+                _size_result(configuration=bench.DEPLOYED_CONFIGURATION)
+            )
+        ]
+
+        self.assertIn("states nothing", bench.rank_configurations(entries)["verdict"])
+
+    def test_a_ranking_without_a_measured_baseline_is_refused(self) -> None:
+        entries = [
+            bench.measured_entry(
+                _size_result(configuration=bench.Configuration((128, 128, 64, 256), 8))
+            )
+        ]
+
+        with self.assertRaises(ValueError):
+            bench.rank_configurations(entries)
+
+
+# --------------------------------------------------------------------------
+# Signature discovery.
+# --------------------------------------------------------------------------
+
+
+@dataclass
+class FakeRotations:
+    intermediate: object
+    gate_suh: object
+    up_suh: object
+    down_svh: object
+
+
+def _fake_build_tiered_maps(tier0, tier1, *, device=None):
+    return (["global_to_combined", tier0, tier1], ["descriptor_map", device])
+
+
+def _fake_compile(
+    *,
+    size_m,
+    hidden_size,
+    intermediate_size,
+    tier0_num_experts,
+    tier1_num_experts,
+    top_k,
+    max_m_blocks,
+    sms,
+    max_shared_mem,
+    force_tile_config,
+    tier0_bits=3,
+    tier1_bits=4,
+    trellis_codebook="mcg",
+    moe_block_size=8,
+    rotation_input_dtype="bf16",
+    route_ids_dtype=None,
+    broadcast_suh=False,
+    broadcast_svh=False,
+    route_num_experts=None,
+):
+    return SimpleNamespace(size_m=size_m, tile=force_tile_config)
+
+
+def _fake_make_buffers(launch, *, device, sms):
+    return SimpleNamespace(launch=launch, device=device, sms=sms)
+
+
+def _fake_run(
+    x,
+    tier0,
+    tier1,
+    topk_weights,
+    topk_ids,
+    global_to_combined,
+    descriptor_map,
+    rotations,
+    launch,
+    buffers,
+    gate_experts=None,
+    up_experts=None,
+):
+    return x
+
+
+def _fake_prepare(
+    w13=None,
+    w2=None,
+    *,
+    hidden_size,
+    intermediate_size,
+    num_experts,
+    activation,
+    fc1_tile_n,
+    fc2_tile_n,
+    device=None,
+    seed=0,
+    params_dtype=None,
+    w13_layout="packed",
+    trellis_bits=None,
+    dummy_scale=None,
+    codebook="mcg",
+    gate_suh=None,
+    up_suh=None,
+    intermediate_rotations=None,
+    down_svh=None,
+    tile_config=None,
+    workspace=None,
+):
+    return SimpleNamespace(
+        num_experts=num_experts,
+        trellis_bits=trellis_bits,
+        tile_config=tile_config,
+        intermediate_rotations=f"intermediate{num_experts}",
+        gate_suh=f"gate{num_experts}",
+        up_suh=f"up{num_experts}",
+        down_svh=f"down{num_experts}",
+    )
+
+
+def _fake_slots(route_slots, block_size, num_experts):
+    return route_slots + num_experts
+
+
+def _fake_modules(**overrides):
+    kernel = SimpleNamespace(
+        build_tiered_maps=_fake_build_tiered_maps,
+        compile_mixed_trellis=_fake_compile,
+        make_mixed_trellis_buffers=_fake_make_buffers,
+        run_mixed_trellis=_fake_run,
+        MixedTrellisRotations=FakeRotations,
+    )
+    for name, value in overrides.items():
+        setattr(kernel, name, value)
+    prepare = SimpleNamespace(prepare_trellis256_moe_weights=_fake_prepare)
+    host = SimpleNamespace(max_packed_route_slots=_fake_slots)
+    return kernel, prepare, host
+
+
+class SignatureRecordTest(unittest.TestCase):
+    def test_positional_and_keyword_parameters_are_separated(self) -> None:
+        record = bench.signature_record(_fake_make_buffers, "make_buffers")
+
+        # A positional-or-keyword parameter appears in both lists, because
+        # either way of passing it is accepted.
+        self.assertEqual(record["positional"], ["launch"])
+        self.assertEqual(record["keywords"], ["launch", "device", "sms"])
+        self.assertFalse(record["var_positional"])
+        self.assertFalse(record["var_keyword"])
+
+    def test_the_recorded_text_shows_the_signature_a_reader_can_check(self) -> None:
+        record = bench.signature_record(_fake_run, "run_mixed_trellis")
+
+        self.assertTrue(record["text"].startswith("run_mixed_trellis(x, tier0"))
+
+    def test_variadic_parameters_are_recorded_as_such(self) -> None:
+        def variadic(*args, **kwargs):
+            return args, kwargs
+
+        record = bench.signature_record(variadic, "variadic")
+
+        self.assertTrue(record["var_positional"])
+        self.assertTrue(record["var_keyword"])
+
+    def test_positional_order_is_accepted_when_the_names_match(self) -> None:
+        record = bench.signature_record(_fake_run, "run_mixed_trellis")
+
+        bench.require_positional_order(record, bench.EXPECTED_RUN_POSITIONAL)
+
+    def test_a_reordered_positional_signature_is_refused_naming_what_was_found(
+        self,
+    ) -> None:
+        def reordered(tier0, tier1, x, topk_ids, topk_weights):
+            return x
+
+        record = bench.signature_record(reordered, "run_mixed_trellis")
+
+        with self.assertRaises(bench.MeasurementUnavailable) as raised:
+            bench.require_positional_order(record, bench.EXPECTED_RUN_POSITIONAL)
+
+        message = str(raised.exception)
+        self.assertIn("run_mixed_trellis(tier0, tier1, x", message)
+        self.assertIn("not", message)
+
+    def test_too_few_positional_parameters_are_refused(self) -> None:
+        record = bench.signature_record(lambda only: only, "build_tiered_maps")
+
+        with self.assertRaises(bench.MeasurementUnavailable):
+            bench.require_positional_count(record, 2)
+
+    def test_variadic_positional_parameters_satisfy_any_count(self) -> None:
+        record = bench.signature_record(lambda *args: args, "combine")
+
+        bench.require_positional_count(record, 10)
+
+    def test_a_missing_keyword_is_refused_and_named(self) -> None:
+        record = bench.signature_record(_fake_make_buffers, "make_buffers")
+
+        with self.assertRaises(bench.MeasurementUnavailable) as raised:
+            bench.require_keywords(record, ("device", "streams"))
+
+        self.assertIn("streams", str(raised.exception))
+
+    def test_a_variadic_keyword_signature_accepts_any_keyword(self) -> None:
+        record = bench.signature_record(lambda **kwargs: kwargs, "flexible")
+
+        bench.require_keywords(record, ("anything",))
+
+
+class ResolveApiTest(unittest.TestCase):
+    def test_a_matching_module_set_binds_and_records_every_signature(self) -> None:
+        api, discovery = bench.resolve_api(*_fake_modules())
+
+        self.assertIs(api.run_mixed_trellis, _fake_run)
+        self.assertIs(api.max_packed_route_slots, _fake_slots)
+        for name in (
+            "build_tiered_maps",
+            "compile_mixed_trellis",
+            "make_mixed_trellis_buffers",
+            "run_mixed_trellis",
+            "prepare_trellis256_moe_weights",
+            "max_packed_route_slots",
+        ):
+            self.assertIn(name, discovery["signatures"])
+
+    def test_an_absent_entry_point_is_refused_and_the_module_contents_named(
+        self,
+    ) -> None:
+        kernel, prepare, host = _fake_modules()
+        del kernel.build_tiered_maps
+
+        with self.assertRaises(bench.MeasurementUnavailable) as raised:
+            bench.resolve_api(kernel, prepare, host)
+
+        message = str(raised.exception)
+        self.assertIn("build_tiered_maps", message)
+        self.assertIn("run_mixed_trellis", message)
+
+    def test_a_build_tiered_maps_without_a_device_keyword_is_refused(self) -> None:
+        kernel, prepare, host = _fake_modules(
+            build_tiered_maps=lambda tier0, tier1: (tier0, tier1)
+        )
+
+        with self.assertRaises(bench.MeasurementUnavailable) as raised:
+            bench.resolve_api(kernel, prepare, host)
+
+        self.assertIn("device", str(raised.exception))
+
+    def test_a_compile_missing_a_keyword_is_refused_before_any_call(self) -> None:
+        def compile_without_tile(*, size_m, hidden_size):
+            return size_m + hidden_size
+
+        kernel, prepare, host = _fake_modules(
+            compile_mixed_trellis=compile_without_tile
+        )
+
+        with self.assertRaises(bench.MeasurementUnavailable) as raised:
+            bench.resolve_api(kernel, prepare, host)
+
+        self.assertIn("force_tile_config", str(raised.exception))
+
+    def test_a_two_argument_route_slot_helper_is_refused(self) -> None:
+        kernel, prepare, host = _fake_modules()
+        host.max_packed_route_slots = lambda slots, block: slots
+
+        with self.assertRaises(bench.MeasurementUnavailable) as raised:
+            bench.resolve_api(kernel, prepare, host)
+
+        self.assertIn("max_packed_route_slots", str(raised.exception))
+
+    def test_the_rotation_source_is_recorded_when_the_module_combines_them(
+        self,
+    ) -> None:
+        kernel, prepare, host = _fake_modules(
+            combine_trellis_rotations=lambda *tiers: FakeRotations(*range(4))
+        )
+
+        _, discovery = bench.resolve_api(kernel, prepare, host)
+
+        self.assertEqual(discovery["rotations_source"], "combine_trellis_rotations")
+        self.assertIn("combine_trellis_rotations", discovery["signatures"])
+
+    def test_the_fallback_rotation_source_is_recorded_when_it_is_absent(self) -> None:
+        _, discovery = bench.resolve_api(*_fake_modules())
+
+        self.assertIn("MixedTrellisRotations", discovery["rotations_source"])
+
+
+class RotationAssemblyTest(unittest.TestCase):
+    class _Tensor:
+        def __init__(self, value):
+            self.value = value
+
+        def contiguous(self):
+            return self
+
+    def _torch(self):
+        return SimpleNamespace(
+            cat=lambda parts, dim=0: self._Tensor(
+                "|".join(str(part) for part in parts)
+            )
+        )
+
+    def test_the_module_helper_is_used_when_it_exists(self) -> None:
+        api, _ = bench.resolve_api(
+            *_fake_modules(
+                combine_trellis_rotations=lambda *tiers: FakeRotations(
+                    len(tiers), 0, 0, 0
+                )
+            )
+        )
+
+        rotations = bench.build_rotations(self._torch(), api, ["a", "b"])
+
+        self.assertEqual(rotations.intermediate, 2)
+
+    def test_tier_rotations_are_concatenated_when_no_helper_exists(self) -> None:
+        api, _ = bench.resolve_api(*_fake_modules())
+        tiers = [_fake_prepare(hidden_size=1, intermediate_size=1, num_experts=n,
+                               activation="silu", fc1_tile_n=128, fc2_tile_n=512)
+                 for n in (192, 64)]
+
+        rotations = bench.build_rotations(self._torch(), api, tiers)
+
+        self.assertEqual(rotations.intermediate.value, "intermediate192|intermediate64")
+        self.assertEqual(rotations.gate_suh.value, "gate192|gate64")
+        self.assertEqual(rotations.down_svh.value, "down192|down64")
+
+    def test_a_tier_missing_a_rotation_is_refused_with_a_reason(self) -> None:
+        api, _ = bench.resolve_api(*_fake_modules())
+
+        with self.assertRaises(bench.MeasurementUnavailable) as raised:
+            bench.build_rotations(self._torch(), api, [SimpleNamespace()])
+
+        self.assertIn("intermediate_rotations", str(raised.exception))
+
+
+class ModulePathTest(unittest.TestCase):
+    def test_a_module_at_the_expected_path_matches(self) -> None:
+        module = SimpleNamespace(__file__=bench.KERNEL_MODULE_PATH)
+
+        record = bench.module_path_record(
+            module, bench.KERNEL_MODULE_PATH, realpath=lambda path: path
+        )
+
+        self.assertTrue(record["matches"])
+        self.assertEqual(record["reason"], "")
+
+    def test_a_module_bound_elsewhere_is_reported_as_a_mismatch(self) -> None:
+        module = SimpleNamespace(__file__="/tmp/shim/mixed_trellis.py")
+
+        record = bench.module_path_record(
+            module, bench.KERNEL_MODULE_PATH, realpath=lambda path: path
+        )
+
+        self.assertFalse(record["matches"])
+        self.assertIn("import hook", record["reason"])
+        self.assertEqual(record["resolved"], "/tmp/shim/mixed_trellis.py")
+
+    def test_a_symlinked_module_matches_through_its_real_path(self) -> None:
+        module = SimpleNamespace(__file__="/opt/link/mixed_trellis.py")
+
+        record = bench.module_path_record(
+            module,
+            bench.KERNEL_MODULE_PATH,
+            realpath=lambda path: bench.KERNEL_MODULE_PATH,
+        )
+
+        self.assertTrue(record["matches"])
+
+    def test_a_module_without_a_file_cannot_be_identified(self) -> None:
+        record = bench.module_path_record(
+            SimpleNamespace(), bench.KERNEL_MODULE_PATH, realpath=lambda path: path
+        )
+
+        self.assertFalse(record["matches"])
+        self.assertIn("__file__", record["reason"])
+
+
+class KernelImportTest(unittest.TestCase):
+    def test_an_unimportable_kernel_module_is_refused_with_its_reason(self) -> None:
+        def importer(name):
+            raise ModuleNotFoundError(f"No module named {name!r}")
+
+        with self.assertRaises(bench.MeasurementUnavailable) as raised:
+            bench.import_kernel_modules(importer=importer)
+
+        self.assertIn("ModuleNotFoundError", str(raised.exception))
+        self.assertIn(bench.KERNEL_MODULE, str(raised.exception))
+
+    def test_all_three_companion_modules_are_imported(self) -> None:
+        seen = []
+
+        def importer(name):
+            seen.append(name)
+            return SimpleNamespace(name=name)
+
+        bench.import_kernel_modules(importer=importer)
+
+        self.assertEqual(
+            seen, [bench.KERNEL_MODULE, bench.PREPARE_MODULE, bench.HOST_MODULE]
+        )
+
+
+# --------------------------------------------------------------------------
+# The timed loop, driven against a stand-in for Torch.
+# --------------------------------------------------------------------------
+
+
+class FakeEvent:
+    def __init__(self, clock):
+        self.clock = clock
+        self.stamp = None
+
+    def record(self):
+        self.clock[0] += 1
+        self.stamp = self.clock[0]
+
+    def elapsed_time(self, other):
+        return float(other.stamp - self.stamp)
+
+
+class FakeBool:
+    def __init__(self, value):
+        self.value = value
+
+    def all(self):
+        return self
+
+    def any(self):
+        return self
+
+    def item(self):
+        return self.value
+
+
+class FakeOutput:
+    def __init__(self, finite=True, nonzero=True):
+        self.finite = finite
+        self.nonzero = nonzero
+
+    def __ne__(self, other):
+        return FakeBool(self.nonzero)
+
+
+class FakeTorch:
+    def __init__(self):
+        self.clock = [0]
+        self.synchronizations = 0
+        self.cuda = SimpleNamespace(
+            Event=lambda enable_timing=False: FakeEvent(self.clock),
+            synchronize=self._synchronize,
+            empty_cache=lambda: None,
+        )
+
+    def _synchronize(self, _device=None):
+        self.synchronizations += 1
+
+    def isfinite(self, output):
+        return FakeBool(output.finite)
+
+
+class TimedLoopTest(unittest.TestCase):
+    def _drive(self, torch_module, output, warmup=3, iterations=6, pool_size=2):
+        calls = []
+
+        def run(x, tier0, tier1, *_rest):
+            calls.append(tier0)
+            return output
+
+        api = SimpleNamespace(run_mixed_trellis=run)
+        pool = [(f"tier0_{index}", f"tier1_{index}", f"rot{index}")
+                for index in range(pool_size)]
+        samples = bench.time_calls(
+            torch_module,
+            api,
+            x="x",
+            topk_weights="weights",
+            topk_ids="ids",
+            global_to_combined="map",
+            descriptor_map="descriptors",
+            pool=pool,
+            launch="launch",
+            buffers="buffers",
+            device="cuda:0",
+            warmup=warmup,
+            iterations=iterations,
+            label="case",
+        )
+        return samples, calls
+
+    def test_one_sample_is_produced_per_timed_call(self) -> None:
+        torch_module = FakeTorch()
+
+        samples, _ = self._drive(torch_module, FakeOutput(), iterations=6)
+
+        self.assertEqual(len(samples), 6)
+        self.assertTrue(all(sample > 0 for sample in samples))
+
+    def test_warmup_runs_before_the_timed_calls_and_is_not_measured(self) -> None:
+        torch_module = FakeTorch()
+
+        samples, calls = self._drive(
+            torch_module, FakeOutput(), warmup=5, iterations=4
+        )
+
+        self.assertEqual(len(calls), 9)
+        self.assertEqual(len(samples), 4)
+
+    def test_the_device_is_synchronized_after_warmup_and_after_the_loop(self) -> None:
+        torch_module = FakeTorch()
+
+        self._drive(torch_module, FakeOutput())
+
+        self.assertEqual(torch_module.synchronizations, 2)
+
+    def test_the_weight_pool_is_cycled_one_set_per_timed_call(self) -> None:
+        torch_module = FakeTorch()
+
+        _, calls = self._drive(
+            torch_module, FakeOutput(), warmup=0, iterations=5, pool_size=2
+        )
+
+        self.assertEqual(
+            calls,
+            ["tier0_0", "tier0_1", "tier0_0", "tier0_1", "tier0_0"],
+        )
+
+    def test_a_non_finite_output_is_refused_rather_than_reported_as_fast(self) -> None:
+        with self.assertRaises(bench.MeasurementUnavailable) as raised:
+            self._drive(FakeTorch(), FakeOutput(finite=False))
+
+        self.assertIn("non-finite", str(raised.exception))
+
+    def test_an_all_zero_output_is_refused(self) -> None:
+        with self.assertRaises(bench.MeasurementUnavailable) as raised:
+            self._drive(FakeTorch(), FakeOutput(nonzero=False))
+
+        self.assertIn("all-zero", str(raised.exception))
+
+
+class PoolFitTest(unittest.TestCase):
+    def test_a_pool_within_the_fraction_is_accepted_and_described(self) -> None:
+        record = bench.require_pool_fits(GEOMETRY, 3, 128 * 1024**3, 0.25)
+
+        self.assertEqual(record["pool_size"], 3)
+        self.assertEqual(
+            record["predicted_bytes"], bench.weight_pool_bytes(GEOMETRY, 3)
+        )
+        self.assertLess(record["fraction_of_device_memory"], 0.25)
+
+    def test_a_pool_above_the_fraction_is_refused_with_the_cost_stated(self) -> None:
+        with self.assertRaises(bench.MeasurementUnavailable) as raised:
+            bench.require_pool_fits(GEOMETRY, 64, 128 * 1024**3, 0.25)
+
+        self.assertIn("--pool-size", str(raised.exception))
+
+    def test_an_unknown_device_memory_size_does_not_block_the_run(self) -> None:
+        record = bench.require_pool_fits(GEOMETRY, 3, 0, 0.25)
+
+        self.assertIsNone(record["fraction_of_device_memory"])
+
+
+class ClockStateTest(unittest.TestCase):
+    def test_an_absent_nvidia_smi_is_reported_with_a_reason(self) -> None:
+        state = bench.read_clock_state(0, which=lambda _name: None)
+
+        self.assertFalse(state["read"])
+        self.assertIn("PATH", state["reason"])
+
+    def test_a_nonzero_exit_is_reported_with_the_last_line_of_output(self) -> None:
+        def runner(_command, **_kwargs):
+            return SimpleNamespace(returncode=9, stdout="", stderr="GPU is lost\n")
+
+        state = bench.read_clock_state(
+            0, which=lambda _name: "/usr/bin/nvidia-smi", runner=runner
+        )
+
+        self.assertFalse(state["read"])
+        self.assertEqual(state["reason"], "GPU is lost")
+
+    def test_pinned_application_clocks_are_reported_as_pinned(self) -> None:
+        row = "NVIDIA GB10, 1400, 1400, 1400, Not Active, Enabled, 61.2, 140.0, 48"
+
+        def runner(_command, **_kwargs):
+            return SimpleNamespace(returncode=0, stdout=row + "\n", stderr="")
+
+        state = bench.read_clock_state(
+            0, which=lambda _name: "/usr/bin/nvidia-smi", runner=runner
+        )
+
+        self.assertTrue(state["read"])
+        self.assertTrue(state["application_clocks_pinned"])
+        self.assertEqual(state["fields"]["clocks.sm"], "1400")
+
+    def test_unset_application_clocks_are_reported_as_not_pinned(self) -> None:
+        row = "NVIDIA GB10, 1400, 1400, [N/A], Not Active, Enabled, 61.2, 140.0, 48"
+
+        def runner(_command, **_kwargs):
+            return SimpleNamespace(returncode=0, stdout=row + "\n", stderr="")
+
+        state = bench.read_clock_state(
+            0, which=lambda _name: "/usr/bin/nvidia-smi", runner=runner
+        )
+
+        self.assertFalse(state["application_clocks_pinned"])
+        self.assertIn("not pinned", state["lock_note"])
+
+    def test_an_unexpected_field_count_is_reported_rather_than_misparsed(self) -> None:
+        def runner(_command, **_kwargs):
+            return SimpleNamespace(returncode=0, stdout="NVIDIA GB10, 1400\n", stderr="")
+
+        state = bench.read_clock_state(
+            0, which=lambda _name: "/usr/bin/nvidia-smi", runner=runner
+        )
+
+        self.assertFalse(state["read"])
+        self.assertIn("fields", state["reason"])
+
+
+class ReportShapeTest(unittest.TestCase):
+    def test_both_modes_name_the_schema(self) -> None:
+        self.assertEqual(_measure_report()["schema"], "gb10-mixed-trellis-roofline/v1")
+        self.assertEqual(_tune_report()["schema"], bench.SCHEMA)
+
+    def test_the_report_states_both_formulas_and_labels_the_flop_count(self) -> None:
+        measurement = _measure_report()["measurement"]
+
+        self.assertEqual(measurement["flop_formula"], bench.FLOP_FORMULA)
+        self.assertEqual(measurement["weight_bytes_formula"], bench.WEIGHT_BYTES_FORMULA)
+        self.assertIn("dense-equivalent", measurement["flop_note"])
+
+    def test_the_report_records_the_module_it_measured(self) -> None:
+        report = _measure_report()
+
+        self.assertEqual(report["module"]["resolved"], bench.KERNEL_MODULE_PATH)
+        self.assertTrue(report["module"]["matches"])
+        self.assertIn("signatures", report["api_discovery"])
+
+    def test_the_report_records_the_weight_pool_and_its_cost(self) -> None:
+        pool = _measure_report()["measurement"]["weight_pool"]
+
+        self.assertEqual(pool["pool_size"], 3)
+        self.assertGreater(pool["predicted_bytes"], 0)
+
+    def test_the_report_records_the_conditions_a_reader_needs(self) -> None:
+        report = _measure_report()
+
+        for key in (
+            "torch_version",
+            "torch_cuda_version",
+            "device_name",
+            "compute_capability",
+            "multi_processor_count",
+        ):
+            self.assertIn(key, report["environment"])
+        self.assertIn("before", report["clocks"])
+        self.assertIn("after", report["clocks"])
+
+    def test_the_report_states_it_is_single_process_and_not_distributed(self) -> None:
+        measurement = _measure_report()["measurement"]
+
+        self.assertTrue(measurement["single_process"])
+        self.assertFalse(measurement["distributed"])
+
+    def test_measure_mode_carries_one_entry_per_token_count(self) -> None:
+        report = _measure_report()
+
+        self.assertEqual(
+            [entry["size_m"] for entry in report["sizes"]], [40, 128, 512]
+        )
+        self.assertEqual(report["configuration"]["tile_config"], [128, 128, 32, 512])
+
+    def test_tune_mode_carries_the_baseline_the_entries_and_the_ranking(self) -> None:
+        report = _tune_report()
+
+        self.assertEqual(report["baseline_configuration"]["role"], bench.ROLE_BASELINE)
+        self.assertEqual(len(report["configurations"]), 4)
+        self.assertEqual(report["tuned_size_m"], 40)
+        self.assertIn("verdict", report["ranking"])
+        self.assertEqual(report["enumeration"]["dropped"], 1)
+
+    def test_both_modes_round_trip_through_json(self) -> None:
+        for report in (_measure_report(), _tune_report()):
+            restored = json.loads(json.dumps(report, sort_keys=True, default=str))
+
+            self.assertEqual(restored["schema"], bench.SCHEMA)
+
+    def test_emit_json_writes_the_document_to_a_path(self) -> None:
+        with TemporaryDirectory() as directory:
+            destination = Path(directory) / "report.json"
+            bench.emit_json(_tune_report(), str(destination))
+            restored = json.loads(destination.read_text(encoding="utf-8"))
+
+        self.assertEqual(restored["mode"], "tune")
+
+    def test_emit_json_writes_to_stdout_for_a_dash(self) -> None:
+        stream = io.StringIO()
+
+        with redirect_stdout(stream):
+            bench.emit_json(_measure_report(), "-")
+
+        self.assertEqual(json.loads(stream.getvalue())["schema"], bench.SCHEMA)
+
+
+class TextRenderTest(unittest.TestCase):
+    def test_the_measure_report_prints_both_formulas_with_the_numbers(self) -> None:
+        rendered = bench.render_text(_measure_report())
+
+        self.assertIn(bench.FLOP_FORMULA, rendered)
+        self.assertIn(bench.WEIGHT_BYTES_FORMULA, rendered)
+
+    def test_the_measure_report_prints_a_median_and_a_dispersion_column(self) -> None:
+        rendered = bench.render_text(_measure_report())
+
+        for column in ("median ms", "IQR ms", "min ms", "max ms", "TFLOP/s med", "GB/s med"):
+            self.assertIn(column, rendered)
+
+    def test_the_measure_report_says_when_the_clock_state_was_not_read(self) -> None:
+        self.assertIn("NOT READ", bench.render_text(_measure_report()))
+
+    def test_the_tune_report_ranks_and_states_the_verdict(self) -> None:
+        rendered = bench.render_text(_tune_report())
+
+        self.assertIn("RANKING BY MEDIAN", rendered)
+        self.assertIn("speedup", rendered)
+        self.assertIn("beat the baseline", rendered)
+
+    def test_the_tune_report_lists_skipped_configurations_with_their_type(self) -> None:
+        rendered = bench.render_text(_tune_report())
+
+        self.assertIn("SKIPPED", rendered)
+        self.assertIn("ValueError", rendered)
+        self.assertIn("tile128x128x32x128_block16", rendered)
+
+    def test_the_tune_report_states_when_the_cap_dropped_configurations(self) -> None:
+        self.assertIn("cap was reached", bench.render_text(_tune_report()))
+
+    def test_the_tune_report_explains_the_control_row_when_one_was_measured(
+        self,
+    ) -> None:
+        entries = _sweep_entries()
+        entries.append(
+            bench.measured_entry(
+                _size_result(
+                    configuration=bench.Configuration(
+                        (64, 256, 64, 256), 8, bench.ROLE_CONTROL
+                    )
+                )
+            )
+        )
+
+        rendered = bench.render_text(_tune_report(entries=entries))
+
+        self.assertIn("CONTROL", rendered)
+        self.assertIn("partial reductions", rendered)
+
+    def test_the_configuration_table_renders_without_a_device(self) -> None:
+        configurations, enumeration = bench.enumerate_configurations()
+
+        rendered = bench.render_configuration_table(
+            configurations, enumeration, GEOMETRY, 40
+        )
+
+        self.assertIn("tile128x128x32x512_block8", rendered)
+        self.assertIn("baseline", rendered)
+        self.assertIn(bench.FLOP_FORMULA, rendered)
+
+
+class ArgumentTest(unittest.TestCase):
+    def test_defaults_measure_the_deployed_geometry_on_device_zero(self) -> None:
+        arguments = bench.parse_args(["measure"])
+
+        self.assertEqual(arguments.mode, "measure")
+        self.assertEqual(arguments.device, 0)
+        self.assertGreaterEqual(arguments.warmup, 1)
+        self.assertGreaterEqual(arguments.iterations, 4)
+        self.assertEqual(arguments.sizes, (40, 128, 512))
+        self.assertEqual(arguments.size_m, 40)
+        self.assertEqual(arguments.pool_size, 3)
+        self.assertEqual(arguments.dtype, "bf16")
+        self.assertEqual(arguments.module, bench.KERNEL_MODULE)
+        self.assertEqual(arguments.module_path, bench.KERNEL_MODULE_PATH)
+        self.assertIsNone(arguments.json)
+
+    def test_the_default_geometry_is_the_deployed_one(self) -> None:
+        geometry = bench.geometry_from_arguments(bench.parse_args(["measure"]))
+
+        self.assertEqual(geometry, bench.DEPLOYED_GEOMETRY)
+        self.assertEqual(geometry.hidden_size, 6144)
+        self.assertEqual(geometry.intermediate_size, 512)
+        self.assertEqual(geometry.tier0_num_experts, 192)
+        self.assertEqual(geometry.tier1_num_experts, 64)
+        self.assertEqual(geometry.total_experts, 256)
+        self.assertEqual(geometry.top_k, 8)
+        self.assertEqual(geometry.sms, 48)
+
+    def test_the_default_baseline_is_the_tile_config_hidden_6144_selects(self) -> None:
+        baseline = bench.baseline_from_arguments(bench.parse_args(["tune"]))
+
+        self.assertEqual(baseline.tile_config, (128, 128, 32, 512))
+        self.assertEqual(baseline.moe_block_size, 8)
+        self.assertEqual(baseline.role, bench.ROLE_BASELINE)
+
+    def test_geometry_overrides_are_accepted(self) -> None:
+        geometry = bench.geometry_from_arguments(
+            bench.parse_args(
+                ["measure", "--hidden-size", "4096", "--top-k", "4", "--sms", "24"]
+            )
+        )
+
+        self.assertEqual(geometry.hidden_size, 4096)
+        self.assertEqual(geometry.top_k, 4)
+        self.assertEqual(geometry.sms, 24)
+
+    def test_the_sweep_space_is_taken_from_the_command_line(self) -> None:
+        arguments = bench.parse_args(
+            [
+                "tune",
+                "--fc2-tile-k",
+                "32 64",
+                "--fc2-tile-n",
+                "256,512",
+                "--moe-block-sizes",
+                "8",
+            ]
+        )
+
+        configurations, enumeration = bench.configurations_from_arguments(arguments)
+
+        self.assertEqual(enumeration["enumerated"], 4)
+        self.assertEqual(
+            {item.tile_config for item in configurations},
+            {
+                (128, 128, 32, 256),
+                (128, 128, 32, 512),
+                (128, 128, 64, 256),
+                (128, 128, 64, 512),
+            },
+        )
+
+    def test_the_control_tile_is_opt_in(self) -> None:
+        without, _ = bench.configurations_from_arguments(bench.parse_args(["tune"]))
+        with_control, _ = bench.configurations_from_arguments(
+            bench.parse_args(["tune", "--include-fc1-control"])
+        )
+
+        self.assertNotIn(
+            bench.ROLE_CONTROL, {item.role for item in without}
+        )
+        self.assertIn(bench.ROLE_CONTROL, {item.role for item in with_control})
+
+    def test_the_configuration_cap_is_applied_from_the_command_line(self) -> None:
+        configurations, enumeration = bench.configurations_from_arguments(
+            bench.parse_args(["tune", "--max-configurations", "3"])
+        )
+
+        self.assertEqual(len(configurations), 3)
+        self.assertTrue(enumeration["truncated"])
+
+    def test_a_baseline_override_is_accepted_as_four_integers(self) -> None:
+        baseline = bench.baseline_from_arguments(
+            bench.parse_args(["tune", "--baseline-tile-config", "128 128 64 256"])
+        )
+
+        self.assertEqual(baseline.tile_config, (128, 128, 64, 256))
+
+    def test_a_tile_config_of_the_wrong_length_is_refused(self) -> None:
+        with self.assertRaises(SystemExit) as raised:
+            with redirect_stderr(io.StringIO()):
+                bench.parse_args(["tune", "--baseline-tile-config", "128 128"])
+
+        self.assertEqual(raised.exception.code, 2)
+
+    def test_a_missing_mode_is_refused(self) -> None:
+        with self.assertRaises(SystemExit):
+            with redirect_stderr(io.StringIO()):
+                bench.parse_args([])
+
+    def test_zero_warmup_is_refused(self) -> None:
+        with self.assertRaises(SystemExit) as raised:
+            with redirect_stderr(io.StringIO()):
+                bench.parse_args(["measure", "--warmup", "0"])
+
+        self.assertEqual(raised.exception.code, 2)
+
+    def test_too_few_iterations_for_an_interquartile_range_is_refused(self) -> None:
+        with self.assertRaises(SystemExit):
+            with redirect_stderr(io.StringIO()):
+                bench.parse_args(["measure", "--iterations", "3"])
+
+    def test_an_empty_weight_pool_is_refused(self) -> None:
+        with self.assertRaises(SystemExit):
+            with redirect_stderr(io.StringIO()):
+                bench.parse_args(["measure", "--pool-size", "0"])
+
+    def test_a_pool_fraction_outside_the_unit_interval_is_refused(self) -> None:
+        with self.assertRaises(SystemExit):
+            with redirect_stderr(io.StringIO()):
+                bench.parse_args(["measure", "--max-pool-fraction", "1.5"])
+
+    def test_a_cap_below_one_is_refused(self) -> None:
+        with self.assertRaises(SystemExit):
+            with redirect_stderr(io.StringIO()):
+                bench.parse_args(["tune", "--max-configurations", "0"])
+
+    def test_list_configurations_measures_nothing_and_succeeds(self) -> None:
+        def refuse_torch():
+            raise AssertionError("--list-configurations must not import torch")
+
+        def refuse_kernel(**_kwargs):
+            raise AssertionError("--list-configurations must not import the kernel")
+
+        stream = io.StringIO()
+        with redirect_stdout(stream):
+            code = bench.main(
+                ["tune", "--list-configurations"],
+                load_torch=refuse_torch,
+                load_kernel=refuse_kernel,
+            )
+
+        self.assertEqual(code, bench.EXIT_OK)
+        self.assertIn("tile128x128x32x512_block8", stream.getvalue())
+
+
+class NoDeviceTest(unittest.TestCase):
+    """The path this repository's development machines actually take."""
+
+    def _torch_without_cuda(self):
+        return SimpleNamespace(
+            cuda=SimpleNamespace(is_available=lambda: False, device_count=lambda: 0)
+        )
+
+    def test_require_cuda_device_refuses_when_no_device_is_visible(self) -> None:
+        with self.assertRaises(bench.MeasurementUnavailable) as raised:
+            bench.require_cuda_device(self._torch_without_cuda(), 0)
+
+        self.assertIn("no CUDA device", str(raised.exception))
+
+    def test_require_cuda_device_refuses_an_index_that_does_not_exist(self) -> None:
+        torch_module = SimpleNamespace(
+            cuda=SimpleNamespace(is_available=lambda: True, device_count=lambda: 1)
+        )
+
+        with self.assertRaises(bench.MeasurementUnavailable) as raised:
+            bench.require_cuda_device(torch_module, 3)
+
+        self.assertIn("does not exist", str(raised.exception))
+
+    def test_main_exits_non_zero_and_explains_when_no_device_is_visible(self) -> None:
+        errors = io.StringIO()
+
+        with redirect_stdout(io.StringIO()), redirect_stderr(errors):
+            code = bench.main(
+                ["measure"],
+                load_torch=self._torch_without_cuda,
+                load_kernel=lambda **_kwargs: _fake_modules(),
+            )
+
+        self.assertEqual(code, bench.EXIT_UNAVAILABLE)
+        self.assertIn("no measurement taken", errors.getvalue())
+        self.assertIn("no CUDA device", errors.getvalue())
+
+    def test_no_report_is_printed_to_stdout_when_no_measurement_was_taken(self) -> None:
+        output = io.StringIO()
+
+        with redirect_stdout(output), redirect_stderr(io.StringIO()):
+            bench.main(["tune"], load_torch=self._torch_without_cuda)
+
+        self.assertEqual(output.getvalue(), "")
+
+    def test_main_exits_non_zero_and_explains_when_torch_is_absent(self) -> None:
+        def refuse():
+            raise bench.MeasurementUnavailable("torch is not importable")
+
+        errors = io.StringIO()
+        with redirect_stdout(io.StringIO()), redirect_stderr(errors):
+            code = bench.main(["measure"], load_torch=refuse)
+
+        self.assertEqual(code, bench.EXIT_UNAVAILABLE)
+        self.assertIn("torch is not importable", errors.getvalue())
+
+    def test_main_refuses_when_the_kernel_module_resolves_elsewhere(self) -> None:
+        torch_module = SimpleNamespace(
+            cuda=SimpleNamespace(
+                is_available=lambda: True,
+                device_count=lambda: 1,
+                set_device=lambda _device: None,
+                get_device_properties=lambda _index: SimpleNamespace(
+                    multi_processor_count=48,
+                    shared_memory_per_block_optin=232448,
+                    total_memory=128 * 1024**3,
+                ),
+                get_device_capability=lambda _index: (12, 1),
+                get_device_name=lambda _index: "NVIDIA GB10",
+            ),
+            device=lambda kind, index: f"{kind}:{index}",
+            version=SimpleNamespace(cuda="13.2"),
+            __version__="2.11.0",
+        )
+        kernel, prepare, host = _fake_modules()
+        kernel.__file__ = "/somewhere/else/mixed_trellis.py"
+
+        errors = io.StringIO()
+        with redirect_stdout(io.StringIO()), redirect_stderr(errors):
+            code = bench.main(
+                ["measure"],
+                load_torch=lambda: torch_module,
+                load_kernel=lambda **_kwargs: (kernel, prepare, host),
+            )
+
+        self.assertEqual(code, bench.EXIT_UNAVAILABLE)
+        self.assertIn("/somewhere/else/mixed_trellis.py", errors.getvalue())
+        self.assertIn("--module-path", errors.getvalue())
+
+
+class SafetyClassTest(unittest.TestCase):
+    def test_the_module_docstring_declares_a_safety_class(self) -> None:
+        self.assertIn("Safety class: OFFLINE", bench.__doc__ or "")
+
+    def test_the_module_docstring_states_the_dense_equivalent_flop_formula(
+        self,
+    ) -> None:
+        self.assertIn("6 * size_m * top_k * hidden_size * intermediate_size", bench.__doc__ or "")
+
+    def test_the_module_docstring_states_why_weights_are_cycled(self) -> None:
+        self.assertIn("WEIGHT-POOL CYCLING", bench.__doc__ or "")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The routed-expert path dispatches `b12x.moe._shared.kernels.w4a16.mixed_trellis` — a compiled fused MoE kernel whose tile geometry and route block are compile-time parameters. Nothing measured it in isolation, so serving-rate attribution stalled at a bracket, and nothing could look for a faster configuration than the deployed `(128,128,32,512)` @ block 8.

Two modes at the deployed geometry (hidden 6144, per-rank intermediate 512, 192×3-bit + 64×4-bit experts, top-k 8):

- **measure** — elapsed, dense-equivalent TFLOP/s (formula printed), and weight-stream GB/s over *compressed* bytes, which decides whether the tier mix affects speed at all
- **tune** — sweeps `force_tile_config` × `moe_block_size` (default 18 configs incl. all three backend branches), groups by tile config because prepared weights derive `fc1/fc2_tile_n` from it, records compile failures as skips with exception types, ranks against the deployed baseline as speedup ratios, and says plainly when nothing beats it

Methodology: weight-pool cycling so weights stream cold, CUDA-event pairs per call, warmup absorbs kernel compilation, clocks read before/after, and the resolved `mixed_trellis.__file__` is asserted + recorded because import hooks in this environment are known to swap module paths. API facts (argument order, `build_tiered_maps` call form, `max_m_blocks` derivation, tile-config branches) are grounded in the vendored caller `runtime/exl3/overlay/.../exl3.py`; anything unverifiable fails with a stated reason.

**The GPU path has not executed — no measured result is claimed.** First run is planned on the two-Spark pair under the 2418 MHz clock pin.

`scripts/bench`: 307 passed (134 new). ruff clean.