### PR TITLE
State composition evidence in the base recipe shape

### DIFF
--- a/recipes/sparkcache/deepseek-v4-flash-0731-tp2-dcp1.json
+++ b/recipes/sparkcache/deepseek-v4-flash-0731-tp2-dcp1.json
@@ -57,25 +57,31 @@
     "native_restore": false,
     "root_requirement": "Use a dedicated rank-local host directory mounted at the same container path on both ranks."
   },
-  "qualification": {
+  "evidence": {
+    "status": "qualified",
+    "conditions": "Two directly cabled NVIDIA DGX Spark systems at TP2/DCP1 using the immutable runtime image, checkpoint identity, dedicated rank-local cache roots, and SparkCache wheel recorded in this file.",
+    "result": "A cold-cache deterministic prompt of 73,774 tokens committed 73,728 reusable tokens as 288 chunks and 300,904,448 bytes on each of 2 ranks. After a coordinated restart that left the cache roots in place, every rank discovered its manifest and restored in 459.8, 517.0 ms. The repeated prompt served 73,728 external-cache hit tokens of 73,814 queried and returned SPARKCACHE_OK:9540; the post-restore canary returned SPARKCACHE_CANARY_OK.",
+    "conclusion": "This composition restores durable prefix state across a coordinated engine restart and continues generating correct output. The result qualifies the exact artifacts and settings recorded in this file; it does not establish general vLLM, checkpoint, topology, or production reliability.",
+    "limitations": [
+      "The 4096-token scheduler budget is the only qualified budget. A budget of 8192 remains unsupported until it passes its own cold-store, coordinated-restart, external-hit, and canary smoke.",
+      "The qualified context limit is 131072 tokens; the base recipe's 1048576-token setting is not qualified with SparkCache.",
+      "DeepSeek DCP2 and DCP4 are unsupported.",
+      "Streaming snapshots and native restore are unsupported."
+    ],
+    "record": "README.md",
     "date": "2026-08-21",
-    "artifact_scope": "The exact SparkCache wheel, runtime image, checkpoint identity, topology, and serving values in this file.",
     "prompt_tokens": 73774,
     "reusable_tokens": 73728,
     "cache_digest": "1b2a4d1b6faf7685d1641e298f16c5ef97ad40a279c0a451ab4c0438d2922925",
     "chunks_per_rank": 288,
     "bytes_per_rank": 300904448,
-    "restore_milliseconds_by_rank": [459.8, 517.0],
+    "restore_milliseconds_by_rank": [
+      459.8,
+      517.0
+    ],
     "external_cache_queried_tokens": 73814,
     "external_cache_hit_tokens": 73728,
     "expected_response": "SPARKCACHE_OK:9540",
-    "post_restore_canary": "SPARKCACHE_CANARY_OK",
-    "record": "README.md"
-  },
-  "limitations": [
-    "The 4096-token scheduler budget is the only qualified budget. A budget of 8192 remains unsupported until it passes its own cold-store, coordinated-restart, external-hit, and canary smoke.",
-    "The qualified context limit is 131072 tokens; the base recipe's 1048576-token setting is not qualified with SparkCache.",
-    "DeepSeek DCP2 and DCP4 are unsupported.",
-    "Streaming snapshots and native restore are unsupported."
-  ]
+    "post_restore_canary": "SPARKCACHE_CANARY_OK"
+  }
 }

--- a/recipes/sparkcache/deepseek-v4-flash-0731-tp4-dcp1.json
+++ b/recipes/sparkcache/deepseek-v4-flash-0731-tp4-dcp1.json
@@ -55,24 +55,32 @@
     "native_restore": false,
     "root_requirement": "Use one dedicated rank-local host directory per physical rank, mounted at the same container path on all four ranks."
   },
