### PR TITLE
Clarify cluster shapes, deployment profiles, and evidence scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,19 +26,24 @@ belongs to profiles rather than the transport.
 
 ## Profiles
 
-| Profile | Model identity | Status | Start here |
-|---|---|---|---|
-| GLM-5.2 EXL3 3.5-bpw | `brandonmusic/GLM-5.2-EXL3-TR3v4-3.5bpw-MTP78@9ab9579774cc432df91567a36f6e9e863e0d4c9f` | qualified on one four-Spark appliance; rebuilt images retain implemented status until promotion | [Quickstart](docs/GLM52_35BPW_QUICKSTART.md) |
-| DeepSeek-V4-Flash-0731 | `deepseek-ai/DeepSeek-V4-Flash-0731` | implemented launch; SIRCL width 4096 is research-only | [Quickstart](docs/DEEPSEEK_V4_FLASH_QUICKSTART.md) |
+| Profile | Model identity | Topology | Status | Start here |
+|---|---|---|---|---|
+| GLM-5.2 EXL3 3.5-bpw | `brandonmusic/GLM-5.2-EXL3-TR3v4-3.5bpw-MTP78@9ab9579774cc432df91567a36f6e9e863e0d4c9f` | four-Spark cycle, TP4/DCP4 | qualified on one appliance; rebuilt images retain implemented status until promotion | [Quickstart](docs/GLM52_35BPW_QUICKSTART.md) |
+| DeepSeek-V4-Flash-0731 | `deepseek-ai/DeepSeek-V4-Flash-0731` | two-Spark pair, TP2/DCP1 | implemented launch; SIRCL is unsupported | [Quickstart](docs/DEEPSEEK_V4_FLASH_QUICKSTART.md) |
+| DeepSeek-V4-Flash-0731 | `deepseek-ai/DeepSeek-V4-Flash-0731` | four-Spark cycle, TP4/DCP1 | implemented launch; SIRCL width 4096 is research-only | [Quickstart](docs/DEEPSEEK_V4_FLASH_QUICKSTART.md) |
+| GLM-5.2 EXL3 3.5-bpw + SparkCache | `brandonmusic/GLM-5.2-EXL3-TR3v4-3.5bpw-MTP78@9ab9579774cc432df91567a36f6e9e863e0d4c9f` | four-Spark cycle, TP4/DCP4 | qualified durable prefix-state composition | [SparkCache compositions](recipes/sparkcache/README.md) |
+| DeepSeek-V4-Flash-0731 + SparkCache | `deepseek-ai/DeepSeek-V4-Flash-0731` | two-Spark pair, TP2/DCP1 | qualified durable prefix-state composition | [SparkCache compositions](recipes/sparkcache/README.md) |
+| DeepSeek-V4-Flash-0731 + SparkCache | `deepseek-ai/DeepSeek-V4-Flash-0731` | four-Spark cycle, TP4/DCP1 | qualified durable prefix-state composition | [SparkCache compositions](recipes/sparkcache/README.md) |
 
-The GLM profile is defined by
+The GLM base profile is defined by
 [`recipes/glm52-exl3-r7-3.5bpw.json`](recipes/glm52-exl3-r7-3.5bpw.json). The
-DeepSeek profile is defined by
-[`recipes/deepseek-v4-flash-0731.json`](recipes/deepseek-v4-flash-0731.json)
-and uses the immutable published image pinned in
+two-Spark and four-Spark DeepSeek base profiles are defined by
+[`recipes/deepseek-v4-flash-0731-pair.json`](recipes/deepseek-v4-flash-0731-pair.json)
+and
+[`recipes/deepseek-v4-flash-0731.json`](recipes/deepseek-v4-flash-0731.json).
+The DeepSeek profiles use the immutable published image pinned in
 [`runtime/faststart-lock.json`](runtime/faststart-lock.json) and the tracked
