### PR TITLE
Redraw the topology diagram and describe the topology in prose

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,11 +22,16 @@ conversation or development history.
 
 ## Supported repository surface
 
-SparkRing supports two serving configurations:
+SparkRing supports two model families across six deployment profiles:
 
-- GLM-5.2 EXL3 3.5-bpw, using the R7 runtime and site/candidate contracts.
-- DeepSeek-V4-Flash-0731, using the published serving image and per-rank
-  environment contract.
+- GLM-5.2 EXL3 3.5-bpw at four-Spark TP4/DCP4, as a base profile and a
+  SparkCache composition, using the R7 runtime and site/candidate contracts.
+- DeepSeek-V4-Flash-0731 at two-Spark TP2/DCP1 and four-Spark TP4/DCP1, as
+  base profiles and SparkCache compositions, using the published serving image
+  and per-rank environment contracts.
+
+Six-Spark GLM and KIMI profiles are in dev and are not part of the supported
+repository surface.
 
 Maintained Python trees are `spark_transport/`, `runtime/`, `scripts/`, and
 `performance/`. The R7 runtime builder is `runtime/exl3-r7/`. Do not add

--- a/README.md
+++ b/README.md
@@ -50,22 +50,42 @@ unsupported until it passes a separate smoke for the exact composition.
 ## Architecture
 
 ```text
-             management network
-          |       |       |       |
-         S0      S1      S2      S3
+management LAN ─┬─────────────┬─────────────┬─────────────┐
+            ┌───┴────┐    ┌───┴────┐    ┌───┴────┐    ┌───┴────┐
+     API ──>│ rank 0 ╞════╡ rank 1 ╞════╡ rank 2 ╞════╡ rank 3 │
+            └───╤────┘    └────────┘    └────────┘    └───╤────┘
+                ╚═════════════════════════════════════════╝
 
-                  200 Gb/s
-             S0 ========== S1
-             ||             ||
-    200 Gb/s ||             || 200 Gb/s
-             ||             ||
-             S3 ========== S2
-                  200 Gb/s
+  ═══  one 200 Gb/s ConnectX-7 DAC per edge (RoCEv2); the inference fabric
+  ───  management LAN: SSH, rendezvous, rank-0 API; never a fabric edge
 ```
 
-SIRCL, the Switchless Inference RDMA Collective Layer, provides the qualified
-collective path. Patched NCCL is the fallback for communication outside that
-path. See [architecture](docs/ARCHITECTURE.md) and [SIRCL](docs/SIRCL.md).
+Four DGX Sparks serve one model as four tensor-parallel ranks, numbered 0
+through 3. The inference fabric is a cycle of four direct cables - rank 0 to
+rank 1, 1 to 2, 2 to 3, and 3 back to 0 - each one 200 Gb/s ConnectX-7 link
+carrying RoCEv2. Every rank has exactly two fabric neighbours, and no switch
+carries collective traffic. A separate management LAN reaches all four ranks
+with SSH, rendezvous, and the client API that rank 0 serves; it is never a
+fabric edge.
+
+A switchless fabric has no shared broadcast domain, so a rank reaches the peer
+opposite it on the cycle only through a neighbour that forwards the traffic.
+Routes, IP forwarding, and Docker forward rules are therefore launch
+prerequisites on every rank, checked by
+[`scripts/ring_doctor.py`](scripts/ring_doctor.py).
+
+Collectives do not take that relay. SIRCL, the Switchless Inference RDMA
+Collective Layer, schedules a four-rank collective as the cycle's two perfect
+matchings - ranks 0-1 with 2-3, then 1-2 with 3-0 - so every step is a
+neighbour exchange and the two steps together use all four links. SIRCL holds
+persistent RDMA sessions and device-published command rings that CUDA graph
+replay resubmits without host work. Patched NCCL is the fallback for collective
+shapes outside SIRCL's qualified families.
+
+DeepSeek-V4-Flash-0731 also deploys as two ranks on a single cabled pair. The
+GLM profile requires the four-Spark cycle.
+
+See [architecture](docs/ARCHITECTURE.md) and [SIRCL](docs/SIRCL.md).
 
 ## Prerequisites and evidence
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > **This repository is changing rapidly.** Documentation, profiles, and
 > branch history are being restructured as SparkRing's scope narrows to
