### PR TITLE
Resolve review findings from PRs #97, #99, and #101

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,10 +68,11 @@ They are sanitized templates. Resolved inputs remain local and untracked.
 Validate configuration changes through the affected tests in `scripts/`; do
 not use an example configuration as evidence of a deployable appliance.
 
-DeepSeek-V4-Flash-0731 uses the per-rank environment template
-[`scripts/config/deepseek-v4-flash-0731.env.example`](scripts/config/deepseek-v4-flash-0731.env.example).
-Keep its placeholders explicit and document any environment-variable
-invariant in the template.
+DeepSeek-V4-Flash-0731 uses separate per-rank environment templates for the
+[four-Spark cycle](scripts/config/deepseek-v4-flash-0731.env.example) and
+[two-Spark pair](scripts/config/deepseek-v4-flash-0731-pair.env.example). Keep
+their placeholders explicit and document environment-variable invariants in
+the applicable template.
 
 ## Performance contributions
 

--- a/README.md
+++ b/README.md
@@ -74,27 +74,29 @@ management LAN ─┬─────────────┬─────�
 Four DGX Sparks serve one model as four tensor-parallel ranks, numbered 0
 through 3. The inference fabric is a cycle of four direct cables - rank 0 to
 rank 1, 1 to 2, 2 to 3, and 3 back to 0 - each one 200 Gb/s ConnectX-7 link
-carrying RoCEv2. Every rank has exactly two fabric neighbours, and no switch
+carrying RoCEv2. Every rank has exactly two fabric neighbors, and no switch
 carries collective traffic. A separate management LAN reaches all four ranks
 with SSH, rendezvous, and the client API that rank 0 serves; it is never a
 fabric edge.
 
-A switchless fabric has no shared broadcast domain, so a rank reaches the peer
-opposite it on the cycle only through a neighbour that forwards the traffic.
-Routes, IP forwarding, and Docker forward rules are therefore launch
-prerequisites on every rank, checked by
+A rank reaches a non-adjacent fabric address only through a neighbor that
+forwards the traffic. Routes to non-adjacent fabric subnets,
+`net.ipv4.ip_forward=1`, and unrestricted `DOCKER-USER` ACCEPT rules between
+the two fabric interfaces are therefore launch prerequisites on every rank,
+checked by
 [`scripts/ring_doctor.py`](scripts/ring_doctor.py).
 
 Collectives do not take that relay. SIRCL, the Switchless Inference RDMA
 Collective Layer, schedules a four-rank collective as the cycle's two perfect
-matchings - ranks 0-1 with 2-3, then 1-2 with 3-0 - so every step is a
-neighbour exchange and the two steps together use all four links. SIRCL holds
+matchings - ranks 0-1 with 2-3, then 1-2 with 3-0 - so every step is a neighbor
+exchange and the two steps together use all four links. SIRCL holds
 persistent RDMA sessions and device-published command rings that CUDA graph
 replay resubmits without host work. Patched NCCL is the fallback for collective
 shapes outside SIRCL's qualified families.
 
-DeepSeek-V4-Flash-0731 also deploys as two ranks on a single cabled pair. The
-GLM profile requires the four-Spark cycle.
+DeepSeek-V4-Flash-0731 has an implemented two-rank launch on a single cabled
+pair using patched NCCL; SIRCL is unsupported on that topology. The GLM
+profile requires the four-Spark cycle.
 
 See [architecture](docs/ARCHITECTURE.md) and [SIRCL](docs/SIRCL.md).
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -2,8 +2,9 @@
 
 SparkRing is a DGX Spark inference stack. It serves the GLM-5.2 EXL3 3.5-bpw
 and DeepSeek-V4-Flash-0731 profiles as four tensor-parallel ranks on a
-switchless 200 Gb/s direct-cable cycle; DeepSeek-V4-Flash-0731 also serves as
-two ranks on a single cabled pair.
+switchless 200 Gb/s direct-cable cycle. DeepSeek-V4-Flash-0731 also has an
+implemented two-rank launch on a single cabled pair using patched NCCL; SIRCL
+is unsupported on that topology.
 
 ## Topology
 
@@ -20,24 +21,25 @@ management LAN ─┬─────────────┬─────�
 
 Four ranks, numbered 0 through 3, are cabled as the cycle `0-1-2-3-0`. Each of
 those four edges is one direct 200 Gb/s ConnectX-7 link carrying RoCEv2, so