-per-rank environment template
-[`scripts/config/deepseek-v4-flash-0731.env.example`](scripts/config/deepseek-v4-flash-0731.env.example).
+per-rank environment templates in [`scripts/config/`](scripts/config/).
 
 Qualified durable prefix-state compositions for the two-Spark DeepSeek,
 four-Spark DeepSeek, and four-Spark GLM profiles are in
@@ -69,9 +74,9 @@ path. See [architecture](docs/ARCHITECTURE.md) and [SIRCL](docs/SIRCL.md).
 
 ## Prerequisites and evidence
 
-Before deploying either profile, complete the four-Spark
+Before deploying a profile, complete the applicable
 [prerequisites](docs/PREREQUISITES.md). Measured results, conditions, and
-limitations are in [results](docs/RESULTS.md). The two-profile registry is
+limitations are in [results](docs/RESULTS.md). The six-profile registry is
 [`docs/profiles/README.md`](docs/profiles/README.md).
 
 ## Repository map

--- a/README.md
+++ b/README.md
@@ -22,15 +22,11 @@ belongs to profiles rather than the transport.
 
 ## Cluster sizes
 
-Availability is profile-scoped; a cluster size does not imply that every model
-runs at that size.
-
-- **2× DGX Spark — direct pair.** Implemented for DeepSeek-V4-Flash-0731;
-  qualified with SparkCache.
-- **4× DGX Spark — physical ring.** Qualified for GLM-5.2 EXL3 3.5-bpw;
-  implemented for DeepSeek-V4-Flash-0731; qualified with SparkCache.
-- **6× DGX Spark — physical ring.** **Coming soon — unsupported; no published
-  launch profile.**
+- **2× DGX Spark — direct pair.** Models: DeepSeek-V4-Flash-0731; compatible
+  with SparkCache.
+- **4× DGX Spark — physical ring.** Models: GLM-5.2 EXL3 3.5-bpw;
+  DeepSeek-V4-Flash-0731; compatible with SparkCache.
+- **6× DGX Spark — physical ring.** **Coming soon.**
 
 ## Profiles
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ SparkRing is a low-latency collective transport and vLLM-based
 inference-serving stack for switchless clusters of NVIDIA DGX Spark systems
 powered by the GB10 Grace Blackwell Superchip.
 
+SparkRing supports GB10 pairs, four-node rings, and (soon) six-node rings.
+
 Models run as tensor-parallel deployments over the direct fabric without an
 external Ethernet or InfiniBand switch. SIRCL provides custom RDMA collectives
 for qualified four-node paths, CUDA-graph command rings support repeated decode

--- a/README.md
+++ b/README.md
@@ -55,8 +55,8 @@ Qualified durable prefix-state compositions for the two-Spark DeepSeek,
 four-Spark DeepSeek, and four-Spark GLM profiles are in
 [`recipes/sparkcache/`](recipes/sparkcache/README.md). They pin the exact
 SparkCache wheel and runtime image used by each live store/restart/restore
-gate. Their qualified scheduler budget is 4,096 tokens; 8,192 remains
-unsupported until it passes a separate smoke for the exact composition.
+gate. Those gates used a 4,096-token scheduler budget. Operators may choose
+other values; 8,192 is known to work but is outside the published receipts.
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ belongs to profiles rather than the transport.
   with SparkCache.
 - **4× DGX Spark — physical ring.** Models: GLM-5.2 EXL3 3.5-bpw;
   DeepSeek-V4-Flash-0731; compatible with SparkCache.
-- **6× DGX Spark — physical ring.** **Coming soon.**
+- **6× DGX Spark — physical ring.** **Coming soon. Models: GLM | KIMI.**
 
 ## Profiles
 

--- a/README.md
+++ b/README.md
@@ -11,18 +11,30 @@ SparkRing is a low-latency collective transport and vLLM-based
 inference-serving stack for switchless clusters of NVIDIA DGX Spark systems
 powered by the GB10 Grace Blackwell Superchip.
 
