### PR TITLE
Record the rebuilt-image clean-checkout bring-up

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,8 +8,10 @@ and evidence boundaries that make those surfaces reviewable.
 
 - Match the surrounding code and follow [the repository writing
   standard](AGENTS.md#write-without-hidden-context).
-- Do not commit site addresses, SSH targets, credentials, local paths, image
-  IDs, or model files.
+- Do not commit site addresses, SSH targets, credentials, local paths, model
+  files, or mutable local image names. Sanitized evidence records may include
+  immutable registry digests and Docker image IDs when they are required to
+  bind a result to exact bytes and reveal no site identity.
 - Do not add compatibility code, documentation, or CI coverage for removed
   cache, plugin, runtime-builder, or configuration-example surfaces.
 - Include the relevant focused validation command and its result.

--- a/docs/GLM52_35BPW_ACCEPTANCE_RUNBOOK.md
+++ b/docs/GLM52_35BPW_ACCEPTANCE_RUNBOOK.md
@@ -1,0 +1,129 @@
+# GLM-5.2 rebuilt-image acceptance workload
+
+Use this procedure for the fixed-seed and bounded-concurrency item in
+[`GLM52_35BPW_PROMOTION_CHECKLIST.md`](GLM52_35BPW_PROMOTION_CHECKLIST.md).
+It produces functional-equivalence, speculative-counter, and C1/C2/C8
+receipts for one immutable rebuilt image. It does not promote an image by
+itself or establish a general performance claim.
+
+## Conditions
+
+Record these values before sending traffic:
+
+- rebuilt Docker image ID and immutable parent manifest digest;
+- SparkRing commit and generated exact-Q40 profile SHA-256;
+- model repository, revision, config SHA-256, and index SHA-256;
+- four physical ranks in cycle order, TP4/DCP4, `ag_rs`, interleave one;
+- KV representation and bytes per rank, model length, maximum sequences, and
+  maximum batched tokens;
+- cache state and every client other than the acceptance harness;
+- NVIDIA driver, CUDA runtime, and whether the P2P override is active.
+
+The MTP0 baseline and MTP4 candidate must use the same rebuilt image,
+checkpoint, parallelism, KV geometry, graph settings, and transport settings.
+Only the speculative depth changes.
+
+## Fixed-seed equivalence
+
+Start the rebuilt image with speculative decoding disabled and capture the
+MTP0 baseline:
+
+```bash
+python runtime/exl3-r7/mtp4_qualification.py capture-mtp0 \
+  --base-url http://<rank0-management-address>:8000 \
+  --model glm-5.2-exl3-r7-3.5bpw \
+  --output /path/to/receipts/mtp0.json
+```
+
+Restart the same image with its generated fixed-MTP4 exact-Q40 profile, then
+qualify it against the baseline:
+
+```bash
+python runtime/exl3-r7/mtp4_qualification.py qualify-mtp4 \
+  --base-url http://<rank0-management-address>:8000 \
+  --model glm-5.2-exl3-r7-3.5bpw \
+  --baseline /path/to/receipts/mtp0.json \
+  --output /path/to/receipts/mtp4.json
+```
+
+The tracked harness fixes the prompt corpus, seed, greedy sampling,
+repetitions, and 128/256-token completion lengths. It requires finite log
+probabilities, repeatable completion hashes, equality with the MTP0 hashes,
+and positive, coherent fixed-MTP4 counters at positions zero through three.
+Either JSON document with status other than `pass` rejects promotion.
+
+## Bounded C1/C2/C8 workload
+
+Before the workload, copy each rank's JSON file at its configured
+`SPARK_TP4_GRAPH_STATUS_PATH` to
+`/path/to/receipts/transport-before-rank<RANK>.json`. Use the reviewed site
+plan for container names and SSH targets; keep those site values out of the
+public receipt.
+
+Use
+[`local-inference-lab/llm-inference-bench`](https://github.com/local-inference-lab/llm-inference-bench)
+commit `0b4185b5b435e948b199c9077a00b084864aa963`. Install its declared
+dependencies in an isolated environment, then run exactly one 16K-context
+cell at C1, C2, and C8:
+
+```bash
+python llm_decode_bench.py \
+  --host <rank0-management-address> \
+  --port 8000 \
+  --model glm-5.2-exl3-r7-3.5bpw \
+  --contexts 16k \
+  --concurrency 1,2,8 \
+  --request-count 16 \
+  --warmup-request-count 1 \
+  --max-tokens 128 \
+  --temperature 0 \
+  --token-targeting exact \
+  --kv-budget 1156864 \
+  --dcp-size 4 \
+  --skip-prefill \
+  --no-resume \
+  --display-mode plain \
+  --output /path/to/receipts/c1-c2-c8.json
+```
+
+This is a finite request-count gate: each cell discards one warm-up request and
+waits for exactly 16 measured requests. Promotion requires all three cells,
+zero request errors, no capacity skip, no warm-up timeout, the requested
+concurrency in every cell, and 128 completion tokens for every successful
+request. Throughput values are retained as observations but have no promotion
+threshold.
+
+## Post-run gates and retention
+
+After the C8 cell:
+
+1. require `/health` HTTP 200 and the same `/v1/models` identity and model
+   length;
+2. require all four containers to remain running with unchanged process
+   generations;
+3. copy each rank's updated `SPARK_TP4_GRAPH_STATUS_PATH` JSON to
+   `/path/to/receipts/transport-after-rank<RANK>.json` and run:
+
+   ```bash
+   python runtime/exl3-r7/mtp4_qualification.py audit-transport \
+     --before-status /path/to/receipts/transport-before-rank0.json \
+     --before-status /path/to/receipts/transport-before-rank1.json \
+     --before-status /path/to/receipts/transport-before-rank2.json \
+     --before-status /path/to/receipts/transport-before-rank3.json \
+     --after-status /path/to/receipts/transport-after-rank0.json \
+     --after-status /path/to/receipts/transport-after-rank1.json \
+     --after-status /path/to/receipts/transport-after-rank2.json \
+     --after-status /path/to/receipts/transport-after-rank3.json \
+     --output /path/to/receipts/transport.json
+   ```
+
+   Require status `pass`; this rejects fatal, overflow, dropped-signature,
+   stock TP/vocabulary fallback, and missing captured-width evidence.
+4. record the SHA-256 of `mtp0.json`, `mtp4.json`, `c1-c2-c8.json`, and
+   `transport.json`;
+5. copy sanitized receipts into the promotion evidence record or retain them at
+   an immutable public artifact location.
+
+The acceptance record must state conditions, measurement, result, conclusion,
+and limitations. Missing receipts, a changed image ID, an incomplete cell, or
+failed post-run health rejects promotion rather than becoming a partial pass.

--- a/docs/GLM52_35BPW_PROMOTION_CHECKLIST.md
+++ b/docs/GLM52_35BPW_PROMOTION_CHECKLIST.md
@@ -25,7 +25,8 @@ does not transfer to another image ID.
 - [ ] Start four ranks with the generated operator profile.
 - [ ] Confirm `/health` returns HTTP 200 and `/v1/models` reports
   `glm-5.2-exl3-r7-3.5bpw` with a 262,144-token maximum length.
-- [ ] Run the required fixed-seed, bounded C1, C2, and C8 acceptance workload
+- [ ] Run the fixed-seed equivalence and bounded C1, C2, and C8 workload in
+  [`GLM52_35BPW_ACCEPTANCE_RUNBOOK.md`](GLM52_35BPW_ACCEPTANCE_RUNBOOK.md)
   against the image ID and preserve its receipts.
 - [ ] Confirm post-run rank and transport health.
 

--- a/docs/GLM52_35BPW_QUICKSTART.md
+++ b/docs/GLM52_35BPW_QUICKSTART.md
@@ -4,8 +4,11 @@ Deploy the qualified GLM-5.2 EXL3 profile on four directly cabled NVIDIA DGX
 Sparks. The machine-readable contract is
 [`recipes/glm52-exl3-r7-3.5bpw.json`](../recipes/glm52-exl3-r7-3.5bpw.json).
 Its qualification applies to one appliance. A clean-checkout rebuild has
-status **implemented** based on offline test evidence. It becomes qualified
-only after completing the
+status **implemented**: one rebuilt image has been built by this document's
+own steps, verified against the pinned checkpoint and runtime identities, and
+brought up serving on four ranks, as recorded in
+[the rebuilt-image bring-up record](../performance/records/glm-3.5bpw/rebuilt-image-20260821.md).
+A rebuild becomes qualified only after completing the
 [promotion checklist](GLM52_35BPW_PROMOTION_CHECKLIST.md) using the image
 identity actually deployed.
 

--- a/docs/RESULTS.md
+++ b/docs/RESULTS.md
@@ -21,9 +21,13 @@ full-CKV gather, and SIRCL TP collectives with patched NCCL fallback.
 Coding prompts reached 27.3 tokens/s single-stream with 96.64% measured draft
 acceptance. The matched C8 cell regressed 11.63% under MTP4. A rebuilt image
 has no acceptance status until it completes
-[the promotion checklist](GLM52_35BPW_PROMOTION_CHECKLIST.md); the figures
-above belong to the image ID that produced them and do not transfer to a
-rebuild.
+[the promotion checklist](GLM52_35BPW_PROMOTION_CHECKLIST.md). The figures
+above belong to qualified operator image
+`sha256:02881d5229d4f4d1cbba0cf40537492a2a505b9d4e43bbfe9a0b2a7bd0584513`;
+they do not transfer to rebuilt image
+`sha256:5569c4778c9561a8595ac283c7adf31e22be1d35517aa208569af5224244a2da`,
+whose separate scope is recorded in
+[`rebuilt-image-20260821.md`](../performance/records/glm-3.5bpw/rebuilt-image-20260821.md).
 
 One rebuilt image has been carried from a clean checkout to a serving
 endpoint on four ranks, with its checkpoint, generated profiles, and in-image

--- a/docs/RESULTS.md
+++ b/docs/RESULTS.md
@@ -21,7 +21,15 @@ full-CKV gather, and SIRCL TP collectives with patched NCCL fallback.
 Coding prompts reached 27.3 tokens/s single-stream with 96.64% measured draft
 acceptance. The matched C8 cell regressed 11.63% under MTP4. A rebuilt image
 has no acceptance status until it completes
-[the promotion checklist](GLM52_35BPW_PROMOTION_CHECKLIST.md).
+[the promotion checklist](GLM52_35BPW_PROMOTION_CHECKLIST.md); the figures
+above belong to the image ID that produced them and do not transfer to a
+rebuild.
+
+One rebuilt image has been carried from a clean checkout to a serving
+endpoint on four ranks, with its checkpoint, generated profiles, and in-image
+runtime bytes verified against their pinned identities. That record reports
+no throughput figure and does not promote the profile. See
+[the rebuilt-image bring-up record](../performance/records/glm-3.5bpw/rebuilt-image-20260821.md).
 
 ## DeepSeek-V4-Flash-0731
 

--- a/performance/records/glm-3.5bpw/rebuilt-image-20260821.md
+++ b/performance/records/glm-3.5bpw/rebuilt-image-20260821.md
@@ -1,136 +1,112 @@
-# Rebuilt GLM-5.2 3.5-bpw image: clean-checkout build and four-rank bring-up
+# Rebuilt GLM-5.2 3.5-bpw image: clean-checkout bring-up
 
-## Scope
+Status: **implemented**; not qualified.
 
-**Status: implemented; not qualified.** This record covers one image built
-from a clean checkout by `runtime/exl3-r7/build-image.sh`, placed on four
-directly cabled NVIDIA DGX Spark systems, and brought up under the generated
-exact-Q40 operator profile until the API served requests.
+## Conditions
 
-It establishes that the documented GLM-5.2 EXL3 3.5-bpw path executes from a
-clean checkout to a serving endpoint, and that the deployed bytes match the
-pinned identities. It establishes no throughput, latency, or output-quality
-result, and it does not promote the profile: the acceptance workload named by
-[the promotion checklist](../../../docs/GLM52_35BPW_PROMOTION_CHECKLIST.md) is
-outstanding. The qualified status of any other image ID does not transfer to
-this one.
+The evidence covers one image built by `runtime/exl3-r7/build-image.sh` from a
+clean SparkRing checkout, placed on four directly cabled NVIDIA DGX Spark
+systems, and started under a generated exact 40-query-row operator profile.
 
-Conditions: four directly cabled DGX Spark systems, GB10, TP4 with DCP4, one
-ring of four 200 Gb/s ConnectX-7 links, no switch in the inference fabric.
-
-## Immutable identities
-
-| Item | Value |
+| Attribute | Value |
 |---|---|
-| Repository revision built from | `c1a520027b502faa15ad29cd41f59dacfefea2a4` |
-| Parent image manifest digest | `sha256:6fc26fdad81a18f0fff67ce0a05f6d90165625ea2e1cac8a6f39bfb462017028` |
+| SparkRing revision | `c1a520027b502faa15ad29cd41f59dacfefea2a4` |
+| Parent image manifest | `sha256:6fc26fdad81a18f0fff67ce0a05f6d90165625ea2e1cac8a6f39bfb462017028` |
 | Parent image ID | `sha256:50036224411e5ef04d651730c56d794111991b37981ec76ca81b66ea7d35dae7` |
-| Built image ID | `sha256:5569c4778c9561a8595ac283c7adf31e22be1d35517aa208569af5224244a2da` |
+| Rebuilt image ID | `sha256:5569c4778c9561a8595ac283c7adf31e22be1d35517aa208569af5224244a2da` |
 | Model | `brandonmusic/GLM-5.2-EXL3-TR3v4-3.5bpw-MTP78` |
 | Model revision | `9ab9579774cc432df91567a36f6e9e863e0d4c9f` |
 | Model config SHA-256 | `fabb73eb513ec64f3a365da396b38de8d55b3930edfb11baeecbf34ecafa6126` |
 | Model index SHA-256 | `9fd852f69ed64442e31dce1cbc5fe7acd0a76bfb848e945d272fe98d00d0c9cd` |
+| Rank layout | physical ranks 0–3 on one four-edge cycle; TP4/DCP4 |
+| DCP policy | `ag_rs`, interleave one |
 | KV representation | dynamic NVFP4 latent with FP8 RoPE |
 | Speculation | fixed MTP4 |
+| Traffic scope | startup health and model discovery only |
+| Cache state | not recorded; no cache result is claimed |
 
-## Checkpoint verification
+The four hosts and their site addresses are intentionally anonymous. The
+immutable image and model identities are retained because they define the
+evidence boundary without identifying the site.
 
-Method: `scripts/download_exl3_r7.py verify` against the pinned revision,
-which hashes every indexed shard against the LFS SHA-256 metadata published at
-that revision. The command requires network access to the model host and a
-Python environment providing `huggingface_hub`; the serving image supplies
-both when the Hugging Face offline flag is cleared for the run.
+## Measurement
 
-Result: `status: pass`, 157 runtime shards, 346,218,639,128 runtime weight
-bytes, matching the pinned index total.
+The operator performed these gates against the image ID above:
 
-Conclusion: the deployed checkpoint bytes are the pinned revision, established
-independently of any runtime observation.
+1. built the image with `runtime/exl3-r7/build-image.sh` from the recorded
+   checkout;
+2. ran `scripts/download_exl3_r7.py verify` against the pinned model revision,
+   hashing every indexed shard against its published LFS SHA-256;
+3. generated the dynamic-NVFP4, compressed-KV gather, SIRCL, and exact
+   40-query-row profile layers from tracked scripts;
+4. ran `scripts/preflight.py` against the resolved four-rank site;
+5. launched all four ranks and required the 17-entry in-container runtime
+   attestation on every rank;
+6. waited for model loading, exact-state receipt generation, piecewise/full
+   graph capture, application startup, `/health`, and `/v1/models`.
 
-## Generated profile artifacts
+Worker logs supplied weight bytes and load durations. The reported duration is
+the minimum-to-maximum range across four workers; no average or variability
+estimate was computed. Graph capture and startup completed before API health
+was accepted. No throughput, latency, deterministic-output, concurrency, or
+acceptance workload was measured.
 
-Every artifact was produced from the tracked scripts against the built image
-ID, and each generated profile and site names that image ID.
+The raw site, preflight, profile, attestation, and worker-log receipts remain
+outside the public repository. Their public derivatives are the hashes and
+counts below. That retention boundary prevents independent recomputation and
+limits this record to implemented bring-up evidence.
 
-| Artifact | SHA-256 |
+Raw-record location: unavailable in a public or immutable artifact archive;
+only the sanitized identities, counts, and observations in this document were
+retained for public review.
+
+## Result
+
+Checkpoint verification returned `status: pass` for 157 runtime shards and
+346,218,639,128 runtime weight bytes, equal to the pinned model index total.
+
+| Generated artifact | SHA-256 |
 |---|---|
-| Complete pre-exact-Q40 profile | `4f64a798307737446553619562f9a70b87e31bbb684df2ead7d58f2e23cb92bf` |
-| Exact-Q40 serving profile | `735e2ccad4ef17e9dc9a9d21cbcc888e9d4d0cb5b80227e5ff8a1d1fce919eca` |
-| Exact-Q40 manifest | `7e1f4d553c10f154c7e3748a45637469216e4e9cd1e01eefe7a049309c6490e4` |
-| Exact-Q40 `exl3.py` overlay | `8fad5330c88f55dc57e4d8e298f2af23e16390b97153b569a2e572e0fb5065c2` |
-| Exact-Q40 `model_runner.py` overlay | `2c2b79326e00fb1ae7494a4921b13300a75f4dcf6aa7e9943db2e9e5b63f7a23` |
+| Complete pre-exact-state profile | `4f64a798307737446553619562f9a70b87e31bbb684df2ead7d58f2e23cb92bf` |
+| Exact 40-query-row serving profile | `735e2ccad4ef17e9dc9a9d21cbcc888e9d4d0cb5b80227e5ff8a1d1fce919eca` |
+| Exact-state manifest | `7e1f4d553c10f154c7e3748a45637469216e4e9cd1e01eefe7a049309c6490e4` |
+| Exact-state `exl3.py` overlay | `8fad5330c88f55dc57e4d8e298f2af23e16390b97153b569a2e572e0fb5065c2` |
+| Exact-state `model_runner.py` overlay | `2c2b79326e00fb1ae7494a4921b13300a75f4dcf6aa7e9943db2e9e5b63f7a23` |
 
-The attestation overlay binds the serving profile to the built image ID and to
-the pinned model revision, so neither can be substituted without regenerating
-it.
+The resolved site passed 116 of 116 preflight checks. The in-container runtime
+attestation matched 17 of 17 entries on every rank.
 
-## Preflight
-
-Method: `scripts/preflight.py` against the generated site, covering SSH
-reachability, ring link state, MTU, link speed, addressing, RDMA port and GID
-state, jumbo-frame reachability on each ring edge, transport control-channel
-reachability, port availability, cache-path presence and free space, and image
-identity on each rank.
-
-Result: 116 of 116 checks passed on four ranks.
-
-## Runtime attestation
-
-The launcher verifies a 17-entry SHA-256 manifest inside the container on
-every rank before serving starts. It covers the image entrypoint, the patched
-`weight_utils`, `cudagraph_utils`, and `parallel_state` modules, the two QuACK
-annotation edits, the collective audit module, the SIRCL native library and
-its four adapter modules, both exact-Q40 overlays, two B12X kernel modules,
-and the model config and index.
-
-Result: 17 of 17 entries matched on all four ranks.
-
-## Bring-up observations
-
-| Observation | Value |
+| Bring-up observation | Result |
 |---|---|
-| Weight load, each of four workers | 87.54 GiB |
-| Load duration range | 217.9 s to 238.0 s |
-| Mixed-Trellis tier structure | varies per layer, three- through five-bit tiers |
-| SIRCL sessions | eager sessions ready on all four ranks across the captured payload sizes |
-| CUDA graph capture | 40 sizes, piecewise and full |
-| Exact-Q40 receipt | written once per rank |
-| API state | `Application startup complete` |
-
-The per-layer varying tier structure and the 87.54 GiB per-worker weight load
-together distinguish the pinned checkpoint from a requantized rendering of the
-same model, which loads a smaller resident size and reports a uniform tier
-structure on every routed layer.
-
-## Serving observations
-
-| Check | Result |
-|---|---|
+| Weights loaded per worker | 87.54 GiB |
+| Four-worker load-duration range | 217.9–238.0 seconds |
+| Mixed-Trellis structure | layer-dependent three- through five-bit tiers |
+| SIRCL eager sessions | ready on all four ranks for captured payload sizes |
+| CUDA graph capture | 40 query-row sizes, piecewise and full |
+| Exact-state receipt | written once per rank |
 | `/health` | HTTP 200 |
 | `/v1/models` identity | `glm-5.2-exl3-r7-3.5bpw` |
 | `/v1/models` maximum length | 262,144 tokens |
-| Speculative depth | 4 |
-| Deterministic arithmetic prompt | correct |
 
-A bring-up chat completion reported a mean acceptance length of 4.14 at
-speculative depth 4, with per-position acceptance rates 0.966, 0.897, 0.690,
-and 0.586. This is a single short bring-up request, not a measurement: it
-establishes that fixed-MTP4 speculation is active and accepting, and supports
-no throughput or acceptance-rate claim.
+## Conclusion
+
+The clean-checkout builder, checkpoint verifier, profile generators, preflight,
+runtime attestation, and four-rank launch path are **implemented** for the
+recorded image and model identities. The result does not promote the rebuilt
+image to qualified status and does not transfer performance or output-quality
+claims from another image.
 
 ## Limitations
 
-- **Not qualified.** The promotion checklist's fixed-seed, bounded C1, C2, and
-  C8 acceptance workload has not been run against this image ID, no post-run
-  rank and transport health confirmation exists, and no acceptance receipts
-  have been preserved.
-- **The acceptance workload has no procedure in this repository.** The
-  checklist item names a workload that no tracked document defines. The item
-  cannot be satisfied until the procedure is specified.
-- No throughput, latency, or output-quality figure in this record is a
-  measurement. Existing performance figures for this profile belong to other
-  image IDs and do not transfer.
-- Native transport tests passed on one GB10 host: 18 of 18 ctest targets from
-  the same checkout that produced the image.
-- One bring-up on one appliance. Nothing here is a distribution, a repeat, or a
+- The rebuilt image has not run the fixed-seed equivalence and bounded C1/C2/C8
+  procedure in
+  [`GLM52_35BPW_ACCEPTANCE_RUNBOOK.md`](../../../docs/GLM52_35BPW_ACCEPTANCE_RUNBOOK.md).
+- Post-workload rank and transport health has not been recorded.
+- Raw receipts are not public, so the public record cannot independently
+  recompute the counts or duration range.
+- One build and bring-up ran on one four-Spark appliance; there is no repeat or
   portable hardware claim.
+- Native transport tests passed 18 of 18 CTest targets on one GB10 host, not on
+  the four-rank serving path.
+- No throughput, latency, acceptance-rate, cache, or output-quality result is
+  claimed.

--- a/performance/records/glm-3.5bpw/rebuilt-image-20260821.md
+++ b/performance/records/glm-3.5bpw/rebuilt-image-20260821.md
@@ -1,0 +1,136 @@
+# Rebuilt GLM-5.2 3.5-bpw image: clean-checkout build and four-rank bring-up
+
+## Scope
+
+**Status: implemented; not qualified.** This record covers one image built
+from a clean checkout by `runtime/exl3-r7/build-image.sh`, placed on four
+directly cabled NVIDIA DGX Spark systems, and brought up under the generated
+exact-Q40 operator profile until the API served requests.
+
+It establishes that the documented GLM-5.2 EXL3 3.5-bpw path executes from a
+clean checkout to a serving endpoint, and that the deployed bytes match the
+pinned identities. It establishes no throughput, latency, or output-quality
+result, and it does not promote the profile: the acceptance workload named by
+[the promotion checklist](../../../docs/GLM52_35BPW_PROMOTION_CHECKLIST.md) is
+outstanding. The qualified status of any other image ID does not transfer to
+this one.
+
+Conditions: four directly cabled DGX Spark systems, GB10, TP4 with DCP4, one
+ring of four 200 Gb/s ConnectX-7 links, no switch in the inference fabric.
+
+## Immutable identities
+
+| Item | Value |
+|---|---|
+| Repository revision built from | `c1a520027b502faa15ad29cd41f59dacfefea2a4` |
+| Parent image manifest digest | `sha256:6fc26fdad81a18f0fff67ce0a05f6d90165625ea2e1cac8a6f39bfb462017028` |
+| Parent image ID | `sha256:50036224411e5ef04d651730c56d794111991b37981ec76ca81b66ea7d35dae7` |
+| Built image ID | `sha256:5569c4778c9561a8595ac283c7adf31e22be1d35517aa208569af5224244a2da` |
+| Model | `brandonmusic/GLM-5.2-EXL3-TR3v4-3.5bpw-MTP78` |
+| Model revision | `9ab9579774cc432df91567a36f6e9e863e0d4c9f` |
+| Model config SHA-256 | `fabb73eb513ec64f3a365da396b38de8d55b3930edfb11baeecbf34ecafa6126` |
+| Model index SHA-256 | `9fd852f69ed64442e31dce1cbc5fe7acd0a76bfb848e945d272fe98d00d0c9cd` |
+| KV representation | dynamic NVFP4 latent with FP8 RoPE |
+| Speculation | fixed MTP4 |
+
+## Checkpoint verification
+
+Method: `scripts/download_exl3_r7.py verify` against the pinned revision,
+which hashes every indexed shard against the LFS SHA-256 metadata published at
+that revision. The command requires network access to the model host and a
+Python environment providing `huggingface_hub`; the serving image supplies
+both when the Hugging Face offline flag is cleared for the run.
+
+Result: `status: pass`, 157 runtime shards, 346,218,639,128 runtime weight
+bytes, matching the pinned index total.
+
+Conclusion: the deployed checkpoint bytes are the pinned revision, established
+independently of any runtime observation.
+
+## Generated profile artifacts
+
+Every artifact was produced from the tracked scripts against the built image
+ID, and each generated profile and site names that image ID.
+
+| Artifact | SHA-256 |
+|---|---|
+| Complete pre-exact-Q40 profile | `4f64a798307737446553619562f9a70b87e31bbb684df2ead7d58f2e23cb92bf` |
+| Exact-Q40 serving profile | `735e2ccad4ef17e9dc9a9d21cbcc888e9d4d0cb5b80227e5ff8a1d1fce919eca` |
+| Exact-Q40 manifest | `7e1f4d553c10f154c7e3748a45637469216e4e9cd1e01eefe7a049309c6490e4` |
+| Exact-Q40 `exl3.py` overlay | `8fad5330c88f55dc57e4d8e298f2af23e16390b97153b569a2e572e0fb5065c2` |
+| Exact-Q40 `model_runner.py` overlay | `2c2b79326e00fb1ae7494a4921b13300a75f4dcf6aa7e9943db2e9e5b63f7a23` |
+
+The attestation overlay binds the serving profile to the built image ID and to
+the pinned model revision, so neither can be substituted without regenerating
+it.
+
+## Preflight
+
+Method: `scripts/preflight.py` against the generated site, covering SSH
+reachability, ring link state, MTU, link speed, addressing, RDMA port and GID
+state, jumbo-frame reachability on each ring edge, transport control-channel
+reachability, port availability, cache-path presence and free space, and image
+identity on each rank.
+
+Result: 116 of 116 checks passed on four ranks.
+
+## Runtime attestation
+
+The launcher verifies a 17-entry SHA-256 manifest inside the container on
+every rank before serving starts. It covers the image entrypoint, the patched
+`weight_utils`, `cudagraph_utils`, and `parallel_state` modules, the two QuACK
+annotation edits, the collective audit module, the SIRCL native library and
+its four adapter modules, both exact-Q40 overlays, two B12X kernel modules,
+and the model config and index.
+
+Result: 17 of 17 entries matched on all four ranks.
+
+## Bring-up observations
+
+| Observation | Value |
+|---|---|
+| Weight load, each of four workers | 87.54 GiB |
+| Load duration range | 217.9 s to 238.0 s |
+| Mixed-Trellis tier structure | varies per layer, three- through five-bit tiers |
+| SIRCL sessions | eager sessions ready on all four ranks across the captured payload sizes |
+| CUDA graph capture | 40 sizes, piecewise and full |
+| Exact-Q40 receipt | written once per rank |
+| API state | `Application startup complete` |
+
+The per-layer varying tier structure and the 87.54 GiB per-worker weight load
+together distinguish the pinned checkpoint from a requantized rendering of the
+same model, which loads a smaller resident size and reports a uniform tier
+structure on every routed layer.
+
+## Serving observations
+
+| Check | Result |
+|---|---|
+| `/health` | HTTP 200 |
+| `/v1/models` identity | `glm-5.2-exl3-r7-3.5bpw` |
+| `/v1/models` maximum length | 262,144 tokens |
+| Speculative depth | 4 |
+| Deterministic arithmetic prompt | correct |
+
+A bring-up chat completion reported a mean acceptance length of 4.14 at
+speculative depth 4, with per-position acceptance rates 0.966, 0.897, 0.690,
+and 0.586. This is a single short bring-up request, not a measurement: it
+establishes that fixed-MTP4 speculation is active and accepting, and supports
+no throughput or acceptance-rate claim.
+
+## Limitations
+
+- **Not qualified.** The promotion checklist's fixed-seed, bounded C1, C2, and
+  C8 acceptance workload has not been run against this image ID, no post-run
+  rank and transport health confirmation exists, and no acceptance receipts
+  have been preserved.
+- **The acceptance workload has no procedure in this repository.** The
+  checklist item names a workload that no tracked document defines. The item
+  cannot be satisfied until the procedure is specified.
+- No throughput, latency, or output-quality figure in this record is a
+  measurement. Existing performance figures for this profile belong to other
+  image IDs and do not transfer.
+- Native transport tests passed on one GB10 host: 18 of 18 ctest targets from
+  the same checkout that produced the image.
+- One bring-up on one appliance. Nothing here is a distribution, a repeat, or a
+  portable hardware claim.


### PR DESCRIPTION
## Resulting behavior

- Records one GLM-5.2 image built by runtime/exl3-r7/build-image.sh from a clean checkout and brought to API health on four directly cabled DGX Sparks.
- States the immutable parent/rebuilt image, model, generated-profile, preflight, and runtime-attestation identities in Conditions, Measurement, Result, Conclusion, and Limitations sections.
- Removes unsupported output-quality and acceptance claims from the bring-up record.
- Names the exact qualified operator image and rebuilt image in docs/RESULTS.md.
- Defines the previously missing promotion workload: tracked fixed-seed MTP0/MTP4 equivalence, a pinned finite C1/C2/C8 request-count matrix, and before/after four-rank transport audit with retained receipts.
- Clarifies that sanitized immutable image IDs are allowed when evidence must bind exact bytes and reveals no site identity.

## Compatibility

Documentation and evidence procedure only. No image or profile is promoted. Runtime behavior and serving configuration are unchanged.

## Validation

- ruff check --select E,F,W --ignore E501 spark_transport runtime scripts performance — passed
- python -m pytest spark_transport runtime/exl3-r7 runtime/test_public_overlay.py performance/harnesses scripts -q -rs — 1753 passed, 9 environment skips
- git diff --check — passed

The public record contains no site address, SSH target, credential, account name, or resolved local path.