### PR TITLE
Add qualified SparkCache serving compositions

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,13 @@ and uses the immutable published image pinned in
 per-rank environment template
 [`scripts/config/deepseek-v4-flash-0731.env.example`](scripts/config/deepseek-v4-flash-0731.env.example).
 
+Qualified durable prefix-state compositions for the two-Spark DeepSeek,
+four-Spark DeepSeek, and four-Spark GLM profiles are in
+[`recipes/sparkcache/`](recipes/sparkcache/README.md). They pin the exact
+SparkCache wheel and runtime image used by each live store/restart/restore
+gate. Their qualified scheduler budget is 4,096 tokens; 8,192 remains
+unsupported until it passes a separate smoke for the exact composition.
+
 ## Architecture
 
 ```text

--- a/recipes/sparkcache/README.md
+++ b/recipes/sparkcache/README.md
@@ -1,0 +1,66 @@
+# SparkCache composition recipes
+
+These recipes add durable, rank-local prefix-state storage to the supported
+SparkRing serving profiles. They are compositions: each file names a base
+SparkRing recipe and records only the serving values, immutable artifacts,
+cache policy, restart contract, evidence, and limitations qualified with
+SparkCache.
+
+| Composition | Parallelism | Qualified context | Qualified scheduler budget |
+|---|---:|---:|---:|
+| [`deepseek-v4-flash-0731-tp2-dcp1.json`](deepseek-v4-flash-0731-tp2-dcp1.json) | TP2/DCP1 | 131,072 | 4,096 |
+| [`deepseek-v4-flash-0731-tp4-dcp1.json`](deepseek-v4-flash-0731-tp4-dcp1.json) | TP4/DCP1 | 524,288 | 4,096 |
+| [`glm52-exl3-r7-3.5bpw-tp4-dcp4.json`](glm52-exl3-r7-3.5bpw-tp4-dcp4.json) | TP4/DCP4 | 262,144 | 4,096 |
+
+Every composition was qualified with SparkCache `0.1.0a1` wheel SHA-256
+`87c17d8dab5052f5a7833349dc9b99b76a3b6531ca6f0d3deff812f724fecdcc`.
+Install that exact wheel into the runtime Python environment on every rank and
+verify its hash before launch. The connector module is
+`sparkcache.spark_context_cache_connector`; the load-failure policy is
+`recompute`, so an unprovable restore becomes a cache miss and serving does not
+consume unverified bytes.
+
+Use a different rank-local host directory for every model stack and physical
+rank. Mount those directories at the same container path across a stack. Do
+not share one cache root between DeepSeek and GLM, between different
+checkpoints, or between incompatible connector settings.
+
+## Scheduler budget
+
+`--max-num-batched-tokens 4096` is the conservative qualified default in all
+three compositions. A value of `8192` is unsupported and is not an operator
+option in these recipes. It can be added to a composition only after the exact
+profile passes a separate cold-store, coordinated-restart, external-hit, and
+post-restore canary smoke at that value.
+
+## Qualification evidence
+
+Conditions: two or four directly cabled NVIDIA DGX Sparks, the immutable
+runtime image and checkpoint identity in each composition, TP and DCP degrees
+recorded in each file, dedicated rank-local cache roots, and the exact
+SparkCache wheel identified above.
+
+Measurement: each gate sent a deterministic semantic prompt on a cold cache,
+required every rank to commit the same reusable-token digest, restarted all
+ranks without removing the cache roots, required manifest discovery on every
+rank, repeated the identical prompt, read vLLM cache metrics, and sent a fresh
+post-restore canary.
+
+Result:
+
+| Composition | Prompt / reusable tokens | Restore time by rank | External hits | Semantic gates |
+|---|---:|---:|---:|---|
+| DeepSeek TP2/DCP1 | 73,774 / 73,728 | 459.8, 517.0 ms | 73,728 | `SPARKCACHE_OK:9540`; canary passed |
+| DeepSeek TP4/DCP1 | 73,774 / 73,728 | 483.9, 413.9, 443.0, 494.6 ms | 73,728 | `SPARKCACHE_OK:9540`; canary passed |
+| GLM TP4/DCP4 | 225,555 / 225,536 | 3,954.2, 3,385.0, 3,649.6, 3,722.4 ms | 225,536 | quorum prime `2`; `SPARKCACHE_OK:9540`; canary passed |
+
+Conclusion: the three exact compositions restore durable prefix state after
+a coordinated engine restart and continue generating correct output. The
+result qualifies the recorded artifacts and settings; it does not establish
+general vLLM, checkpoint, topology, or production reliability.
+
+Limitations: DeepSeek DCP2 and DCP4, streaming snapshots, native restore,
+other scheduler budgets, other images, other checkpoints, and other cache
+geometries are unsupported. The GLM composition also requires the Q40 receipt
+preservation and regeneration procedure recorded in its recipe before every
+coordinated restart.

--- a/recipes/sparkcache/deepseek-v4-flash-0731-tp2-dcp1.json
+++ b/recipes/sparkcache/deepseek-v4-flash-0731-tp2-dcp1.json
@@ -1,0 +1,81 @@
+{
+  "schema": "sparkring-sparkcache-composition/v1",
+  "recipe_id": "deepseek-v4-flash-0731-sparkcache-tp2-dcp1",
+  "status": "qualified",
+  "base_recipe": "../deepseek-v4-flash-0731-pair.json",
+  "hardware": {
+    "platform": "linux/arm64",
+    "cuda_arch": "sm_121",
+    "ranks": 2,
+    "topology": "direct-pair-2"
+  },
+  "model": {
+    "repository": "deepseek-ai/DeepSeek-V4-Flash-0731",
+    "checkpoint_sha256": "bd6b0117ca28997acc9f22022814bb6bc50b5c3e1bc466d148b1d45067fe714f"
+  },
+  "runtime": {
+    "image_id": "sha256:50036224411e5ef04d651730c56d794111991b37981ec76ca81b66ea7d35dae7",
+    "sparkcache": {
+      "package": "sparkcache",
+      "version": "0.1.0a1",
+      "wheel_sha256": "87c17d8dab5052f5a7833349dc9b99b76a3b6531ca6f0d3deff812f724fecdcc",
+      "source_repository": "https://github.com/FujitsuPolycom/sparkcache",
+      "source_tag": "v0.1.0a1"
+    }
+  },
+  "serving": {
+    "tensor_parallel_size": 2,
+    "decode_context_parallel_size": 1,
+    "node_count": 2,
+    "max_model_len": 131072,
+    "max_num_seqs": 6,
+    "max_num_batched_tokens": 4096,
+    "scheduler_budget_status": "qualified",
+    "gpu_memory_utilization": 0.78,
+    "kv_cache_memory_bytes_per_rank": 17179869184,
+    "kv_cache_dtype": "fp8_ds_mla",
+    "block_size": 256,
+    "max_cudagraph_capture_size_requested": 36,
+    "max_cudagraph_capture_size_observed": 32
+  },
+  "sparkcache": {
+    "kv_connector": "SparkContextCacheConnector",
+    "kv_connector_module_path": "sparkcache.spark_context_cache_connector",
+    "kv_load_failure_policy": "recompute",
+    "kv_role": "kv_both",
+    "model_profile": "deepseek-v4-fp8-hma",
+    "draft_policy": "colocated_target",
+    "scheduler_probe": "none",
+    "store": true,
+    "restore": true,
+    "max_bytes_per_rank": 214748364800,
+    "low_watermark_bytes_per_rank": 193273528320,
+    "ttl_seconds": 0,
+    "min_span_tokens": 256,
+    "max_span_tokens": 131072,
+    "streaming_snapshots": false,
+    "native_restore": false,
+    "root_requirement": "Use a dedicated rank-local host directory mounted at the same container path on both ranks."
+  },
+  "qualification": {
+    "date": "2026-08-21",
+    "artifact_scope": "The exact SparkCache wheel, runtime image, checkpoint identity, topology, and serving values in this file.",
+    "prompt_tokens": 73774,
+    "reusable_tokens": 73728,
+    "cache_digest": "1b2a4d1b6faf7685d1641e298f16c5ef97ad40a279c0a451ab4c0438d2922925",
+    "chunks_per_rank": 288,
+    "bytes_per_rank": 300904448,
+    "restore_milliseconds_by_rank": [459.8, 517.0],
+    "external_cache_queried_tokens": 73814,
+    "external_cache_hit_tokens": 73728,
+    "expected_response": "SPARKCACHE_OK:9540",
+    "post_restore_canary": "SPARKCACHE_CANARY_OK",
+    "record": "README.md"
+  },
+  "limitations": [
+    "The 4096-token scheduler budget is the only qualified budget. A budget of 8192 remains unsupported until it passes its own cold-store, coordinated-restart, external-hit, and canary smoke.",
+    "The qualified context limit is 131072 tokens; the base recipe's 1048576-token setting is not qualified with SparkCache.",
+    "DeepSeek DCP2 and DCP4 are unsupported.",
+    "Streaming snapshots and native restore are unsupported."
+  ]
+}

--- a/recipes/sparkcache/deepseek-v4-flash-0731-tp4-dcp1.json
+++ b/recipes/sparkcache/deepseek-v4-flash-0731-tp4-dcp1.json
@@ -1,0 +1,78 @@
+{
+  "schema": "sparkring-sparkcache-composition/v1",
+  "recipe_id": "deepseek-v4-flash-0731-sparkcache-tp4-dcp1",
+  "status": "qualified",
+  "base_recipe": "../deepseek-v4-flash-0731.json",
+  "hardware": {
+    "platform": "linux/arm64",
+    "cuda_arch": "sm_121",
+    "ranks": 4,
+    "topology": "direct-cycle-4"
+  },
+  "model": {
+    "repository": "deepseek-ai/DeepSeek-V4-Flash-0731",
+    "checkpoint_sha256": "bd6b0117ca28997acc9f22022814bb6bc50b5c3e1bc466d148b1d45067fe714f"
+  },
+  "runtime": {
+    "image_id": "sha256:50036224411e5ef04d651730c56d794111991b37981ec76ca81b66ea7d35dae7",
+    "sparkcache": {
+      "package": "sparkcache",
+      "version": "0.1.0a1",
+      "wheel_sha256": "87c17d8dab5052f5a7833349dc9b99b76a3b6531ca6f0d3deff812f724fecdcc",
+      "source_repository": "https://github.com/FujitsuPolycom/sparkcache",
+      "source_tag": "v0.1.0a1"
+    }
+  },
+  "serving": {
+    "tensor_parallel_size": 4,
+    "decode_context_parallel_size": 1,
+    "node_count": 4,
+    "max_model_len": 524288,
+    "max_num_seqs": 32,
+    "max_num_batched_tokens": 4096,
+    "scheduler_budget_status": "qualified",
+    "gpu_memory_utilization": 0.7,
+    "kv_cache_memory_bytes_per_rank": 34359738368,
+    "kv_cache_dtype": "fp8_ds_mla",
+    "block_size": 256
+  },
+  "sparkcache": {
+    "kv_connector": "SparkContextCacheConnector",
+    "kv_connector_module_path": "sparkcache.spark_context_cache_connector",
+    "kv_load_failure_policy": "recompute",
+    "kv_role": "kv_both",
+    "model_profile": "deepseek-v4-fp8-hma",
+    "draft_policy": "colocated_target",
+    "scheduler_probe": "none",
+    "store": true,
+    "restore": true,
+    "max_bytes_per_rank": 214748364800,
+    "low_watermark_bytes_per_rank": 193273528320,
+    "ttl_seconds": 0,
+    "min_span_tokens": 256,
+    "max_span_tokens": 524288,
+    "streaming_snapshots": false,
+    "native_restore": false,
+    "root_requirement": "Use one dedicated rank-local host directory per physical rank, mounted at the same container path on all four ranks."
+  },
+  "qualification": {
+    "date": "2026-08-21",
+    "artifact_scope": "The exact SparkCache wheel, runtime image, checkpoint identity, topology, and serving values in this file.",
+    "prompt_tokens": 73774,
+    "reusable_tokens": 73728,
+    "cache_digest": "c17e6fbaefea740b4a83890f20d0e72e792cf9db9429633340e3c48d41d02d1c",
+    "chunks_per_rank": 288,
+    "bytes_per_rank": 300908544,
+    "restore_milliseconds_by_rank": [483.9, 413.9, 443.0, 494.6],
+    "external_cache_queried_tokens": 73814,
+    "external_cache_hit_tokens": 73728,
+    "expected_response": "SPARKCACHE_OK:9540",
+    "post_restore_canary": "SPARKCACHE_CANARY_OK",
+    "record": "README.md"
+  },
+  "limitations": [
+    "The 4096-token scheduler budget is the only qualified budget. A budget of 8192 remains unsupported until it passes its own cold-store, coordinated-restart, external-hit, and canary smoke.",
+    "DeepSeek DCP2 and DCP4 are unsupported.",
+    "Streaming snapshots and native restore are unsupported."
+  ]
+}

--- a/recipes/sparkcache/glm52-exl3-r7-3.5bpw-tp4-dcp4.json
+++ b/recipes/sparkcache/glm52-exl3-r7-3.5bpw-tp4-dcp4.json
@@ -1,0 +1,89 @@
+{
+  "schema": "sparkring-sparkcache-composition/v1",
+  "recipe_id": "glm52-exl3-r7-3.5bpw-sparkcache-tp4-dcp4",
+  "status": "qualified",
+  "base_recipe": "../glm52-exl3-r7-3.5bpw.json",
+  "hardware": {
+    "platform": "linux/arm64",
+    "cuda_arch": "sm_121",
+    "ranks": 4,
+    "topology": "direct-cycle-4"
+  },
+  "model": {
+    "repository": "brandonmusic/GLM-5.2-EXL3-TR3v4-3.5bpw-MTP78",
+    "revision": "9ab9579774cc432df91567a36f6e9e863e0d4c9f",
+    "checkpoint_sha256": "9fd852f69ed64442e31dce1cbc5fe7acd0a76bfb848e945d272fe98d00d0c9cd"
+  },
+  "runtime": {
+    "image_id": "sha256:02881d5229d4f4d1cbba0cf40537492a2a505b9d4e43bbfe9a0b2a7bd0584513",
+    "sparkcache": {
+      "package": "sparkcache",
+      "version": "0.1.0a1",
+      "wheel_sha256": "87c17d8dab5052f5a7833349dc9b99b76a3b6531ca6f0d3deff812f724fecdcc",
+      "source_repository": "https://github.com/FujitsuPolycom/sparkcache",
+      "source_tag": "v0.1.0a1"
+    }
+  },
+  "serving": {
+    "tensor_parallel_size": 4,
+    "decode_context_parallel_size": 4,
+    "node_count": 4,
+    "dcp_backend": "ag_rs",
+    "dcp_kv_cache_interleave_size": 1,
+    "max_model_len": 262144,
+    "max_num_seqs": 8,
+    "max_num_batched_tokens": 4096,
+    "scheduler_budget_status": "qualified",
+    "gpu_memory_utilization": 0.85,
+    "kv_cache_memory_bytes_per_rank": 9250000000,
+    "kv_cache_dtype": "nvfp4_ds_mla",
+    "block_size": 64,
+    "async_scheduling": false,
+    "max_cudagraph_capture_size": 40
+  },
+  "sparkcache": {
+    "kv_connector": "SparkContextCacheConnector",
+    "kv_connector_module_path": "sparkcache.spark_context_cache_connector",
+    "kv_load_failure_policy": "recompute",
+    "kv_role": "kv_both",
+    "model_profile": "glm52-exl3-r7-3.5bpw",
+    "draft_policy": "colocated_target",
+    "scheduler_probe": "none",
+    "store": true,
+    "restore": true,
+    "max_bytes_per_rank": 214748364800,
+    "low_watermark_bytes_per_rank": 193273528320,
+    "ttl_seconds": 0,
+    "min_span_tokens": 256,
+    "max_span_tokens": 262144,
+    "streaming_snapshots": false,
+    "native_restore": false,
+    "root_requirement": "Use one dedicated rank-local host directory per physical rank, mounted at the same container path on all four ranks."
+  },
+  "restart_contract": {
+    "receipt_path_template": "/var/lib/sparkring/jit-cache/q40-exact-state-serving-v1-rank<RANK>.json",
+    "procedure": "Before every coordinated restart, stop all four containers, record each receipt SHA-256, move each receipt to a unique hash-preserving backup name, start all four containers, require fresh Q40 attestation on every rank, and require serving health before sending traffic."
+  },
+  "qualification": {
+    "date": "2026-08-21",
+    "artifact_scope": "The exact SparkCache wheel, runtime image, checkpoint identity, topology, and serving values in this file.",
+    "prompt_tokens": 225555,
+    "reusable_tokens": 225536,
+    "cache_digest": "fd441fa9535cd5eba7a261b0ef908cebe278d1667fd676d12a3e016c65d4d31a",
+    "chunks_per_rank": 881,
+    "bytes_per_rank": 1803702724,
+    "restore_milliseconds_by_rank": [3954.2, 3385.0, 3649.6, 3722.4],
+    "external_cache_queried_tokens": 225633,
+    "external_cache_hit_tokens": 225536,
+    "local_prefix_cache_hit_tokens": 0,
+    "quorum_prime": "2",
+    "expected_response": "SPARKCACHE_OK:9540",
+    "post_restore_canary": "SPARKCACHE_CANARY_OK",
+    "record": "README.md"
+  },
+  "limitations": [
+    "The 4096-token scheduler budget is the only qualified budget. A budget of 8192 remains unsupported until it passes its own cold-store, coordinated-restart, external-hit, and canary smoke.",
+    "The qualified lane requires the exact Q40 runtime receipt procedure before every coordinated restart.",
+    "Streaming snapshots and native restore are unsupported."
+  ]
+}

--- a/scripts/test_sparkcache_recipes.py
+++ b/scripts/test_sparkcache_recipes.py
@@ -1,0 +1,57 @@
+"""GPU-free contract tests for the qualified SparkCache compositions."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+RECIPE_DIR = ROOT / "recipes" / "sparkcache"
+RECIPE_PATHS = sorted(RECIPE_DIR.glob("*.json"))
+WHEEL_SHA256 = (
+    "87c17d8dab5052f5a7833349dc9b99b76a3b6531ca6f0d3deff812f724fecdcc"
+)
+
+
+def _load(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def test_composition_registry_has_all_qualified_profiles() -> None:
+    assert [path.name for path in RECIPE_PATHS] == [
+        "deepseek-v4-flash-0731-tp2-dcp1.json",
+        "deepseek-v4-flash-0731-tp4-dcp1.json",
+        "glm52-exl3-r7-3.5bpw-tp4-dcp4.json",
+    ]
+
+
+def test_compositions_pin_artifact_and_fail_closed_policy() -> None:
+    for path in RECIPE_PATHS:
+        recipe = _load(path)
+        assert recipe["schema"] == "sparkring-sparkcache-composition/v1"
+        assert recipe["status"] == "qualified"
+        assert (path.parent / recipe["base_recipe"]).resolve().is_file()
+        assert recipe["runtime"]["sparkcache"]["version"] == "0.1.0a1"
+        assert recipe["runtime"]["sparkcache"]["wheel_sha256"] == WHEEL_SHA256
+        assert recipe["serving"]["max_num_batched_tokens"] == 4096
+        assert recipe["serving"]["scheduler_budget_status"] == "qualified"
+        assert recipe["sparkcache"]["kv_load_failure_policy"] == "recompute"
+        assert recipe["sparkcache"]["streaming_snapshots"] is False
+        assert recipe["sparkcache"]["native_restore"] is False
+
+
+def test_unsupported_scheduler_budget_is_not_an_operator_setting() -> None:
+    for path in RECIPE_PATHS:
+        recipe = _load(path)
+        assert 8192 not in recipe["serving"].values()
+        assert any("8192 remains unsupported" in item for item in recipe["limitations"])
+
+
+def test_parallelism_matches_physical_rank_count() -> None:
+    for path in RECIPE_PATHS:
+        recipe = _load(path)
+        serving = recipe["serving"]
+        assert serving["tensor_parallel_size"] == recipe["hardware"]["ranks"]
+        assert serving["node_count"] == recipe["hardware"]["ranks"]
+        assert serving["decode_context_parallel_size"] in (1, 4)


### PR DESCRIPTION
## Result

Adds qualified SparkCache composition recipes for:

- DeepSeek-V4-Flash-0731 TP2/DCP1 on two DGX Sparks
- DeepSeek-V4-Flash-0731 TP4/DCP1 on four DGX Sparks
- GLM-5.2 EXL3 3.5-bpw TP4/DCP4 on four DGX Sparks

Each recipe pins SparkCache 0.1.0a1 wheel SHA-256 87c17d8dab5052f5a7833349dc9b99b76a3b6531ca6f0d3deff812f724fecdcc, the qualified runtime image and checkpoint identity, fail-closed connector policy, cache geometry, restart contract, and live store/restart/external-hit evidence. The only qualified scheduler budget is 4096; 8192 remains unsupported until a separate smoke passes for the exact composition.

## Validation

- ruff check --select E,F,W --ignore E501 spark_transport runtime scripts performance
- python -m pytest spark_transport runtime/exl3-r7 runtime/test_public_overlay.py performance/harnesses scripts -q -rs
- 1753 passed, 9 skipped