-Four 200 Gb/s ConnectX-7 links connect four DGX Sparks in a physical ring.
-Models run as tensor-parallel deployments without an Ethernet or InfiniBand
-switch in the inference fabric.
+Two DGX Sparks connect as a directly cabled pair. Four 200 Gb/s ConnectX-7
+links connect four DGX Sparks in a physical ring. Models run as
+tensor-parallel deployments without an Ethernet or InfiniBand switch in the
+inference fabric.
 
-SparkRing routes qualified vLLM collectives through SIRCL, its custom RDMA
-transport for the four-node ring. CUDA-graph command rings support repeated
-decode work, while patched NCCL handles communication outside SIRCL's
-supported paths.
+SparkRing routes qualified four-node vLLM collectives through SIRCL, its custom
+RDMA transport for the physical ring. CUDA-graph command rings support
+repeated decode work, while patched NCCL handles communication outside SIRCL's
+supported paths, including the two-node DeepSeek pair.
 
 The repository provides launch tooling, speculative-decoding integration,
 model profiles, and qualification evidence. Model-specific policy
 belongs to profiles rather than the transport.
+
+## Cluster sizes
+
+Availability is profile-scoped; a cluster size does not imply that every model
+runs at that size.
+
+| DGX Sparks | Physical topology | Availability |
+|---:|---|---|
+| **2×** | one directly cabled pair | implemented for DeepSeek-V4-Flash-0731; qualified with SparkCache |
+| **4×** | four-link switchless cycle | qualified for GLM-5.2 EXL3 3.5-bpw; implemented for DeepSeek-V4-Flash-0731; qualified with SparkCache |
+| **6×** | planned switchless topology | **Coming soon — unsupported; no published launch profile** |
 
 ## Profiles
 

--- a/README.md
+++ b/README.md
@@ -11,15 +11,10 @@ SparkRing is a low-latency collective transport and vLLM-based
 inference-serving stack for switchless clusters of NVIDIA DGX Spark systems
 powered by the GB10 Grace Blackwell Superchip.
 
-Two DGX Sparks connect as a directly cabled pair. Four 200 Gb/s ConnectX-7
-links connect four DGX Sparks in a physical ring. Models run as
-tensor-parallel deployments without an Ethernet or InfiniBand switch in the
-inference fabric.
-
-SparkRing routes qualified four-node vLLM collectives through SIRCL, its custom
-RDMA transport for the physical ring. CUDA-graph command rings support
-repeated decode work, while patched NCCL handles communication outside SIRCL's
-supported paths, including the two-node DeepSeek pair.
+Models run as tensor-parallel deployments over the direct fabric without an
+external Ethernet or InfiniBand switch. SIRCL provides custom RDMA collectives
+for qualified four-node paths, CUDA-graph command rings support repeated decode
+work, and patched NCCL handles communication outside SIRCL's supported paths.
 
 The repository provides launch tooling, speculative-decoding integration,
 model profiles, and qualification evidence. Model-specific policy
@@ -30,11 +25,12 @@ belongs to profiles rather than the transport.
 Availability is profile-scoped; a cluster size does not imply that every model
 runs at that size.
 
-| DGX Sparks | Physical topology | Availability |
-|---:|---|---|
-| **2×** | one directly cabled pair | implemented for DeepSeek-V4-Flash-0731; qualified with SparkCache |
-| **4×** | four-link switchless cycle | qualified for GLM-5.2 EXL3 3.5-bpw; implemented for DeepSeek-V4-Flash-0731; qualified with SparkCache |
-| **6×** | planned switchless topology | **Coming soon — unsupported; no published launch profile** |
+- **2× DGX Spark — direct pair.** Implemented for DeepSeek-V4-Flash-0731;
+  qualified with SparkCache.
+- **4× DGX Spark — physical ring.** Qualified for GLM-5.2 EXL3 3.5-bpw;
+  implemented for DeepSeek-V4-Flash-0731; qualified with SparkCache.
+- **6× DGX Spark — physical ring.** **Coming soon — unsupported; no published
+  launch profile.**
 
 ## Profiles
 

