### PR TITLE
Align the graph-command test with the Q512 allreduce geometry

### DIFF
--- a/spark_transport/tests/tp4_graph_command_test.cpp
+++ b/spark_transport/tests/tp4_graph_command_test.cpp
@@ -74,9 +74,9 @@ int main() {
       kTp4GraphMaximumQ + 1,
       tp4_graph_payload_bytes(kTp4GraphMaximumQ + 1)));
   static_assert(kTp4GraphMaximumQ == 40);
-  static_assert(kTp4GraphAllreduceMaximumQ == 1024);
+  static_assert(kTp4GraphAllreduceMaximumQ == 512);
   static_assert(tp4_graph_payload_bytes(kTp4GraphAllreduceMaximumQ) ==
-                12U * 1024U * 1024U);
+                6U * 1024U * 1024U);
   assert(tp4_graph_allreduce_command_descriptor_valid(
       kTp4GraphAllreduceMaximumQ,
       tp4_graph_payload_bytes(kTp4GraphAllreduceMaximumQ)));
@@ -91,13 +91,16 @@ int main() {
   constexpr std::uint32_t deepseek_bytes_per_row = 4096U * 2U;
   static_assert(tp4_graph_payload_bytes(1, deepseek_bytes_per_row) ==
                 8192U);
-  static_assert(tp4_graph_payload_bytes(1024, deepseek_bytes_per_row) ==
-                8U * 1024U * 1024U);
+  static_assert(tp4_graph_payload_bytes(kTp4GraphAllreduceMaximumQ,
+                                        deepseek_bytes_per_row) ==
+                4U * 1024U * 1024U);
   assert(tp4_graph_command_layout_valid(
       30, tp4_graph_payload_bytes(30, deepseek_bytes_per_row),
       deepseek_bytes_per_row, kTp4GraphAllreduceMaximumQ));
   assert(tp4_graph_command_layout_valid(
-      1024, tp4_graph_payload_bytes(1024, deepseek_bytes_per_row),
+      kTp4GraphAllreduceMaximumQ,
+      tp4_graph_payload_bytes(kTp4GraphAllreduceMaximumQ,
+                              deepseek_bytes_per_row),
       deepseek_bytes_per_row, kTp4GraphAllreduceMaximumQ));
   assert(!tp4_graph_command_layout_valid(
       30, tp4_graph_payload_bytes(30), deepseek_bytes_per_row,
@@ -145,7 +148,7 @@ int main() {
       &allreduce_maximum_q, 1, &allreduce_maximum_q_command));
   assert(allreduce_maximum_q_command.q == kTp4GraphAllreduceMaximumQ);
   assert(allreduce_maximum_q_command.payload_bytes ==
-         12U * 1024U * 1024U);
+         6U * 1024U * 1024U);
 
   std::uint64_t sequence{99};
   assert(!tp4_graph_command_publish_descriptor(


### PR DESCRIPTION
## Behavior

`spark_transport/tests/tp4_graph_command_test.cpp` asserts the geometry that `spark_transport/include/spark_transport/tp4_graph_command.hpp` declares: `kTp4GraphAllreduceMaximumQ = 512`, a 6 MiB maximum payload at 12,288 bytes per row, and 4 MiB at the 8,192-byte DeepSeek row.

## Technical reason

The header declares the 512-row allreduce geometry, but the test asserted the superseded 1024-row values (12 MiB and 8 MiB payloads). The mismatch is a `static_assert` compile failure that also blocks every ctest target ordered after this one, so the native test suite cannot run on `main`.

## Compatibility impact

Test-only. No library, ABI, or interface change. The Python transport modules already carry the 512-row cap (`_ALLREDUCE_PREFILL_MAX_QUERY_ROWS = 512`) and are unchanged.

## Validation

On a GB10 aarch64 host: `cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_CUDA_ARCHITECTURES=121` configures, every target builds and links, and `ctest` passes 18 of 18.