-every rank has exactly two fabric neighbours - rank 0 neighbours ranks 1 and 3,
-rank 1 neighbours ranks 0 and 2, and so on around the cycle - and no switch
-sits in the inference fabric. Ranks use both cycle neighbours for RDMA
+every rank has exactly two fabric neighbors - rank 0 neighbors ranks 1 and 3,
+rank 1 neighbors ranks 0 and 2, and so on around the cycle - and no switch
+sits in the inference fabric. Ranks use both cycle neighbors for RDMA
 communication.
 
 The management network reaches all four ranks and carries SSH, rendezvous, and
 rank 0's API traffic. It is not an inference-fabric edge.
 
-A switchless fabric has no shared broadcast domain, so a rank reaches the peer
-opposite it on the cycle only through a neighbour that forwards the traffic.
+A switchless fabric has no shared broadcast domain, so a rank reaches a
+non-adjacent fabric address only through a neighbor that forwards the traffic.
 Routes to each non-adjacent fabric subnet, `net.ipv4.ip_forward=1`, and an
 unrestricted `DOCKER-USER` forward rule are launch prerequisites on every rank;
 [prerequisites](PREREQUISITES.md) states the conditions and
 [`scripts/ring_doctor.py`](../scripts/ring_doctor.py) verifies them.
 
-The DeepSeek two-Spark pair holds ranks 0 and 1 only, joined by one direct
-cable cage 0 to cage 0, with rank 0 serving the API and no relayed fabric hop.
-The GLM profile requires the four-Spark cycle.
+The implemented DeepSeek two-Spark profile holds ranks 0 and 1 only, joined by
+one direct cable from cage 0 to cage 0, with rank 0 serving the API and no
+relayed fabric hop. It uses patched NCCL; SIRCL is unsupported on the pair. The
+GLM profile requires the four-Spark cycle.
 
 ## Collective path
 
@@ -45,15 +47,17 @@ SIRCL (Switchless Inference RDMA Collective Layer) owns persistent RDMA
 sessions and graph-replayable command rings for qualified tensor-parallel
 collectives. On the four-rank cycle, a collective is scheduled as the cycle's
 two perfect matchings - ranks 0-1 with 2-3, then 1-2 with 3-0 - so every step
-is a neighbour exchange and no rank relays another rank's collective data. See
+is a neighbor exchange and no rank relays another rank's collective data. See
 [SIRCL](SIRCL.md) for the transport boundary.
 
 Patched NCCL is the fallback for collective shapes and phases outside SIRCL's
 qualified path. The GLM profile uses SIRCL for qualified TP all-reduce and
 vocabulary families; its DCP and indexer collectives remain stock. The
-DeepSeek quickstart uses the patched NCCL configuration from
-`scripts/config/deepseek-v4-flash-0731.env.example`; width-4096 SIRCL graph
-collectives are research-only.
+four-Spark DeepSeek profile uses
+`scripts/config/deepseek-v4-flash-0731.env.example`; the two-Spark profile uses
+`scripts/config/deepseek-v4-flash-0731-pair.env.example`. Both use patched
+NCCL. Width-4096 SIRCL graph collectives are research-only on the four-Spark
+cycle and unsupported on the pair.
 
 ## Profile composition
 

--- a/performance/records/glm-3.5bpw/rebuilt-image-20260821.md
+++ b/performance/records/glm-3.5bpw/rebuilt-image-20260821.md
@@ -47,9 +47,10 @@ The operator performed these gates against the image ID above:
 
 Worker logs supplied weight bytes and load durations. The reported duration is
 the minimum-to-maximum range across four workers; no average or variability
-estimate was computed. Graph capture and startup completed before API health
-was accepted. No throughput, latency, deterministic-output, concurrency, or
-acceptance workload was measured.
+estimate was computed. That range is a single-run startup measurement, not a
+qualified performance distribution. Graph capture and startup completed before
+API health was accepted. No serving throughput, request latency,
+deterministic-output, concurrency, or acceptance workload was measured.
 
 The raw site, preflight, profile, attestation, and worker-log receipts remain
 outside the public repository. Their public derivatives are the hashes and
@@ -108,5 +109,5 @@ claims from another image.
   portable hardware claim.
 - Native transport tests passed 18 of 18 CTest targets on one GB10 host, not on
   the four-rank serving path.
-- No throughput, latency, acceptance-rate, cache, or output-quality result is
-  claimed.
+- No serving-throughput, request-latency, acceptance-rate, cache, or
+  output-quality result is claimed.

--- a/recipes/sparkcache/deepseek-v4-flash-0731-tp2-dcp1.json
+++ b/recipes/sparkcache/deepseek-v4-flash-0731-tp2-dcp1.json
@@ -69,6 +69,7 @@
       "This recipe disables streaming snapshots and native restore; the published receipt does not cover either mode."
     ],
     "record": "recipes/sparkcache/README.md",