--- a/docs/profiles/README.md
+++ b/docs/profiles/README.md
@@ -1,10 +1,18 @@
-# Four-Spark profiles
+# Deployment profiles
 
-A profile names one model identity, its four-rank serving configuration, and the
-evidence scope for that configuration. SparkRing supports exactly the following
-two profiles.
+A profile names one model identity, hardware topology, serving configuration,
+and evidence scope. SparkRing supports exactly the following six profiles.
 
-| Profile | Model identity | Status and evidence scope | Documentation |
+| Profile | Topology | Status and evidence scope | Documentation |
 |---|---|---|---|
-| GLM-5.2 EXL3 3.5-bpw | `brandonmusic/GLM-5.2-EXL3-TR3v4-3.5bpw-MTP78@9ab9579774cc432df91567a36f6e9e863e0d4c9f` | qualified on one four-DGX-Spark appliance; a rebuilt image retains implemented status until promotion | [Quickstart](../GLM52_35BPW_QUICKSTART.md), [serving contract](../GLM52_35BPW_FIXED_MTP4_PROFILE.md) |
-| DeepSeek-V4-Flash-0731 | `deepseek-ai/DeepSeek-V4-Flash-0731` (no revision pinned) | implemented four-Spark launch; SIRCL width 4096 is research-only | [Recipe](../../recipes/deepseek-v4-flash-0731.json), [quickstart](../DEEPSEEK_V4_FLASH_QUICKSTART.md), [profile record](DEEPSEEK_V4_FLASH_0731.md) |
+| GLM-5.2 EXL3 3.5-bpw | four-Spark cycle, TP4/DCP4 | qualified on one four-DGX-Spark appliance; a rebuilt image retains implemented status until promotion | [Recipe](../../recipes/glm52-exl3-r7-3.5bpw.json), [quickstart](../GLM52_35BPW_QUICKSTART.md), [serving contract](../GLM52_35BPW_FIXED_MTP4_PROFILE.md) |
+| DeepSeek-V4-Flash-0731 | two-Spark pair, TP2/DCP1 | implemented launch; the checkpoint revision is not pinned and SIRCL is unsupported | [Recipe](../../recipes/deepseek-v4-flash-0731-pair.json), [quickstart](../DEEPSEEK_V4_FLASH_QUICKSTART.md) |
+| DeepSeek-V4-Flash-0731 | four-Spark cycle, TP4/DCP1 | implemented launch; the checkpoint revision is not pinned and SIRCL width 4096 is research-only | [Recipe](../../recipes/deepseek-v4-flash-0731.json), [quickstart](../DEEPSEEK_V4_FLASH_QUICKSTART.md), [profile record](DEEPSEEK_V4_FLASH_0731.md) |
+| GLM-5.2 EXL3 3.5-bpw + SparkCache | four-Spark cycle, TP4/DCP4 | qualified durable prefix-state composition for the exact artifacts and settings in the recipe | [Recipe](../../recipes/sparkcache/glm52-exl3-r7-3.5bpw-tp4-dcp4.json), [composition evidence](../../recipes/sparkcache/README.md) |
+| DeepSeek-V4-Flash-0731 + SparkCache | two-Spark pair, TP2/DCP1 | qualified durable prefix-state composition for the exact artifacts and settings in the recipe | [Recipe](../../recipes/sparkcache/deepseek-v4-flash-0731-tp2-dcp1.json), [composition evidence](../../recipes/sparkcache/README.md) |
+| DeepSeek-V4-Flash-0731 + SparkCache | four-Spark cycle, TP4/DCP1 | qualified durable prefix-state composition for the exact artifacts and settings in the recipe | [Recipe](../../recipes/sparkcache/deepseek-v4-flash-0731-tp4-dcp1.json), [composition evidence](../../recipes/sparkcache/README.md) |
+
+The GLM profiles pin model revision
+`9ab9579774cc432df91567a36f6e9e863e0d4c9f`. The DeepSeek base recipes do
+not pin a checkpoint revision; each SparkCache composition records the exact
+checkpoint hash used by its qualification gate.

