### PR TITLE
Verify only the two shipped SIRCL families at runtime

### DIFF
--- a/runtime/exl3-r7/test_build_image_hardening.py
+++ b/runtime/exl3-r7/test_build_image_hardening.py
@@ -45,8 +45,16 @@ def test_build_script_fails_closed_on_base_image_drift() -> None:
 
 
 def test_build_script_passes_base_image_id_as_build_arg() -> None:
-    """The immutable image ID must be forwarded to the Containerfile."""
-    assert '--build-arg "BASE_IMAGE=${observed_base}"' in BUILD_SCRIPT
+    """The immutable image ID must be forwarded to the Containerfile.
+
+    BuildKit resolves a bare sha256 ID in FROM against the registry, so the
+    verified parent is retagged under a build-local name; the immutable ID
+    still travels as BASE_IMAGE_ID, and the tag is applied to the observed
+    ID only after the drift check.
+    """
+    assert '"${engine}" tag "${observed_base}" "${parent_build_tag}"' in BUILD_SCRIPT
+    assert '--build-arg "BASE_IMAGE=${parent_build_tag}"' in BUILD_SCRIPT
+    assert '--build-arg "BASE_IMAGE_ID=${observed_base}"' in BUILD_SCRIPT
 
 
 def test_containerfile_labels_parent_image_id() -> None:

--- a/runtime/exl3-r7/test_exl3_r7_verify_runtime.py
+++ b/runtime/exl3-r7/test_exl3_r7_verify_runtime.py
@@ -113,7 +113,7 @@ def test_wrapper_chain_rejects_non_callable_original_link() -> None:
         )
 
 
