### PR TITLE
Report Wi-Fi management profiles that stop reconnecting

### DIFF
--- a/docs/PREREQUISITES.md
+++ b/docs/PREREQUISITES.md
@@ -110,6 +110,24 @@ Required:
 - `sudo` access when initial networking, package, or service repair is needed;
 - no credentials, passwords, or tokens committed to `site.yaml`.
 
+A Wi-Fi management interface must recover from an access-point restart without
+manual action. Its active NetworkManager profile must carry
+`connection.autoconnect yes` and `connection.autoconnect-retries 0`, and Wi-Fi
+power save must be disabled in both the profile
+(`802-11-wireless.powersave disable`) and the driver. nm-settings defines zero
+retries as retry forever; `-1` selects the global default of four attempts,
+after which autoconnect blocks until a NetworkManager timeout expires, and any
+positive value is a finite cap — either leaves the node off the management
+network for the blocked window when an outage outlasts the attempts. Power
+save causes silent de-association. Set the retry behavior with:
+
+```bash
+nmcli connection modify <name> connection.autoconnect-retries 0
+```
+
+`scripts/ring_doctor.py` reports these settings for every wireless interface
+that has an active NetworkManager connection.
+
 After filling the management targets in `site.yaml`, check them:
 
 ```bash

--- a/scripts/ring_doctor.py
+++ b/scripts/ring_doctor.py
@@ -9,6 +9,8 @@ Repair covers the fabric interfaces and the routes between them. The launch
 endpoints a distributed job names — the rendezvous address and the per-node
 NCCL and GLOO socket interfaces — are reported against what each node observes
 and are never changed, because they can sit on networks outside this fabric.
+The NetworkManager reconnection settings of wireless management interfaces are
+read and diagnosed the same way, never changed.
 """
 
 from __future__ import annotations
@@ -108,6 +110,51 @@ class RendezvousRoute:
 
 
 @dataclasses.dataclass(frozen=True)
+class WifiInterfaceState:
+    """Reconnection settings observed for one wireless management interface.
+
+    An interface appears here only when a NetworkManager connection was active
+    on it during the probe. The three profile settings hold the raw ``nmcli``
+    values (``autoconnect_retries`` uses ``0`` for retry-forever), or None
+    when the per-profile query produced no value. ``driver_power_save`` holds
+    the ``iw`` power-save state, ``on`` or ``off``, or None when ``iw`` was
+    unavailable on the node.
+    """
+
+    device: str
+    connection: str
+    autoconnect: str | None
+    autoconnect_retries: str | None
+    powersave: str | None
+    driver_power_save: str | None
+
+    def to_dict(self) -> dict[str, Any]:
+        return dataclasses.asdict(self)
+
+
+@dataclasses.dataclass(frozen=True)
+class WifiObservation:
+    """Wireless management reconnection evidence for one node.
+
+    ``nmcli_available`` is False when the node has no ``nmcli``, in which case
+    no wireless interface can be enumerated there. ``interfaces`` holds every
+    wireless interface that had an active NetworkManager connection when
+    probed; a node whose management runs over a wired path has none.
+    """
+
+    nmcli_available: bool
+    interfaces: tuple[WifiInterfaceState, ...] = ()
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "nmcli_available": self.nmcli_available,
+            "interfaces": [
+                interface.to_dict() for interface in self.interfaces
+            ],
+        }
+
+
+@dataclasses.dataclass(frozen=True)
 class CommandResult:
     ok: bool
     stdout: str = ""
@@ -179,7 +226,9 @@ class NodeObservation:
     ``interfaces`` holds only the two fabric interfaces the ring is built from.
     ``host_interfaces`` holds every interface the node reported, so a name that
     a launch configuration gives to NCCL or GLOO can be checked for existence
-    and for an IPv4 address without a second remote round.
+    and for an IPv4 address without a second remote round. ``wifi`` holds the
+    wireless management reconnection evidence gathered by the same probe, or
+    None when the probe output carried no wifi section.
     """
 
     spec: NodeSpec
@@ -196,6 +245,7 @@ class NodeObservation:
         default_factory=dict
     )
     rendezvous_route: RendezvousRoute | None = None
+    wifi: WifiObservation | None = None
 
     @property
     def label(self) -> str:
@@ -237,6 +287,7 @@ class NodeObservation:
             "rendezvous_route": (
                 self.rendezvous_route.to_dict() if self.rendezvous_route else None
             ),
+            "wifi": self.wifi.to_dict() if self.wifi else None,
             "ip_forward": self.ip_forward,
             "forward_policy": self.forward_policy,
             "docker_user_rules": (
@@ -444,6 +495,47 @@ def _require_unique_specs(specs: Sequence[NodeSpec]) -> None:
         raise ConfigurationError("node SSH targets must be unique")
 
 
+# Shell for the probe section holding wireless management reconnection
+# evidence. It prints the raw ``nmcli`` terse device rows, then, for every
+# row whose TYPE is exactly ``wifi`` and whose CONNECTION is non-empty, a
+# ``PROFILE <device> <connection>`` line, the three per-profile setting values
+# (one per line), and an ``IW <device> <on|off|unavailable>`` driver
+# power-save line. The per-profile query needs the connection names the same
+# section just discovered, so the shell loops over them itself instead of
+# adding a second remote contact. ``nmcli -t`` escapes ``:`` and ``\\`` in
+# connection names with a backslash; ``sed`` removes those escapes before the
+# name is reused. A node without ``nmcli`` prints the unavailable sentinel and
+# never fails the probe.
+_WIFI_PROBE = f"""printf '%s\\n' '__RING_DOCTOR_WIFI__'
+if command -v nmcli >/dev/null 2>&1; then
+  rd_wifi_rows=$(nmcli -t -f DEVICE,TYPE,STATE,CONNECTION device status 2>/dev/null)
+  printf '%s\\n' "$rd_wifi_rows"
+  printf '%s\\n' "$rd_wifi_rows" | while IFS= read -r rd_row; do
+    rd_dev=${{rd_row%%:*}}
+    rd_rest=${{rd_row#*:}}
+    rd_type=${{rd_rest%%:*}}
+    rd_rest=${{rd_rest#*:}}
+    rd_name=$(printf '%s\\n' "${{rd_rest#*:}}" | sed 's/\\\\\\(.\\)/\\1/g')
+    [ "$rd_type" = wifi ] || continue
+    [ -n "$rd_name" ] || continue
+    printf 'PROFILE %s %s\\n' "$rd_dev" "$rd_name"
+    nmcli -t -g connection.autoconnect,connection.autoconnect-retries,802-11-wireless.powersave connection show "$rd_name" 2>/dev/null || printf '%s\\n' '{UNAVAILABLE}'
+    if command -v iw >/dev/null 2>&1; then
+      case "$(iw dev "$rd_dev" get power_save 2>/dev/null)" in
+        *': on') printf 'IW %s on\\n' "$rd_dev" ;;
+        *': off') printf 'IW %s off\\n' "$rd_dev" ;;
+        *) printf 'IW %s unavailable\\n' "$rd_dev" ;;
+      esac
+    else
+      printf 'IW %s unavailable\\n' "$rd_dev"
+    fi
+  done
+else
+  printf '%s\\n' '{UNAVAILABLE}'
+fi
+"""
+
+
 def build_probe_command(
     interfaces: Sequence[str],
     rendezvous_address: ipaddress.IPv4Address | None = None,
@@ -451,7 +543,9 @@ def build_probe_command(
     """Build the read-only remote probe that emits sectioned evidence.
 
     Naming a rendezvous address adds one route lookup to the same probe, so a
-    node is still contacted once per discovery attempt.
+    node is still contacted once per discovery attempt. The wifi section
+    likewise rides the same contact: it enumerates wireless interfaces and
+    reads each active profile's reconnection settings inside this one command.
     """
     for index, interface in enumerate(interfaces):
         _validate_interface(interface, f"fabric_interfaces[{index}]")
@@ -478,7 +572,7 @@ printf '%s\\n' '__RING_DOCTOR_FORWARD_CHAIN__'
 sudo -n iptables -S FORWARD 2>/dev/null || printf '%s\\n' '{UNAVAILABLE}'
 printf '%s\\n' '__RING_DOCTOR_DOCKER_USER__'
 sudo -n iptables -S DOCKER-USER 2>/dev/null || printf '%s\\n' '{UNAVAILABLE}'
-{rendezvous_probe}printf '%s\\n' '__RING_DOCTOR_INTERFACES__'
+{_WIFI_PROBE}{rendezvous_probe}printf '%s\\n' '__RING_DOCTOR_INTERFACES__'
 printf '%s\\n' {names}
 """
 
@@ -636,6 +730,86 @@ def parse_route_get(
     )
 
 
+_NMCLI_ESCAPE_RE = re.compile(r"\\(.)")
+
+
+def parse_wifi_observation(text: str) -> WifiObservation | None:
+    """Parse the wifi probe section into per-interface reconnection evidence.
+
+    The section body holds the raw ``nmcli -t -f DEVICE,TYPE,STATE,CONNECTION
+    device status`` rows, then one block per wireless interface with an active
+    connection: a ``PROFILE <device> <connection>`` line, the three values
+    printed one per line by ``nmcli -t -g connection.autoconnect,connection.
+    autoconnect-retries,802-11-wireless.powersave connection show``, and an
+    ``IW <device> <on|off|unavailable>`` line holding the driver power-save
+    state. Only rows whose TYPE is exactly ``wifi`` name a wireless
+    interface: the ``wifi-p2p`` row NetworkManager adds for the same radio,
+    whose DEVICE carries a ``p2p-dev-`` prefix, is a sub-device, never an
+    interface. Returns None for an absent or empty section, and an
+    observation with ``nmcli_available=False`` when the section holds the
+    sentinel a node without ``nmcli`` prints.
+    """
+    stripped = text.strip()
+    if not stripped:
+        return None
+    if stripped == UNAVAILABLE:
+        return WifiObservation(nmcli_available=False)
+    active: dict[str, str] = {}
+    settings: dict[str, tuple[str | None, str | None, str | None]] = {}
+    driver: dict[str, str | None] = {}
+    lines = text.splitlines()
+    index = 0
+    while index < len(lines):
+        line = lines[index]
+        if line.startswith("PROFILE "):
+            head = line.split(" ", 2)
+            device = head[1] if len(head) > 1 else ""
+            index += 1
+            values: list[str] = []
+            while (
+                index < len(lines)
+                and len(values) < 3
+                and not lines[index].startswith(("PROFILE ", "IW "))
+            ):
+                values.append(lines[index].strip())
+                index += 1
+            if UNAVAILABLE in values:
+                settings[device] = (None, None, None)
+            else:
+                padded = values + [""] * (3 - len(values))
+                settings[device] = (
+                    padded[0] or None,
+                    padded[1] or None,
+                    padded[2] or None,
+                )
+            continue
+        if line.startswith("IW "):
+            fields = line.split()
+            if len(fields) >= 3:
+                driver[fields[1]] = (
+                    fields[2] if fields[2] in {"on", "off"} else None
+                )
+            index += 1
+            continue
+        fields = line.split(":", 3)
+        if len(fields) == 4:
+            device, device_type, _state, connection = fields
+            connection = _NMCLI_ESCAPE_RE.sub(r"\1", connection)
+            if device_type == "wifi" and connection and device not in active:
+                active[device] = connection
+        index += 1
+    interfaces = tuple(
+        WifiInterfaceState(
+            device,
+            connection,
+            *settings.get(device, (None, None, None)),
+            driver_power_save=driver.get(device),
+        )
+        for device, connection in active.items()
+    )
+    return WifiObservation(True, interfaces)
+
+
 def parse_probe_output(
     spec: NodeSpec,
     text: str,
@@ -692,6 +866,7 @@ def parse_probe_output(
         proxy_jump_used=proxy_jump_used,
         host_interfaces=host_interfaces,
         rendezvous_route=rendezvous_route,
+        wifi=parse_wifi_observation(sections.get("WIFI", "")),
     )
 
 
@@ -1171,6 +1346,206 @@ def diagnose_launch_endpoints(
     return findings
 
 
+def diagnose_wifi_resilience(
+    specs: Sequence[NodeSpec],
+    observations: Mapping[str, NodeObservation],
+) -> list[Finding]:
+    """Check that wireless management interfaces survive an access-point blip.
+
+    A wireless management interface recovers from an access-point restart on
+    its own only when its active NetworkManager profile autoconnects, retries
+    without a cap, and runs with Wi-Fi power save disabled. Any other
+    combination is a latent fault: every reachability check passes while the
+    interface is associated, then one blip leaves the node off the management
+    network until someone reconnects it by hand. Every wireless interface with
+    an active NetworkManager connection on a reachable node is checked, from
+    evidence the discovery probe gathered in its single contact per node. The
+    check reports observations only and never proposes a profile change. A
+    node with no such interface contributes nothing, because wired management
+    is not a fault; a node without ``nmcli`` is reported as unobserved,
+    because nothing about its wireless configuration could be read.
+
+    When at least one wireless interface was checked and nothing was faulted
+    or unreadable, the result carries one ``info`` finding recording the
+    affirmative outcome, so a passing check is distinguishable from a site
+    with wired-only management, where the check contributes nothing. An
+    ``info`` finding does not affect the process exit code.
+    """
+    findings: list[Finding] = []
+    sound: list[str] = []
+    for spec in specs:
+        observation = observations.get(spec.name)
+        if observation is None or not observation.reachable:
+            continue
+        wifi = observation.wifi
+        if wifi is None:
+            continue
+        if not wifi.nmcli_available:
+            findings.append(
+                Finding(
+                    "warning",
+                    "wifi-resilience-unobserved",
+                    spec.name,
+                    "nmcli is not installed on this node, so no wireless "
+                    "management interface here can be checked for the "
+                    "NetworkManager settings that reconnect it after an "
+                    "access-point restart.",
+                    "command -v nmcli found no executable",
+                )
+            )
+            continue
+        for interface in wifi.interfaces:
+            if (
+                interface.autoconnect is None
+                or interface.autoconnect_retries is None
+                or interface.powersave is None
+            ):
+                findings.append(
+                    Finding(
+                        "warning",
+                        "wifi-resilience-unobserved",
+                        spec.name,
+                        f"NetworkManager reports profile "
+                        f"{interface.connection} active on wireless "
+                        f"interface {interface.device}, but the profile's "
+                        "reconnection settings could not be read, so the "
+                        "interface is neither confirmed resilient nor "
+                        "confirmed faulted.",
+                        "nmcli -t -g connection.autoconnect,"
+                        "connection.autoconnect-retries,"
+                        "802-11-wireless.powersave connection show "
+                        f"{interface.connection} returned no values",
+                    )
+                )
+                continue
+            faulted = False
+            if interface.autoconnect != "yes":
+                faulted = True
+                findings.append(
+                    Finding(
+                        "warning",
+                        "wifi-autoconnect-disabled",
+                        spec.name,
+                        f"NetworkManager profile {interface.connection} on "
+                        f"wireless interface {interface.device} sets "
+                        f"connection.autoconnect={interface.autoconnect}, so "
+                        "after any disconnect NetworkManager does not rejoin "
+                        "the network and the node stays off the management "
+                        "network until the profile is activated by hand.",
+                        f"connection.autoconnect={interface.autoconnect}",
+                    )
+                )
+            try:
+                retries: int | None = int(interface.autoconnect_retries)
+            except ValueError:
+                retries = None
+            if retries is None:
+                faulted = True
+                findings.append(
+                    Finding(
+                        "warning",
+                        "wifi-resilience-unobserved",
+                        spec.name,
+                        f"NetworkManager profile {interface.connection} on "
+                        f"wireless interface {interface.device} reports "
+                        "connection.autoconnect-retries="
+                        f"{interface.autoconnect_retries}, which is not an "
+                        "integer, so the reconnection cap here cannot be "
+                        "determined.",
+                        "connection.autoconnect-retries="
+                        f"{interface.autoconnect_retries}",
+                    )
+                )
+            elif retries != 0:
+                faulted = True
+                if retries == -1:
+                    cap_clause = (
+                        "connection.autoconnect-retries=-1, the global "
+                        "default of four reconnection attempts"
+                    )
+                    count = "four"
+                else:
+                    cap_clause = (
+                        f"connection.autoconnect-retries={retries}, a finite "
+                        f"cap of {retries} reconnection attempts"
+                    )
+                    count = str(retries)
+                findings.append(
+                    Finding(
+                        "warning",
+                        "wifi-retries-limited",
+                        spec.name,
+                        f"NetworkManager profile {interface.connection} on "
+                        f"wireless interface {interface.device} sets "
+                        f"{cap_clause}. nm-settings defines zero as retry "
+                        f"forever; after {count} failed attempts autoconnect "
+                        "blocks until a NetworkManager timeout expires, so an "
+                        "access-point outage that outlasts them leaves the "
+                        "node off the management network for that window.",
+                        "connection.autoconnect-retries="
+                        f"{interface.autoconnect_retries}",
+                    )
+                )
+            profile_powersave_on = interface.powersave in {"3", "enable"}
+            driver_powersave_on = interface.driver_power_save == "on"
+            if profile_powersave_on or driver_powersave_on:
+                faulted = True
+                if profile_powersave_on:
+                    cause = (
+                        f"NetworkManager profile {interface.connection} on "
+                        f"wireless interface {interface.device} enables "
+                        "Wi-Fi power save (802-11-wireless.powersave="
+                        f"{interface.powersave})"
+                    )
+                else:
+                    cause = (
+                        "The wireless driver reports power save on for "
+                        f"interface {interface.device}, whose active "
+                        f"NetworkManager profile {interface.connection} sets "
+                        "802-11-wireless.powersave="
+                        f"{interface.powersave}"
+                    )
+                findings.append(
+                    Finding(
+                        "warning",
+                        "wifi-powersave-enabled",
+                        spec.name,
+                        f"{cause}. Wi-Fi power save causes silent "
+                        "de-association from the access point, so the node "
+                        "can drop off the management network with no failure "
+                        "recorded.",
+                        f"802-11-wireless.powersave={interface.powersave}; "
+                        "iw power_save="
+                        + (interface.driver_power_save or "unobserved"),
+                    )
+                )
+            if not faulted:
+                sound.append(
+                    f"{spec.name}:{interface.device} profile "
+                    f"{interface.connection} autoconnect="
+                    f"{interface.autoconnect} retries="
+                    f"{interface.autoconnect_retries} powersave="
+                    f"{interface.powersave} driver_power_save="
+                    + (interface.driver_power_save or "unobserved")
+                )
+    if not sound or findings:
+        return findings
+    findings.append(
+        Finding(
+            "info",
+            "wifi-resilience-observed",
+            None,
+            "Every wireless interface with an active NetworkManager "
+            "connection on a reachable node autoconnects, retries without "
+            "limit, and runs with Wi-Fi power save disabled, so management "
+            "over Wi-Fi survives an access-point restart without manual "
+            "action.",
+            " | ".join(sound),
+        )
+    )
+    return findings
+
+
 def diagnose(
     specs: Sequence[NodeSpec],
     observations: Mapping[str, NodeObservation],
@@ -1355,6 +1730,7 @@ def diagnose(
     findings.extend(
         diagnose_launch_endpoints(specs, observations, rendezvous_address)
     )
+    findings.extend(diagnose_wifi_resilience(specs, observations))
     return findings
 
 

--- a/scripts/test_ring_doctor.py
+++ b/scripts/test_ring_doctor.py
@@ -7,6 +7,7 @@ import unittest
 
 from scripts.ring_doctor import (
     FABRIC_INTERFACES,
+    UNAVAILABLE,
     CommandResult,
     InterfaceState,
     NodeObservation,
@@ -15,6 +16,7 @@ from scripts.ring_doctor import (
     build_probe_command,
     diagnose,
     diagnose_launch_endpoints,
+    diagnose_wifi_resilience,
     discover_nodes,
     docker_user_accepts,
     infer_adjacency,
@@ -22,6 +24,7 @@ from scripts.ring_doctor import (
     parse_all_addresses,
     parse_brief_addresses,
     parse_route_get,
+    parse_wifi_observation,
     select_route,
     validate_cycle,
 )
@@ -41,6 +44,7 @@ def observation(
     socket_interfaces: tuple[str, ...] = (),
     host_addresses: str | None = None,
     route_get: str | None = None,
+    wifi: str | None = None,
 ) -> NodeObservation:
     interfaces = parse_brief_addresses(addresses)
     interfaces = {
@@ -63,6 +67,11 @@ def observation(
         ),
         rendezvous_route=(
             parse_route_get(RENDEZVOUS, route_get) if route_get is not None else None
+        ),
+        wifi=(
+            parse_wifi_observation(wifi)
+            if wifi is not None and reachable
+            else None
         ),
     )
 
@@ -94,10 +103,12 @@ def probe_output(
     route_get: str | None = None,
     routes: str = "",
     docker_rules: str = "-N DOCKER-USER",
+    wifi: str | None = None,
 ) -> str:
     rendezvous = (
         f"__RING_DOCTOR_RENDEZVOUS__\n{route_get}\n" if route_get is not None else ""
     )
+    wifi_evidence = f"__RING_DOCTOR_WIFI__\n{wifi}\n" if wifi is not None else ""
     return f"""__RING_DOCTOR_HOSTNAME__
 {hostname}
 __RING_DOCTOR_ADDR__
@@ -113,7 +124,7 @@ __RING_DOCTOR_FORWARD_CHAIN__
 -P FORWARD DROP
 __RING_DOCTOR_DOCKER_USER__
 {docker_rules}
-{rendezvous}__RING_DOCTOR_INTERFACES__
+{wifi_evidence}{rendezvous}__RING_DOCTOR_INTERFACES__
 {IF0}
 {IF1}
 """
@@ -318,6 +329,43 @@ UNADDRESSED_WIFI_LISTING = f"""lo UNKNOWN 127.0.0.1/8
 LOCAL_ROUTE = f"local {RENDEZVOUS} dev lo src {RENDEZVOUS} uid 1000\n    cache <local>"
 FABRIC_ROUTE = f"{RENDEZVOUS} dev {IF1} src 10.0.1.11 uid 1000\n    cache"
 UNREACHABLE_ROUTE = "RTNETLINK answers: Network is unreachable"
+
+WIFI_PROFILE_NAME = "CSmiles"
+
+WIFI_DEVICE_ROWS = (
+    f"{WIFI}:wifi:connected:{WIFI_PROFILE_NAME}\n"
+    f"p2p-dev-{WIFI}:wifi-p2p:disconnected:\n"
+    f"{IF0}:ethernet:connected:fabric-101\n"
+    "lo:loopback:unmanaged:"
+)
+
+WIRED_DEVICE_ROWS = (
+    f"{IF0}:ethernet:connected:fabric-101\n"
+    f"{IF1}:ethernet:connected:fabric-102\n"
+    "lo:loopback:unmanaged:"
+)
+
+DISCONNECTED_WIFI_ROWS = (
+    f"{WIFI}:wifi:disconnected:\n"
+    f"{IF0}:ethernet:connected:fabric-101\n"
+    "lo:loopback:unmanaged:"
+)
+
+
+def wifi_section(
+    autoconnect: str = "yes",
+    retries: str = "0",
+    powersave: str = "disable",
+    driver: str = "off",
+) -> str:
+    return (
+        f"{WIFI_DEVICE_ROWS}\n"
+        f"PROFILE {WIFI} {WIFI_PROFILE_NAME}\n"
+        f"{autoconnect}\n"
+        f"{retries}\n"
+        f"{powersave}\n"
+        f"IW {WIFI} {driver}"
+    )
 
 
 class RouteLookupParsingTests(unittest.TestCase):
@@ -543,6 +591,225 @@ class LaunchEndpointTests(unittest.TestCase):
         )
 
 
+class WifiResilienceTests(unittest.TestCase):
+    @staticmethod
+    def wifi_findings(sections):
+        observations = {
+            name: observation(name, ADDRESSED_WIFI_LISTING, wifi=section)
+            for name, section in sections.items()
+        }
+        return diagnose_wifi_resilience(
+            [item.spec for item in observations.values()], observations
+        )
+
+    def test_probe_gathers_wifi_evidence_in_the_same_contact(self) -> None:
+        command = build_probe_command(FABRIC_INTERFACES)
+
+        self.assertEqual(command.count("__RING_DOCTOR_WIFI__"), 1)
+        self.assertIn("command -v nmcli", command)
+        self.assertIn(
+            "nmcli -t -f DEVICE,TYPE,STATE,CONNECTION device status", command
+        )
+        self.assertIn(
+            "nmcli -t -g connection.autoconnect,"
+            "connection.autoconnect-retries,802-11-wireless.powersave "
+            "connection show",
+            command,
+        )
+        self.assertIn("get power_save", command)
+
+    def test_sound_profiles_on_every_wifi_node_report_one_affirmative_info(
+        self,
+    ) -> None:
+        findings = self.wifi_findings(
+            {"r0": wifi_section(), "r1": wifi_section()}
+        )
+
+        self.assertEqual(
+            [finding.code for finding in findings], ["wifi-resilience-observed"]
+        )
+        self.assertEqual(findings[0].severity, "info")
+        self.assertIsNone(findings[0].node)
+        self.assertIn(f"r0:{WIFI}", findings[0].evidence)
+        self.assertIn(f"r1:{WIFI}", findings[0].evidence)
+        self.assertIn(WIFI_PROFILE_NAME, findings[0].evidence)
+        self.assertIn("retries=0", findings[0].evidence)
+
+    def test_default_retry_limit_is_reported_as_four_attempts(self) -> None:
+        findings = self.wifi_findings(
+            {"r0": wifi_section(), "r1": wifi_section(retries="-1")}
+        )
+
+        self.assertEqual(len(findings), 1)
+        finding = findings[0]
+        self.assertEqual(
+            (finding.severity, finding.code, finding.node),
+            ("warning", "wifi-retries-limited", "r1"),
+        )
+        self.assertIn(WIFI, finding.message)
+        self.assertIn(WIFI_PROFILE_NAME, finding.message)
+        self.assertIn("four", finding.message)
+        self.assertIn("blocks until a NetworkManager timeout", " ".join(finding.message.split()))
+        self.assertIn("off the management network", finding.message)
+        self.assertIn("connection.autoconnect-retries=-1", finding.evidence)
+
+    def test_finite_retry_cap_is_reported_with_its_count(self) -> None:
+        findings = self.wifi_findings({"r0": wifi_section(retries="3")})
+
+        self.assertEqual(len(findings), 1)
+        finding = findings[0]
+        self.assertEqual(finding.code, "wifi-retries-limited")
+        self.assertIn("cap of 3 reconnection attempts", finding.message)
+        self.assertIn("after 3 failed attempts", finding.message)
+        self.assertIn("connection.autoconnect-retries=3", finding.evidence)
+
+    def test_disabled_autoconnect_is_reported(self) -> None:
+        findings = self.wifi_findings({"r0": wifi_section(autoconnect="no")})
+
+        self.assertEqual(len(findings), 1)
+        finding = findings[0]
+        self.assertEqual(
+            (finding.severity, finding.code, finding.node),
+            ("warning", "wifi-autoconnect-disabled", "r0"),
+        )
+        self.assertIn(WIFI, finding.message)
+        self.assertIn(WIFI_PROFILE_NAME, finding.message)
+        self.assertIn("connection.autoconnect=no", finding.evidence)
+
+    def test_profile_powersave_enable_is_reported(self) -> None:
+        for value in ("enable", "3"):
+            with self.subTest(powersave=value):
+                findings = self.wifi_findings(
+                    {"r0": wifi_section(powersave=value)}
+                )
+
+                self.assertEqual(len(findings), 1)
+                finding = findings[0]
+                self.assertEqual(
+                    (finding.severity, finding.code, finding.node),
+                    ("warning", "wifi-powersave-enabled", "r0"),
+                )
+                self.assertIn("de-association", finding.message)
+                self.assertIn(
+                    f"802-11-wireless.powersave={value}", finding.evidence
+                )
+
+    def test_driver_power_save_on_is_reported_despite_a_disabling_profile(
+        self,
+    ) -> None:
+        findings = self.wifi_findings(
+            {"r0": wifi_section(powersave="disable", driver="on")}
+        )
+
+        self.assertEqual(len(findings), 1)
+        finding = findings[0]
+        self.assertEqual(finding.code, "wifi-powersave-enabled")
+        self.assertIn("driver reports power save on", finding.message)
+        self.assertIn("iw power_save=on", finding.evidence)
+
+    def test_absent_iw_leaves_the_profile_verdict_standing(self) -> None:
+        findings = self.wifi_findings(
+            {"r0": wifi_section(driver="unavailable")}
+        )
+
+        self.assertEqual(
+            [finding.code for finding in findings], ["wifi-resilience-observed"]
+        )
+        self.assertIn("driver_power_save=unobserved", findings[0].evidence)
+
+    def test_nodes_without_an_active_wifi_profile_contribute_nothing(
+        self,
+    ) -> None:
+        wired_only = self.wifi_findings(
+            {"r0": WIRED_DEVICE_ROWS, "r1": DISCONNECTED_WIFI_ROWS}
+        )
+        with_one_wifi_node = self.wifi_findings(
+            {
+                "r0": WIRED_DEVICE_ROWS,
+                "r1": DISCONNECTED_WIFI_ROWS,
+                "r2": wifi_section(),
+            }
+        )
+
+        self.assertEqual(wired_only, [])
+        self.assertEqual(
+            [finding.code for finding in with_one_wifi_node],
+            ["wifi-resilience-observed"],
+        )
+        self.assertIn(f"r2:{WIFI}", with_one_wifi_node[0].evidence)
+        self.assertNotIn("r0", with_one_wifi_node[0].evidence)
+
+    def test_missing_nmcli_is_reported_as_unobserved(self) -> None:
+        findings = self.wifi_findings(
+            {"r0": UNAVAILABLE, "r1": wifi_section()}
+        )
+
+        self.assertEqual(len(findings), 1)
+        finding = findings[0]
+        self.assertEqual(
+            (finding.severity, finding.code, finding.node),
+            ("warning", "wifi-resilience-unobserved", "r0"),
+        )
+        self.assertIn("nmcli", finding.message)
+
+    def test_unreadable_profile_settings_are_unobserved_not_sound(self) -> None:
+        section = (
+            f"{WIFI_DEVICE_ROWS}\n"
+            f"PROFILE {WIFI} {WIFI_PROFILE_NAME}\n"
+            f"{UNAVAILABLE}\n"
+            f"IW {WIFI} off"
+        )
+
+        findings = self.wifi_findings({"r0": section})
+
+        self.assertEqual(len(findings), 1)
+        finding = findings[0]
+        self.assertEqual(
+            (finding.severity, finding.code, finding.node),
+            ("warning", "wifi-resilience-unobserved", "r0"),
+        )
+        self.assertIn(WIFI_PROFILE_NAME, finding.message)
+
+    def test_p2p_sub_device_is_never_treated_as_an_interface(self) -> None:
+        section = (
+            f"{WIFI}:wifi:connected:{WIFI_PROFILE_NAME}\n"
+            f"p2p-dev-{WIFI}:wifi-p2p:connected:{WIFI_PROFILE_NAME}-p2p\n"
+            "lo:loopback:unmanaged:\n"
+            f"PROFILE {WIFI} {WIFI_PROFILE_NAME}\n"
+            "yes\n"
+            "0\n"
+            "disable\n"
+            f"IW {WIFI} off"
+        )
+
+        parsed = parse_wifi_observation(section)
+        findings = self.wifi_findings({"r0": section})
+
+        self.assertIsNotNone(parsed)
+        assert parsed is not None
+        self.assertTrue(parsed.nmcli_available)
+        self.assertEqual(
+            [interface.device for interface in parsed.interfaces], [WIFI]
+        )
+        self.assertEqual(
+            [finding.code for finding in findings], ["wifi-resilience-observed"]
+        )
+
+    def test_unreachable_nodes_and_wifi_less_probe_output_are_skipped(
+        self,
+    ) -> None:
+        observations = {
+            "r0": observation("r0", "", reachable=False),
+            "r1": observation("r1", ADDRESSED_WIFI_LISTING),
+        }
+
+        findings = diagnose_wifi_resilience(
+            [item.spec for item in observations.values()], observations
+        )
+
+        self.assertEqual(findings, [])
+
+
 CROSS_ACCEPT_RULES = (
     f"-N DOCKER-USER\n"
     f"-A DOCKER-USER -i {IF0} -o {IF1} -j ACCEPT\n"
@@ -593,6 +860,7 @@ class HealthyRingLaunchEndpointTests(unittest.TestCase):
                 entry[3],
                 routes=entry[2],
                 docker_rules=CROSS_ACCEPT_RULES,
+                wifi=wifi_section() if name == "r0" else WIRED_DEVICE_ROWS,
             )
             for name, entry in HEALTHY_RING.items()
         }
@@ -608,11 +876,74 @@ class HealthyRingLaunchEndpointTests(unittest.TestCase):
         self.assertTrue(topology.valid_cycle, topology.reason)
         self.assertEqual(
             [(finding.severity, finding.code) for finding in findings],
-            [("info", "launch-endpoints-observed")],
+            [
+                ("info", "launch-endpoints-observed"),
+                ("info", "wifi-resilience-observed"),
+            ],
         )
         self.assertIn(str(RENDEZVOUS), findings[0].message)
         for name in HEALTHY_RING:
             self.assertIn(name, findings[0].evidence)
+        self.assertIn(f"r0:{WIFI}", findings[1].evidence)
+
+
+class WifiDiscoveryIntegrationTests(unittest.TestCase):
+    def test_one_probe_round_carries_wifi_evidence_for_every_node(self) -> None:
+        specs = tuple(
+            NodeSpec(name, f"operator@{name}") for name in HEALTHY_RING
+        )
+        wifi_by_node = {
+            "r0": wifi_section(),
+            "r1": WIRED_DEVICE_ROWS,
+            "r2": wifi_section(retries="-1"),
+            "r3": UNAVAILABLE,
+        }
+        outputs = {
+            f"operator@{name}": probe_output(
+                entry[0][0],
+                entry[1],
+                routes=entry[2],
+                docker_rules=CROSS_ACCEPT_RULES,
+                wifi=wifi_by_node[name],
+            )
+            for name, entry in HEALTHY_RING.items()
+        }
+        runner = FakeDiscoveryRunner(outputs, set())
+
+        observations = discover_nodes(specs, runner)
+        topology = infer_topology(observations)
+        plans = build_plans(observations, topology)
+        findings = diagnose(specs, observations, topology, plans)
+
+        self.assertEqual(len(runner.calls), len(specs))
+        self.assertTrue(topology.valid_cycle, topology.reason)
+        checked = observations["r0"].wifi
+        self.assertIsNotNone(checked)
+        assert checked is not None
+        self.assertEqual(
+            [interface.connection for interface in checked.interfaces],
+            [WIFI_PROFILE_NAME],
+        )
+        self.assertEqual(checked.interfaces[0].driver_power_save, "off")
+        wired = observations["r1"].wifi
+        self.assertIsNotNone(wired)
+        assert wired is not None
+        self.assertTrue(wired.nmcli_available)
+        self.assertEqual(wired.interfaces, ())
+        self.assertEqual(
+            [
+                (finding.severity, finding.code, finding.node)
+                for finding in findings
+            ],
+            [
+                ("warning", "wifi-retries-limited", "r2"),
+                ("warning", "wifi-resilience-unobserved", "r3"),
+            ],
+        )
+        self.assertEqual(
+            observations["r0"].to_dict()["wifi"]["interfaces"][0]["device"],
+            WIFI,
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
A wireless management interface whose NetworkManager profile limits autoconnect retries looks healthy until an access-point outage — then it stays off the management network while autoconnect is blocked. Nothing observed that configuration; the launch-endpoint checks only see the interface after it has already lost its address. This is the latent-fault class behind a rank repeatedly needing a manual Wi-Fi rejoin.

## What ring_doctor gains

One new section in the existing single probe round (no extra SSH): NetworkManager device rows, per-active-wireless-profile `autoconnect` / `autoconnect-retries` / `powersave`, and the driver's power-save state.

Findings, observations only, no repair path:

- `wifi-retries-limited` (warning) — retries not zero; message states how many attempts and that autoconnect then blocks until a NetworkManager timeout expires
- `wifi-autoconnect-disabled`, `wifi-powersave-enabled` (warning) — the profile setting or the driver state; power save causes silent de-association
- `wifi-resilience-unobserved` (warning) — `nmcli` absent or a settings query returned nothing
- `wifi-resilience-observed` (info, exit-neutral) — wireless interfaces checked, none faulted

Wired-management nodes contribute nothing. The `wifi-p2p` sub-device rows NetworkManager lists for the same radio are excluded in both the probe shell and the parser.

## The semantics correction worth reading

The first draft warned on anything ≠ `-1`, from a field observation read backwards. `man nm-settings-nmcli` on the deployed NetworkManager 1.46.0 defines it the other way:

> "Zero means forever, -1 means the global default (4 times if not overridden)… after a timeout, NetworkManager will try to autoconnect again."

The check, the tests, and the prerequisites all follow the man page: **zero is the required value**, `-1` warns as the default-of-four, positive N warns as a finite cap. The four-Spark ranks were set to zero after verifying this against the man page on the hardware.

Prerequisites gain the durable-Wi-Fi-management paragraph with the one-line `nmcli` fix.

`scripts/test_ring_doctor.py`: 32 passed (13 new). `scripts` + `runtime`: 2133 passed, 12 skipped. ruff clean. Publication consistency: PASS.