### PR TITLE
Run the cudagraph bake before the vLLM bake in the image build

### DIFF
--- a/runtime/exl3-r7/Containerfile
+++ b/runtime/exl3-r7/Containerfile
@@ -69,6 +69,8 @@ ENV TORCH_CUDA_ARCH_LIST=12.1a \
 RUN --mount=type=cache,id=sparkring-r7-ccache,target=/cache/jit/ccache,sharing=locked \
     rm -f /opt/venv/lib/python3.12/site-packages/sparkring_nf3_hybrid.pth \
  && /opt/venv/bin/python /opt/r7-src/runtime/bake_runtime_artifacts.py \
+      cudagraph /opt/r7-src/vllm \
+ && /opt/venv/bin/python /opt/r7-src/runtime/bake_runtime_artifacts.py \
       vllm /opt/r7-src/vllm \
  && /opt/venv/bin/python \
       /opt/r7-src/runtime/build_parallel_state_shared_capture_overlay.py \

--- a/runtime/exl3-r7/build-image.sh
+++ b/runtime/exl3-r7/build-image.sh
@@ -84,6 +84,8 @@ cp "${here}/verify_runtime.py" "${context}/bundle/runtime/verify_runtime.py"
 cp "${here}/entrypoint.sh" "${context}/bundle/runtime/entrypoint.sh"
 cp "${here}/bake_runtime_artifacts.py" \
   "${context}/bundle/runtime/bake_runtime_artifacts.py"
+cp "${here}/cudagraph_shared_stream.patch" \
+  "${context}/bundle/runtime/cudagraph_shared_stream.patch"
 cp "${here}/build_parallel_state_shared_capture_overlay.py" \
   "${context}/bundle/runtime/build_parallel_state_shared_capture_overlay.py"
 cp "${here}/requirements-quack.txt" \


### PR DESCRIPTION
## Resulting behavior

The Containerfile runs `bake_runtime_artifacts.py cudagraph` before the `vllm` component, and `build-image.sh` ships `cudagraph_shared_stream.patch` into the build bundle.

## Technical reason

The `vllm` bake's pre-install check requires `cudagraph_utils.py` at its post-patch hash, but no build step invoked the `cudagraph` component that applies the pinned patch, so the check always failed against the unpatched file.

## Compatibility impact

None. The produced image carries the cudagraph edit the vllm bake already required; the component is idempotent when the file already carries it.

## Validation

On a GB10 aarch64 host the unpatched build fails the vllm bake with a `cudagraph_utils.py` SHA-256 mismatch (expected `ef03d642…`, got `a55362bc…`); the cudagraph component transforms exactly that input hash to the expected value.