+    "artifact_scope": "The exact SparkCache wheel, runtime image, checkpoint identity, topology, and serving values in this file.",
     "date": "2026-08-21",
     "prompt_tokens": 73774,
     "reusable_tokens": 73728,

--- a/recipes/sparkcache/deepseek-v4-flash-0731-tp4-dcp1.json
+++ b/recipes/sparkcache/deepseek-v4-flash-0731-tp4-dcp1.json
@@ -66,6 +66,7 @@
       "This recipe disables streaming snapshots and native restore; the published receipt does not cover either mode."
     ],
     "record": "recipes/sparkcache/README.md",
+    "artifact_scope": "The exact SparkCache wheel, runtime image, checkpoint identity, topology, and serving values in this file.",
     "date": "2026-08-21",
     "prompt_tokens": 73774,
     "reusable_tokens": 73728,

--- a/recipes/sparkcache/glm52-exl3-r7-3.5bpw-tp4-dcp4.json
+++ b/recipes/sparkcache/glm52-exl3-r7-3.5bpw-tp4-dcp4.json
@@ -76,6 +76,7 @@
       "Full GLM reasoning-trace equality is an inconclusive diagnostic under this runtime: repeated temperature-zero and fixed-seed requests produced different non-empty reasoning bodies with identical final content and finish reason stop."
     ],
     "record": "https://github.com/FujitsuPolycom/sparkcache/blob/999bc13d6c0b52a6cee3c90487ac9b8643ba3f99/GLM52_A2_LIVE_VALIDATION.md",
+    "artifact_scope": "The exact SparkCache wheel, runtime image, checkpoint identity, topology, and serving values in this file.",
     "date": "2026-08-21",
     "prompt_tokens": 225555,
     "reusable_tokens": 225536,

--- a/scripts/test_sparkcache_recipes.py
+++ b/scripts/test_sparkcache_recipes.py
@@ -72,20 +72,23 @@ def test_parallelism_matches_physical_rank_count() -> None:
         assert serving["decode_context_parallel_size"] in (1, 4)
 
 
-def test_composition_evidence_matches_the_base_recipe_shape() -> None:
-    """Both recipe schemas state evidence in one shape.
-
-    A composition carries extra measurement fields, but the keys a reader
-    relies on to judge a claim -- what was run, what came out, what it means,
-    and what it excludes -- are the same as in a base recipe.
-    """
+def test_composition_evidence_has_claim_shape_and_valid_base() -> None:
+    """Each composition states a full claim and names its actual base recipe."""
     required = {"status", "conditions", "result", "conclusion", "limitations", "record"}
-    base = _load(ROOT / "recipes" / "deepseek-v4-flash-0731.json")["evidence"]
-    assert set(base) == required
     for path in RECIPE_PATHS:
-        evidence = _load(path)["evidence"]
-        assert set(base) <= set(evidence), path.name
-        assert evidence["status"] == _load(path)["status"]
+        recipe = _load(path)
+        base = _load((path.parent / recipe["base_recipe"]).resolve())
+        evidence = recipe["evidence"]
+        assert required <= set(evidence), path.name
+        assert evidence["status"] == recipe["status"]
         assert evidence["conclusion"].strip()
         assert evidence["result"].strip()
         assert evidence["record"] != "README.md"
+        assert evidence["artifact_scope"].strip()
+        assert base["schema"] == "sparkring-recipe/v1"
+        assert base["model"]["repository"] == recipe["model"]["repository"]
+        assert base["hardware"]["ranks"] == recipe["hardware"]["ranks"]
+        if "evidence" in base:
+            assert required <= set(base["evidence"])
+        else:
+            assert {"status", "evidence"} <= set(base["publication"])

--- a/spark_transport/src/topology.cpp
+++ b/spark_transport/src/topology.cpp
@@ -58,9 +58,8 @@ std::vector<std::uint32_t> Topology::ranks() const {
 }
 
 Topology Topology::four_spark_direct_cycle() {
-  // vLLM global ranks map to physical nodes as
-  // 0=spark0, 1=spark1, 2=spark3, 3=spark2. The four undirected pairs below
-  // are the direct-cable cycle 0-1-3-2-0 in that logical rank space.
+  // vLLM global ranks follow the physical direct-cable cycle 0-1-2-3-0.
+  // The pairs below are the two perfect matchings used by the TP4 schedule.
   // Exact device assignment is injected at deployment; these logical edges
   // intentionally do not embed host-specific interface names.
   std::vector<EdgeConfig> edges;
@@ -75,8 +74,8 @@ Topology Topology::four_spark_direct_cycle() {
   };
   add_pair(0, 1, 9410);
   add_pair(2, 3, 9420);
-  add_pair(0, 2, 9430);
-  add_pair(1, 3, 9440);
+  add_pair(0, 3, 9430);
+  add_pair(1, 2, 9440);
   return Topology(std::move(edges));
 }
 

