### PR TITLE
Resolve the build parent from the local store under BuildKit

### DIFF
--- a/runtime/exl3-r7/build-image.sh
+++ b/runtime/exl3-r7/build-image.sh
@@ -95,11 +95,20 @@ mv "${context}/sources/b12x" "${context}/bundle/b12x"
 source_receipt_sha="$(sha256sum "${context}/sources/receipt.json" | awk '{print $1}')"
 rm -rf -- "${context}/sources"
 
+# BuildKit resolves a bare sha256 image ID in FROM against the registry, not
+# the local store, so the verified parent is retagged under a local name for
+# the build. Identity remains enforced: the tag is applied to the observed ID
+# after the drift check, and the ID itself is recorded via BASE_IMAGE_ID.
+parent_build_tag="sparkring-r7-parent:${observed_base#sha256:}"
+parent_build_tag="${parent_build_tag:0:70}"
+"${engine}" tag "${observed_base}" "${parent_build_tag}"
+trap '"${engine}" rmi "${parent_build_tag}" >/dev/null 2>&1 || true; rm -rf -- "${context}"' EXIT
+
 "${engine}" build \
   --platform linux/arm64 \
   --file "${context}/Containerfile" \
   --tag "${image}" \
-  --build-arg "BASE_IMAGE=${observed_base}" \
+  --build-arg "BASE_IMAGE=${parent_build_tag}" \
   --build-arg "BASE_IMAGE_ID=${observed_base}" \
   --build-arg "BASE_IMAGE_LICENSES=${base_image_licenses}" \
   --build-arg "IMAGE_LICENSES=${image_licenses}" \


### PR DESCRIPTION
## Resulting behavior

`runtime/exl3-r7/build-image.sh` retags the verified parent image ID under a build-local name, passes that name as the `BASE_IMAGE` build argument, and removes the tag on exit. `BASE_IMAGE_ID` still records the immutable ID.

## Technical reason

The script passed the bare sha256 image ID into the Containerfile `FROM`. BuildKit resolves a bare ID as a registry repository name, so the build fails with a pull-authorization error wherever BuildKit is the default builder; the legacy builder resolves the ID locally but never sets `TARGETARCH`, which the Containerfile requires. No engine configuration satisfies both without this change.

## Compatibility impact

None. The produced image, its labels, and the identity gate are unchanged: the tag is applied only to the observed ID after the drift check.

## Validation

On a GB10 aarch64 host with Docker defaulting to BuildKit, the unpatched script fails at `FROM` with `pull access denied`; the patched script proceeds past parent resolution into the build steps.