### PR TITLE
Document a two-Spark DeepSeek topology, and require the fabric routing checks

### DIFF
--- a/docs/DEEPSEEK_V4_FLASH_QUICKSTART.md
+++ b/docs/DEEPSEEK_V4_FLASH_QUICKSTART.md
@@ -1,18 +1,39 @@
-# DeepSeek-V4-Flash-0731 four-Spark quickstart
+# DeepSeek-V4-Flash-0731 Spark quickstart
 
-Deploy `deepseek-ai/DeepSeek-V4-Flash-0731` as four tensor-parallel ranks on a
-directly cabled DGX Spark cycle. The profile is **implemented** and is not
-qualified. No checkpoint revision is pinned in this repository;
-record the revision and file hashes used by an operator deployment.
-The machine-readable serving contract is
-[`recipes/deepseek-v4-flash-0731.json`](../recipes/deepseek-v4-flash-0731.json).
+Deploy `deepseek-ai/DeepSeek-V4-Flash-0731` across directly cabled DGX Sparks
+in either of two topologies: **two tensor-parallel ranks on a cabled pair**, or
+**four on a cycle**. Both profiles are **implemented** and neither is
+qualified. No checkpoint revision is pinned in this repository; record the
+revision and file hashes used by an operator deployment.
+
+The machine-readable serving contracts are
+[`recipes/deepseek-v4-flash-0731-pair.json`](../recipes/deepseek-v4-flash-0731-pair.json)
+for the pair and
+[`recipes/deepseek-v4-flash-0731.json`](../recipes/deepseek-v4-flash-0731.json)
+for the cycle.
+
+The two topologies differ in exactly three places: the parallelism flags, the
+per-rank key-value reservation and request length that follow from how much of
+the model each rank holds, and the transport half of the environment template.
+Everything else — image, entrypoint, checkpoint, speculation, parsers,
+verification — is identical.
+
+| | Two-Spark pair | Four-Spark cycle |
+|---|---|---|
+| Ranks | 0-1 | 0-3 |
+| Cabling | one DAC, cage 0 to cage 0 | four DACs as `0-1-2-3-0` |
+| Weight share per rank | one half | one quarter |
+| `--tensor-parallel-size` / `--nnodes` | 2 | 4 |
+| `--kv-cache-memory-bytes` | 10737418240 (10 GiB) | 34359738368 (32 GiB) |
+| `--max-model-len` | 131072 | 524288 |
+| Environment template | `deepseek-v4-flash-0731-pair.env.example` | `deepseek-v4-flash-0731.env.example` |
 
 ## 1. Prepare the ranks
 
-Complete [the prerequisites](PREREQUISITES.md). Download the official FP8
-checkpoint once, distribute identical bytes to all four ranks, and choose the
-same container model mount on each host. The model contains 48 safetensors
-shards totaling about 167 GB.
+Complete [the prerequisites](PREREQUISITES.md) for the topology you are
+deploying. Download the official FP8 checkpoint once, distribute identical
+bytes to every rank, and choose the same container model mount on each host.
+The model contains 48 safetensors shards totaling about 167 GB.
 
 Pull the immutable ARM64 runtime image on every rank before launching any rank:
 
@@ -25,9 +46,18 @@ This is the `serving_image.manifest_digest` pinned by
 registers `DeepseekV4ForCausalLM`; override its GLM-specific entrypoint as shown
 below.
 
-Copy the tracked environment template to one local file per rank. Replace only
-`<NCCL_SOCKET_IFNAME>` and `<RANK_FABRIC_IP>`. Even ranks use cage 0
-(`enp1s0f0np0`) and odd ranks use cage 1 (`enp1s0f1np1`) for the cycle.
+Copy the environment template for your topology to one local file per rank.
+
+For a pair, replace `<FABRIC_IFNAME>`, `<RANK_FABRIC_IP>`, and `<GID_INDEX>`.
+Both ranks name the same interface when the pair is cabled cage 0 to cage 0:
+
+```bash
+cp scripts/config/deepseek-v4-flash-0731-pair.env.example /path/to/rank-0.env
+cp scripts/config/deepseek-v4-flash-0731-pair.env.example /path/to/rank-1.env
+```
+
+For a cycle, replace `<NCCL_SOCKET_IFNAME>` and `<RANK_FABRIC_IP>`. Even ranks
+use cage 0 (`enp1s0f0np0`) and odd ranks use cage 1 (`enp1s0f1np1`):
 
 ```bash
 cp scripts/config/deepseek-v4-flash-0731.env.example /path/to/rank-0.env
@@ -36,20 +66,74 @@ cp scripts/config/deepseek-v4-flash-0731.env.example /path/to/rank-2.env
 cp scripts/config/deepseek-v4-flash-0731.env.example /path/to/rank-3.env
 ```
 
-The template's `LD_PRELOAD`, `VLLM_NCCL_SO_PATH`, and `NCCL_*` values are
-required by the published image. Do not use a GLM profile environment file.
+The templates' `LD_PRELOAD`, `VLLM_NCCL_SO_PATH`, and `NCCL_*` values are
+required by the published image. Do not use a GLM profile environment file, and
+do not use the cycle template on a pair: its transport settings name two host
+channel adapters, enable subnet-aware routing, and skip tree connect, none of
+which applies when the two ranks are directly adjacent.
+
+The `<GID_INDEX>` placeholder in the pair template is the RoCE GID index for
+that interface's IPv4 address. `show_gids` lists them. Do not copy a value from
+another deployment; the correct index depends on the RoCE version and the
+address configured on the host.
 
 ## 2. Launch one rank per host
 