--- a/spark_transport/tests/test_topology_schedule_source_contract.py
+++ b/spark_transport/tests/test_topology_schedule_source_contract.py
@@ -1,0 +1,32 @@
+"""Keep the published four-rank topology aligned with the TP4 round schedule."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_direct_cycle_edges_match_tp4_round_masks() -> None:
+    topology = (ROOT / "src" / "topology.cpp").read_text(encoding="utf-8")
+    schedule = (ROOT / "src" / "tp4_schedule.cpp").read_text(encoding="utf-8")
+
+    configured = {
+        tuple(sorted((int(left), int(right))))
+        for left, right in re.findall(
+            r"add_pair\((\d+),\s*(\d+),\s*\d+\);", topology
+        )
+    }
+    masks = re.search(
+        r"round\s*==\s*0\s*\?\s*(\d+)U\s*:\s*(\d+)U", schedule
+    )
+    assert masks is not None
+    expected = {
+        tuple(sorted((rank, rank ^ int(mask))))
+        for rank in range(4)
+        for mask in masks.groups()
+    }
+
+    assert configured == expected == {(0, 1), (1, 2), (2, 3), (0, 3)}

--- a/spark_transport/tests/topology_test.cpp
+++ b/spark_transport/tests/topology_test.cpp
@@ -1,4 +1,5 @@
 #include "spark_transport/topology.hpp"
+#include "spark_transport/tp4_schedule.hpp"
 
 #include <cassert>
 #include <set>
@@ -9,7 +10,7 @@ int main() {
 
   const std::set<std::pair<std::uint32_t, std::uint32_t>> expected{
       {0, 1}, {1, 0}, {2, 3}, {3, 2},
-      {0, 2}, {2, 0}, {1, 3}, {3, 1},
+      {0, 3}, {3, 0}, {1, 2}, {2, 1},
   };
   for (const auto& [local, peer] : expected) {
     const auto& edge = topology.edge(local, peer);
@@ -21,4 +22,12 @@ int main() {
   assert(topology.edges_for(1).size() == 2);
   assert(topology.edges_for(2).size() == 2);
   assert(topology.edges_for(3).size() == 2);
+
+  for (std::uint32_t rank = 0; rank < 4; ++rank) {
+    for (std::uint32_t round = 0; round < 2; ++round) {
+      const auto plan = spark_transport::make_tp4_round_plan(rank, round);
+      const auto& edge = topology.edge(rank, plan.peer_rank);
+      assert(edge.peer_rank == plan.peer_rank);
+    }
+  }
 }


### PR DESCRIPTION
## Resulting behavior

This follow-up resolves the remaining review findings from merged PRs #97, #99, and #101.

- The rebuilt-image record identifies its load-duration range as a single-run startup measurement and distinguishes it from unmeasured serving throughput and request latency.
- SparkCache composition evidence retains `artifact_scope` and its contract test validates every composition against its own `base_recipe` instead of assuming every base recipe has the DeepSeek evidence shape.
- The README and architecture document state the two-Spark DeepSeek maturity and SIRCL boundary, link both DeepSeek environment templates, and name the exact route, IPv4-forwarding, and `DOCKER-USER` prerequisites.
- `Topology::four_spark_direct_cycle()` now exposes the documented `0-1-2-3-0` physical edges and exactly matches `make_tp4_round_plan()`. The C++ test and a GPU-free source-contract test prevent those definitions from drifting again.
- The contributor guide names both DeepSeek environment templates.

## Technical reason

The three PRs were merged before their reviews were acted on. Their final merge updates resolved some findings, including image-ID policy and the 8192 operator-choice wording, but left evidence terminology, schema metadata, per-topology documentation, and native topology definitions inconsistent.

## Compatibility impact

Serving recipes and launch values are unchanged. `artifact_scope` is restored as additive evidence metadata. The native topology helper changes its second matching from diagonal pairs to the physical ring pairs used by the TP4 schedule; repository search shows that helper is consumed only by its tests in this checkout.

## Validation

- `ruff check --select E,F,W --ignore E501 spark_transport runtime scripts performance`
- `python -m pytest spark_transport runtime/exl3-r7 runtime/test_public_overlay.py performance/harnesses scripts -q -rs`: 1,755 passed, 9 skipped.
- Standalone `g++ -std=c++17 -Wall -Wextra -Wpedantic -Werror` build and execution of `topology_test`: passed.
- CI-equivalent Markdown link checker: 118 repository-relative links resolved.
- `git diff --check`