-> switchless four-Spark collective transport and serving. Published
+> switchless multi-Spark collective transport and serving. Published
 > branches may be rebased and documents may be moved, renamed, or
 > replaced without a deprecation period. Pin a commit if you depend on a
 > specific state of this tree.
@@ -11,7 +11,7 @@ SparkRing is a low-latency collective transport and vLLM-based
 inference-serving stack for switchless clusters of NVIDIA DGX Spark systems
 powered by the GB10 Grace Blackwell Superchip.
 
-SparkRing supports GB10 pairs, four-node rings, and (soon) six-node rings.
+SparkRing supports GB10 pairs and four-node rings. Six-node rings are in dev.
 
 Models run as tensor-parallel deployments over the direct fabric without an
 external Ethernet or InfiniBand switch. SIRCL provides custom RDMA collectives
@@ -28,7 +28,7 @@ belongs to profiles rather than the transport.
   with SparkCache.
 - **4× DGX Spark — physical ring.** Models: GLM-5.2 EXL3 3.5-bpw;
   DeepSeek-V4-Flash-0731; compatible with SparkCache.
-- **6× DGX Spark — physical ring.** **Coming soon. Models: GLM | KIMI.**
+- **6× DGX Spark — physical ring.** **In dev. Target models: GLM | KIMI.**
 
 ## Profiles
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,32 +1,52 @@
 # SparkRing architecture
 
-SparkRing is a four-DGX-Spark inference stack. It serves the GLM-5.2 EXL3
-3.5-bpw and DeepSeek-V4-Flash-0731 profiles as four tensor-parallel ranks on a
-switchless 200 Gb/s direct-cable cycle.
+SparkRing is a DGX Spark inference stack. It serves the GLM-5.2 EXL3 3.5-bpw
+and DeepSeek-V4-Flash-0731 profiles as four tensor-parallel ranks on a
+switchless 200 Gb/s direct-cable cycle; DeepSeek-V4-Flash-0731 also serves as
+two ranks on a single cabled pair.
 
 ## Topology
 
 ```text
-             management network
-          |       |       |       |
-         S0      S1      S2      S3
+management LAN ─┬─────────────┬─────────────┬─────────────┐
+            ┌───┴────┐    ┌───┴────┐    ┌───┴────┐    ┌───┴────┐
+     API ──>│ rank 0 ╞════╡ rank 1 ╞════╡ rank 2 ╞════╡ rank 3 │
+            └───╤────┘    └────────┘    └────────┘    └───╤────┘
+                ╚═════════════════════════════════════════╝
 
-             S0 ========== S1
-             ||             ||
-             ||             ||
-             S3 ========== S2
+  ═══  one 200 Gb/s ConnectX-7 DAC per edge (RoCEv2); the inference fabric
+  ───  management LAN: SSH, rendezvous, rank-0 API; never a fabric edge
 ```
 