-  "qualification": {
+  "evidence": {
+    "status": "qualified",
+    "conditions": "Four directly cabled NVIDIA DGX Spark systems at TP4/DCP1 using the immutable runtime image, checkpoint identity, dedicated rank-local cache roots, and SparkCache wheel recorded in this file.",
+    "result": "A cold-cache deterministic prompt of 73,774 tokens committed 73,728 reusable tokens as 288 chunks and 300,908,544 bytes on each of 4 ranks. After a coordinated restart that left the cache roots in place, every rank discovered its manifest and restored in 483.9, 413.9, 443.0, 494.6 ms. The repeated prompt served 73,728 external-cache hit tokens of 73,814 queried and returned SPARKCACHE_OK:9540; the post-restore canary returned SPARKCACHE_CANARY_OK.",
+    "conclusion": "This composition restores durable prefix state across a coordinated engine restart and continues generating correct output. The result qualifies the exact artifacts and settings recorded in this file; it does not establish general vLLM, checkpoint, topology, or production reliability.",
+    "limitations": [
+      "The 4096-token scheduler budget is the only qualified budget. A budget of 8192 remains unsupported until it passes its own cold-store, coordinated-restart, external-hit, and canary smoke.",
+      "DeepSeek DCP2 and DCP4 are unsupported.",
+      "Streaming snapshots and native restore are unsupported."
+    ],
+    "record": "README.md",
     "date": "2026-08-21",
-    "artifact_scope": "The exact SparkCache wheel, runtime image, checkpoint identity, topology, and serving values in this file.",
     "prompt_tokens": 73774,
     "reusable_tokens": 73728,
     "cache_digest": "c17e6fbaefea740b4a83890f20d0e72e792cf9db9429633340e3c48d41d02d1c",
     "chunks_per_rank": 288,
     "bytes_per_rank": 300908544,
-    "restore_milliseconds_by_rank": [483.9, 413.9, 443.0, 494.6],
+    "restore_milliseconds_by_rank": [
+      483.9,
+      413.9,
+      443.0,
+      494.6
+    ],
     "external_cache_queried_tokens": 73814,
     "external_cache_hit_tokens": 73728,
     "expected_response": "SPARKCACHE_OK:9540",
-    "post_restore_canary": "SPARKCACHE_CANARY_OK",
-    "record": "README.md"
-  },
-  "limitations": [
-    "The 4096-token scheduler budget is the only qualified budget. A budget of 8192 remains unsupported until it passes its own cold-store, coordinated-restart, external-hit, and canary smoke.",
-    "DeepSeek DCP2 and DCP4 are unsupported.",
-    "Streaming snapshots and native restore are unsupported."
-  ]
+    "post_restore_canary": "SPARKCACHE_CANARY_OK"
+  }
 }

--- a/recipes/sparkcache/glm52-exl3-r7-3.5bpw-tp4-dcp4.json
+++ b/recipes/sparkcache/glm52-exl3-r7-3.5bpw-tp4-dcp4.json
@@ -64,26 +64,34 @@
     "receipt_path_template": "/var/lib/sparkring/jit-cache/q40-exact-state-serving-v1-rank<RANK>.json",
     "procedure": "Before every coordinated restart, stop all four containers, record each receipt SHA-256, move each receipt to a unique hash-preserving backup name, start all four containers, require fresh Q40 attestation on every rank, and require serving health before sending traffic."
   },
-  "qualification": {
+  "evidence": {
+    "status": "qualified",
+    "conditions": "Four directly cabled NVIDIA DGX Spark systems at TP4/DCP4 using the immutable runtime image, checkpoint identity, dedicated rank-local cache roots, and SparkCache wheel recorded in this file.",
+    "result": "A cold-cache deterministic prompt of 225,555 tokens committed 225,536 reusable tokens as 881 chunks and 1,803,702,724 bytes on each of 4 ranks. After a coordinated restart that left the cache roots in place, every rank discovered its manifest and restored in 3,954.2, 3,385.0, 3,649.6, 3,722.4 ms. The repeated prompt served 225,536 external-cache hit tokens of 225,633 queried and returned SPARKCACHE_OK:9540; the post-restore canary returned SPARKCACHE_CANARY_OK. Rank quorum prime 2 was required and met. No tokens were served from the native prefix cache.",
+    "conclusion": "This composition restores durable prefix state across a coordinated engine restart and continues generating correct output. The result qualifies the exact artifacts and settings recorded in this file; it does not establish general vLLM, checkpoint, topology, or production reliability.",
+    "limitations": [
+      "The 4096-token scheduler budget is the only qualified budget. A budget of 8192 remains unsupported until it passes its own cold-store, coordinated-restart, external-hit, and canary smoke.",
+      "The qualified lane requires the exact Q40 runtime receipt procedure before every coordinated restart.",
+      "Streaming snapshots and native restore are unsupported."
+    ],
+    "record": "README.md",
     "date": "2026-08-21",
-    "artifact_scope": "The exact SparkCache wheel, runtime image, checkpoint identity, topology, and serving values in this file.",
     "prompt_tokens": 225555,
     "reusable_tokens": 225536,
     "cache_digest": "fd441fa9535cd5eba7a261b0ef908cebe278d1667fd676d12a3e016c65d4d31a",
     "chunks_per_rank": 881,
     "bytes_per_rank": 1803702724,
-    "restore_milliseconds_by_rank": [3954.2, 3385.0, 3649.6, 3722.4],
+    "restore_milliseconds_by_rank": [
+      3954.2,
+      3385.0,
+      3649.6,
+      3722.4
+    ],
     "external_cache_queried_tokens": 225633,
     "external_cache_hit_tokens": 225536,
     "local_prefix_cache_hit_tokens": 0,
     "quorum_prime": "2",
     "expected_response": "SPARKCACHE_OK:9540",
-    "post_restore_canary": "SPARKCACHE_CANARY_OK",
-    "record": "README.md"
-  },
-  "limitations": [
-    "The 4096-token scheduler budget is the only qualified budget. A budget of 8192 remains unsupported until it passes its own cold-store, coordinated-restart, external-hit, and canary smoke.",
-    "The qualified lane requires the exact Q40 runtime receipt procedure before every coordinated restart.",
-    "Streaming snapshots and native restore are unsupported."
-  ]
+    "post_restore_canary": "SPARKCACHE_CANARY_OK"
+  }
 }

