### PR TITLE
Prepare exact-Q40 overlay inputs inside the image build context

### DIFF
--- a/runtime/exl3-r7/build-image.sh
+++ b/runtime/exl3-r7/build-image.sh
@@ -65,6 +65,15 @@ else
   python3 "${here}/prepare_context.py" "${context}/sources"
 fi
 
+# The image bake verifies the exact-Q40 overlay input state of the vLLM tree
+# (bake_runtime_artifacts.py pins the post-preparation exl3.py hash), while
+# receipt verification accepts only the pristine prepared tree. Apply the
+# overlay-input preparation to the build-context copy so both gates hold: the
+# original prepared tree stays receipt-clean, and the tree entering the image
+# carries the state the bake requires.
+python3 "${repo_root}/scripts/glm35_q40/prepare_q40_overlay_inputs.py" \
+  "${context}/sources/vllm"
+
 cp "${here}/Containerfile" "${context}/Containerfile"
 python3 "${here}/prepare_build_deps.py" "${deps_cache}"
 python3 "${here}/prepare_build_deps.py" --verify "${deps_cache}"


### PR DESCRIPTION
## Resulting behavior

`build-image.sh` runs `scripts/glm35_q40/prepare_q40_overlay_inputs.py` on the build-context copy of the vLLM tree after materializing or receipt-verifying sources. The original prepared tree stays receipt-clean; the tree entering the image carries the overlay-input state.

## Technical reason

`bake_runtime_artifacts.py` pins `exl3.py` to its post-preparation hash, while `build-image.sh` accepts prepared sources only when pristine against their receipt. A raw tree fails the bake; a prepared-input tree fails receipt verification. No source state satisfied both gates, so the documented image build could not complete.

## Compatibility impact

None. The produced image content is what the bake already required.

## Validation

On a GB10 aarch64 host the unpatched build fails in the bake step with an `exl3.py` SHA-256 mismatch (expected `8e0051fa…`, got `42c0e915…`); the overlay-input tool transforms exactly that input hash to the expected value.