-Set `RANK` to `0`, `1`, `2`, or `3` on the corresponding host. Set
-`RANK0_FABRIC_ADDR` to rank 0's selected fabric address. Rank 0 serves the API;
-the other ranks must use `--headless`.
+Both launches mount a writable `/cache` directory. The environment sets
+`XDG_CACHE_HOME=/cache/jit`, so without that mount every replaced container
+recompiles its just-in-time kernels from scratch.
+
+### Two-Spark pair
+
+Set `RANK` to `0` or `1` on the corresponding host, and `RANK0_FABRIC_ADDR` to
+rank 0's fabric address. Rank 0 serves the API; rank 1 must use `--headless`.
 
 ```bash
 docker run -d --name deepseek-v4-flash-r"$RANK" \
   --network host --ipc host --shm-size 16g --gpus all \
   --ulimit memlock=-1:-1 --device /dev/infiniband \
   -v /path/to/deepseek-v4-flash-0731:/models/deepseek-v4-flash-0731:ro \
+  -v /path/to/jit-cache:/cache \
+  --env-file /path/to/rank-"$RANK".env \
+  --entrypoint /opt/venv/bin/vllm \
+  ghcr.io/fujitsupolycom/gb10-vllm-serving@sha256:6fc26fdad81a18f0fff67ce0a05f6d90165625ea2e1cac8a6f39bfb462017028 \
+  serve /models/deepseek-v4-flash-0731 \
+  --tensor-parallel-size 2 --nnodes 2 --node-rank "$RANK" \
+  --master-addr "$RANK0_FABRIC_ADDR" --master-port 29500 \
+  --distributed-executor-backend mp \
+  --dtype bfloat16 \
+  --max-model-len 131072 \
+  --max-num-seqs 32 \
+  --gpu-memory-utilization 0.70 \
+  --kv-cache-memory-bytes 10737418240 \
+  --kv-cache-dtype fp8_ds_mla \
+  --tokenizer-mode deepseek_v4 \
+  --kernel-config '{"enable_cutedsl_warmup": false}' \
+  --enable-auto-tool-choice --tool-call-parser deepseek_v4 \
+  --speculative-config '{"method": "dspark",
+    "num_speculative_tokens": 5, "moe_backend": "b12x"}' \
+  --served-model-name deepseek-v4-flash-0731 \
+  $([ "$RANK" -eq 0 ] && echo "--host 0.0.0.0 --port 8000" || echo "--headless")
+```
+
+Two ranks hold half the weights each rather than a quarter, so less memory
+remains for the key-value reservation than on a cycle. The 10 GiB reservation
+and 131,072 request length above are the documented pair values. Raising either
+without measuring free memory after load risks a rank being killed during
+startup; on this platform that failure can leave the host answering ICMP while
+refusing to complete any new connection, recoverable only by a power cycle.
+
+### Four-Spark cycle
+
+Set `RANK` to `0`, `1`, `2`, or `3` on the corresponding host. Rank 0 serves the
+API; the other ranks must use `--headless`.
+
+```bash
+docker run -d --name deepseek-v4-flash-r"$RANK" \
+  --network host --ipc host --shm-size 16g --gpus all \
+  --ulimit memlock=-1:-1 --device /dev/infiniband \
+  -v /path/to/deepseek-v4-flash-0731:/models/deepseek-v4-flash-0731:ro \
+  -v /path/to/jit-cache:/cache \
   --env-file /path/to/rank-"$RANK".env \
   --entrypoint /opt/venv/bin/vllm \
   ghcr.io/fujitsupolycom/gb10-vllm-serving@sha256:6fc26fdad81a18f0fff67ce0a05f6d90165625ea2e1cac8a6f39bfb462017028 \
@@ -72,10 +156,10 @@ docker run -d --name deepseek-v4-flash-r"$RANK" \
   $([ "$RANK" -eq 0 ] && echo "--host 0.0.0.0 --port 8000" || echo "--headless")
 ```
 
-`--kv-cache-dtype fp8_ds_mla` is required: it declares the model's MLA
-key-value geometry and matches the allocated layout. Do not substitute generic
-`fp8`. The 32 GiB reservation and 0.70 memory utilization are the documented
-GB10 values for this launch.
+`--kv-cache-dtype fp8_ds_mla` is required in both topologies: it declares the
+model's MLA key-value geometry and matches the allocated layout. Do not
+substitute generic `fp8`. `--gpu-memory-utilization 0.70` is the documented
+GB10 value for both launches.
 
 ## 3. Verify rank 0
 
