### PR TITLE
Record what a four-rank stand-up from a clean checkout established

### DIFF
--- a/docs/GLM52_35BPW_QUICKSTART.md
+++ b/docs/GLM52_35BPW_QUICKSTART.md
@@ -78,6 +78,23 @@ The rollback profile and site are byte-identical to the MTP3 KV9.25 inputs.
 The MTP3 rollback is documented in
 [GLM52_35BPW_FIXED_MTP3_PROFILE.md](GLM52_35BPW_FIXED_MTP3_PROFILE.md).
 
+## What it serves, measured
+
+Figures from the operator-accepted deployment; conditions and evidence in
+[GLM52_35BPW_FIXED_MTP4_PROFILE.md](GLM52_35BPW_FIXED_MTP4_PROFILE.md).
+
+| context | 4K | 8K | 16K | 32K | 64K | 128K |
+|---|---|---|---|---|---|---|
+| prefill, tokens/s | | 679 | 673 | 666 | 657 | 645 |
+| decode, one stream | 22.6 | 22.0 | 21.3 | 20.4 | 21.4 | |
+| decode, four streams | 50.3 | 51.9 | 49.2 | 45.6 | 47.2 | |
+| decode, eight streams | 78.4 | 71.3 | 70.0 | 65.5 | 67.8 | |
+
+Coding prompts peak at 27.3 tokens/s on one stream because MTP4 draft
+acceptance is higher there; the measured acceptance rate is 96.64%. The
+key-value pool holds 1,156,864 tokens: four concurrent requests at the
+full 262,144-token context, or roughly 140 at 8K.
+
 ## Literal identifiers
 
 Scripts, directories, environment variables, and container paths spell this
@@ -104,6 +121,30 @@ Do not commit `scripts/config/site.yaml`. It contains local identities
 and paths. Review every resolved rank, NIC, GID, direct-ring peer, model
 path, and storage path before proceeding. The image fields remain unresolved
 until step 3, so validate the complete file after updating them there.
+
+Two properties of the site configuration are load-bearing beyond schema
+validation, and a four-rank launch established both:
+
+- **The management interface must be a LAN interface.** The launcher
+  derives the rendezvous address and the NCCL and GLOO out-of-band
+  interface from each rank's `management` block, and NCCL communicator
+  initialisation does not complete over a mesh-VPN interface: with
+  management on a Tailscale device, bootstrap TCP connected between every
+  rank and initialisation still made no progress in twenty minutes, while
+  the identical stack with management on the LAN formed every group in
+  seconds. Ring ports are rejected as management by the validator, so a
+  rank whose LAN link is down has no valid configuration until the link
+  returns.
+- **`runtime.model_path` is one path for every rank.** A checkpoint kept
+  under per-user home directories needs the same mount point on each
+  rank first. Bind-mount it; the Docker daemon refuses a symlink as a
+  bind source:
+
+  ```bash
+  sudo mkdir -p /var/tmp/glm52-r7-model
+  sudo mount --bind /home/<user>/models/GLM-5.2-EXL3-TR3v4-3.5bpw-MTP78 \
+    /var/tmp/glm52-r7-model
+  ```
 
 ## 2. Download and verify the immutable checkpoint
 
@@ -165,6 +206,55 @@ emits, so its output hash depends on the image it was generated for, and
 `prepare_q40_exact_state_serving.py` sets `SPARK_Q40_EXACT_STATE_IMAGE_ID` from
 the same site identity. Generating the overlay against the image you run is
 what makes the two agree; section 7 covers that step.
