### PR TITLE
Track the per-rank environment the DeepSeek quickstart depends on

### DIFF
--- a/docs/DEEPSEEK_V4_FLASH_QUICKSTART.md
+++ b/docs/DEEPSEEK_V4_FLASH_QUICKSTART.md
@@ -152,15 +152,16 @@ docker run -d --name deepseek-v4-flash-r"$RANK" \
   $([ "$RANK" -eq 0 ] && echo "--host 0.0.0.0 --port 8000" || echo "--headless")
 ```
 
-The environment a rank needs is larger than the five variables in
-section 4. A launch also requires `LD_PRELOAD` naming
-`/usr/local/cuda/compat/libcuda.so.1` and the patched
-`/opt/sparkring/nccl/libnccl.so.2`, and roughly twenty `NCCL_*`
-variables that select the ring algorithm, the two host channel adapters,
-and GID index 3. Without the compat preload the worker aborts on an
-undefined `cuTensorMapEncodeTiled`; without the NCCL configuration it
-aborts on an unhandled system error. A deployment carries these in a
-per-rank environment file.
+The full per-rank environment is tracked:
+[`scripts/config/deepseek-v4-flash-0731.env.example`](../scripts/config/deepseek-v4-flash-0731.env.example),
+taken verbatim from the environment of a deployment that serves this
+checkpoint. Copy it to one file per rank and replace its two
+placeholders — the rank's fabric interface (`enp1s0f0np0` on even ranks,
+`enp1s0f1np1` on odd, matching the ring cabling) and that interface's
+address. Everything else is identical on every rank. `LD_PRELOAD` and the
+patched NCCL it names are required: without the compat preload the worker
+aborts on an undefined `cuTensorMapEncodeTiled`, and without the `NCCL_*`
+configuration it aborts on an unhandled system error.
 
 Every rank must hold the image before any rank launches. Rendezvous
 waits 601 seconds for all four; a rank still pulling when the others
@@ -195,15 +196,10 @@ misread as load-bearing:
   variable such as `SPARKRING_MTP_DRAFT_PATH` is absent, which it is for
   this checkpoint.
 
-Environment the B12X kernel family needs on every rank:
-
-```bash
-VLLM_USE_B12X_MOE=1
-VLLM_USE_B12X_FP8_GEMM=1
-VLLM_USE_B12X_SPARSE_INDEXER=1
-VLLM_USE_B12X_MHC=1
-VLLM_DSPARK_GPU_REJECTED_CONTEXT_MASK=1
-```
+The B12X and DSpark variables the kernel family reads are part of the
+tracked environment file above; nothing beyond it is required. The
+serving environment this page's observations come from does not set
+`VLLM_DSPARK_GPU_REJECTED_CONTEXT_MASK`.
 
 This launch attaches no external key-value cache tier. The engine's
 own prefix caching is unaffected and remains active; external reuse is

--- a/scripts/config/deepseek-v4-flash-0731.env.example
+++ b/scripts/config/deepseek-v4-flash-0731.env.example
@@ -1,0 +1,90 @@
+# Per-rank container environment for serving DeepSeek-V4-Flash-0731 on the
+# four-Spark ring, consumed by the docker run --env-file in
+# docs/DEEPSEEK_V4_FLASH_QUICKSTART.md. Copy to one file per rank and replace
+# the two placeholders; everything else is identical on every rank.
+#
+#   <NCCL_SOCKET_IFNAME>  the rank's cage-0 netdev on even ranks
+#                         (enp1s0f0np0) and cage-1 on odd ranks (enp1s0f1np1),
+#                         matching the ring cabling in docs/ARCHITECTURE.md
+#   <RANK_FABRIC_IP>      this rank's address on that interface; the launch's
+#                         --master-addr is rank 0's value of it
+#
+# Every library path below exists in the published serving image
+# ghcr.io/fujitsupolycom/gb10-vllm-serving@sha256:6fc26fdad81a18f0fff67ce0a0
+# 5f6d90165625ea2e1cac8a6f39bfb462017028; the loader preload and the patched
+# NCCL are required, and a worker aborts without them.
+
+LD_PRELOAD=/usr/local/cuda/compat/libcuda.so.1:/opt/sparkring/nccl/libnccl.so.2
+VLLM_NCCL_SO_PATH=/opt/sparkring/nccl/libnccl.so.2
+TORCH_USE_RTLD_GLOBAL=1
+
+NCCL_SOCKET_IFNAME=<NCCL_SOCKET_IFNAME>
+GLOO_SOCKET_IFNAME=<NCCL_SOCKET_IFNAME>
+VLLM_HOST_IP=<RANK_FABRIC_IP>
+
+NCCL_NET=IB
+NCCL_NET_PLUGIN=none
+NCCL_IB_DISABLE=0
+NCCL_IB_HCA=rocep1s0f0,rocep1s0f1
+NCCL_IB_GID_INDEX=3
+NCCL_IB_SUBNET_PREFIX_LEN=24
+NCCL_IB_SUBNET_AWARE_ROUTING=1
+NCCL_IB_MERGE_NICS=0
+NCCL_ALGO=Ring
+NCCL_PROTO=LL,LL128,Simple
+NCCL_P2P_LEVEL=SYS
+NCCL_MIN_NCHANNELS=4
+NCCL_MAX_NCHANNELS=4
+NCCL_CROSS_NIC=1
+NCCL_CUMEM_ENABLE=0
+NCCL_SKIP_TREE_CONNECT=1
+NCCL_IGNORE_CPU_AFFINITY=1
+NCCL_DEBUG=WARN
+NCCL_LOCAL_INFERENCE_PATH=/opt/libnccl-local-inference.so.2.30.4
+NCCL_PR2127_PATH=/opt/libnccl-local-inference.so.2.30.4
+
+VLLM_USE_B12X_MOE=1
+VLLM_USE_B12X_FP8_GEMM=1
+VLLM_USE_B12X_SPARSE_INDEXER=1
+VLLM_USE_B12X_MHC=1
+VLLM_USE_B12X_DCP_A2A=1
+VLLM_USE_B12X_WO_PROJECTION=1
+B12X_DENSE_SPLITK_TURBO=1
+B12X_MLA_SM120_UNIFIED=1
+B12X_MOE_FORCE_A16=1
+B12X_MOE_FORCE_A8=0
+B12X_W4A16_TC_DECODE=1
+B12X_W4A8_TINY_DECODE=1
+
+VLLM_DSPARK_IMPL=upstream
+VLLM_DSPARK_GREEDY_DRAFT=0
+VLLM_DSPARK_FP8_BATCH_ADAPTIVE=0
+VLLM_DSPARK_FP8_LM_HEAD=1
+VLLM_DSPARK_FP8_MAIN_PROJ=1
+VLLM_DSPARK_KV_QAT=1
+VLLM_DSPARK_CONFIDENCE_SCHEDULER=off
+VLLM_DSPARK_CONFIDENCE_THRESHOLD=0.0
+VLLM_DSPARK_MARKOV_SCALE=1.0
+VLLM_DSPARK_MARKOV_W2_BF16=1
+VLLM_DSPARK_MARKOV_W2_FP8=1
+VLLM_DSPARK_REPLICATE_MARKOV_W1=1
+VLLM_DSPARK_REPLICATE_MARKOV_W2=1
+VLLM_DSPARK_FUSED_MARKOV_ARGMAX=0
+VLLM_DSPARK_PREFIX_HIT_HOLDBACK=0
+
+CUTE_DSL_ARCH=sm_121a
+FLASHINFER_CUDA_ARCH_LIST=12.1f
+FLASHINFER_LOCAL_VERSION=cu132
+FLASHINFER_DISABLE_VERSION_CHECK=1
+FLASHINFER_WORKSPACE_BASE=/cache/jit/flashinfer
+CUDA_DEVICE_ORDER=PCI_BUS_ID
+CUDA_DEVICE_MAX_CONNECTIONS=32
+PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True
+SAFETENSORS_FAST_GPU=1
+OMP_NUM_THREADS=16
+HF_HOME=/root/.cache/huggingface
+HF_HUB_OFFLINE=1
+XDG_CACHE_HOME=/cache/jit
+TRITON_CACHE_DIR=/cache/jit/triton
+VLLM_CACHE_ROOT=/cache/jit/vllm
+VLLM_NO_USAGE_STATS=1


### PR DESCRIPTION
The quickstart's launch consumes an `--env-file` it described only by category — a loader preload, ~20 `NCCL_*` variables, a kernel-family block — *"a deployment carries these in a per-rank environment file."* A reader had every command except the file the commands require. Same gap class the GLM path had.

## What's added

`scripts/config/deepseek-v4-flash-0731.env.example` — the environment, verbatim from a deployment that serves this checkpoint, reduced to what that deployment sets (~80 variables). Two placeholders vary per rank: the fabric interface (cage 0 on even ranks, cage 1 on odd, matching the ring cabling) and its address. Every library path the file names was verified present in the pinned published digest (`libcuda` compat symlink, patched NCCL 2.30.7, the local-inference NCCL build).

The quickstart replaces both prose inventories with the tracked file. One drift fixed: the page required `VLLM_DSPARK_GPU_REJECTED_CONTEXT_MASK=1`, and the serving deployment's environment does not set it — the requirement is gone, and the page says so.

## Verification boundary, stated in the page itself

A four-rank launch supplying the tracked file **alone** has not run; the page says the file's sufficiency is inherited from the deployment it was taken from rather than demonstrated, and removing that sentence requires running that launch. The live pass is fully staged — pull the pinned digest on all four ranks, render the template per rank, launch verbatim, health + completion — and blocked only on the ring being free.

`scripts` + `runtime`: 2133 passed, 12 skipped. Publication consistency: PASS.