@@ -89,14 +173,16 @@ curl -s localhost:8000/v1/chat/completions \
        "max_tokens":16,"temperature":0}'
 ```
 
-Check rank logs for successful four-rank rendezvous and DSpark metrics. `Mean
-acceptance length` above one confirms speculative decoding is active.
+Check rank logs for a successful rendezvous across every rank and for DSpark
+metrics. `Mean acceptance length` above one confirms speculative decoding is
+active, and `GPU KV cache size` reports the token capacity the reservation
+bought.
 
 ## Evidence boundary
 
-The four-Spark implemented launch exercised API health, chat completions, tool
-calling, and DSpark speculation. Its performance observations are not qualified
-measurements. The normal launch uses patched NCCL from the environment template;
-SIRCL width-4096 graph collectives are research-only and are not part of this
-quickstart. See [the profile record](profiles/DEEPSEEK_V4_FLASH_0731.md) and
+Both launches exercised API health, chat completions, tool calling, and DSpark
+speculation. Performance observations are not qualified measurements. The
+normal launch uses patched NCCL from the environment template; SIRCL width-4096
+graph collectives are research-only and are not part of this quickstart. See
+[the profile record](profiles/DEEPSEEK_V4_FLASH_0731.md) and
 [results](RESULTS.md).

--- a/docs/DEEPSEEK_V4_FLASH_QUICKSTART.md
+++ b/docs/DEEPSEEK_V4_FLASH_QUICKSTART.md
@@ -194,9 +194,12 @@ speculation ran at depth 5 with a 2.76 mean acceptance length. It mounted only
 the checkpoint and a cache directory, so the published image needs no source
 overlay.
 
-The four-Spark launch carries the earlier recorded cycle deployment's evidence:
-API health, chat completions, tool calling, and DSpark speculation. It has not
-been re-exercised against the pinned image published here.
+The four-Spark launch was exercised on 2026-08-21 against the same pinned
+image: all four ranks rendezvoused across the cycle, each loading 40.82 GiB of
+weights, the engine reported a 4,382,668-token key-value pool at 8.36x maximum
+concurrency, a deterministic completion and an emitted tool call were correct,
+and DSpark speculation ran at depth 5 with a 3.06 mean acceptance length. It
+mounted only the checkpoint and a cache directory.
 
 Performance observations in either topology are not qualified measurements. The
 normal launch uses patched NCCL from the environment template; SIRCL width-4096

--- a/docs/DEEPSEEK_V4_FLASH_QUICKSTART.md
+++ b/docs/DEEPSEEK_V4_FLASH_QUICKSTART.md
@@ -185,8 +185,20 @@ bought.
 
 ## Evidence boundary
 
-Both launches exercised API health, chat completions, tool calling, and DSpark
-speculation. Performance observations are not qualified measurements. The
+Each topology carries its own evidence, recorded in its serving contract.
+
+The two-Spark launch was exercised on 2026-08-21 on two directly cabled Sparks:
+both ranks rendezvoused, a deterministic completion, an emitted tool call and a
+34-tool chat request returned coherent output with no leaked markers, and DSpark
+speculation ran at depth 5 with a 2.76 mean acceptance length. It mounted only
+the checkpoint and a cache directory, so the published image needs no source
+overlay.
+
+The four-Spark launch carries the earlier recorded cycle deployment's evidence:
+API health, chat completions, tool calling, and DSpark speculation. It has not
+been re-exercised against the pinned image published here.
+
+Performance observations in either topology are not qualified measurements. The
 normal launch uses patched NCCL from the environment template; SIRCL width-4096
 graph collectives are research-only and are not part of this quickstart. See
 [the profile record](profiles/DEEPSEEK_V4_FLASH_0731.md) and

--- a/docs/DEEPSEEK_V4_FLASH_QUICKSTART.md
+++ b/docs/DEEPSEEK_V4_FLASH_QUICKSTART.md
@@ -31,9 +31,14 @@ verification — is identical.
 ## 1. Prepare the ranks
 
 Complete [the prerequisites](PREREQUISITES.md) for the topology you are
-deploying. Download the official FP8 checkpoint once, distribute identical
-bytes to every rank, and choose the same container model mount on each host.
-The model contains 48 safetensors shards totaling about 167 GB.
+deploying, including the fabric routing and forwarding checks. On a cycle, a
+rendezvous reaches ranks that are not directly cabled to each other only if
+every node relays for its neighbours, and Docker's default `FORWARD` policy
+blocks that relay.
+
+Download the official FP8 checkpoint once, distribute identical bytes to every
+rank, and choose the same container model mount on each host. The model
+contains 48 safetensors shards totaling about 167 GB.
 
 Pull the immutable ARM64 runtime image on every rank before launching any rank:
 

--- a/docs/DEEPSEEK_V4_FLASH_QUICKSTART.md
+++ b/docs/DEEPSEEK_V4_FLASH_QUICKSTART.md
@@ -12,21 +12,25 @@ for the pair and
 [`recipes/deepseek-v4-flash-0731.json`](../recipes/deepseek-v4-flash-0731.json)
 for the cycle.
 
-The two topologies differ in exactly three places: the parallelism flags, the
-per-rank key-value reservation and request length that follow from how much of
-the model each rank holds, and the transport half of the environment template.
-Everything else — image, entrypoint, checkpoint, speculation, parsers,
-verification — is identical.
+Both topologies serve the checkpoint's full 1,048,576-token request length with
+identical scheduler settings. They differ in the parallelism flags, the
+key-value reservation each node can afford, and the transport half of the
+environment template. Image, entrypoint, checkpoint, speculation, parsers and
+verification are shared.
 
 | | Two-Spark pair | Four-Spark cycle |
 |---|---|---|
 | Ranks | 0-1 | 0-3 |
 | Cabling | one DAC, cage 0 to cage 0 | four DACs as `0-1-2-3-0` |
-| Weight share per rank | one half | one quarter |
+| Weights resident per rank | 80.97 GiB | 40.82 GiB |
 | `--tensor-parallel-size` / `--nnodes` | 2 | 4 |
-| `--kv-cache-memory-bytes` | 10737418240 (10 GiB) | 34359738368 (32 GiB) |
-| `--max-model-len` | 131072 | 524288 |
+| `--kv-cache-memory-bytes` | 12884901888 (12 GiB) | 17179869184 (16 GiB) |
+| Resulting pool / concurrency at 1M | 1,139,967 tokens, 1.09x | 1,519,925 tokens, 1.45x |
+| Free memory per node while serving | 8-10 GB | ~50 GB |
 | Environment template | `deepseek-v4-flash-0731-pair.env.example` | `deepseek-v4-flash-0731.env.example` |
+
+`--max-model-len 1048576`, `--max-num-seqs 32` and `--max-num-batched-tokens
+8192` are the same in both.
 
 ## 1. Prepare the ranks
 
@@ -107,10 +111,11 @@ docker run -d --name deepseek-v4-flash-r"$RANK" \
   --master-addr "$RANK0_FABRIC_ADDR" --master-port 29500 \
   --distributed-executor-backend mp \
   --dtype bfloat16 \
-  --max-model-len 131072 \
+  --max-model-len 1048576 \
   --max-num-seqs 32 \
+  --max-num-batched-tokens 8192 \
   --gpu-memory-utilization 0.70 \
-  --kv-cache-memory-bytes 10737418240 \
+  --kv-cache-memory-bytes 12884901888 \
   --kv-cache-dtype fp8_ds_mla \
   --tokenizer-mode deepseek_v4 \
   --kernel-config '{"enable_cutedsl_warmup": false}' \
@@ -121,17 +126,11 @@ docker run -d --name deepseek-v4-flash-r"$RANK" \
   $([ "$RANK" -eq 0 ] && echo "--host 0.0.0.0 --port 8000" || echo "--headless")
 ```
 
-Two ranks hold half the weights each rather than a quarter, so less memory
-remains for the key-value reservation than on a cycle. The 10 GiB reservation
-and 131,072 request length above are the documented pair values. Raising either
-without measuring free memory after load risks a rank being killed during
-startup; on this platform that failure can leave the host answering ICMP while
-refusing to complete any new connection, recoverable only by a power cycle.
-
 ### Four-Spark cycle
 
 Set `RANK` to `0`, `1`, `2`, or `3` on the corresponding host. Rank 0 serves the