-Each edge is one direct 200 Gb/s ConnectX-7 link. The management network carries
-SSH, rendezvous, and rank 0's API traffic; it is not an inference-fabric edge.
-Ranks use both cycle neighbors for RDMA communication.
+Four ranks, numbered 0 through 3, are cabled as the cycle `0-1-2-3-0`. Each of
+those four edges is one direct 200 Gb/s ConnectX-7 link carrying RoCEv2, so
+every rank has exactly two fabric neighbours - rank 0 neighbours ranks 1 and 3,
+rank 1 neighbours ranks 0 and 2, and so on around the cycle - and no switch
+sits in the inference fabric. Ranks use both cycle neighbours for RDMA
+communication.
+
+The management network reaches all four ranks and carries SSH, rendezvous, and
+rank 0's API traffic. It is not an inference-fabric edge.
+
+A switchless fabric has no shared broadcast domain, so a rank reaches the peer
+opposite it on the cycle only through a neighbour that forwards the traffic.
+Routes to each non-adjacent fabric subnet, `net.ipv4.ip_forward=1`, and an
+unrestricted `DOCKER-USER` forward rule are launch prerequisites on every rank;
+[prerequisites](PREREQUISITES.md) states the conditions and
+[`scripts/ring_doctor.py`](../scripts/ring_doctor.py) verifies them.
+
+The DeepSeek two-Spark pair holds ranks 0 and 1 only, joined by one direct
+cable cage 0 to cage 0, with rank 0 serving the API and no relayed fabric hop.
+The GLM profile requires the four-Spark cycle.
 
 ## Collective path
 
 SIRCL (Switchless Inference RDMA Collective Layer) owns persistent RDMA
 sessions and graph-replayable command rings for qualified tensor-parallel
-collectives. On the four-rank cycle, a collective is scheduled as two perfect
-matchings. See [SIRCL](SIRCL.md) for the transport boundary.
+collectives. On the four-rank cycle, a collective is scheduled as the cycle's
+two perfect matchings - ranks 0-1 with 2-3, then 1-2 with 3-0 - so every step
+is a neighbour exchange and no rank relays another rank's collective data. See
+[SIRCL](SIRCL.md) for the transport boundary.
 
 Patched NCCL is the fallback for collective shapes and phases outside SIRCL's
 qualified path. The GLM profile uses SIRCL for qualified TP all-reduce and


### PR DESCRIPTION
The architecture section carried a two-part sketch: a management-network row
over four bare host labels, then a separate square of `====` edges. Neither
part named the ranks, and the surrounding prose described only the collective
path, so a reader who could not see the picture learned nothing about the
topology.

## Diagram

One diagram carries the whole topology: ranks 0 through 3 in cycle order, the
wrap-around edge that closes the cycle, the management LAN reaching every rank,
the API entry on rank 0, and line weight distinguishing the 200 Gb/s fabric
from the management LAN.

```text
management LAN ─┬─────────────┬─────────────┬─────────────┐
            ┌───┴────┐    ┌───┴────┐    ┌───┴────┐    ┌───┴────┐
     API ──>│ rank 0 ╞════╡ rank 1 ╞════╡ rank 2 ╞════╡ rank 3 │
            └───╤────┘    └────────┘    └────────┘    └───╤────┘
                ╚═════════════════════════════════════════╝

  ═══  one 200 Gb/s ConnectX-7 DAC per edge (RoCEv2); the inference fabric
  ───  management LAN: SSH, rendezvous, rank-0 API; never a fabric edge
```

## Prose

The prose beside it states the same content without the diagram: the four cycle
edges enumerated, one 200 Gb/s ConnectX-7 link carrying RoCEv2 per edge, two
fabric neighbours per rank, no switch in the collective path, and what the
management LAN carries.

It adds two consequences the section left implicit. A switchless fabric has no
shared broadcast domain, so a rank reaches its non-adjacent peer only through a
forwarding neighbour, which is why routes, IP forwarding, and the `DOCKER-USER`
rule are launch prerequisites. Collectives do not take that relay, because
SIRCL schedules a four-rank collective as the cycle's two perfect matchings,
ranks 0-1 with 2-3 then 1-2 with 3-0.

`docs/ARCHITECTURE.md` carries the same diagram, names those matching pairs in
its collective-path section, and opens by stating both shipped topologies: four
tensor-parallel ranks on the cycle, and two ranks on a cabled pair for
DeepSeek-V4-Flash-0731.

## Compatibility and validation

Documentation only; no executable content changes. The diagram uses UTF-8
box-drawing characters, and both files were ASCII before. CRLF line endings are
unchanged, and every repo-relative link in both files resolves.