+
+#### Complete a pulled image's serving contract
+
+The generated profiles attest seven files the published image does not
+carry — its deployment lineage supplied them through bind mounts. Every
+producer is tracked, so a derived image closes the gap. From a checkout
+holding the prepared tree of section 4 of the
+[reproduction guide](GLM52_35BPW_REPRODUCTION.md):
+
+```bash
+tree=.sparkring/r7-prepared-sources/vllm
+python spark_transport/experiments/moe_round_floor/prepare_q40_overlay_inputs.py "$tree"
+python runtime/exl3-r7/bake_runtime_artifacts.py cudagraph "$tree"
+python runtime/exl3-r7/bake_runtime_artifacts.py vllm "$tree"
+python runtime/exl3-r7/build_parallel_state_shared_capture_overlay.py \
+  --source "$tree/vllm/distributed/parallel_state.py" --output parallel_state.py
+
+build=/var/tmp/glm52-image-contract
+mkdir -p "$build"
+cp runtime/exl3-r7/entrypoint.sh "$build/"
+cp "$tree/vllm/model_executor/model_loader/weight_utils.py" "$build/"
+cp "$tree/vllm/v1/worker/gpu/cudagraph_utils.py" "$build/"
+cp parallel_state.py "$build/"
+cp spark_transport/integrations/vllm/spark_dcp_collective_audit.py "$build/"
+cp runtime/exl3-r7/bake_runtime_artifacts.py "$build/"
+```
+
+The wheel named by `runtime/exl3-r7/requirements-tvm-ffi.txt` goes into
+the same directory. The image then bakes everything:
+
+```dockerfile
+FROM ghcr.io/fujitsupolycom/gb10-vllm-serving@sha256:6fc26fdad81a18f0fff67ce0a05f6d90165625ea2e1cac8a6f39bfb462017028
+COPY entrypoint.sh /usr/local/bin/sparkring-r7-entrypoint
+COPY weight_utils.py /opt/venv/lib/python3.12/site-packages/vllm/model_executor/model_loader/weight_utils.py
+COPY cudagraph_utils.py /opt/venv/lib/python3.12/site-packages/vllm/v1/worker/gpu/cudagraph_utils.py
+COPY parallel_state.py /opt/venv/lib/python3.12/site-packages/vllm/distributed/parallel_state.py
+COPY spark_dcp_collective_audit.py /opt/spark-vllm/spark_dcp_collective_audit.py
+COPY bake_runtime_artifacts.py apache_tvm_ffi-0.1.10-*.whl /tmp/
+RUN chmod 0755 /usr/local/bin/sparkring-r7-entrypoint \
+ && /opt/venv/bin/python /tmp/bake_runtime_artifacts.py quack /opt/venv/lib/python3.12/site-packages/quack \
+ && /opt/venv/bin/pip install --no-cache-dir --no-index --no-deps \
+      --target /opt/sparkring-r7-tvm-ffi /tmp/apache_tvm_ffi-0.1.10-*.whl \
+ && rm /tmp/bake_runtime_artifacts.py /tmp/apache_tvm_ffi-0.1.10-*.whl
+```
+
+Every profile start verifies the resulting hashes before running the
+engine, so a wrong input fails the launch rather than serving. A
+four-rank start from an image built this way passed that attestation on
+every rank and served through section 9's checks.
 
 ### Option B: Use an existing local image by immutable ID
 

--- a/docs/GLM52_35BPW_REPRODUCTION.md
+++ b/docs/GLM52_35BPW_REPRODUCTION.md
@@ -162,6 +162,13 @@ sparse indexer use their stock paths.
 
 ## 5. Compile and bind tiered/deferred SIRCL
 