-def test_dcp_mode_requires_dcp_marker_in_stacked_group_chain(
+def test_vocab_mode_requires_vocab_marker_in_group_chain(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
@@ -126,24 +126,13 @@ def test_dcp_mode_requires_dcp_marker_in_stacked_group_chain(
     all_reduce_wrapper._spark_original = all_reduce_terminal  # type: ignore[attr-defined]
     all_reduce_wrapper._spark_tp4_backend = True  # type: ignore[attr-defined]
 
-    def all_gather_terminal(
+    def all_gather_stock(
         self: object,
         output_tensor: object,
         input_tensor: object,
         stream: object,
     ) -> None:
         del self, output_tensor, input_tensor, stream
-
-    def all_gather_wrapper(
-        self: object,
-        output_tensor: object,
-        input_tensor: object,
-        stream: object,
-    ) -> None:
-        del self, output_tensor, input_tensor, stream
-
-    all_gather_wrapper._spark_original = all_gather_terminal  # type: ignore[attr-defined]
-    all_gather_wrapper._spark_tp4_allgather_backend = True  # type: ignore[attr-defined]
 
     def group_terminal(
         self: object,
@@ -159,16 +148,7 @@ def test_dcp_mode_requires_dcp_marker_in_stacked_group_chain(
     ) -> None:
         del self, input_tensor, dim
 
-    def dcp_wrapper(
-        self: object,
-        input_tensor: object,
-        dim: int,
-    ) -> None:
-        del self, input_tensor, dim
-
     vocabulary_wrapper._spark_original = group_terminal  # type: ignore[attr-defined]
-    vocabulary_wrapper._spark_tp4_vocab_backend = True  # type: ignore[attr-defined]
-    dcp_wrapper._spark_original = vocabulary_wrapper  # type: ignore[attr-defined]
 
     cuda_module = types.ModuleType(
         "vllm.distributed.device_communicators.cuda_communicator"
@@ -180,11 +160,11 @@ def test_dcp_mode_requires_dcp_marker_in_stacked_group_chain(
         "vllm.distributed.device_communicators.pynccl"
     )
     pynccl_module.PyNcclCommunicator = types.SimpleNamespace(
-        all_gather=all_gather_wrapper
+        all_gather=all_gather_stock
     )
     parallel_state = types.ModuleType("vllm.distributed.parallel_state")
     parallel_state.GroupCoordinator = types.SimpleNamespace(
-        _all_gather_out_place=dcp_wrapper
+        _all_gather_out_place=vocabulary_wrapper
     )
     for name, module in {
         cuda_module.__name__: cuda_module,
@@ -205,22 +185,20 @@ def test_dcp_mode_requires_dcp_marker_in_stacked_group_chain(
     library.write_bytes(b"test")
     for name in (
         "VLLM_SPARK_TP4_MODE",
-        "VLLM_SPARK_TP4_ALLGATHER_MODE",
         "VLLM_SPARK_TP4_VOCAB_MODE",
-        "VLLM_SPARK_TP4_DCP_MODE",
     ):
         monkeypatch.setenv(name, "custom")
     monkeypatch.setenv("SPARK_TP4_LIBRARY", str(library))
 
     with pytest.raises(
         RuntimeError,
-        match="_spark_tp4_dcp_backend is absent",
+        match="_spark_tp4_vocab_backend is absent",
     ):
         verify_runtime.verify_sircl_hooks({})
 
-    dcp_wrapper._spark_tp4_dcp_backend = True  # type: ignore[attr-defined]
+    vocabulary_wrapper._spark_tp4_vocab_backend = True  # type: ignore[attr-defined]
     evidence: dict[str, object] = {}
     verify_runtime.verify_sircl_hooks(evidence)
     assert evidence["sircl"]["targets"][  # type: ignore[index]
-        "GroupCoordinator._all_gather_out_place[DCP]"
+        "GroupCoordinator._all_gather_out_place"
     ] == ["self", "input_", "dim"]

--- a/runtime/exl3-r7/verify_runtime.py
+++ b/runtime/exl3-r7/verify_runtime.py
@@ -28,27 +28,21 @@ REQUIRED_SOURCE_MARKERS = {
     ),
 }
 
+# SIRCL ships two collective families: the TP all-reduce and the vocabulary
+# all-gather. DCP, indexer, and every other collective use patched NCCL, so
+# no hook module exists for them and none is verified here.
 SIRCL_HOOK_MARKERS = {
     "sitecustomize": (
         "VLLM_SPARK_TP4_MODE",
-        "VLLM_SPARK_TP4_ALLGATHER_MODE",
         "VLLM_SPARK_TP4_VOCAB_MODE",
     ),
     "spark_tp4_backend": (
         "CudaCommunicator.all_reduce = spark_all_reduce",
         "_spark_tp4_backend",
     ),
-    "spark_tp4_allgather_backend": (
-        "PyNcclCommunicator.all_gather = spark_all_gather",
-        "_spark_tp4_allgather_backend",
-    ),
     "spark_tp4_vocab_allgather_backend": (
         "GroupCoordinator._all_gather_out_place = spark_vocab_all_gather",
         "_spark_tp4_vocab_backend",
-    ),
-    "spark_tp4_dcp_backend": (
-        "GroupCoordinator._all_gather_out_place = spark_dcp_all_gather",
-        "_spark_tp4_dcp_backend",
     ),
 }
 _MAX_SIRCL_ORIGINAL_LINKS = 64
@@ -153,7 +147,9 @@ def verify_sircl_hooks(evidence: dict[str, object]) -> None:
             PyNcclCommunicator.all_gather,
             ("self", "output_tensor", "input_tensor", "stream"),
             "_spark_tp4_allgather_backend",
-            "VLLM_SPARK_TP4_ALLGATHER_MODE",
+            # No SIRCL family hooks this target; the signature check proves
+            # the patched-NCCL path is unwrapped.
+            "",
         ),
         (
             "GroupCoordinator._all_gather_out_place",
@@ -161,13 +157,6 @@ def verify_sircl_hooks(evidence: dict[str, object]) -> None:
             ("self", "input_", "dim"),
             "_spark_tp4_vocab_backend",
             "VLLM_SPARK_TP4_VOCAB_MODE",
-        ),
-        (
-            "GroupCoordinator._all_gather_out_place[DCP]",
-            GroupCoordinator._all_gather_out_place,
-            ("self", "input_", "dim"),
-            "_spark_tp4_dcp_backend",
-            "VLLM_SPARK_TP4_DCP_MODE",
         ),
     )
     target_signatures: dict[str, list[str]] = {}


### PR DESCRIPTION
## Resulting behavior

`verify_runtime.py`'s marker table and hook contracts cover exactly the shipped SIRCL surface: the TP all-reduce and vocabulary all-gather families. The `PyNcclCommunicator.all_gather` signature check remains to prove the patched-NCCL path is unwrapped. The DCP-hook unit test is replaced by a vocabulary-family test, and the build hardening test asserts the retag-based parent forwarding.

## Technical reason

The verifier required a `VLLM_SPARK_TP4_ALLGATHER_MODE` marker in `sitecustomize` and imported `spark_tp4_allgather_backend` and `spark_tp4_dcp_backend` — none of which the repository ships, since patched NCCL owns DCP, indexer, and every collective outside the two SIRCL families. Against the shipped `sitecustomize`, the check fails with a missing-marker error before any serving verification runs, blocking both the image build's installed-runtime gate and the profile health check.

## Compatibility impact

None; the removed checks referenced modules absent from the repository and the public overlay.

## Validation

pytest over `runtime/exl3-r7`, `spark_transport`, and `scripts`: 764 passed, 9 skipped; Ruff clean; the image build's installed-runtime verification passes the sitecustomize gate on a GB10 host.