--- a/scripts/test_sparkcache_recipes.py
+++ b/scripts/test_sparkcache_recipes.py
@@ -45,7 +45,8 @@ def test_unsupported_scheduler_budget_is_not_an_operator_setting() -> None:
     for path in RECIPE_PATHS:
         recipe = _load(path)
         assert 8192 not in recipe["serving"].values()
-        assert any("8192 remains unsupported" in item for item in recipe["limitations"])
+        limitations = recipe["evidence"]["limitations"]
+        assert any("8192 remains unsupported" in item for item in limitations)
 
 
 def test_parallelism_matches_physical_rank_count() -> None:
@@ -55,3 +56,21 @@ def test_parallelism_matches_physical_rank_count() -> None:
         assert serving["tensor_parallel_size"] == recipe["hardware"]["ranks"]
         assert serving["node_count"] == recipe["hardware"]["ranks"]
         assert serving["decode_context_parallel_size"] in (1, 4)
+
+
+def test_composition_evidence_matches_the_base_recipe_shape() -> None:
+    """Both recipe schemas state evidence in one shape.
+
+    A composition carries extra measurement fields, but the keys a reader
+    relies on to judge a claim -- what was run, what came out, what it means,
+    and what it excludes -- are the same as in a base recipe.
+    """
+    required = {"status", "conditions", "result", "conclusion", "limitations", "record"}
+    base = _load(ROOT / "recipes" / "deepseek-v4-flash-0731.json")["evidence"]
+    assert required <= set(base)
+    for path in RECIPE_PATHS:
+        evidence = _load(path)["evidence"]
+        assert required <= set(evidence), path.name
+        assert evidence["status"] == _load(path)["status"]
+        assert evidence["conclusion"].strip()
+        assert evidence["result"].strip()


### PR DESCRIPTION
## Resulting behavior

SparkCache composition recipes carry an `evidence` block with the same six keys a base recipe uses — `status`, `conditions`, `result`, `conclusion`, `limitations`, `record` — and retain every measurement field. A contract test asserts both schemas share that key set.

## Technical reason

A base recipe and a composition recipe carry the same idea in two layouts: the base states evidence as `evidence{...}`, while a composition states it as `qualification{...}` with no `result` or `conclusion` field and with `limitations` at the top level. A reader comparing the two meets two shapes for one idea, and the composition omits the result and conclusion the writing standard requires when stating evidence.

The `result` text states each gate's committed tokens, per-rank restore times, external-cache hits, semantic response, and canary outcome. The `conclusion` states what the gate establishes and what it excludes. Both are sourced from `recipes/sparkcache/README.md`; no claim is added or strengthened.

## Compatibility impact

`recipes/sparkcache/*.json` rename `qualification` to `evidence` and move top-level `limitations` into it. The composition schema name (`sparkring-sparkcache-composition/v1`), serving values, pins, and statuses are unchanged. No measurement is dropped.

## Validation

pytest over the CI trees: 1,754 passed, 9 environment skips. Ruff clean. 94 repo-relative Markdown links and anchors resolve.