--- a/recipes/sparkcache/README.md
+++ b/recipes/sparkcache/README.md
@@ -14,9 +14,10 @@ SparkCache.
 
 Every composition was qualified with SparkCache `0.1.0a1` wheel SHA-256
 `87c17d8dab5052f5a7833349dc9b99b76a3b6531ca6f0d3deff812f724fecdcc`.
-Install that exact wheel into the runtime Python environment on every rank and
-verify its hash before launch. The connector module is
-`sparkcache.spark_context_cache_connector`; the load-failure policy is
+Use that exact wheel and verify its hash on every rank when reproducing the
+published qualification gates. Operators may use another SparkCache build;
+the receipts on this page do not describe that artifact. The connector module
+is `sparkcache.spark_context_cache_connector`; the load-failure policy is
 `recompute`, so an unprovable restore becomes a cache miss and serving does not
 consume unverified bytes.
 
@@ -27,11 +28,11 @@ checkpoints, or between incompatible connector settings.
 
 ## Scheduler budget
 
-`--max-num-batched-tokens 4096` is the conservative qualified default in all
-three compositions. A value of `8192` is unsupported and is not an operator
-option in these recipes. It can be added to a composition only after the exact
-profile passes a separate cold-store, coordinated-restart, external-hit, and
-post-restore canary smoke at that value.
+`--max-num-batched-tokens 4096` is the scheduler budget used by the published
+qualification gates for all three compositions; it is not a configuration
+ceiling. Operators may change the value, and `8192` is known to work. The
+receipts below cover `4096`; performance and capacity behavior at other values
+is outside their evidence scope.
 
 ## Qualification evidence
 
@@ -59,8 +60,11 @@ a coordinated engine restart and continue generating correct output. The
 result qualifies the recorded artifacts and settings; it does not establish
 general vLLM, checkpoint, topology, or production reliability.
 
-Limitations: DeepSeek DCP2 and DCP4, streaming snapshots, native restore,
-other scheduler budgets, other images, other checkpoints, and other cache
-geometries are unsupported. The GLM composition also requires the Q40 receipt
+Limitations: The published receipts use a 4,096-token scheduler budget; other
+budgets are operator choices whose performance and capacity behavior is not
+recorded here. The DeepSeek receipts cover DCP1, not DCP2 or DCP4. These
+recipes disable streaming snapshots and native restore, so the receipts do not
+cover either mode. Other images, checkpoints, and cache geometries are also
+outside the recorded evidence. The GLM composition requires the Q40 receipt
 preservation and regeneration procedure recorded in its recipe before every
 coordinated restart.

--- a/recipes/sparkcache/deepseek-v4-flash-0731-tp2-dcp1.json
+++ b/recipes/sparkcache/deepseek-v4-flash-0731-tp2-dcp1.json
@@ -73,9 +73,9 @@
     "record": "README.md"
   },
   "limitations": [
-    "The 4096-token scheduler budget is the only qualified budget. A budget of 8192 remains unsupported until it passes its own cold-store, coordinated-restart, external-hit, and canary smoke.",
+    "The published qualification receipt used a 4096-token scheduler budget. Operators may choose other values; 8192 is known to work, but its performance and capacity behavior is outside this receipt.",
     "The qualified context limit is 131072 tokens; the base recipe's 1048576-token setting is not qualified with SparkCache.",
-    "DeepSeek DCP2 and DCP4 are unsupported.",
-    "Streaming snapshots and native restore are unsupported."
+    "The published receipt covers DeepSeek DCP1, not DCP2 or DCP4.",
+    "This recipe disables streaming snapshots and native restore; the published receipt does not cover either mode."
   ]
 }