+The CUDA compiler must be resolvable; a host whose login environment does
+not put it on `PATH` needs both named explicitly:
+
+```bash
+export CUDACXX=/usr/local/cuda/bin/nvcc PATH=/usr/local/cuda/bin:$PATH
+```
+
 ```bash
 cmake -S spark_transport -B .sparkring/sircl-sm121-build \
   -G Ninja \

--- a/runtime/exl3-r7/bake_runtime_artifacts.py
+++ b/runtime/exl3-r7/bake_runtime_artifacts.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 
 import argparse
 import hashlib
+import subprocess
 from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
 
 
 class ArtifactError(RuntimeError):
@@ -74,6 +77,61 @@ def bake_vllm(root: Path) -> None:
             )
 
 
+CUDAGRAPH_RELATIVE = "vllm/v1/worker/gpu/cudagraph_utils.py"
+CUDAGRAPH_PATCH = HERE / "cudagraph_shared_stream.patch"
+CUDAGRAPH_PATCH_SHA256 = "76a8575adfc98ba26a50d56dc7d2296b48fdc818e257c56fd496d88d470cce13"
+CUDAGRAPH_INPUT_SHA256 = (
+    "a55362bcaa8c31b111c88d083a0a015f401d516d2623f171a0080cc978dc08d5"
+)
+CUDAGRAPH_OUTPUT_SHA256 = (
+    "ef03d64297ed2d1a5161847b48a435bf8ae5feda7a5b81b668d00ae9a1d65a2a"
+)
+
+
+def bake_cudagraph(root: Path) -> None:
+    """Gate full-graph capture on the shared capture stream, hash-bound.
+
+    The pinned vLLM tree captures every full CUDA graph on a private
+    stream. Spark TP4 graph sessions require one stable caller stream, so
+    the serving image carries this edit. The diff regions include a pure
+    insertion, which a byte replacement cannot anchor, so the edit ships
+    as a patch pinned by its own SHA-256 and by the file's before and
+    after hashes.
+    """
+
+    path = root / CUDAGRAPH_RELATIVE
+    observed = sha256(path)
+    if observed == CUDAGRAPH_OUTPUT_SHA256:
+        return
+    if observed != CUDAGRAPH_INPUT_SHA256:
+        raise ArtifactError(
+            f"{path}: expected {CUDAGRAPH_INPUT_SHA256}, got {observed}"
+        )
+    patch_hash = sha256(CUDAGRAPH_PATCH)
+    if patch_hash != CUDAGRAPH_PATCH_SHA256:
+        raise ArtifactError(
+            f"{CUDAGRAPH_PATCH.name}: expected {CUDAGRAPH_PATCH_SHA256}, "
+            f"got {patch_hash}"
+        )
+    result = subprocess.run(
+        ["git", "apply", str(CUDAGRAPH_PATCH)],
+        cwd=root,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout).strip().splitlines()
+        raise ArtifactError(
+            "cudagraph patch did not apply: "
+            + (detail[-1] if detail else "no detail")
+        )
+    observed = sha256(path)
+    if observed != CUDAGRAPH_OUTPUT_SHA256:
+        raise ArtifactError(
+            f"{path}: produced {observed}, expected {CUDAGRAPH_OUTPUT_SHA256}"
+        )
+
+
 def bake_quack(root: Path) -> None:
     replace_exact(
         root / "layout_utils.py",
@@ -96,11 +154,13 @@ def bake_quack(root: Path) -> None:
 
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("component", choices=("vllm", "quack"))
+    parser.add_argument("component", choices=("vllm", "quack", "cudagraph"))
     parser.add_argument("root", type=Path)
     args = parser.parse_args()
     if args.component == "vllm":
         bake_vllm(args.root.resolve())
+    elif args.component == "cudagraph":
+        bake_cudagraph(args.root.resolve())
     else:
         bake_quack(args.root.resolve())
     return 0

--- a/runtime/exl3-r7/cudagraph_shared_stream.patch
+++ b/runtime/exl3-r7/cudagraph_shared_stream.patch
@@ -1,0 +1,27 @@
+--- a/vllm/v1/worker/gpu/cudagraph_utils.py
++++ b/vllm/v1/worker/gpu/cudagraph_utils.py
+@@ -513,12 +513,23 @@
+                         # Sync offloader's copy stream before capture.
+                         # Ensure any pre-capture prefetches from offloader are complete.
+                         get_offloader().sync_prev_onload()
++                        if (
++                            os.getenv("VLLM_SPARK_SHARED_CAPTURE_STREAM", "0")
++                            == "1"
++                        ):
++                            full_graph_context = torch.cuda.graph(
++                                graph,
++                                self.pool,
++                                stream=torch.cuda.current_stream(self.device),
++                            )
++                        else:
++                            full_graph_context = torch.cuda.graph(graph, self.pool)
+                         with (
+                             guard_b12x_kernel_resolution(
+                                 "vLLM full CUDA graph capture after B12X warmup"
+                             ),
+                             vllm_cudagraph_capture_scope(),
+-                            torch.cuda.graph(graph, self.pool),
++                            full_graph_context,
+                         ):
+                             forward_fn(CUDAGraphMode.NONE)
+                             # Join offloader's copy stream after forward to avoid

--- a/runtime/exl3-r7/test_bake_runtime_artifacts.py
+++ b/runtime/exl3-r7/test_bake_runtime_artifacts.py
@@ -47,3 +47,32 @@ def test_replace_exact_checks_replacement_count(tmp_path: Path) -> None:
             output_sha256="0" * 64,
             replacements=((b"before", b"after"),),
         )
+
+
+def test_cudagraph_component_is_hash_bound() -> None:
+    """The patch on disk matches its pin, and the contract names both states."""
+
+    import hashlib
+
+    patch = BAKER.CUDAGRAPH_PATCH
+    assert patch.is_file()
+    observed = hashlib.sha256(patch.read_bytes()).hexdigest()
+    assert observed == BAKER.CUDAGRAPH_PATCH_SHA256
+    assert BAKER.CUDAGRAPH_INPUT_SHA256 != BAKER.CUDAGRAPH_OUTPUT_SHA256
+    for digest in (BAKER.CUDAGRAPH_INPUT_SHA256, BAKER.CUDAGRAPH_OUTPUT_SHA256):
+        assert len(digest) == 64 and int(digest, 16) >= 0
+    text = patch.read_text(encoding="utf-8")
+    assert "VLLM_SPARK_SHARED_CAPTURE_STREAM" in text
+    assert "vllm/v1/worker/gpu/cudagraph_utils.py" in text
+
+
+def test_cudagraph_component_refuses_an_unexpected_tree(tmp_path) -> None:
+    target = tmp_path / "vllm/v1/worker/gpu/cudagraph_utils.py"
+    target.parent.mkdir(parents=True)
+    target.write_bytes(b"unrelated source\n")
+    try:
+        BAKER.bake_cudagraph(tmp_path)
+    except BAKER.ArtifactError as error:
+        assert "expected" in str(error)
+    else:  # pragma: no cover - the refusal is the contract
+        raise AssertionError("an unexpected tree must be refused")


### PR DESCRIPTION
A full stand-up of GLM-5.2 3.5bpw through the documented chain — public clone on rank 0 → section 9's checks passing — surfaced conditions the pages didn't state and one producer the repo didn't carry. This records each where a reader meets it, bounded by that launch.

- **Quickstart opens with measured figures** (prefill/decode table, 96.64% acceptance, KV pool) with the evidence link — what it does before how to stand it up.
- **Prerequisites:** NCCL communicator init does not complete over a mesh-VPN management interface (bootstrap TCP connects; 20 min of no progress over Tailscale vs seconds over the LAN, same stack) · `model_path` is global, so per-user checkpoint homes need the same bind mount on every rank; the daemon refuses symlink sources.
- **Pulled-image completion recipe:** the seven attested files the published image lacks, with every producer tracked. New here: `cudagraph_shared_stream.patch` + a `bake_runtime_artifacts.py cudagraph` component, hash-bound on patch/input/output (its diff has a pure insertion, so a byte replacement can't anchor it). A start from an image built by this recipe passed per-rank attestation and served.
- **Transport build:** `CUDACXX`/`PATH` note for hosts without `nvcc` on the login PATH.

`runtime` + `scripts`: 2119 passed, 12 skipped. Publication consistency: PASS.