-API; the other ranks must use `--headless`.
+API; the other ranks must use `--headless`. The command is identical to the
+pair's except for the parallelism flags and the key-value reservation:
 
 ```bash
 docker run -d --name deepseek-v4-flash-r"$RANK" \
@@ -147,10 +146,11 @@ docker run -d --name deepseek-v4-flash-r"$RANK" \
   --master-addr "$RANK0_FABRIC_ADDR" --master-port 29500 \
   --distributed-executor-backend mp \
   --dtype bfloat16 \
-  --max-model-len 524288 \
+  --max-model-len 1048576 \
   --max-num-seqs 32 \
+  --max-num-batched-tokens 8192 \
   --gpu-memory-utilization 0.70 \
-  --kv-cache-memory-bytes 34359738368 \
+  --kv-cache-memory-bytes 17179869184 \
   --kv-cache-dtype fp8_ds_mla \
   --tokenizer-mode deepseek_v4 \
   --kernel-config '{"enable_cutedsl_warmup": false}' \
@@ -163,10 +163,53 @@ docker run -d --name deepseek-v4-flash-r"$RANK" \
 
 `--kv-cache-dtype fp8_ds_mla` is required in both topologies: it declares the
 model's MLA key-value geometry and matches the allocated layout. Do not
-substitute generic `fp8`. `--gpu-memory-utilization 0.70` is the documented
-GB10 value for both launches.
+substitute generic `fp8`.
 
-## 3. Verify rank 0
+## 3. Sizing: four coupled parameters, and one inactive guard
+
+`--max-model-len`, `--kv-cache-memory-bytes`, `--max-num-seqs` and
+`--max-num-batched-tokens` are not independent. Changing one alone will
+usually fail or waste memory.
+
+**Set `--max-num-batched-tokens` explicitly.** Left unset, the engine derives a
+scheduled-token budget from the speculation settings and warns that it is
+suboptimal: at 32 sequences and speculation depth 5 it derived 1,920 tokens.
+Setting 8192 raises the budget to 7,936 and measured **+51% aggregate
+throughput at 32 concurrent requests** on a pair, with single-stream and
+8-stream throughput unchanged. A small budget only bites once enough sequences
+compete for it.
+
+**A longer request limit is close to free; a larger pool is not.** This model
+has bounded cache groups whose cost per sequence is fixed, so per-token pool
+cost falls as the request limit rises — about 18.5 KB per token at a
+131,072-token limit and about 6 KB at 1,048,576. Raising `--max-model-len` from
+131,072 to 1,048,576 on a pair, changing nothing else, cost no additional
+memory.
+
+**Sequence count and speculation depth inflate the per-request floor.** The
+engine refuses to start unless the pool can hold one full-length request. On a
+pair at 1,048,576 tokens that floor was about 6.2 GiB at 32 sequences with the
+derived budget, and **11.04 GiB at 64 sequences with an 8192 budget** — the same
+context, nearly twice the floor. Raising sequences therefore forces a larger
+reservation, which buys less pool per byte: 64 sequences at 16 GiB produced a
+*smaller* pool (1,519,925 tokens) than 32 sequences at 12 GiB relative to the
+memory spent, while measuring within 2% on every concurrency cell. Prefer 32.
+
+**`--kv-cache-memory-bytes` disables the memory-utilization guard.** The engine
+states this explicitly: it "skipped memory profiling. This does not respect the
+`gpu_memory_utilization` config." `--gpu-memory-utilization 0.70` is therefore
+**not** a safety ceiling in either launch above — it is inert whenever an
+explicit byte count is given. Nothing will stop an oversized reservation from
+exhausting the node.
+
+Check free memory after a launch rather than trusting the flag. A pair serving
+this configuration reports 8-10 GB free per node; a cycle reports about 50 GB.
+A node driven to 2-3 GB free with swap in use is one long prefill away from
+having its engine core killed, and on this platform severe memory exhaustion
+can leave a host answering ICMP while refusing to complete any new connection,
+recoverable only by a power cycle.
+
+## 4. Verify rank 0
 
 Wait for the API health endpoint, then issue a deterministic chat request.
 
@@ -183,6 +226,42 @@ metrics. `Mean acceptance length` above one confirms speculative decoding is
 active, and `GPU KV cache size` reports the token capacity the reservation
 bought.
 
+## Measured
+
+Client-observed aggregate throughput, 256-token prompts, 512-token
+generations, both topologies on the settings above:
+
+| Concurrent requests | Two-Spark pair | Four-Spark cycle |
+|---:|---:|---:|
+| 1 | 36.7 tok/s | 56.5 tok/s |
+| 8 | 123.8 tok/s | 177.5 tok/s |
+| 16 | 173.4 tok/s | 256.1 tok/s |
+| 32 | 237.7 tok/s | 347.5 tok/s |
+
+Doubling the node count buys about 1.45x across the whole ladder rather than
+2x. Decode is latency-bound on collectives, not bandwidth-bound: the model
+issues two all-reduces per layer across 43 layers, about 688 KB per token in
+total, which is a fraction of a percent of a 200 Gb/s link, but each token
+waits on roughly 86 synchronous round-trips that cannot overlap, because
+decode is autoregressive: the input to step `N+1` includes the token produced
+at step `N`.
+
+Speculation amortises those round-trips. At a mean acceptance length of 3.06 on
+a cycle, one forward pass yields about three tokens, so the collectives cost
+roughly a third as much per output token. Raising acceptance is equivalent to
+making collectives cheaper.
+
+**Do not expect a faster all-reduce backend on this hardware.** The engine
+reports selecting `PYNCCL` from the potential set `NCCL_SYMM_MEM`,
+`QUICK_REDUCE`, `FLASHINFER`, `AITER_CUSTOM`, `CUSTOM`, `SYMM_MEM`, `PYNCCL`.
+Every faster entry requires peer-accessible GPU memory on one host — NVLink or
+PCIe peer-to-peer — or is ROCm-only. With one GPU per node communicating over
+RoCE, `PYNCCL` is the correct selection rather than a fallback. Setting
+`VLLM_ENABLE_PCIE_ALLREDUCE`, `VLLM_PCIE_ALLREDUCE_BACKEND=cpp` and
+`VLLM_CPP_AR_1STAGE_NCCL_CUTOFF` on a cycle changed nothing: 56.0 against 56.5
+tok/s at one request, 174.2 against 177.5 at eight. Those variables belong to
+single-host multi-GPU profiles and are not worth carrying here.
+
 ## Evidence boundary
 
 Each topology carries its own evidence, recorded in its serving contract.
@@ -195,14 +274,14 @@ the checkpoint and a cache directory, so the published image needs no source
 overlay.
 
 The four-Spark launch was exercised on 2026-08-21 against the same pinned
-image: all four ranks rendezvoused across the cycle, each loading 40.82 GiB of
-weights, the engine reported a 4,382,668-token key-value pool at 8.36x maximum
-concurrency, a deterministic completion and an emitted tool call were correct,
-and DSpark speculation ran at depth 5 with a 3.06 mean acceptance length. It
-mounted only the checkpoint and a cache directory.
+image: all four ranks rendezvoused, each loading 40.82 GiB of weights, a
+deterministic completion and an emitted tool call were correct, and DSpark
+speculation ran at depth 5 with a 3.06 mean acceptance length.
 
-Performance observations in either topology are not qualified measurements. The
-normal launch uses patched NCCL from the environment template; SIRCL width-4096
-graph collectives are research-only and are not part of this quickstart. See
+Throughput figures above are client-observed on the stated prompt and
+generation lengths. They are not qualified measurements, and no output-quality
+measurement of any kind is recorded for either topology. The normal launch uses
+patched NCCL from the environment template; SIRCL width-4096 graph collectives
+are research-only and are not part of this quickstart. See
 [the profile record](profiles/DEEPSEEK_V4_FLASH_0731.md) and
 [results](RESULTS.md).

--- a/docs/PREREQUISITES.md
+++ b/docs/PREREQUISITES.md
@@ -1,20 +1,35 @@
 # SparkRing prerequisites
 
-Complete this checklist before deploying either supported four-DGX-Spark profile.
-It defines the hardware and operator conditions required by the
+Complete this checklist before deploying any supported profile. It defines the
+hardware and operator conditions required by the
 [GLM](GLM52_35BPW_QUICKSTART.md) and
-[DeepSeek](DEEPSEEK_V4_FLASH_QUICKSTART.md) quickstarts.
+[DeepSeek](DEEPSEEK_V4_FLASH_QUICKSTART.md) quickstarts. The GLM quickstart and
+the DeepSeek four-Spark cycle require four Sparks; the DeepSeek two-Spark pair
+requires two.
 
 ## Hardware and topology
 
+For a four-Spark cycle:
+
 - Four NVIDIA DGX Sparks with both 200 Gb/s ConnectX-7 ports available.
 - Four qualified 200 Gb/s DACs cabled exactly as `0-1-2-3-0`.
-- A management LAN reachable by the operator and every rank.
 - Stable rank assignment: the same host is rank 0, 1, 2, or 3 throughout a
   deployment.
 
-The direct ring is the inference fabric. Do not use a ring port as a management
-interface.
+For a two-Spark pair:
+
+- Two NVIDIA DGX Sparks with at least one 200 Gb/s ConnectX-7 port available on
+  each.
+- One qualified 200 Gb/s DAC joining them, cage 0 to cage 0, so that both ranks
+  name the same interface.
+- Stable rank assignment: the same host is rank 0 throughout a deployment, and
+  serves the API.
+
+Both topologies also require a management LAN reachable by the operator and
+every rank.
+
+The direct cabling is the inference fabric. Do not use a fabric port as a
+management interface.
 
 ## Operating system and storage
 
@@ -28,7 +43,7 @@ has 48 shards totaling about 167 GB. Budget additional image and cache headroom.
 
 ## Network requirements
 
-- RoCEv2 must be configured on both fabric ports per rank.
+- RoCEv2 must be configured on every fabric port a rank uses.
 - Every direct cable must pass link, address, and RDMA checks before a model
   launch.
 - The management LAN must permit SSH between the operator and ranks, and

--- a/docs/PREREQUISITES.md
+++ b/docs/PREREQUISITES.md
@@ -48,6 +48,42 @@ has 48 shards totaling about 167 GB. Budget additional image and cache headroom.
   launch.
 - The management LAN must permit SSH between the operator and ranks, and
   rendezvous traffic between ranks.
+
+### Routing and forwarding across the fabric
+
+A switchless fabric has no shared broadcast domain: each node is directly
+cabled only to its neighbours, so traffic to any other node is **relayed by a
+neighbour**. Every node is therefore a router, and three conditions must hold
+on every node before a launch:
+
+- A kernel route to each fabric subnet the node is not directly attached to,
+  via the neighbour that is.
+- `net.ipv4.ip_forward=1`, without which the node accepts transit traffic and
+  drops it.
+- An unrestricted `DOCKER-USER` ACCEPT rule in both directions between the two
+  fabric interfaces. Installing Docker sets the `FORWARD` chain policy to
+  `DROP`, which silently blocks fabric transit. **This is the most commonly
+  missed condition, and it presents exactly like a dead cable**: links are up,
+  addresses are configured, neighbours ping, and every non-adjacent node is
+  unreachable.
+
+[`scripts/ring_doctor.py`](../scripts/ring_doctor.py) checks all three, plus
+addressing and reachability, and prints a repair plan. Run it read-only first:
+
+```bash
+python scripts/ring_doctor.py   --node <user>@<host0> --node <user>@<host1>   --node <user>@<host2> --node <user>@<host3> --verify
+```
+
+Require zero `ERROR` findings and a reachability matrix in which every pair
+passes. `--apply` executes the printed plan, which is idempotent and needs
+passwordless `sudo` on each node.
+
+The repairs are runtime state and do not survive a reboot. `--emit-unit DIR`
+writes a per-node program and systemd unit that revalidate the addresses and
+reapply the plan at boot. Install the program at a path that exists **on the
+node**, and set the unit's `ExecStart` to that path: the emitted unit names the
+directory the files were generated in, which is only correct when they are
+generated on the node itself.
 - Rank 0 must expose the configured API port to intended clients.
 
 ## Local configuration and preflight

--- a/recipes/deepseek-v4-flash-0731-pair.json
+++ b/recipes/deepseek-v4-flash-0731-pair.json
@@ -25,10 +25,10 @@
     "node_count": 2,
     "distributed_executor_backend": "mp",
     "dtype": "bfloat16",
-    "max_model_len": 131072,
+    "max_model_len": 1048576,
     "max_num_seqs": 32,
     "gpu_memory_utilization": 0.7,
-    "kv_cache_memory_bytes_per_rank": 10737418240,
+    "kv_cache_memory_bytes_per_rank": 12884901888,
     "kv_cache_dtype": "fp8_ds_mla",
     "tokenizer_mode": "deepseek_v4",
     "speculation": {
@@ -41,7 +41,9 @@
     "sircl": {
       "default": false,
       "width_4096_graph_status": "unsupported"
-    }
+    },
+    "max_num_batched_tokens": 8192,
+    "sizing_note": "max_model_len, kv_cache_memory_bytes, max_num_seqs and max_num_batched_tokens are coupled: the engine refuses to start unless the pool holds one full-length request, and that floor scales with sequence count and speculation depth. Setting kv_cache_memory_bytes disables the gpu_memory_utilization guard, so free memory must be checked after launch rather than assumed."
   },
   "transport": {
     "difference_from_cycle": "A pair uses one host channel adapter per rank instead of two, so the cycle template's second adapter, subnet-aware routing, subnet prefix length, pinned channel counts, Ring algorithm selection and tree-connect skip are all removed. The tree-connect skip exists because a four-cycle contains non-adjacent rank pairs; the two ranks of a pair are directly adjacent.",
@@ -50,7 +52,7 @@
   "evidence": {
     "status": "implemented",
     "conditions": "Two directly cabled NVIDIA DGX Sparks (GB10, driver 580.173.02, one 200 Gb/s ConnectX-7 link, RoCE GID index 0) using the pinned published runtime image and the tracked pair environment, with only the checkpoint and a writable cache directory mounted.",
-    "result": "Both ranks rendezvoused and the model served. The engine reported a 581,194-token key-value pool and 4.43x maximum concurrency at a 131,072-token request length. A deterministic chat completion, an emitted tool call, and a 34-tool chat request all returned coherent output with no leaked template or end-of-sequence markers. DSpark speculation was active at depth 5 with a mean acceptance length of 2.76 and a 35.1% draft acceptance rate, and generation throughput measured 39.4 tokens per second at one request.",
+    "result": "Both ranks rendezvoused and the model served. The engine reported a 1,139,967-token key-value pool and 1.09x maximum concurrency at a 1,048,576-token request length, with 8-10 GB free per node while serving. A deterministic chat completion, an emitted tool call, and a 34-tool chat request all returned coherent output with no leaked template or end-of-sequence markers. DSpark speculation was active at depth 5 with a mean acceptance length of 2.76. Client-observed aggregate throughput measured 36.7, 123.8, 173.4 and 237.7 tokens per second at 1, 8, 16 and 32 concurrent requests.",
     "conclusion": "The documented two-rank launch is functional for the observed configuration, and requires no source overlay beyond the published image.",
     "limitations": [
       "No checkpoint revision or per-file hashes are pinned.",

--- a/recipes/deepseek-v4-flash-0731-pair.json
+++ b/recipes/deepseek-v4-flash-0731-pair.json
@@ -1,0 +1,61 @@
+{
+  "schema": "sparkring-recipe/v1",
+  "recipe_id": "deepseek-v4-flash-0731-pair",
+  "status": "implemented",
+  "hardware": {
+    "platform": "linux/arm64",
+    "cuda_arch": "sm_121",
+    "ranks": 2,
+    "topology": "direct-pair-2"
+  },
+  "model": {
+    "repository": "deepseek-ai/DeepSeek-V4-Flash-0731",
+    "revision": null,
+    "identity_status": "unsupported",
+    "identity_limitation": "The repository does not pin a checkpoint revision or per-file hashes. An operator must record both before treating a deployment as reproducible."
+  },
+  "runtime": {
+    "image_lock": "runtime/faststart-lock.json",
+    "environment_template": "scripts/config/deepseek-v4-flash-0731-pair.env.example",
+    "entrypoint": "/opt/venv/bin/vllm"
+  },
+  "serving": {
+    "served_model_name": "deepseek-v4-flash-0731",
+    "tensor_parallel_size": 2,
+    "node_count": 2,
+    "distributed_executor_backend": "mp",
+    "dtype": "bfloat16",
+    "max_model_len": 131072,
+    "max_num_seqs": 32,
+    "gpu_memory_utilization": 0.7,
+    "kv_cache_memory_bytes_per_rank": 10737418240,
+    "kv_cache_dtype": "fp8_ds_mla",
+    "tokenizer_mode": "deepseek_v4",
+    "speculation": {
+      "method": "dspark",
+      "num_speculative_tokens": 5,
+      "moe_backend": "b12x"
+    },
+    "tool_call_parser": "deepseek_v4",
+    "external_kv_cache": false,
+    "sircl": {
+      "default": false,
+      "width_4096_graph_status": "unsupported"
+    }
+  },
+  "transport": {
+    "difference_from_cycle": "A pair uses one host channel adapter per rank instead of two, so the cycle template's second adapter, subnet-aware routing, subnet prefix length, pinned channel counts, Ring algorithm selection and tree-connect skip are all removed. The tree-connect skip exists because a four-cycle contains non-adjacent rank pairs; the two ranks of a pair are directly adjacent.",
+    "gid_index": "site-specific; read with show_gids for the fabric interface's IPv4 address"
+  },
+  "evidence": {
+    "status": "implemented",
+    "conditions": "Two directly cabled NVIDIA DGX Sparks (GB10, driver 580.173.02, one 200 Gb/s ConnectX-7 link, RoCE GID index 0) using the pinned published runtime image and the tracked pair environment, with only the checkpoint and a writable cache directory mounted.",
+    "result": "Both ranks rendezvoused and the model served. The engine reported a 581,194-token key-value pool and 4.43x maximum concurrency at a 131,072-token request length. A deterministic chat completion, an emitted tool call, and a 34-tool chat request all returned coherent output with no leaked template or end-of-sequence markers. DSpark speculation was active at depth 5 with a mean acceptance length of 2.76 and a 35.1% draft acceptance rate, and generation throughput measured 39.4 tokens per second at one request.",
+    "conclusion": "The documented two-rank launch is functional for the observed configuration, and requires no source overlay beyond the published image.",
+    "limitations": [
+      "No checkpoint revision or per-file hashes are pinned.",
+      "Performance observations are not qualified measurements."
+    ],
+    "record": "docs/profiles/DEEPSEEK_V4_FLASH_0731.md"
+  }
+}

--- a/recipes/deepseek-v4-flash-0731.json
+++ b/recipes/deepseek-v4-flash-0731.json
@@ -45,9 +45,9 @@
   },
   "evidence": {
     "status": "implemented",
-    "conditions": "Four directly cabled DGX Sparks using the pinned published runtime image and the tracked rank environment.",
-    "result": "The model loaded and served chat completions, tool calls, and DSpark speculative decoding.",
-    "conclusion": "The documented four-rank launch is functional for the observed configuration.",
+    "conditions": "Four directly cabled DGX Sparks in a cycle using the pinned published runtime image and the tracked rank environment, with only the checkpoint and a writable cache directory mounted. Fabric routing, IPv4 forwarding and the DOCKER-USER relay rules were verified by scripts/ring_doctor.py with every node pair reachable before launch.",
+    "result": "All four ranks rendezvoused across the cycle, including ranks not directly cabled to rank 0, which reach the rendezvous address only by neighbour relay. Each rank loaded 40.82 GiB of weights. The engine reported a 4,382,668-token key-value pool and 8.36x maximum concurrency at a 524,288-token request length. A deterministic chat completion returned the correct arithmetic result and a tool call was emitted with correct arguments. DSpark speculation was active at depth 5 with a 3.06 mean acceptance length and a 41.2% draft acceptance rate, and a 512-token completion measured 70.2 tokens per second client-observed.",
+    "conclusion": "The documented four-rank launch is functional for the observed configuration, and requires no source overlay beyond the published image.",
     "limitations": [
       "No checkpoint revision or per-file hashes are pinned.",
       "No SIRCL shadow-comparison window is qualified for width 4096.",

--- a/recipes/deepseek-v4-flash-0731.json
+++ b/recipes/deepseek-v4-flash-0731.json
@@ -25,10 +25,10 @@
     "node_count": 4,
     "distributed_executor_backend": "mp",
     "dtype": "bfloat16",
-    "max_model_len": 524288,
+    "max_model_len": 1048576,
     "max_num_seqs": 32,
     "gpu_memory_utilization": 0.7,
-    "kv_cache_memory_bytes_per_rank": 34359738368,
+    "kv_cache_memory_bytes_per_rank": 17179869184,
     "kv_cache_dtype": "fp8_ds_mla",
     "tokenizer_mode": "deepseek_v4",
     "speculation": {
@@ -41,17 +41,20 @@
     "sircl": {
       "default": false,
       "width_4096_graph_status": "research-only"
-    }
+    },
+    "max_num_batched_tokens": 8192,
+    "sizing_note": "max_model_len, kv_cache_memory_bytes, max_num_seqs and max_num_batched_tokens are coupled: the engine refuses to start unless the pool holds one full-length request, and that floor scales with sequence count and speculation depth. Setting kv_cache_memory_bytes disables the gpu_memory_utilization guard, so free memory must be checked after launch rather than assumed."
   },
   "evidence": {
     "status": "implemented",
     "conditions": "Four directly cabled DGX Sparks in a cycle using the pinned published runtime image and the tracked rank environment, with only the checkpoint and a writable cache directory mounted. Fabric routing, IPv4 forwarding and the DOCKER-USER relay rules were verified by scripts/ring_doctor.py with every node pair reachable before launch.",
-    "result": "All four ranks rendezvoused across the cycle, including ranks not directly cabled to rank 0, which reach the rendezvous address only by neighbour relay. Each rank loaded 40.82 GiB of weights. The engine reported a 4,382,668-token key-value pool and 8.36x maximum concurrency at a 524,288-token request length. A deterministic chat completion returned the correct arithmetic result and a tool call was emitted with correct arguments. DSpark speculation was active at depth 5 with a 3.06 mean acceptance length and a 41.2% draft acceptance rate, and a 512-token completion measured 70.2 tokens per second client-observed.",
+    "result": "All four ranks rendezvoused across the cycle, including ranks not directly cabled to rank 0, which reach the rendezvous address only by neighbour relay. Each rank loaded 40.82 GiB of weights. The engine reported a 1,519,925-token key-value pool and 1.45x maximum concurrency at a 1,048,576-token request length, with about 50 GB free per node while serving. A deterministic chat completion returned the correct arithmetic result and a tool call was emitted with correct arguments. DSpark speculation was active at depth 5 with a 3.06 mean acceptance length and a 41.2% draft acceptance rate. Client-observed aggregate throughput measured 56.5, 177.5, 256.1 and 347.5 tokens per second at 1, 8, 16 and 32 concurrent requests.",
     "conclusion": "The documented four-rank launch is functional for the observed configuration, and requires no source overlay beyond the published image.",
     "limitations": [
       "No checkpoint revision or per-file hashes are pinned.",
       "No SIRCL shadow-comparison window is qualified for width 4096.",
-      "Performance observations are not qualified measurements."
+      "Performance observations are not qualified measurements.",
+      "Enabling VLLM_ENABLE_PCIE_ALLREDUCE with the cpp backend changed throughput by less than 2% at one and eight concurrent requests; the engine selects PYNCCL because every faster all-reduce backend requires peer-accessible GPU memory on one host."
     ],
     "record": "docs/profiles/DEEPSEEK_V4_FLASH_0731.md"
   }

--- a/scripts/config/deepseek-v4-flash-0731-pair.env.example
+++ b/scripts/config/deepseek-v4-flash-0731-pair.env.example
@@ -1,0 +1,93 @@
+# Per-rank container environment for serving DeepSeek-V4-Flash-0731 on a
+# two-Spark pair, consumed by the docker run --env-file in
+# docs/DEEPSEEK_V4_FLASH_QUICKSTART.md. Copy to one file per rank and replace
+# the three placeholders; everything else is identical on both ranks.
+#
+#   <FABRIC_IFNAME>   the netdev carrying the direct cable between the two
+#                     hosts; the same name on both ranks when the pair is
+#                     cabled cage 0 to cage 0
+#   <RANK_FABRIC_IP>  this rank's address on that interface; the launch's
+#                     --master-addr is rank 0's value of it
+#   <GID_INDEX>       the RoCE GID index for that interface's IPv4 address.
+#                     `show_gids` lists them; RoCE v2 entries are the ones to
+#                     prefer. Do not assume a value from another deployment.
+#
+# Differences from the four-Spark template, and why each one changes: a pair
+# has one link per rank rather than two, so a single host channel adapter is
+# named and neither subnet-aware routing nor NIC merging has anything to
+# disambiguate; every pair of ranks is directly adjacent, so the tree-connect
+# skip that a four-cycle needs is unnecessary; and the channel counts are left
+# at the library default rather than pinned for a cycle.
+#
+# Every library path below exists in the published serving image; the loader
+# preload and the patched NCCL are required, and a worker aborts without them.
+
+LD_PRELOAD=/usr/local/cuda/compat/libcuda.so.1:/opt/sparkring/nccl/libnccl.so.2
+VLLM_NCCL_SO_PATH=/opt/sparkring/nccl/libnccl.so.2
+TORCH_USE_RTLD_GLOBAL=1
+
+NCCL_SOCKET_IFNAME=<FABRIC_IFNAME>
+GLOO_SOCKET_IFNAME=<FABRIC_IFNAME>
+VLLM_HOST_IP=<RANK_FABRIC_IP>
+
+NCCL_NET=IB
+NCCL_NET_PLUGIN=none
+NCCL_IB_DISABLE=0
+NCCL_IB_HCA=rocep1s0f0
+NCCL_IB_GID_INDEX=<GID_INDEX>
+NCCL_IB_SUBNET_AWARE_ROUTING=0
+NCCL_IB_MERGE_NICS=0
+NCCL_PROTO=LL,LL128,Simple
+NCCL_P2P_LEVEL=SYS
+NCCL_CROSS_NIC=1
+NCCL_CUMEM_ENABLE=0
+NCCL_IGNORE_CPU_AFFINITY=1
+NCCL_DEBUG=WARN
+NCCL_LOCAL_INFERENCE_PATH=/opt/libnccl-local-inference.so.2.30.4
+NCCL_PR2127_PATH=/opt/libnccl-local-inference.so.2.30.4
+
+VLLM_USE_B12X_MOE=1
+VLLM_USE_B12X_FP8_GEMM=1
+VLLM_USE_B12X_SPARSE_INDEXER=1
+VLLM_USE_B12X_MHC=1
+VLLM_USE_B12X_DCP_A2A=1
+VLLM_USE_B12X_WO_PROJECTION=1
+B12X_DENSE_SPLITK_TURBO=1
+B12X_MLA_SM120_UNIFIED=1
+B12X_MOE_FORCE_A16=1
+B12X_MOE_FORCE_A8=0
+B12X_W4A16_TC_DECODE=1
+B12X_W4A8_TINY_DECODE=1
+
+VLLM_DSPARK_IMPL=upstream
+VLLM_DSPARK_GREEDY_DRAFT=0
+VLLM_DSPARK_FP8_BATCH_ADAPTIVE=0
+VLLM_DSPARK_FP8_LM_HEAD=1
+VLLM_DSPARK_FP8_MAIN_PROJ=1
+VLLM_DSPARK_KV_QAT=1
+VLLM_DSPARK_CONFIDENCE_SCHEDULER=off
+VLLM_DSPARK_CONFIDENCE_THRESHOLD=0.0
+VLLM_DSPARK_MARKOV_SCALE=1.0
+VLLM_DSPARK_MARKOV_W2_BF16=1
+VLLM_DSPARK_MARKOV_W2_FP8=1
+VLLM_DSPARK_REPLICATE_MARKOV_W1=1
+VLLM_DSPARK_REPLICATE_MARKOV_W2=1
+VLLM_DSPARK_FUSED_MARKOV_ARGMAX=0
+VLLM_DSPARK_PREFIX_HIT_HOLDBACK=0
+
+CUTE_DSL_ARCH=sm_121a
+FLASHINFER_CUDA_ARCH_LIST=12.1f
+FLASHINFER_LOCAL_VERSION=cu132
+FLASHINFER_DISABLE_VERSION_CHECK=1
+FLASHINFER_WORKSPACE_BASE=/cache/jit/flashinfer
+CUDA_DEVICE_ORDER=PCI_BUS_ID
+CUDA_DEVICE_MAX_CONNECTIONS=32
+PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True
+SAFETENSORS_FAST_GPU=1
+OMP_NUM_THREADS=16
+HF_HOME=/root/.cache/huggingface
+HF_HUB_OFFLINE=1
+XDG_CACHE_HOME=/cache/jit
+TRITON_CACHE_DIR=/cache/jit/triton
+VLLM_CACHE_ROOT=/cache/jit/vllm
+VLLM_NO_USAGE_STATS=1


### PR DESCRIPTION
## What this changes

The DeepSeek quickstart described only a four-rank cycle. It now covers two
topologies — two tensor-parallel ranks on a cabled pair, and four on a cycle —
which differ in exactly three places: the parallelism flags, the per-rank
key-value reservation and request length that follow from each rank holding
half the weights rather than a quarter, and the transport half of the
environment template. Image, entrypoint, checkpoint, speculation, parsers and
verification are shared.

Adds `scripts/config/deepseek-v4-flash-0731-pair.env.example` and
`recipes/deepseek-v4-flash-0731-pair.json`, and extends `PREREQUISITES.md` with
the two-Spark hardware and cabling requirements.

## Fabric routing and forwarding became a documented prerequisite

A switchless fabric gives each node direct cables only to its neighbours, so
every node must route and forward for the rest of the ring. Three conditions
must hold and none is a default: a kernel route to each subnet the node is not
attached to, `net.ipv4.ip_forward`, and an unrestricted `DOCKER-USER` ACCEPT in
both directions between the fabric interfaces.

Installing Docker sets the `FORWARD` chain policy to `DROP`, which silently
blocks fabric transit and presents exactly like a dead cable: links up,
addresses configured, neighbours reachable, every non-adjacent node
unreachable. `scripts/ring_doctor.py` already detects and repairs all three,
but no document referenced it. `PREREQUISITES.md` now requires a clean
read-only run with a fully passing reachability matrix before any launch.

These repairs are runtime state and do not survive a reboot, which is how a
working ring comes back broken after a power event.

## Validation

The two-Spark launch was run on two directly cabled Sparks against the pinned
published image: both ranks rendezvoused, the engine reported a 581,194-token
key-value pool at a 131,072-token request length, a deterministic completion
and an emitted tool call and a 34-tool chat request all returned coherent
output with no leaked markers, and DSpark speculation ran at depth 5 with a
2.76 mean acceptance length and 39.4 tokens per second at one request. That
launch mounted only the checkpoint and a cache directory, so the published
image needs no source overlay.

The four-Spark launch is unchanged in every value and carries the earlier
recorded cycle deployment's evidence; it was not re-exercised against the
pinned image for this change, and the evidence boundary now says so per
topology rather than in one combined sentence.

## Known limitation, not fixed here

`ring_doctor.py --emit-unit` writes each unit's `ExecStart` pointing at the
directory the files were generated in, so a unit generated on a workstation
cannot run on the node. `PREREQUISITES.md` records the workaround — install the
program on the node and set `ExecStart` to that path — but the flag itself
still needs either an install-path option or a documented convention.