--- a/recipes/sparkcache/deepseek-v4-flash-0731-tp4-dcp1.json
+++ b/recipes/sparkcache/deepseek-v4-flash-0731-tp4-dcp1.json
@@ -71,8 +71,8 @@
     "record": "README.md"
   },
   "limitations": [
-    "The 4096-token scheduler budget is the only qualified budget. A budget of 8192 remains unsupported until it passes its own cold-store, coordinated-restart, external-hit, and canary smoke.",
-    "DeepSeek DCP2 and DCP4 are unsupported.",
-    "Streaming snapshots and native restore are unsupported."
+    "The published qualification receipt used a 4096-token scheduler budget. Operators may choose other values; 8192 is known to work, but its performance and capacity behavior is outside this receipt.",
+    "The published receipt covers DeepSeek DCP1, not DCP2 or DCP4.",
+    "This recipe disables streaming snapshots and native restore; the published receipt does not cover either mode."
   ]
 }

--- a/recipes/sparkcache/glm52-exl3-r7-3.5bpw-tp4-dcp4.json
+++ b/recipes/sparkcache/glm52-exl3-r7-3.5bpw-tp4-dcp4.json
@@ -82,8 +82,8 @@
     "record": "README.md"
   },
   "limitations": [
-    "The 4096-token scheduler budget is the only qualified budget. A budget of 8192 remains unsupported until it passes its own cold-store, coordinated-restart, external-hit, and canary smoke.",
+    "The published qualification receipt used a 4096-token scheduler budget. Operators may choose other values; 8192 is known to work, but its performance and capacity behavior is outside this receipt.",
     "The qualified lane requires the exact Q40 runtime receipt procedure before every coordinated restart.",
-    "Streaming snapshots and native restore are unsupported."
+    "This recipe disables streaming snapshots and native restore; the published receipt does not cover either mode."
   ]
 }

--- a/scripts/test_sparkcache_recipes.py
+++ b/scripts/test_sparkcache_recipes.py
@@ -41,11 +41,14 @@ def test_compositions_pin_artifact_and_fail_closed_policy() -> None:
         assert recipe["sparkcache"]["native_restore"] is False
 
 
-def test_unsupported_scheduler_budget_is_not_an_operator_setting() -> None:
+def test_scheduler_budget_records_evidence_without_an_operator_ceiling() -> None:
     for path in RECIPE_PATHS:
         recipe = _load(path)
-        assert 8192 not in recipe["serving"].values()
-        assert any("8192 remains unsupported" in item for item in recipe["limitations"])
+        limitations = " ".join(recipe["limitations"])
+        assert "Operators may choose other values" in limitations
+        assert "8192 is known to work" in limitations
+        assert "8192 remains unsupported" not in limitations
+        assert "only qualified budget" not in limitations
 
 
 def test_parallelism_matches_physical_rank_count() -> None:


### PR DESCRIPTION
## Result

- Shows the 2×, 4×, and planned 6× DGX Spark cluster shapes near the top of the front page.
- Lists all six deployable profiles: three base serving profiles and three SparkCache compositions.
- Aligns the deployment-profile registry and profile-count wording with the recipe files.
- Separates published SparkCache evidence scope from operator configuration choices. The qualification receipts used a 4,096-token scheduler budget; operators may change it, and 8,192 is known to work.
- Describes alternate SparkCache builds, DCP settings, snapshots, restore modes, images, checkpoints, and cache geometries as outside the published receipts instead of broadly prohibiting them.

## Compatibility

Documentation and contract-test wording only. Runtime behavior, recipe serving values, launch configuration, and recorded qualification results are unchanged.

## Validation

- `ruff check --select E,F,W --ignore E501 .`
- `python -m pytest spark_transport runtime/exl3-r7 runtime/test_public_overlay.py performance/harnesses scripts -q -rs`: 1,753 passed, 9 skipped.
- CI-equivalent Markdown link checker: 108 repository-relative links checked successfully.
- `git diff --check`