### PR TITLE
Bootstrap blank SparkRing clusters and deepen Ring Doctor

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@ powered by the GB10 Grace Blackwell Superchip.
 
 SparkRing supports GB10 pairs, four-node rings, and Six-node rings (in dev).
 
+Start with a blank DGX Spark using the
+[bootstrap guide](docs/BOOTSTRAP.md). The model-independent `sparkring cluster
+init` workflow enrolls nodes, discovers management and ConnectX-7 hardware,
+generates the cluster inventory, and launches Ring Doctor before any model
+profile is selected.
+
 Models run as tensor-parallel deployments over the direct fabric without an
 external Ethernet or InfiniBand switch. [SIRCL](https://github.com/FujitsuPolycom/sparkring/blob/main/docs/SIRCL.md) provides custom RDMA collectives
 for tested paths, CUDA-graph command rings support repeated decode

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# Install the SparkRing operator command on a blank DGX Spark.
+set -euo pipefail
+
+REPOSITORY="https://github.com/FujitsuPolycom/sparkring.git"
+REF="main"
+INSTALL_DIR="${HOME}/.local/share/sparkring"
+BIN_DIR="${HOME}/.local/bin"
+ASSUME_YES=0
+
+usage() {
+  cat <<'EOF'
+usage: bash bootstrap.sh [--ref BRANCH_OR_TAG] [--install-dir DIR] [--yes]
+
+Downloads SparkRing, verifies local prerequisites, and installs the
+`sparkring` command under ~/.local/bin. It does not configure networking or
+contact another Spark.
+EOF
+}
+
+while (($#)); do
+  case "$1" in
+    --ref)
+      REF=${2:?--ref requires a value}
+      shift 2
+      ;;
+    --install-dir)
+      INSTALL_DIR=${2:?--install-dir requires a value}
+      shift 2
+      ;;
+    --yes)
+      ASSUME_YES=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+for command_name in git python3 ssh ssh-keygen ssh-keyscan ssh-copy-id; do
+  if ! command -v "$command_name" >/dev/null 2>&1; then
+    echo "missing required command: $command_name" >&2
+    exit 1
+  fi
+done
+
+if ! python3 -c 'import yaml' >/dev/null 2>&1; then
+  echo "PyYAML is required (Ubuntu package: python3-yaml)."
+  if ((ASSUME_YES == 0)); then
+    read -r -p "Install python3-yaml with apt? Type yes: " answer
+    if [[ ${answer,,} != yes ]]; then
+      echo "installation cancelled" >&2
+      exit 1
+    fi
+  fi
+  sudo apt-get update
+  sudo apt-get install -y python3-yaml
+fi
+
+if [[ -e "$INSTALL_DIR" ]]; then
+  if [[ ! -d "$INSTALL_DIR/.git" ]]; then
+    echo "refusing to replace non-git path: $INSTALL_DIR" >&2
+    exit 1
+  fi
+  if [[ -n $(git -C "$INSTALL_DIR" status --porcelain) ]]; then
+    echo "refusing to update dirty managed checkout: $INSTALL_DIR" >&2
+    exit 1
+  fi
+  git -C "$INSTALL_DIR" fetch --tags origin
+  if git -C "$INSTALL_DIR" show-ref --verify --quiet "refs/remotes/origin/$REF"; then
+    git -C "$INSTALL_DIR" checkout -B "$REF" "origin/$REF"
+  else
+    git -C "$INSTALL_DIR" checkout --detach "$REF"
+  fi
+else
+  mkdir -p "$(dirname "$INSTALL_DIR")"
+  git clone --branch "$REF" --single-branch "$REPOSITORY" "$INSTALL_DIR"
+fi
+
+mkdir -p "$BIN_DIR"
+launcher="$BIN_DIR/sparkring"
+if [[ -L "$launcher" ]]; then
+  if [[ $(readlink "$launcher") == "$INSTALL_DIR/scripts/sparkring.py" ]]; then
+    rm "$launcher"
+  else
+    backup="$launcher.before-sparkring-bootstrap-$(date -u +%Y%m%dT%H%M%SZ)"
+    mv "$launcher" "$backup"
+    echo "backed up existing launcher symlink to $backup"
+  fi
+elif [[ -e "$launcher" ]]; then
+  backup="$launcher.before-sparkring-bootstrap-$(date -u +%Y%m%dT%H%M%SZ)"
+  mv "$launcher" "$backup"
+  echo "backed up existing launcher to $backup"
+fi
+printf '#!/usr/bin/env bash\nexec python3 %q "$@"\n' \
+  "$INSTALL_DIR/scripts/sparkring.py" > "$launcher"
+chmod 0755 "$launcher"
+chmod 0755 "$INSTALL_DIR/scripts/sparkring.py"
+
+echo
+echo "SparkRing installed at $INSTALL_DIR"
+echo "Command installed at $launcher"
+case ":${PATH}:" in
+  *":${BIN_DIR}:"*) ;;
+  *) echo "Add this to your shell profile: export PATH=\"${BIN_DIR}:\$PATH\"" ;;
+esac
+echo
+echo "Check this Spark first:"
+echo "  sparkring host check"
+echo
+echo "Then start a new ring on the head Spark:"
+echo "  sparkring cluster init --size 4"

--- a/docs/BOOTSTRAP.md
+++ b/docs/BOOTSTRAP.md
@@ -1,0 +1,162 @@
+# Bootstrap a blank SparkRing cluster
+
+Status: implemented for four- and six-Spark direct rings.
+
+This procedure starts with one blank DGX Spark whose management IPv4 address,
+username, and password are known. That first Spark becomes rank 0 and the
+normal Ring Doctor controller. Passwords are used only by the interactive
+OpenSSH `ssh-copy-id` command; SparkRing never reads or stores them.
+
+## 1. Connect to the head Spark
+
+From a laptop on the management network:
+
+```bash
+ssh <username>@<rank0-management-ip>
+```
+
+## 2. Download and inspect the installer
+
+```bash
+curl -fLO \
+  https://raw.githubusercontent.com/FujitsuPolycom/sparkring/main/bootstrap.sh
+less bootstrap.sh
+bash bootstrap.sh
+```
+
+The installer checks for Git, Python, OpenSSH, `ssh-copy-id`, and PyYAML. If
+PyYAML is absent, it asks before installing Ubuntu's `python3-yaml` package.
+It installs a managed checkout under `~/.local/share/sparkring` and the command
+`~/.local/bin/sparkring`. It does not contact another Spark or configure a
+network.
+
+If `~/.local/bin` is not already in `PATH`:
+
+```bash
+export PATH="$HOME/.local/bin:$PATH"
+```
+
+## 3. Check the blank Spark
+
+Before adding other nodes, run the read-only single-host check:
+
+```bash
+sparkring host check
+```
+
+It verifies DGX release metadata, GPU driver visibility, Docker, NVIDIA
+Container Toolkit, ConnectX-7 PCI/RDMA inventory, failed systemd units, root
+free space, and reports the `nvidia-dgx-telemetry.service` state. To make
+enabled telemetry a failing policy check:
+
+```bash
+sparkring host check --require-telemetry-disabled
+```
+
+The default check reports telemetry without changing or condemning the user's
+first-boot consent choice.
+
+## 4. Cable and initialize the ring
+
+Use the standard direct cycle:
+
+- Four Sparks: `0-1-2-3-0`
+- Six Sparks: `0-1-2-3-4-5-0`
+
+Rank `N` port `enp1s0f0np0` connects to rank `N+1` port
+`enp1s0f1np1`. The last rank connects back to rank 0.
+
+On rank 0:
+
+```bash
+sparkring cluster init --size 4
+```
+
+The command prompts for `username@IPv4` for rank 0 and every worker. Before
+enrollment it prints the complete plan. It idempotently authorizes rank 0's
+generated key for self-SSH, then verifies rank 0's management host key. For
+each worker it:
+
+1. scans the Ed25519 SSH host key;
+2. displays the fingerprint and requires the operator to type `yes`;
+3. invokes the system `ssh-copy-id`, which prompts for the password once;
+4. proves that non-interactive key access works;
+5. inventories hostname, management interface, ConnectX-7 interfaces, and
+   RDMA mappings; and
+6. writes `~/.config/sparkring/cluster.yaml`.
+
+The default fabric allocation is `198.18.0.0/21`, divided into one `/24`
+per direct cable. Override it when that range overlaps the management network:
+
+```bash
+sparkring cluster init \
+  --size 4 \
+  --fabric-supernet 10.77.0.0/21
+```
+
+Initialization fails rather than generating an inventory when management
+addresses overlap the selected fabric range, expected ConnectX-7 interfaces
+are absent, RDMA mappings differ, ranks are duplicated, or SSH enrollment does
+not produce key-only access.
+
+## 5. Review and install fabric addresses
+
+First print the exact netplan for every rank:
+
+```bash
+sparkring cluster configure
+```
+
+Generated netplans contain only the two fabric interfaces. They never name the
+management interface or a default route. After review:
+
+```bash
+sparkring cluster configure --apply
+```
+
+The command backs up any prior SparkRing fabric netplan, runs
+`netplan generate`, applies it, and immediately verifies that the configured
+management address remains on the same interface. A failed management check
+restores the prior netplan and stops before changing another rank.
+
+## 6. Run the read-only diagnosis
+
+```bash
+sparkring doctor --verify
+```
+
+Require:
+
+- controller `rank0`;
+- one valid four- or six-node cycle;
+- canonical fabric preflight `PASS`;
+- full reachability matrix `PASS`;
+- management repair guard `READY`; and
+- no failed or unknown diagnostic checks.
+
+The command prints a repair plan but changes nothing without `--apply`.
+
+## 7. Apply fabric routing only after review
+
+```bash
+sparkring doctor --verify --apply
+```
+
+Ring Doctor can change only observed fabric routes, IPv4 forwarding, and
+fabric-to-fabric `DOCKER-USER` accepts. It checks the active management address
+and return route before and after every individual operation and stops at the
+first mismatch.
+
+## Worker-controller recovery
+
+Prepare and test worker recovery while rank 0 is healthy. Then, if rank 0
+cannot run Doctor, execute from an enrolled worker:
+
+```bash
+sparkring doctor --allow-worker-controller --verify
+```
+
+The flag never permits an arbitrary laptop or unknown host. The local machine
+must match one configured worker rank. Worker recovery also requires that
+worker to have verified key access to every rank; automated recovery-key
+preparation is tracked separately from basic head-node bootstrap.

--- a/docs/PREREQUISITES.md
+++ b/docs/PREREQUISITES.md
@@ -9,6 +9,11 @@ hardware and operator conditions required by the
 GLM, Qwen cycle, and DeepSeek cycle configurations require four Sparks; the
 DeepSeek and Qwen pair profiles require two.
 
+Ring Doctor, canonical site validation, and fabric preflight support closed
+four- and six-Spark cycles. Six-Spark serving profiles remain `research-only`
+until their runtime and performance evidence are qualified; infrastructure
+support here does not promote those profiles into the supported surface.
+
 ## Hardware and topology
 
 For a four-Spark cycle:
@@ -17,6 +22,14 @@ For a four-Spark cycle:
 - Four qualified 200 Gb/s DACs cabled exactly as `0-1-2-3-0`.
 - Stable rank assignment: the same host is rank 0, 1, 2, or 3 throughout a
   deployment.
+
+For a six-Spark cycle (`research-only` serving profiles):
+
+- Six NVIDIA DGX Sparks with both 200 Gb/s ConnectX-7 ports available.
+- Six qualified 200 Gb/s DACs cabled exactly as `0-1-2-3-4-5-0`.
+- Stable rank assignment from rank 0 through rank 5 throughout a deployment.
+- A canonical site file with six edges and six ranks; every rank still owns
+  exactly two distinct fabric interfaces and two ring neighbours.
 
 For a two-Spark pair:
 
@@ -74,15 +87,58 @@ on every node before a launch:
   unreachable.
 
 [`scripts/ring_doctor.py`](../scripts/ring_doctor.py) checks all three, plus
-addressing and reachability, and prints a repair plan. Run it read-only first:
+addressing and reachability, and prints a repair plan. When a canonical site
+file is available, Ring Doctor also reuses the preflight implementation for
+negotiated link speed, expected MTU and address, active RDMA ports, Ethernet
+link mode, the configured RoCEv2 GID, and a don't-fragment jumbo ping. Run it
+read-only first:
 
 ```bash
-python scripts/ring_doctor.py   --node <user>@<host0> --node <user>@<host1>   --node <user>@<host2> --node <user>@<host3> --verify
+python scripts/ring_doctor.py \
+  --site scripts/config/site.yaml \
+  --verify
 ```
 
-Require zero `ERROR` findings and a reachability matrix in which every pair
-passes. `--apply` executes the printed plan, which is idempotent and needs
-passwordless `sudo` on each node.
+Run Ring Doctor on rank 0, the head node. The command verifies local identity
+against the configured rank management addresses and SSH hostnames before it
+contacts the cluster. If rank 0 cannot run the tool, run it from a configured
+worker with the explicit recovery flag:
+
+```bash
+python scripts/ring_doctor.py \
+  --site scripts/config/site.yaml \
+  --allow-worker-controller \
+  --verify
+```
+
+The flag does not permit execution from a laptop or unknown control host; the
+local machine must still identify as one configured worker rank. The report
+records when worker recovery mode was used.
+
+Require zero `ERROR` findings, a passing canonical fabric preflight, and a
+reachability matrix in which every pair passes. `--apply` executes the printed
+plan only after both the discovered cycle and canonical fabric checks pass. It
+is idempotent and needs passwordless `sudo` on each node.
+
+### Management safety during repair
+
+Ring Doctor treats management reachability as a hard mutation invariant. It
+does not change management addresses, links, routes, or NetworkManager
+profiles. Before `--apply` or `--emit-unit`, every node must meet all of these
+conditions:
+
+- discovery reached the node directly, not through a fabric jump host;
+- the canonical management interface exists and holds an IPv4 address; and
+- the management interface is distinct from both fabric interfaces.
+
+Each repair operation is restricted to observed fabric interfaces and fabric
+subnets. Ring Doctor checks that the active SSH session terminates on a guarded
+management address and that its return route uses a guarded management
+interface immediately before and after every individual change. The remaining
+plan stops on the first mismatch. Generated boot programs also verify the exact
+recorded management addresses before and after every change. If a legacy
+`--node` invocation is used instead of `--site`, name the management interface
+for every node with `--socket-interface`; otherwise all mutation is withheld.
 
 The repairs are runtime state and do not survive a reboot. `--emit-unit DIR`
 writes a per-node program and systemd unit that revalidate the addresses and

--- a/docs/QWEN38_27B_EXL3_K5K6_QUICKSTART.md
+++ b/docs/QWEN38_27B_EXL3_K5K6_QUICKSTART.md
@@ -72,8 +72,8 @@ Docker and the NVIDIA container runtime using the platform's supported DGX
 Spark procedure.
 
 Assign stable ranks 0-3 and cable the four fabric edges as `0-1`, `1-2`,
-`2-3`, and `3-0`. From the clean SparkRing checkout, run the read-only topology
-check from a control host:
+`2-3`, and `3-0`. From the clean SparkRing checkout on rank 0, run the
+read-only topology check:
 
 ```bash
 python scripts/ring_doctor.py \

--- a/scripts/preflight.py
+++ b/scripts/preflight.py
@@ -62,10 +62,17 @@ from sparkring_site import (  # noqa: E402  (local import after sys.path fix)
     ipv4_mapped_gid,
     load_site,
 )
+from sparkring_cluster import ClusterConfig  # noqa: E402
+from sparkring_diagnostics import (  # noqa: E402
+    CheckStatus,
+    DiagnosticCheck,
+    build_receipt,
+)
 
 EVIDENCE_SCHEMA = "sparkring-preflight/v1"
 PROBE_SENTINEL = "SPARKRING-PREFLIGHT-READY"
 PREFLIGHT_SCOPES = ("full", "fabric")
+FabricConfiguration = SiteConfig | ClusterConfig
 
 # --------------------------------------------------------------------------
 # Stable check ids.  These are contract: they appear in evidence JSON and are
@@ -186,7 +193,7 @@ def assert_read_only(command: str) -> None:
     """Raise :class:`ReadOnlyViolation` unless ``command`` is read-only.
 
     This is a guard rail, not a sandbox: it exists so that a well-meaning edit
-    to :func:`build_probe_script` cannot start mutating four production nodes
+    to :func:`build_probe_script` cannot start mutating production nodes
     without someone noticing.  Redirection to anywhere other than /dev/null is
     treated as a write.
     """
@@ -229,6 +236,19 @@ class CheckResult:
             "passed": self.passed,
             "detail": self.detail,
         }
+
+    def to_diagnostic_check(self) -> DiagnosticCheck:
+        """Represent a preflight result in the shared diagnostic receipt."""
+        return DiagnosticCheck(
+            check_id=self.check_id,
+            status=CheckStatus.PASS if self.passed else CheckStatus.FAIL,
+            scope=("fabric" if self.check_id.startswith("RING.") else "host"),
+            subject=self.subject,
+            summary=CHECK_DESCRIPTIONS[self.check_id],
+            evidence=self.detail,
+            node=f"rank{self.rank}",
+            source="preflight",
+        )
 
 
 @dataclass(frozen=True)
@@ -315,8 +335,19 @@ def _validate_scope(scope: str) -> None:
         )
 
 
+def _validate_configuration_scope(
+    configuration: FabricConfiguration, scope: str
+) -> None:
+    _validate_scope(scope)
+    if isinstance(configuration, ClusterConfig) and scope != "fabric":
+        raise ValueError(
+            "a cluster inventory supports fabric preflight only; use a "
+            "deployment site for runtime, image, disk, and port checks"
+        )
+
+
 def build_probe_script(
-    site: SiteConfig,
+    site: FabricConfiguration,
     rank: Rank,
     scope: str = "full",
 ) -> str:
@@ -326,7 +357,7 @@ def build_probe_script(
     :func:`parse_probe_output`.  Every value is guarded so that a missing sysfs
     file becomes the literal ``-`` rather than a shifted field.
     """
-    _validate_scope(scope)
+    _validate_configuration_scope(site, scope)
     lines: list[str] = [
         "set -u",
         # v <path>: print the file's contents, or '-' if absent/empty.
@@ -542,13 +573,13 @@ def _normalise_digest(value: str) -> str:
 
 
 def evaluate_rank(
-    site: SiteConfig,
+    site: FabricConfiguration,
     rank: Rank,
     state: ProbeState,
     scope: str = "full",
 ) -> list[CheckResult]:
     """Turn one rank's probe state into check results.  Pure: no I/O."""
-    _validate_scope(scope)
+    _validate_configuration_scope(site, scope)
     results: list[CheckResult] = []
 
     def record(check_id: str, subject: str, passed: bool, detail: str) -> None:
@@ -662,7 +693,7 @@ def evaluate_rank(
     return results
 
 
-def _evaluate_ring_port(site: SiteConfig, rank: Rank, port: RingPort,
+def _evaluate_ring_port(site: FabricConfiguration, rank: Rank, port: RingPort,
                         state: ProbeState) -> list[CheckResult]:
     results: list[CheckResult] = []
     subject = f"{port.interface} [{port.edge}]"
@@ -743,13 +774,13 @@ def unreachable_results(rank: Rank, detail: str) -> list[CheckResult]:
 
 
 def check_rank(
-    site: SiteConfig,
+    site: FabricConfiguration,
     rank: Rank,
     runner: Runner,
     scope: str = "full",
 ) -> list[CheckResult]:
     """Probe one rank and evaluate it.  Never mutates remote state."""
-    _validate_scope(scope)
+    _validate_configuration_scope(site, scope)
     script = build_probe_script(site, rank, scope=scope)
     outcome = runner.run(rank.ssh_target, script)
     state = parse_probe_output(outcome.stdout)
@@ -762,12 +793,12 @@ def check_rank(
     return evaluate_rank(site, rank, state, scope=scope)
 
 
-def run_preflight(site: SiteConfig, runner: Runner,
+def run_preflight(site: FabricConfiguration, runner: Runner,
                   ranks: Sequence[int] | None = None,
                   max_workers: int = 4,
                   scope: str = "full") -> list[CheckResult]:
     """Probe every selected rank in parallel and return all check results."""
-    _validate_scope(scope)
+    _validate_configuration_scope(site, scope)
     selected = [
         rank for rank in site.ranks
         if ranks is None or rank.id in set(ranks)
@@ -834,14 +865,15 @@ def build_evidence(site: SiteConfig, results: Sequence[CheckResult],
     summary = summarise(results)
     if warnings is None:
         warnings = site.placeholder_warnings()
+    receipt_generated_at = generated_at or time.strftime(
+        "%Y-%m-%dT%H:%M:%SZ", time.gmtime()
+    )
     by_rank: dict[int, list[CheckResult]] = {}
     for result in results:
         by_rank.setdefault(result.rank, []).append(result)
     return {
         "schema": EVIDENCE_SCHEMA,
-        "generated_at": generated_at or time.strftime(
-            "%Y-%m-%dT%H:%M:%SZ", time.gmtime()
-        ),
+        "generated_at": receipt_generated_at,
         "read_only": True,
         "scope": scope,
         "passed": summary.ok,
@@ -859,6 +891,11 @@ def build_evidence(site: SiteConfig, results: Sequence[CheckResult],
         "failed_ranks": list(summary.failed_ranks),
         "placeholder_warnings": list(warnings),
         "known_check_ids": list(CHECK_IDS),
+        "diagnostics": build_receipt(
+            [result.to_diagnostic_check() for result in results],
+            generated_at=receipt_generated_at,
+            source="preflight",
+        ),
         "ranks": [
             {
                 "rank": rank.id,

--- a/scripts/ring_doctor.py
+++ b/scripts/ring_doctor.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Discover, diagnose, repair, and verify a four-node SparkRing fabric.
+"""Discover, diagnose, repair, and verify a supported SparkRing fabric.
 
 The default operation is read-only. Remote changes require ``--apply``. Every
 route next hop and every boot-time address guard comes from addresses observed
@@ -22,11 +22,28 @@ import json
 import os
 import re
 import shlex
+import socket
 import subprocess
 import sys
 from collections import deque
 from pathlib import Path
 from typing import Any, Mapping, Protocol, Sequence
+
+try:
+    from .sparkring_cluster import ClusterConfig, ClusterConfigError, load_cluster
+    from .sparkring_site import (
+        SUPPORTED_RING_SIZES,
+        SiteConfig,
+        SiteConfigError,
+        load_site,
+    )
+    from .sparkring_diagnostics import CheckStatus, DiagnosticCheck, build_receipt
+    from .preflight import assert_read_only, run_preflight
+except ImportError:  # Direct execution: python scripts/ring_doctor.py
+    from sparkring_cluster import ClusterConfig, ClusterConfigError, load_cluster
+    from sparkring_site import SUPPORTED_RING_SIZES, SiteConfig, SiteConfigError, load_site
+    from sparkring_diagnostics import CheckStatus, DiagnosticCheck, build_receipt
+    from preflight import assert_read_only, run_preflight
 
 FABRIC_INTERFACES = ("enp1s0f0np0", "enp1s0f1np1")
 SSH_TARGET_RE = re.compile(r"^[A-Za-z0-9._-]+@[A-Za-z0-9._-]+$")
@@ -41,18 +58,48 @@ class ConfigurationError(ValueError):
 
 
 @dataclasses.dataclass(frozen=True)
+class LoadedInputs:
+    """One validated Ring Doctor invocation, optionally backed by SiteConfig."""
+
+    specs: tuple[NodeSpec, ...]
+    interfaces: tuple[str, ...]
+    timeout: int
+    rendezvous_address: ipaddress.IPv4Address | None
+    site: SiteConfig | None = None
+    cluster: ClusterConfig | None = None
+
+    @property
+    def fabric_configuration(self) -> SiteConfig | ClusterConfig | None:
+        return self.cluster or self.site
+
+
+@dataclasses.dataclass(frozen=True)
+class ControllerIdentity:
+    """Hostnames and non-loopback IPv4 addresses observed on this machine."""
+
+    hostnames: frozenset[str]
+    addresses: frozenset[ipaddress.IPv4Address]
+
+
+@dataclasses.dataclass(frozen=True)
 class NodeSpec:
     """One management SSH target and its optional discovery jump host.
 
     ``socket_interfaces`` holds the interface names a distributed launch gives
     to ``NCCL_SOCKET_IFNAME`` and ``GLOO_SOCKET_IFNAME`` on this node. They are
     inputs to be checked against the node, never values this tool sets.
+
+    ``fabric_interfaces`` is empty for the legacy discovery interface, which
+    applies the invocation-wide defaults. Site-driven discovery fills it from
+    the rank's canonical ``SiteConfig`` ring ports, so ranks may use different
+    Linux interface names without creating a second topology description.
     """
 
     name: str
     target: str
     proxy_jump: str | None = None
     socket_interfaces: tuple[str, ...] = ()
+    fabric_interfaces: tuple[str, ...] = ()
 
 
 @dataclasses.dataclass(frozen=True)
@@ -219,6 +266,17 @@ class SshRunner:
         )
 
 
+class ReadOnlyRunnerAdapter:
+    """Expose Ring Doctor's SSH runner to checks guarded as read-only."""
+
+    def __init__(self, runner: Runner) -> None:
+        self.runner = runner
+
+    def run(self, target: str, command: str) -> CommandResult:
+        assert_read_only(command)
+        return self.runner.run(target, command)
+
+
 @dataclasses.dataclass
 class NodeObservation:
     """Discovery evidence for one configured node, including probe failures.
@@ -311,6 +369,30 @@ class Finding:
     def to_dict(self) -> dict[str, Any]:
         return dataclasses.asdict(self)
 
+    def to_diagnostic_check(self) -> DiagnosticCheck:
+        """Represent the legacy finding in the shared diagnostic receipt."""
+        status = {
+            "info": CheckStatus.PASS,
+            "warning": CheckStatus.UNKNOWN,
+            "error": CheckStatus.FAIL,
+        }[self.severity]
+        if self.code.startswith("wifi-"):
+            scope = "management"
+        elif self.code.startswith(("rendezvous-", "socket-interface-", "launch-")):
+            scope = "distributed"
+        else:
+            scope = "fabric"
+        return DiagnosticCheck(
+            check_id=self.code,
+            status=status,
+            scope=scope,
+            subject=self.node or "cluster",
+            summary=self.message,
+            evidence=self.evidence,
+            node=self.node,
+            source="ring-doctor",
+        )
+
 
 @dataclasses.dataclass(frozen=True)
 class ProposedRoute:
@@ -368,6 +450,47 @@ class NodePlan:
                 for ingress, egress in sorted(self.relay_directions)
             ],
             "commands": self.commands(),
+        }
+
+
+@dataclasses.dataclass(frozen=True)
+class ManagementGuard:
+    """Management interfaces and addresses that must survive every repair."""
+
+    node: str
+    interfaces: tuple[InterfaceState, ...]
+
+    def shell_command(self) -> str:
+        checks: list[str] = []
+        guarded_addresses: list[str] = []
+        guarded_interfaces: list[str] = []
+        for interface in self.interfaces:
+            name = shlex.quote(interface.name)
+            guarded_interfaces.append(interface.name)
+            checks.append(f"ip link show dev {name} >/dev/null")
+            for address in interface.addresses:
+                guarded_addresses.append(str(address.ip))
+                literal = shlex.quote(str(address))
+                checks.append(
+                    f"ip -4 -o addr show dev {name} | grep -F -q -- {literal}"
+                )
+        server_cases = "|".join(shlex.quote(value) for value in guarded_addresses)
+        route_devices = "|".join(re.escape(value) for value in guarded_interfaces)
+        checks.extend(
+            (
+                'set -- $SSH_CONNECTION; test "$#" -ge 4',
+                f'case "$3" in {server_cases}) ;; *) exit 91 ;; esac',
+                'management_route=$(ip -4 route get "$1")',
+                f"printf '%s\\n' \"$management_route\" | "
+                f"grep -E -q -- ' dev ({route_devices})( |$)'",
+            )
+        )
+        return "\n".join(checks)
+
+    def address_map(self) -> dict[str, list[str]]:
+        return {
+            interface.name: sorted(str(address) for address in interface.addresses)
+            for interface in self.interfaces
         }
 
 
@@ -429,6 +552,143 @@ def _validate_interface(value: str, field: str) -> str:
 
 def _default_name(target: str) -> str:
     return target.split("@", 1)[1]
+
+
+def _interfaces_for(
+    spec: NodeSpec, defaults: Sequence[str] = FABRIC_INTERFACES
+) -> tuple[str, ...]:
+    """Return the canonical fabric interface names for one node."""
+    return spec.fabric_interfaces or tuple(defaults)
+
+
+def node_specs_from_configuration(
+    configuration: SiteConfig | ClusterConfig,
+) -> tuple[NodeSpec, ...]:
+    """Adapt canonical cluster facts to Ring Doctor discovery inputs."""
+    specs: list[NodeSpec] = []
+    for rank in sorted(configuration.ranks, key=lambda item: item.id):
+        fabric_interfaces = tuple(port.interface for port in rank.ring_ports)
+        if len(fabric_interfaces) != 2 or len(set(fabric_interfaces)) != 2:
+            raise ConfigurationError(
+                f"site rank{rank.id} must name two distinct fabric interfaces"
+            )
+        for index, name in enumerate(fabric_interfaces):
+            _validate_interface(name, f"site rank{rank.id} ring port {index + 1}")
+        management_interface = _validate_interface(
+            rank.management.interface, f"site rank{rank.id} management interface"
+        )
+        specs.append(
+            NodeSpec(
+                name=f"rank{rank.id}",
+                target=_validate_ssh_target(
+                    rank.ssh_target, f"site rank{rank.id} ssh_target"
+                ),
+                socket_interfaces=(management_interface,),
+                fabric_interfaces=fabric_interfaces,
+            )
+        )
+    _require_unique_specs(specs)
+    return tuple(specs)
+
+
+def node_specs_from_site(site: SiteConfig) -> tuple[NodeSpec, ...]:
+    """Compatibility name for existing callers."""
+    return node_specs_from_configuration(site)
+
+
+def read_controller_identity() -> ControllerIdentity:
+    """Observe enough local identity to prove which configured rank runs us."""
+    raw_names = {socket.gethostname(), socket.getfqdn()}
+    names = {
+        value.lower().rstrip(".")
+        for name in raw_names
+        for value in (name, name.split(".", 1)[0])
+        if value
+    }
+    addresses: set[ipaddress.IPv4Address] = set()
+    for name in raw_names:
+        try:
+            records = socket.getaddrinfo(name, None, socket.AF_INET)
+        except socket.gaierror:
+            continue
+        for record in records:
+            address = ipaddress.ip_address(record[4][0])
+            if isinstance(address, ipaddress.IPv4Address) and not address.is_loopback:
+                addresses.add(address)
+    try:
+        completed = subprocess.run(
+            ["ip", "-j", "-4", "addr", "show"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+        if completed.returncode == 0:
+            for row in json.loads(completed.stdout):
+                for item in row.get("addr_info", []):
+                    if item.get("family") != "inet":
+                        continue
+                    address = ipaddress.ip_address(item["local"])
+                    if not address.is_loopback:
+                        addresses.add(address)
+    except (OSError, subprocess.SubprocessError, ValueError, json.JSONDecodeError):
+        pass
+    return ControllerIdentity(frozenset(names), frozenset(addresses))
+
+
+def identify_controller_node(
+    loaded: LoadedInputs,
+    identity: ControllerIdentity,
+) -> str:
+    """Return the one configured rank proven to be the local machine."""
+    matches: list[str] = []
+    for spec in loaded.specs:
+        target_host = spec.target.split("@", 1)[1].lower().rstrip(".")
+        target_short = target_host.split(".", 1)[0]
+        matched = target_host in identity.hostnames or target_short in identity.hostnames
+        configuration = loaded.fabric_configuration
+        if configuration is not None:
+            rank_id = int(spec.name.removeprefix("rank"))
+            management_address = configuration.rank(rank_id).management.address
+            matched = matched or management_address in identity.addresses
+        else:
+            try:
+                target_address = ipaddress.ip_address(target_host)
+            except ValueError:
+                target_address = None
+            matched = matched or target_address in identity.addresses
+        if matched:
+            matches.append(spec.name)
+    if not matches:
+        raise ConfigurationError(
+            "Ring Doctor must run on a configured Spark. This machine did not "
+            "match any rank management address or SSH hostname."
+        )
+    if len(matches) != 1:
+        raise ConfigurationError(
+            "controller identity is ambiguous across configured ranks: "
+            + ", ".join(matches)
+        )
+    return matches[0]
+
+
+def enforce_controller_location(
+    loaded: LoadedInputs,
+    *,
+    allow_worker: bool,
+    identity: ControllerIdentity | None = None,
+) -> str:
+    """Require rank 0 unless explicit worker-controller recovery is enabled."""
+    controller = identify_controller_node(
+        loaded, identity if identity is not None else read_controller_identity()
+    )
+    head = loaded.specs[0].name
+    if controller == head or allow_worker:
+        return controller
+    raise ConfigurationError(
+        f"Ring Doctor is running on worker {controller}; run it on head node "
+        f"{head}, or use --allow-worker-controller only for head-node recovery."
+    )
 
 
 def parse_node_specs(document: Mapping[str, Any]) -> tuple[NodeSpec, ...]:
@@ -877,7 +1137,6 @@ def discover_nodes(
     rendezvous_address: ipaddress.IPv4Address | None = None,
 ) -> dict[str, NodeObservation]:
     """Probe nodes directly, then retry failures through discovered jump hosts."""
-    command = build_probe_command(interfaces, rendezvous_address)
     observations: dict[str, NodeObservation] = {}
     attempted: dict[str, list[str]] = {spec.name: [] for spec in specs}
 
@@ -886,10 +1145,12 @@ def discover_nodes(
         if label in attempted[spec.name]:
             return False
         attempted[spec.name].append(label)
+        node_interfaces = _interfaces_for(spec, interfaces)
+        command = build_probe_command(node_interfaces, rendezvous_address)
         result = runner.run(spec.target, command, jump)
         if result.ok:
             observations[spec.name] = parse_probe_output(
-                spec, result.stdout, interfaces, jump, rendezvous_address
+                spec, result.stdout, node_interfaces, jump, rendezvous_address
             )
             return True
         observations[spec.name] = NodeObservation(
@@ -1571,7 +1832,7 @@ def diagnose(
                 )
             )
             continue
-        for interface_name in interfaces:
+        for interface_name in _interfaces_for(spec, interfaces):
             state = observation.interfaces.get(interface_name)
             if state is None:
                 findings.append(
@@ -1749,41 +2010,191 @@ def _probe_by_name(
     return observations, topology, plans, findings
 
 
+def discovery_sufficient(
+    specs: Sequence[NodeSpec],
+    observations: Mapping[str, NodeObservation],
+    topology: Topology,
+) -> bool:
+    """Require a complete qualified-size cycle before persistence or repair."""
+    return (
+        len(specs) in SUPPORTED_RING_SIZES
+        and len(observations) == len(specs)
+        and all(observation.reachable for observation in observations.values())
+        and topology.valid_cycle
+        and len(topology.cycle) == len(specs)
+    )
+
+
+def build_management_guards(
+    specs: Sequence[NodeSpec],
+    observations: Mapping[str, NodeObservation],
+) -> tuple[dict[str, ManagementGuard], list[Finding]]:
+    """Fail closed unless every repair target has a direct management path."""
+    guards: dict[str, ManagementGuard] = {}
+    findings: list[Finding] = []
+    for spec in specs:
+        observation = observations[spec.name]
+        if not observation.reachable:
+            continue
+        if observation.proxy_jump_used is not None:
+            findings.append(
+                Finding(
+                    "error",
+                    "management-direct-path-unavailable",
+                    spec.name,
+                    "Repair is unsafe because discovery reached this node through "
+                    "a jump host instead of its direct management path.",
+                    f"proxy_jump_used={observation.proxy_jump_used}",
+                )
+            )
+            continue
+        if not spec.socket_interfaces:
+            findings.append(
+                Finding(
+                    "error",
+                    "management-guard-unconfigured",
+                    spec.name,
+                    "Repair is unsafe because no management interface was named. "
+                    "Use the canonical site file or identify it with "
+                    "--socket-interface.",
+                    "socket_interfaces=none",
+                )
+            )
+            continue
+        guarded: list[InterfaceState] = []
+        unsafe = False
+        for name in spec.socket_interfaces:
+            if name in observation.interfaces:
+                unsafe = True
+                findings.append(
+                    Finding(
+                        "error",
+                        "management-interface-is-fabric",
+                        spec.name,
+                        f"Repair is unsafe because {name} is named as both a "
+                        "management and fabric interface.",
+                        f"fabric interfaces={','.join(sorted(observation.interfaces))}",
+                    )
+                )
+                continue
+            state = observation.host_interfaces.get(name)
+            if state is None or not state.addresses:
+                unsafe = True
+                findings.append(
+                    Finding(
+                        "error",
+                        "management-interface-unaddressed",
+                        spec.name,
+                        f"Repair is unsafe because management interface {name} "
+                        "was not observed with an IPv4 address.",
+                        "interface absent" if state is None else "IPv4 addresses=none",
+                    )
+                )
+                continue
+            guarded.append(state)
+        if not unsafe and guarded:
+            guards[spec.name] = ManagementGuard(spec.name, tuple(guarded))
+    return guards, findings
+
+
+def validate_plan_management_safety(
+    observation: NodeObservation,
+    plan: NodePlan,
+    guard: ManagementGuard,
+) -> str | None:
+    """Return an explanation when a plan could overlap management state."""
+    fabric_names = set(observation.interfaces)
+    management_names = {interface.name for interface in guard.interfaces}
+    if fabric_names & management_names:
+        return "management and fabric interface sets overlap"
+    management_addresses = {
+        address.ip
+        for interface in guard.interfaces
+        for address in interface.addresses
+    }
+    for route in plan.routes:
+        if route.device not in fabric_names:
+            return f"route device {route.device} is not an observed fabric interface"
+        if route.destination.prefixlen == 0:
+            return "plan attempts to replace a default route"
+        if any(address in route.destination for address in management_addresses):
+            return f"fabric route {route.destination} contains a management address"
+    for ingress, egress in plan.relay_directions:
+        if ingress not in fabric_names or egress not in fabric_names:
+            return f"relay direction {ingress}->{egress} is not fabric-only"
+    return None
+
+
 def apply_plans(
     observations: Mapping[str, NodeObservation],
     plans: Mapping[str, NodePlan],
+    guards: Mapping[str, ManagementGuard],
     runner: Runner,
 ) -> list[Finding]:
-    """Execute complete plans through the SSH paths proven by discovery."""
+    """Apply one fabric change at a time while management stays invariant."""
     findings: list[Finding] = []
     for name, plan in sorted(plans.items()):
         commands = plan.commands()
         if not commands:
             continue
         observation = observations[name]
-        result = runner.run(
-            observation.spec.target,
-            "set -e\n" + "\n".join(commands),
-            observation.proxy_jump_used,
-        )
-        if not result.ok:
+        guard = guards.get(name)
+        if guard is None:
             findings.append(
                 Finding(
                     "error",
                     "apply-failed",
                     name,
-                    "The idempotent repair plan did not complete.",
-                    result.detail or result.stderr.strip() or "remote command failed",
+                    "The repair plan was withheld because no verified management "
+                    "guard exists for this node.",
+                    "management guard missing",
                 )
             )
+            continue
+        unsafe = validate_plan_management_safety(observation, plan, guard)
+        if unsafe:
+            findings.append(
+                Finding(
+                    "error",
+                    "apply-failed",
+                    name,
+                    "The repair plan was withheld because it is not fabric-only.",
+                    unsafe,
+                )
+            )
+            continue
+        guard_command = guard.shell_command()
+        for index, command in enumerate(commands, start=1):
+            result = runner.run(
+                observation.spec.target,
+                "set -e\n" + guard_command + "\n" + command + "\n" + guard_command,
+                None,
+            )
+            if result.ok:
+                continue
+            findings.append(
+                Finding(
+                    "error",
+                    "apply-failed",
+                    name,
+                    "The repair stopped immediately because a change failed or "
+                    "the management invariant did not hold afterward.",
+                    f"operation={index}/{len(commands)}; "
+                    + (result.detail or result.stderr.strip() or "remote command failed"),
+                )
+            )
+            break
     return findings
 
 
-def _unit_program(observation: NodeObservation, plan: NodePlan) -> str:
-    expected = {
+def _unit_program(
+    observation: NodeObservation, plan: NodePlan, guard: ManagementGuard
+) -> str:
+    expected_fabric = {
         name: sorted(str(address) for address in interface.addresses)
         for name, interface in sorted(observation.interfaces.items())
     }
+    expected_management = guard.address_map()
     route_argv = [
         [
             "ip",
@@ -1806,7 +2217,8 @@ import json
 import subprocess
 import sys
 
-EXPECTED = {expected!r}
+EXPECTED_FABRIC = {expected_fabric!r}
+EXPECTED_MANAGEMENT = {expected_management!r}
 ROUTES = {route_argv!r}
 RELAY_DIRECTIONS = {directions!r}
 
@@ -1831,25 +2243,44 @@ def observed_addresses(interface):
     return sorted(addresses)
 
 
-def main():
-    for interface, expected in EXPECTED.items():
+def check_addresses(expected_by_interface, label):
+    for interface, expected in expected_by_interface.items():
         try:
             actual = observed_addresses(interface)
         except (OSError, subprocess.SubprocessError, ValueError, json.JSONDecodeError) as exc:
-            print(f"ADDRESS CHECK FAILED {{interface}}: {{exc}}", file=sys.stderr)
-            return 1
+            print(f"{{label}} ADDRESS CHECK FAILED {{interface}}: {{exc}}", file=sys.stderr)
+            return False
         if actual != expected:
             print(
-                f"ADDRESS MISMATCH {{interface}}: expected={{expected}} actual={{actual}}",
+                f"{{label}} ADDRESS MISMATCH {{interface}}: "
+                f"expected={{expected}} actual={{actual}}",
                 file=sys.stderr,
             )
-            return 1
+            return False
+    return True
+
+
+def require_management():
+    if not check_addresses(EXPECTED_MANAGEMENT, "MANAGEMENT"):
+        raise RuntimeError("management invariant failed")
+
+
+def main():
+    if not check_addresses(EXPECTED_FABRIC, "FABRIC"):
+        return 1
+    try:
+        require_management()
+    except RuntimeError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
     for command in ROUTES:
         subprocess.run(command, check=True)
+        require_management()
     if RELAY_DIRECTIONS:
         subprocess.run(
             ["sysctl", "-w", "net.ipv4.ip_forward=1"], check=True
         )
+        require_management()
     for ingress, egress in RELAY_DIRECTIONS:
         rule = ["-i", ingress, "-o", egress, "-j", "ACCEPT"]
         check = subprocess.run(
@@ -1859,6 +2290,7 @@ def main():
             subprocess.run(
                 ["iptables", "-I", "DOCKER-USER", "1", *rule], check=True
             )
+        require_management()
     return 0
 
 
@@ -1871,16 +2303,20 @@ def emit_units(
     directory: Path,
     observations: Mapping[str, NodeObservation],
     plans: Mapping[str, NodePlan],
+    guards: Mapping[str, ManagementGuard],
 ) -> list[str]:
     """Write one fail-closed systemd service and program per observed node."""
     directory.mkdir(parents=True, exist_ok=True)
     written: list[str] = []
     for name, plan in sorted(plans.items()):
         observation = observations[name]
+        guard = guards[name]
         slug = re.sub(r"[^A-Za-z0-9_.-]", "-", name)
         program_path = (directory / f"ring-doctor-{slug}.py").resolve()
         unit_path = directory / f"ring-doctor-{slug}.service"
-        program_path.write_text(_unit_program(observation, plan), encoding="utf-8")
+        program_path.write_text(
+            _unit_program(observation, plan, guard), encoding="utf-8"
+        )
         os.chmod(program_path, 0o755)
         unit = f"""[Unit]
 Description=Reapply verified SparkRing fabric plan for {name}
@@ -1971,9 +2407,72 @@ def _render_matrix(matrix: Mapping[str, Mapping[str, bool | None]]) -> list[str]
     return lines
 
 
+def build_diagnostic_checks(
+    topology: Topology,
+    findings: Sequence[Finding],
+    verification: Mapping[str, Any] | None = None,
+) -> list[DiagnosticCheck]:
+    """Translate Ring Doctor evidence into the shared diagnostic interface."""
+    checks = [finding.to_diagnostic_check() for finding in findings]
+    checks.insert(
+        0,
+        DiagnosticCheck(
+            check_id="fabric-topology-cycle",
+            status=(CheckStatus.PASS if topology.valid_cycle else CheckStatus.FAIL),
+            scope="fabric",
+            subject="cluster",
+            summary=(
+                "The observed fabric forms one cycle."
+                if topology.valid_cycle
+                else "The observed fabric does not form one cycle."
+            ),
+            evidence=topology.reason,
+            source="ring-doctor",
+        ),
+    )
+    if verification is not None:
+        if verification["failed"]:
+            status = CheckStatus.FAIL
+            summary = "At least one observed fabric address was unreachable."
+        elif verification["unknown"]:
+            status = CheckStatus.UNKNOWN
+            summary = "At least one fabric reachability result was unavailable."
+        else:
+            status = CheckStatus.PASS
+            summary = "Every observed fabric address was reachable from every node."
+        checks.append(
+            DiagnosticCheck(
+                check_id="fabric-ip-reachability",
+                status=status,
+                scope="fabric",
+                subject="cluster",
+                summary=summary,
+                evidence=json.dumps(verification["matrix"], sort_keys=True),
+                source="ring-doctor",
+            )
+        )
+    return checks
+
+
 def render_text(report: Mapping[str, Any]) -> str:
     """Render the complete report for an operator without hidden context."""
     lines = ["SparkRing fabric diagnosis"]
+    site = report.get("site")
+    if site:
+        lines.append(
+            f"Canonical site: {site['name']} (schema {site['schema_version']}, "
+            f"source={site['source']})"
+        )
+    cluster = report.get("cluster")
+    if cluster:
+        lines.append(
+            f"Cluster inventory: {cluster['name']} "
+            f"(schema {cluster['schema_version']}, source={cluster['source']})"
+        )
+    controller = report.get("controller")
+    if controller:
+        mode = "worker recovery override" if controller["worker_override"] else "head"
+        lines.append(f"Controller: {controller['node']} ({mode})")
     topology = report["topology"]
     if topology["valid_cycle"]:
         cycle = topology["cycle"]
@@ -2022,6 +2521,32 @@ def render_text(report: Mapping[str, Any]) -> str:
         lines.append(f"Repair application: {outcome}")
     if report.get("verification"):
         lines.extend(_render_matrix(report["verification"]["matrix"]))
+    repair_safety = report.get("repair_safety")
+    if repair_safety:
+        lines.append(
+            "Management repair guard: "
+            + ("READY" if repair_safety["management_guard_ready"] else "NOT READY")
+        )
+        if repair_safety["guarded_nodes"]:
+            lines.append(
+                "  guarded nodes: " + ", ".join(repair_safety["guarded_nodes"])
+            )
+        for issue in repair_safety["issues"]:
+            lines.append(
+                f"  [{issue['severity'].upper()}] {issue['code']} "
+                f"{issue['node']}: {issue['message']}"
+            )
+    fabric_preflight = report.get("fabric_preflight") or []
+    if fabric_preflight:
+        failures = [result for result in fabric_preflight if not result["passed"]]
+        lines.append(
+            "Canonical fabric preflight: " + ("PASS" if not failures else "FAIL")
+        )
+        for result in failures:
+            lines.append(
+                f"  [FAIL] {result['check_id']} rank{result['rank']} "
+                f"{result['subject']}: {result['detail']}"
+            )
     return "\n".join(lines)
 
 
@@ -2039,15 +2564,70 @@ def _parse_rendezvous_address(value: str, field: str) -> ipaddress.IPv4Address:
 
 def _load_inputs(
     args: argparse.Namespace,
-) -> tuple[tuple[NodeSpec, ...], tuple[str, ...], int, ipaddress.IPv4Address | None]:
+) -> LoadedInputs:
     interfaces = tuple(args.interface or FABRIC_INTERFACES)
-    timeout = args.ssh_timeout
+    timeout = args.ssh_timeout if args.ssh_timeout is not None else 20
+    site: SiteConfig | None = None
+    cluster: ClusterConfig | None = None
     rendezvous_address = (
         _parse_rendezvous_address(args.rendezvous_address, "--rendezvous-address")
         if args.rendezvous_address
         else None
     )
-    if args.config:
+    if args.cluster:
+        conflicting = []
+        for option, value in (
+            ("--site", args.site),
+            ("--config", args.config),
+            ("--node", args.node),
+            ("--proxy-jump", args.proxy_jump),
+            ("--interface", args.interface),
+            ("--socket-interface", args.socket_interface),
+        ):
+            if value:
+                conflicting.append(option)
+        if conflicting:
+            raise ConfigurationError(
+                "--cluster cannot be combined with " + ", ".join(conflicting)
+            )
+        try:
+            cluster = load_cluster(args.cluster)
+        except ClusterConfigError as exc:
+            raise ConfigurationError(f"could not load --cluster: {exc}") from exc
+        specs = node_specs_from_configuration(cluster)
+        interfaces = specs[0].fabric_interfaces
+        if args.ssh_timeout is None:
+            timeout = cluster.preflight.ssh_timeout_seconds
+        if rendezvous_address is None:
+            rendezvous_address = cluster.head_rank.management.address
+    elif args.site:
+        conflicting = []
+        for option, value in (
+            ("--config", args.config),
+            ("--node", args.node),
+            ("--proxy-jump", args.proxy_jump),
+            ("--interface", args.interface),
+            ("--socket-interface", args.socket_interface),
+        ):
+            if value:
+                conflicting.append(option)
+        if conflicting:
+            raise ConfigurationError(
+                "--site cannot be combined with " + ", ".join(conflicting)
+            )
+        try:
+            site = load_site(args.site)
+        except SiteConfigError as exc:
+            raise ConfigurationError(f"could not load --site: {exc}") from exc
+        specs = node_specs_from_configuration(site)
+        interfaces = specs[0].fabric_interfaces
+        if args.ssh_timeout is None:
+            timeout = site.preflight.ssh_timeout_seconds
+        if rendezvous_address is None:
+            rendezvous_address = site.rank(
+                site.serving.master_rank
+            ).management.address
+    elif args.config:
         try:
             document = json.loads(Path(args.config).read_text(encoding="utf-8"))
         except (OSError, json.JSONDecodeError) as exc:
@@ -2089,7 +2669,9 @@ def _load_inputs(
             )
     else:
         if not args.node:
-            raise ConfigurationError("provide --config or at least one --node user@host")
+            raise ConfigurationError(
+                "provide --cluster, --site, --config, or at least one --node user@host"
+            )
         sockets: dict[str, tuple[str, ...]] = {}
         for item in args.socket_interface or []:
             if "=" not in item:
@@ -2145,18 +2727,28 @@ def _load_inputs(
         _validate_interface(interface, f"fabric_interfaces[{index}]")
     if not isinstance(timeout, int) or not 1 <= timeout <= 3600:
         raise ConfigurationError("--ssh-timeout must be an integer from 1 to 3600")
-    return specs, interfaces, timeout, rendezvous_address
+    return LoadedInputs(
+        specs, interfaces, timeout, rendezvous_address, site, cluster
+    )
 
 
 def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="ring-doctor",
         description=(
-            "Discover and diagnose a four-node switchless SparkRing fabric. "
+            "Discover and diagnose a 4- or 6-node switchless SparkRing fabric. "
             "The default operation is read-only and prints a repair plan."
         ),
     )
-    parser.add_argument("--config", help="JSON file containing node SSH targets")
+    parser.add_argument(
+        "--site",
+        help=(
+            "canonical SparkRing site YAML; supplies ranks, per-rank fabric "
+            "interfaces, management socket interfaces, rendezvous address, "
+            "and SSH timeout"
+        ),
+    )
+    parser.add_argument("--config", help="legacy JSON file containing node SSH targets")
     parser.add_argument(
         "--node", action="append", metavar="USER@HOST", help="seed SSH target; repeatable"
     )
@@ -2193,7 +2785,27 @@ def _build_parser() -> argparse.ArgumentParser:
         ),
     )
     parser.add_argument(
-        "--ssh-timeout", type=int, default=20, help="SSH command timeout in seconds"
+        "--ssh-timeout",
+        type=int,
+        default=None,
+        help=(
+            "SSH command timeout in seconds; defaults to the site preflight "
+            "value with --site, otherwise 20"
+        ),
+    )
+    parser.add_argument(
+        "--cluster",
+        help=(
+            "model-independent SparkRing cluster YAML generated during bootstrap"
+        ),
+    )
+    parser.add_argument(
+        "--allow-worker-controller",
+        action="store_true",
+        help=(
+            "emergency recovery: allow execution from a configured worker "
+            "rank when the head node cannot run Ring Doctor"
+        ),
     )
     parser.add_argument(
         "--apply", action="store_true", help="execute the verified idempotent repair plan"
@@ -2217,44 +2829,83 @@ def _build_parser() -> argparse.ArgumentParser:
 def main(argv: Sequence[str] | None = None) -> int:
     args = _build_parser().parse_args(argv)
     try:
-        specs, interfaces, timeout, rendezvous_address = _load_inputs(args)
+        loaded = _load_inputs(args)
+        controller_node = enforce_controller_location(
+            loaded, allow_worker=args.allow_worker_controller
+        )
     except ConfigurationError as exc:
         print(f"INVALID RING DOCTOR INPUT: {exc}", file=sys.stderr)
         return 2
-    runner = SshRunner(timeout_seconds=timeout)
+    specs = loaded.specs
+    interfaces = loaded.interfaces
+    rendezvous_address = loaded.rendezvous_address
+    runner = SshRunner(timeout_seconds=loaded.timeout)
     observations, topology, plans, findings = _probe_by_name(
         specs, runner, interfaces, rendezvous_address
     )
+    fabric_configuration = loaded.fabric_configuration
+    fabric_preflight = (
+        run_preflight(
+            fabric_configuration,
+            ReadOnlyRunnerAdapter(runner),
+            scope="fabric",
+        )
+        if fabric_configuration is not None
+        else []
+    )
+    fabric_preflight_ok = (
+        fabric_configuration is None
+        or (bool(fabric_preflight) and all(result.passed for result in fabric_preflight))
+    )
+    management_guards, management_guard_findings = build_management_guards(
+        specs, observations
+    )
+    management_repair_safe = (
+        not management_guard_findings
+        and len(management_guards)
+        == sum(observation.reachable for observation in observations.values())
+    )
     apply_findings: list[Finding] = []
+    if (args.apply or args.emit_unit) and management_guard_findings:
+        apply_findings.extend(management_guard_findings)
     apply_executed = False
-    enough = len(specs) == 4 and all(
-        observation.reachable for observation in observations.values()
-    ) and topology.valid_cycle
+    enough = discovery_sufficient(specs, observations, topology)
+    repair_safe = enough and fabric_preflight_ok and management_repair_safe
     if args.apply:
-        if enough:
+        if repair_safe:
             apply_executed = True
-            apply_findings = apply_plans(observations, plans, runner)
+            apply_findings.extend(
+                apply_plans(observations, plans, management_guards, runner)
+            )
             observations, topology, plans, findings = _probe_by_name(
                 specs, runner, interfaces, rendezvous_address
             )
-            enough = len(specs) == 4 and all(
-                observation.reachable for observation in observations.values()
-            ) and topology.valid_cycle
+            enough = discovery_sufficient(specs, observations, topology)
+            repair_safe = enough and fabric_preflight_ok and management_repair_safe
         else:
+            if not enough:
+                reason = topology.reason
+            elif not fabric_preflight_ok:
+                reason = "canonical site fabric preflight has one or more failures"
+            else:
+                reason = "direct addressed management guards are not ready on every node"
             apply_findings.append(
                 Finding(
                     "error",
                     "apply-withheld",
                     None,
-                    "No repair was applied because the complete four-node cycle was not observed.",
-                    topology.reason,
+                    "No repair was applied because the complete supported cycle "
+                    "and canonical fabric checks did not both pass.",
+                    reason,
                 )
             )
     unit_files: list[str] = []
     if args.emit_unit:
-        if enough:
+        if repair_safe:
             try:
-                unit_files = emit_units(Path(args.emit_unit), observations, plans)
+                unit_files = emit_units(
+                    Path(args.emit_unit), observations, plans, management_guards
+                )
             except OSError as exc:
                 apply_findings.append(
                     Finding(
@@ -2271,16 +2922,53 @@ def main(argv: Sequence[str] | None = None) -> int:
                     "error",
                     "unit-withheld",
                     None,
-                    "No systemd files were written because the complete four-node cycle was not observed.",
-                    topology.reason,
+                    "No systemd files were written because the complete supported "
+                    "cycle and canonical fabric checks did not both pass.",
+                    (
+                        topology.reason
+                        if not enough
+                        else (
+                            "canonical site fabric preflight has failures"
+                            if not fabric_preflight_ok
+                            else "management guards are not ready on every node"
+                        )
+                    ),
                 )
             )
     findings.extend(apply_findings)
     verification = (
         verify_reachability(specs, observations, runner) if args.verify else None
     )
+    diagnostic_checks = build_diagnostic_checks(topology, findings, verification)
+    diagnostic_checks.extend(
+        result.to_diagnostic_check() for result in fabric_preflight
+    )
+    diagnostics = build_receipt(diagnostic_checks, source="ring-doctor")
     report = {
         "schema": "sparkring-ring-doctor/v1",
+        "controller": {
+            "node": controller_node,
+            "head": loaded.specs[0].name,
+            "worker_override": controller_node != loaded.specs[0].name,
+        },
+        "site": (
+            {
+                "name": loaded.site.name,
+                "schema_version": loaded.site.schema_version,
+                "source": loaded.site.source,
+            }
+            if loaded.site is not None
+            else None
+        ),
+        "cluster": (
+            {
+                "name": loaded.cluster.name,
+                "schema_version": loaded.cluster.schema_version,
+                "source": loaded.cluster.source,
+            }
+            if loaded.cluster is not None
+            else None
+        ),
         "rendezvous_address": (
             str(rendezvous_address) if rendezvous_address else None
         ),
@@ -2290,6 +2978,13 @@ def main(argv: Sequence[str] | None = None) -> int:
         },
         "topology": topology.to_dict(),
         "findings": [finding.to_dict() for finding in findings],
+        "diagnostics": diagnostics,
+        "fabric_preflight": [result.to_dict() for result in fabric_preflight],
+        "repair_safety": {
+            "management_guard_ready": management_repair_safe,
+            "guarded_nodes": sorted(management_guards),
+            "issues": [finding.to_dict() for finding in management_guard_findings],
+        },
         "plans": {name: plan.to_dict() for name, plan in plans.items()},
         "apply": {
             "requested": args.apply,
@@ -2310,9 +3005,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         print(render_text(report))
     if not enough:
         return 2
-    if any(finding.severity != "info" for finding in findings):
-        return 1
-    if verification and (verification["failed"] or verification["unknown"]):
+    if not diagnostics["passed"]:
         return 1
     return 0
 

--- a/scripts/spark_doctor.py
+++ b/scripts/spark_doctor.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""Read-only acceptance checks for one blank DGX Spark."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+from dataclasses import dataclass
+from typing import Protocol, Sequence
+
+try:
+    from .sparkring_diagnostics import CheckStatus, DiagnosticCheck, build_receipt
+except ImportError:
+    from sparkring_diagnostics import CheckStatus, DiagnosticCheck, build_receipt
+
+
+@dataclass(frozen=True)
+class CommandResult:
+    returncode: int
+    stdout: str = ""
+    stderr: str = ""
+
+
+class Runner(Protocol):
+    def run(self, argv: Sequence[str]) -> CommandResult: ...
+
+
+class LocalRunner:
+    def run(self, argv: Sequence[str]) -> CommandResult:
+        completed = subprocess.run(
+            list(argv), capture_output=True, text=True, check=False
+        )
+        return CommandResult(completed.returncode, completed.stdout, completed.stderr)
+
+
+def _command_check(
+    runner: Runner,
+    *,
+    check_id: str,
+    command: Sequence[str],
+    summary: str,
+    contains: str | None = None,
+) -> DiagnosticCheck:
+    if shutil.which(command[0]) is None and isinstance(runner, LocalRunner):
+        return DiagnosticCheck(
+            check_id,
+            CheckStatus.FAIL,
+            "host",
+            command[0],
+            summary,
+            f"command not found: {command[0]}",
+            source="spark-doctor",
+        )
+    result = runner.run(command)
+    output = (result.stdout + "\n" + result.stderr).strip()
+    passed = result.returncode == 0 and (contains is None or contains in output)
+    return DiagnosticCheck(
+        check_id,
+        CheckStatus.PASS if passed else CheckStatus.FAIL,
+        "host",
+        " ".join(command),
+        summary,
+        output[:2000] or f"exit={result.returncode}",
+        source="spark-doctor",
+    )
+
+
+def run_host_checks(
+    runner: Runner | None = None,
+    *,
+    require_telemetry_disabled: bool = False,
+) -> list[DiagnosticCheck]:
+    runner = runner or LocalRunner()
+    checks = [
+        _command_check(
+            runner,
+            check_id="HOST.DGX_RELEASE",
+            command=("sh", "-c", "test -r /etc/dgx-release && cat /etc/dgx-release"),
+            summary="DGX release metadata is readable.",
+        ),
+        _command_check(
+            runner,
+            check_id="HOST.GPU",
+            command=("nvidia-smi", "-L"),
+            summary="The NVIDIA GPU driver inventories a GPU.",
+            contains="GPU 0:",
+        ),
+        _command_check(
+            runner,
+            check_id="HOST.DOCKER",
+            command=("docker", "version", "--format", "{{.Server.Version}}"),
+            summary="The Docker daemon answers.",
+        ),
+        _command_check(
+            runner,
+            check_id="HOST.NVIDIA_CONTAINER_TOOLKIT",
+            command=("nvidia-ctk", "--version"),
+            summary="NVIDIA Container Toolkit is installed.",
+        ),
+        _command_check(
+            runner,
+            check_id="HOST.CONNECTX7_PCI",
+            command=("sh", "-c", "lspci | grep -i 'Mellanox.*ConnectX-7'"),
+            summary="PCI inventory contains ConnectX-7.",
+        ),
+        _command_check(
+            runner,
+            check_id="HOST.CONNECTX7_RDMA_MAP",
+            command=("ibdev2netdev",),
+            summary="ConnectX-7 RDMA devices map to Linux interfaces.",
+            contains="rocep1s0f0",
+        ),
+        _command_check(
+            runner,
+            check_id="HOST.SYSTEMD",
+            command=("sh", "-c", "test -z \"$(systemctl --failed --no-legend)\""),
+            summary="No systemd unit is failed.",
+        ),
+        _command_check(
+            runner,
+            check_id="HOST.ROOT_FREE",
+            command=(
+                "sh",
+                "-c",
+                "test $(df -PB1 / | awk 'NR==2 {print $4}') -ge 21474836480",
+            ),
+            summary="Root filesystem has at least 20 GiB free.",
+        ),
+    ]
+    telemetry = runner.run(
+        ("systemctl", "is-enabled", "nvidia-dgx-telemetry.service")
+    )
+    telemetry_state = telemetry.stdout.strip() or telemetry.stderr.strip() or "unknown"
+    disabled = telemetry_state in {"disabled", "masked", "not-found"}
+    checks.append(
+        DiagnosticCheck(
+            "HOST.NVIDIA_TELEMETRY",
+            (
+                CheckStatus.PASS
+                if disabled or not require_telemetry_disabled
+                else CheckStatus.FAIL
+            ),
+            "host",
+            "nvidia-dgx-telemetry.service",
+            (
+                "NVIDIA telemetry state was observed."
+                if not require_telemetry_disabled
+                else "NVIDIA telemetry is disabled or masked."
+            ),
+            f"is-enabled={telemetry_state}",
+            source="spark-doctor",
+        )
+    )
+    return checks
+
+
+def render_text(checks: Sequence[DiagnosticCheck]) -> str:
+    lines = ["DGX Spark host diagnosis (read-only)"]
+    for check in checks:
+        lines.append(
+            f"[{check.status.value.upper():7}] {check.check_id}: {check.summary}"
+        )
+        lines.append(f"          {check.evidence.splitlines()[0]}")
+    receipt = build_receipt(checks, source="spark-doctor")
+    lines.append("host diagnosis: " + ("PASS" if receipt["passed"] else "FAIL"))
+    return "\n".join(lines)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Diagnose one DGX Spark")
+    parser.add_argument("--json", action="store_true")
+    parser.add_argument("--require-telemetry-disabled", action="store_true")
+    args = parser.parse_args(argv)
+    checks = run_host_checks(
+        require_telemetry_disabled=args.require_telemetry_disabled
+    )
+    receipt = build_receipt(checks, source="spark-doctor")
+    print(json.dumps(receipt, indent=2, sort_keys=True) if args.json else render_text(checks))
+    return 0 if receipt["passed"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/sparkring.py
+++ b/scripts/sparkring.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""Operator command for bootstrapping and diagnosing SparkRing clusters."""
+
+from __future__ import annotations
+
+import argparse
+import getpass
+import sys
+from pathlib import Path
+from typing import Sequence
+
+try:
+    from . import ring_doctor
+    from . import spark_doctor
+    from .sparkring_bootstrap import (
+        DEFAULT_FABRIC_SUPERNET,
+        BootstrapError,
+        apply_fabric_network,
+        initialise_cluster,
+        render_rank_netplan,
+    )
+    from .sparkring_cluster import ClusterConfigError, load_cluster
+    from .sparkring_site import SUPPORTED_RING_SIZES
+except ImportError:  # Direct execution
+    import ring_doctor
+    import spark_doctor
+    from sparkring_bootstrap import (
+        DEFAULT_FABRIC_SUPERNET,
+        BootstrapError,
+        apply_fabric_network,
+        initialise_cluster,
+        render_rank_netplan,
+    )
+    from sparkring_cluster import ClusterConfigError, load_cluster
+    from sparkring_site import SUPPORTED_RING_SIZES
+
+DEFAULT_CLUSTER_PATH = Path.home() / ".config" / "sparkring" / "cluster.yaml"
+
+
+def _confirm(prompt: str, assume_yes: bool) -> None:
+    if assume_yes:
+        return
+    if input(prompt + " Type yes: ").strip().lower() != "yes":
+        raise BootstrapError("operation cancelled")
+
+
+def _target(prompt: str, default_user: str | None = None) -> str:
+    suffix = f" [{default_user}@IP]" if default_user else " [username@IP]"
+    value = input(prompt + suffix + ": ").strip()
+    if "@" not in value and default_user:
+        value = f"{default_user}@{value}"
+    return value
+
+
+def _cluster_init(args: argparse.Namespace) -> int:
+    default_user = getpass.getuser()
+    head = args.head or _target("Head/rank-0 management address", default_user)
+    workers = list(args.node or [])
+    while len(workers) < args.size - 1:
+        rank = len(workers) + 1
+        workers.append(_target(f"Rank {rank} management address", default_user))
+    if len(workers) != args.size - 1:
+        raise BootstrapError(
+            f"size {args.size} needs {args.size - 1} --node values"
+        )
+    output = Path(args.output).expanduser()
+    print("\nSparkRing cluster initialization plan")
+    print(f"  size             : {args.size}")
+    print(f"  head             : {head}")
+    for rank, target in enumerate(workers, start=1):
+        print(f"  rank {rank:<10}: {target}")
+    print(f"  fabric supernet  : {args.fabric_supernet}")
+    print(f"  output           : {output}")
+    print(
+        "  SSH enrollment   : "
+        + ("skipped" if args.skip_enroll else "password once per untrusted worker")
+    )
+    _confirm("Continue?", args.yes)
+    cluster = initialise_cluster(
+        size=args.size,
+        head_target=head,
+        worker_targets=workers,
+        name=args.name,
+        fabric_supernet=args.fabric_supernet,
+        output=output,
+        enroll=not args.skip_enroll,
+    )
+    print("\n".join(cluster.summary_lines()))
+    print(f"\nWrote {output}")
+    print("Next:")
+    print(f"  sparkring doctor --cluster {output}")
+    print(
+        "The first Doctor run is read-only. On blank fabric interfaces it will "
+        "report the addresses/routes that still need configuration."
+    )
+    return 0
+
+
+def _cluster_show(args: argparse.Namespace) -> int:
+    cluster = load_cluster(Path(args.cluster).expanduser())
+    print("\n".join(cluster.summary_lines()))
+    return 0
+
+
+def _cluster_configure(args: argparse.Namespace) -> int:
+    path = Path(args.cluster).expanduser()
+    cluster = load_cluster(path)
+    print("SparkRing fabric network plan")
+    print("Management interfaces are absent from every generated netplan.")
+    for rank in cluster.ranks:
+        print(f"\n--- rank {rank.id} ({rank.ssh_target}) ---")
+        print(render_rank_netplan(cluster, rank.id).rstrip())
+    if not args.apply:
+        print("\nPlan only; no node was changed. Add --apply after review.")
+        return 0
+    _confirm(
+        "Install these fabric-only netplans with per-rank management rollback?",
+        args.yes,
+    )
+    apply_fabric_network(cluster)
+    print("\nFabric addresses installed. Next run the read-only diagnosis:")
+    print(f"  sparkring doctor --cluster {path} --verify")
+    return 0
+
+
+def _doctor(args: argparse.Namespace, remainder: Sequence[str]) -> int:
+    cluster = str(Path(args.cluster).expanduser())
+    doctor_args = ["--cluster", cluster, *remainder]
+    return ring_doctor.main(doctor_args)
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="sparkring")
+    subcommands = parser.add_subparsers(dest="command", required=True)
+
+    cluster = subcommands.add_parser("cluster", help="cluster bootstrap and inventory")
+    cluster_commands = cluster.add_subparsers(dest="cluster_command", required=True)
+    init = cluster_commands.add_parser("init", help="bootstrap a blank 4/6-Spark ring")
+    init.add_argument("--size", type=int, choices=SUPPORTED_RING_SIZES, required=True)
+    init.add_argument("--head", metavar="USER@IP")
+    init.add_argument("--node", action="append", metavar="USER@IP")
+    init.add_argument("--name", default="sparkring")
+    init.add_argument("--fabric-supernet", default=DEFAULT_FABRIC_SUPERNET)
+    init.add_argument("--output", default=str(DEFAULT_CLUSTER_PATH))
+    init.add_argument(
+        "--skip-enroll",
+        action="store_true",
+        help="require SSH keys to be configured already",
+    )
+    init.add_argument("--yes", action="store_true", help="accept the printed plan")
+
+    show = cluster_commands.add_parser("show", help="validate and show an inventory")
+    show.add_argument("--cluster", default=str(DEFAULT_CLUSTER_PATH))
+
+    configure = cluster_commands.add_parser(
+        "configure", help="plan or apply fabric-only netplan"
+    )
+    configure.add_argument("--cluster", default=str(DEFAULT_CLUSTER_PATH))
+    configure.add_argument("--apply", action="store_true")
+    configure.add_argument("--yes", action="store_true", help="accept the printed plan")
+
+    doctor = subcommands.add_parser("doctor", help="run Ring Doctor")
+    doctor.add_argument("--cluster", default=str(DEFAULT_CLUSTER_PATH))
+
+    host = subcommands.add_parser("host", help="diagnose one blank DGX Spark")
+    host_commands = host.add_subparsers(dest="host_command", required=True)
+    host_check = host_commands.add_parser("check", help="run read-only host checks")
+    host_check.add_argument("--json", action="store_true")
+    host_check.add_argument("--require-telemetry-disabled", action="store_true")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    raw = list(argv if argv is not None else sys.argv[1:])
+    parser = _parser()
+    if raw and raw[0] == "doctor":
+        known, remainder = parser.parse_known_args(raw)
+    else:
+        known = parser.parse_args(raw)
+        remainder = []
+    try:
+        if known.command == "cluster" and known.cluster_command == "init":
+            return _cluster_init(known)
+        if known.command == "cluster" and known.cluster_command == "show":
+            return _cluster_show(known)
+        if known.command == "cluster" and known.cluster_command == "configure":
+            return _cluster_configure(known)
+        if known.command == "doctor":
+            return _doctor(known, remainder)
+        if known.command == "host" and known.host_command == "check":
+            host_args = []
+            if known.json:
+                host_args.append("--json")
+            if known.require_telemetry_disabled:
+                host_args.append("--require-telemetry-disabled")
+            return spark_doctor.main(host_args)
+    except (BootstrapError, ClusterConfigError) as exc:
+        print(f"SPARKRING ERROR: {exc}", file=sys.stderr)
+        return 2
+    parser.error("unsupported command")
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/sparkring_bootstrap.py
+++ b/scripts/sparkring_bootstrap.py
@@ -1,0 +1,593 @@
+#!/usr/bin/env python3
+"""Bootstrap a blank set of DGX Sparks into a Ring Doctor inventory.
+
+Passwords are handled only by the system ``ssh-copy-id`` interaction. This
+module never accepts, reads, stores, logs, or forwards a password itself.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import base64
+import getpass
+import ipaddress
+import json
+import os
+import re
+import subprocess
+import tempfile
+import time
+from pathlib import Path
+from typing import Callable, Sequence
+
+import yaml
+
+try:
+    from .sparkring_cluster import ClusterConfig, validate_cluster, write_cluster
+    from .sparkring_site import SUPPORTED_RING_SIZES
+except ImportError:  # Direct execution
+    from sparkring_cluster import ClusterConfig, validate_cluster, write_cluster
+    from sparkring_site import SUPPORTED_RING_SIZES
+
+TARGET_RE = re.compile(r"^[A-Za-z0-9._-]+@([0-9]{1,3}(?:\.[0-9]{1,3}){3})$")
+PUBLIC_KEY_RE = re.compile(r"^ssh-ed25519 [A-Za-z0-9+/=]+(?: [^\r\n]+)?$")
+DEFAULT_FABRIC_SUPERNET = "198.18.0.0/21"
+DEFAULT_INTERFACES = ("enp1s0f0np0", "enp1s0f1np1")
+DEFAULT_RDMA_DEVICES = ("rocep1s0f0", "rocep1s0f1")
+PROBE_ADDR_MARKER = "__SPARKRING_ADDR__"
+PROBE_RDMA_MARKER = "__SPARKRING_RDMA__"
+
+
+class BootstrapError(RuntimeError):
+    """Bootstrap cannot safely continue."""
+
+
+@dataclasses.dataclass(frozen=True)
+class NodeFacts:
+    rank: int
+    target: str
+    hostname: str
+    management_interface: str
+    management_address: ipaddress.IPv4Address
+    fabric_interfaces: tuple[str, str]
+    rdma_devices: tuple[str, str]
+
+
+def parse_target(value: str) -> tuple[str, ipaddress.IPv4Address]:
+    match = TARGET_RE.fullmatch(value)
+    if not match:
+        raise BootstrapError(
+            f"target {value!r} must have the form username@IPv4-address"
+        )
+    try:
+        address = ipaddress.ip_address(match.group(1))
+    except ValueError as exc:
+        raise BootstrapError(f"target {value!r} has an invalid IPv4 address") from exc
+    if not isinstance(address, ipaddress.IPv4Address):
+        raise BootstrapError("only IPv4 management addresses are supported")
+    return value.split("@", 1)[0], address
+
+
+def _run(
+    argv: Sequence[str],
+    *,
+    input_text: str | None = None,
+    capture: bool = True,
+    check: bool = False,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        list(argv),
+        input=input_text,
+        capture_output=capture,
+        text=True,
+        check=check,
+    )
+
+
+def ensure_local_key() -> Path:
+    ssh_dir = Path.home() / ".ssh"
+    private_key = ssh_dir / "id_ed25519"
+    public_key = ssh_dir / "id_ed25519.pub"
+    if private_key.exists() and public_key.exists():
+        return public_key
+    ssh_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
+    completed = _run(
+        [
+            "ssh-keygen",
+            "-q",
+            "-t",
+            "ed25519",
+            "-N",
+            "",
+            "-C",
+            f"{getpass.getuser()}@{os.uname().nodename}-sparkring",
+            "-f",
+            str(private_key),
+        ]
+    )
+    if completed.returncode:
+        raise BootstrapError(completed.stderr.strip() or "ssh-keygen failed")
+    return public_key
+
+
+def authorize_local_key(
+    public_key: Path,
+    *,
+    ssh_dir: Path | None = None,
+) -> Path:
+    """Idempotently authorize the bootstrap key for head self-SSH."""
+    directory = ssh_dir or (Path.home() / ".ssh")
+    directory.mkdir(mode=0o700, parents=True, exist_ok=True)
+    directory.chmod(0o700)
+    authorized = directory / "authorized_keys"
+    key = public_key.read_text(encoding="utf-8").strip()
+    if not PUBLIC_KEY_RE.fullmatch(key):
+        raise BootstrapError(f"unexpected public key format in {public_key}")
+    existing = authorized.read_text(encoding="utf-8") if authorized.exists() else ""
+    lines = [line.strip() for line in existing.splitlines() if line.strip()]
+    if key not in lines:
+        if authorized.exists():
+            backup = directory / (
+                "authorized_keys.before-sparkring-"
+                + time.strftime("%Y%m%dT%H%M%SZ", time.gmtime())
+            )
+            backup.write_bytes(authorized.read_bytes())
+            backup.chmod(0o600)
+        lines.append(key)
+        authorized.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    authorized.chmod(0o600)
+    return authorized
+
+
+def _known_host_exists(host: str) -> bool:
+    known_hosts = Path.home() / ".ssh" / "known_hosts"
+    if not known_hosts.exists():
+        return False
+    result = _run(["ssh-keygen", "-F", host, "-f", str(known_hosts)])
+    return result.returncode == 0
+
+
+def trust_host(
+    target: str,
+    *,
+    confirm: Callable[[str], str] = input,
+) -> None:
+    _user, address = parse_target(target)
+    host = str(address)
+    if _known_host_exists(host):
+        return
+    scan = _run(["ssh-keyscan", "-T", "5", "-t", "ed25519", host])
+    lines = [
+        line for line in scan.stdout.splitlines()
+        if line and not line.startswith("#")
+    ]
+    if scan.returncode or len(lines) != 1:
+        raise BootstrapError(f"could not obtain one Ed25519 host key from {host}")
+    fingerprint = _run(
+        ["ssh-keygen", "-lf", "-"], input_text=lines[0] + "\n"
+    )
+    if fingerprint.returncode:
+        raise BootstrapError(f"could not fingerprint the host key for {host}")
+    answer = confirm(
+        f"Trust {target} host key?\n  {fingerprint.stdout.strip()}\nType yes: "
+    )
+    if answer.strip().lower() != "yes":
+        raise BootstrapError(f"host key for {target} was not accepted")
+    known_hosts = Path.home() / ".ssh" / "known_hosts"
+    known_hosts.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+    with known_hosts.open("a", encoding="utf-8", newline="\n") as handle:
+        handle.write(lines[0] + "\n")
+    known_hosts.chmod(0o600)
+
+
+def enroll_target(target: str, public_key: Path) -> None:
+    trust_host(target)
+    probe = _run(
+        ["ssh", "-o", "BatchMode=yes", "-o", "ConnectTimeout=5", target, "true"]
+    )
+    if probe.returncode == 0:
+        return
+    print(f"Password required once to enroll {target}.")
+    result = _run(
+        ["ssh-copy-id", "-i", str(public_key), target], capture=False
+    )
+    if result.returncode:
+        raise BootstrapError(f"ssh-copy-id failed for {target}")
+    verified = _run(
+        ["ssh", "-o", "BatchMode=yes", "-o", "ConnectTimeout=5", target, "true"]
+    )
+    if verified.returncode:
+        raise BootstrapError(
+            f"key enrollment for {target} did not produce non-interactive SSH: "
+            f"{verified.stderr.strip()}"
+        )
+
+
+def _probe_command() -> str:
+    return (
+        "hostname\n"
+        f"printf '%s\\n' {PROBE_ADDR_MARKER}\n"
+        "ip -j -4 addr show\n"
+        f"printf '%s\\n' {PROBE_RDMA_MARKER}\n"
+        "ibdev2netdev 2>/dev/null || true\n"
+    )
+
+
+def _parse_probe(
+    rank: int,
+    target: str,
+    management_address: ipaddress.IPv4Address,
+    output: str,
+) -> NodeFacts:
+    try:
+        hostname_text, remainder = output.split(PROBE_ADDR_MARKER, 1)
+        address_text, rdma_text = remainder.split(PROBE_RDMA_MARKER, 1)
+        rows = json.loads(address_text.strip())
+    except (ValueError, json.JSONDecodeError) as exc:
+        raise BootstrapError(f"rank {rank} returned malformed inventory output") from exc
+    hostname = hostname_text.strip().splitlines()[0]
+    management_interface = None
+    observed_interfaces: set[str] = set()
+    for row in rows:
+        name = row.get("ifname")
+        if isinstance(name, str):
+            observed_interfaces.add(name)
+        for item in row.get("addr_info", []):
+            if item.get("family") == "inet" and item.get("local") == str(
+                management_address
+            ):
+                management_interface = name
+    if not management_interface:
+        raise BootstrapError(
+            f"rank {rank} does not hold management address {management_address}"
+        )
+    missing = [name for name in DEFAULT_INTERFACES if name not in observed_interfaces]
+    if missing:
+        raise BootstrapError(
+            f"rank {rank} is missing expected ConnectX-7 interface(s): "
+            + ", ".join(missing)
+        )
+    mappings = rdma_text.strip()
+    for interface, device in zip(DEFAULT_INTERFACES, DEFAULT_RDMA_DEVICES):
+        expected = f"{device} port 1 ==> {interface}"
+        if expected not in mappings:
+            raise BootstrapError(
+                f"rank {rank} did not report expected RDMA mapping {expected!r}"
+            )
+    if management_interface in DEFAULT_INTERFACES:
+        raise BootstrapError(
+            f"rank {rank} management interface overlaps the fabric"
+        )
+    return NodeFacts(
+        rank=rank,
+        target=target,
+        hostname=hostname,
+        management_interface=management_interface,
+        management_address=management_address,
+        fabric_interfaces=DEFAULT_INTERFACES,
+        rdma_devices=DEFAULT_RDMA_DEVICES,
+    )
+
+
+def probe_local(rank: int, target: str) -> NodeFacts:
+    _user, address = parse_target(target)
+    result = _run(["sh", "-c", _probe_command()])
+    if result.returncode:
+        raise BootstrapError(result.stderr.strip() or "local inventory probe failed")
+    return _parse_probe(rank, target, address, result.stdout)
+
+
+def probe_remote(rank: int, target: str) -> NodeFacts:
+    _user, address = parse_target(target)
+    result = _run(
+        [
+            "ssh",
+            "-o",
+            "BatchMode=yes",
+            "-o",
+            "ConnectTimeout=8",
+            target,
+            _probe_command(),
+        ]
+    )
+    if result.returncode:
+        raise BootstrapError(
+            f"could not inventory rank {rank} ({target}): "
+            f"{result.stderr.strip()}"
+        )
+    return _parse_probe(rank, target, address, result.stdout)
+
+
+def _edge_subnets(supernet: str, count: int) -> list[ipaddress.IPv4Network]:
+    try:
+        network = ipaddress.ip_network(supernet, strict=True)
+    except ValueError as exc:
+        raise BootstrapError(f"invalid fabric supernet {supernet!r}: {exc}") from exc
+    if not isinstance(network, ipaddress.IPv4Network) or network.prefixlen > 24:
+        raise BootstrapError("fabric supernet must be an IPv4 network at least /24")
+    subnets = list(network.subnets(new_prefix=24))
+    if len(subnets) < count:
+        raise BootstrapError(
+            f"fabric supernet {network} has {len(subnets)} /24s; {count} are required"
+        )
+    return subnets[:count]
+
+
+def build_cluster_document(
+    facts: Sequence[NodeFacts],
+    *,
+    name: str,
+    fabric_supernet: str,
+    mtu: int = 9000,
+    link_speed_mbps: int = 200000,
+) -> dict:
+    size = len(facts)
+    if size not in SUPPORTED_RING_SIZES:
+        raise BootstrapError(f"ring size must be one of {SUPPORTED_RING_SIZES}")
+    ordered = sorted(facts, key=lambda item: item.rank)
+    if [item.rank for item in ordered] != list(range(size)):
+        raise BootstrapError("facts must contain contiguous ranks starting at zero")
+    management_addresses = {item.management_address for item in ordered}
+    if len(management_addresses) != size:
+        raise BootstrapError("management addresses must be unique")
+    subnets = _edge_subnets(fabric_supernet, size)
+    if any(
+        address in subnet
+        for address in management_addresses
+        for subnet in subnets
+    ):
+        raise BootstrapError("fabric supernet overlaps a management address")
+    edges = [
+        {
+            "id": f"r{rank}-r{(rank + 1) % size}",
+            "subnet": str(subnets[rank]),
+            "endpoints": [rank, (rank + 1) % size],
+        }
+        for rank in range(size)
+    ]
+    ranks = []
+    for fact in ordered:
+        rank = fact.rank
+        previous = (rank - 1) % size
+        following = (rank + 1) % size
+        incoming = subnets[previous]
+        outgoing = subnets[rank]
+        ranks.append(
+            {
+                "id": rank,
+                "ssh_target": fact.target,
+                "management": {
+                    "interface": fact.management_interface,
+                    "address": str(fact.management_address),
+                },
+                "ring_ports": [
+                    {
+                        "edge": f"r{rank}-r{following}",
+                        "interface": fact.fabric_interfaces[0],
+                        "address": str(list(outgoing.hosts())[9]),
+                        "rdma_device": fact.rdma_devices[0],
+                        "rdma_port": 1,
+                        "roce_gid_index": 3,
+                    },
+                    {
+                        "edge": f"r{previous}-r{rank}",
+                        "interface": fact.fabric_interfaces[1],
+                        "address": str(list(incoming.hosts())[10]),
+                        "rdma_device": fact.rdma_devices[1],
+                        "rdma_port": 1,
+                        "roce_gid_index": 3,
+                    },
+                ],
+                "transport_peers": [
+                    {
+                        "rank": previous,
+                        "address": str(ordered[previous].management_address),
+                    },
+                    {
+                        "rank": following,
+                        "address": str(ordered[following].management_address),
+                    },
+                ],
+            }
+        )
+    return {
+        "schema_version": 1,
+        "cluster": {
+            "name": name,
+            "description": (
+                f"Bootstrapped {size}-Spark direct ConnectX-7 ring."
+            ),
+        },
+        "topology": {
+            "mtu": mtu,
+            "link_speed_mbps": link_speed_mbps,
+            "edges": edges,
+        },
+        "ranks": ranks,
+        "preflight": {
+            "ssh_timeout_seconds": 45,
+            "required_free_ports": [],
+        },
+    }
+
+
+def initialise_cluster(
+    *,
+    size: int,
+    head_target: str,
+    worker_targets: Sequence[str],
+    name: str,
+    fabric_supernet: str,
+    output: str | Path,
+    enroll: bool = True,
+) -> ClusterConfig:
+    if size not in SUPPORTED_RING_SIZES:
+        raise BootstrapError(f"ring size must be one of {SUPPORTED_RING_SIZES}")
+    if len(worker_targets) != size - 1:
+        raise BootstrapError(
+            f"ring size {size} requires exactly {size - 1} worker targets"
+        )
+    targets = [head_target, *worker_targets]
+    for target in targets:
+        parse_target(target)
+    if enroll:
+        public_key = ensure_local_key()
+        authorize_local_key(public_key)
+        trust_host(head_target)
+        head_access = _run(
+            [
+                "ssh",
+                "-o",
+                "BatchMode=yes",
+                "-o",
+                "ConnectTimeout=5",
+                head_target,
+                "true",
+            ]
+        )
+        if head_access.returncode:
+            raise BootstrapError(
+                "head self-SSH did not work after local key authorization: "
+                + head_access.stderr.strip()
+            )
+        for target in worker_targets:
+            enroll_target(target, public_key)
+    facts = [probe_local(0, head_target)]
+    facts.extend(
+        probe_remote(rank, target)
+        for rank, target in enumerate(worker_targets, start=1)
+    )
+    document = build_cluster_document(
+        facts, name=name, fabric_supernet=fabric_supernet
+    )
+    config = validate_cluster(document, source=str(output))
+    write_cluster(config, output)
+    return config
+
+
+def render_rank_netplan(cluster: ClusterConfig, rank_id: int) -> str:
+    """Render a fabric-only netplan; management is intentionally absent."""
+    rank = cluster.rank(rank_id)
+    document = {
+        "network": {
+            "version": 2,
+            "renderer": "NetworkManager",
+            "ethernets": {
+                port.interface: {
+                    "addresses": [port.cidr],
+                    "dhcp4": False,
+                    "dhcp6": False,
+                    "mtu": cluster.topology.mtu,
+                    "optional": True,
+                }
+                for port in rank.ring_ports
+            },
+        }
+    }
+    return yaml.safe_dump(document, sort_keys=False)
+
+
+def _network_apply_script(cluster: ClusterConfig, rank_id: int) -> str:
+    rank = cluster.rank(rank_id)
+    target = "/etc/netplan/40-sparkring-fabric.yaml"
+    timestamp = time.strftime("%Y%m%dT%H%M%SZ", time.gmtime())
+    backup = f"{target}.before-sparkring-{timestamp}"
+    management_cidr_fragment = f" {rank.management.address}/"
+    return "\n".join(
+        [
+            "set -eu",
+            f"target={target}",
+            f"backup={backup}",
+            "had_previous=0",
+            'if test -f "$target"; then cp -a "$target" "$backup"; had_previous=1; fi',
+            'rollback() { if test "$had_previous" -eq 1; then '
+            'cp -a "$backup" "$target"; else rm -f "$target"; fi; }',
+            "install -m 600 /tmp/sparkring-fabric.yaml \"$target\"",
+            "if ! netplan generate; then",
+            "  rollback",
+            "  exit 1",
+            "fi",
+            "if ! netplan apply; then",
+            "  rollback",
+            "  netplan generate",
+            "  netplan apply || true",
+            "  echo 'netplan apply failed; prior fabric netplan restored' >&2",
+            "  exit 1",
+            "fi",
+            f"if ! ip -4 -o addr show dev {rank.management.interface} | "
+            f"grep -F -q -- '{management_cidr_fragment}'; then",
+            "  rollback",
+            "  netplan generate",
+            "  netplan apply",
+            "  echo 'management invariant failed; fabric netplan rolled back' >&2",
+            "  exit 91",
+            "fi",
+            "rm -f /tmp/sparkring-fabric.yaml",
+        ]
+    )
+
+
+def apply_fabric_network(cluster: ClusterConfig) -> None:
+    """Install fabric-only netplan on each rank with management rollback."""
+    for rank in cluster.ranks:
+        content = render_rank_netplan(cluster, rank.id)
+        encoded = base64.b64encode(content.encode("utf-8")).decode("ascii")
+        stage_command = (
+            f"printf '%s' {encoded} | base64 -d > /tmp/sparkring-fabric.yaml && "
+            "chmod 600 /tmp/sparkring-fabric.yaml"
+        )
+        script = _network_apply_script(cluster, rank.id)
+        if rank.id == 0:
+            with tempfile.NamedTemporaryFile(
+                mode="w", encoding="utf-8", delete=False, suffix=".yaml"
+            ) as handle:
+                handle.write(content)
+                staged = Path(handle.name)
+            try:
+                copy = _run(
+                    ["sudo", "install", "-m", "600", str(staged), "/tmp/sparkring-fabric.yaml"],
+                    capture=False,
+                )
+                if copy.returncode:
+                    raise BootstrapError("could not stage rank 0 fabric netplan")
+                result = _run(["sudo", "sh", "-c", script], capture=False)
+            finally:
+                staged.unlink(missing_ok=True)
+        else:
+            stage = _run(
+                ["ssh", "-o", "BatchMode=yes", rank.ssh_target, stage_command]
+            )
+            if stage.returncode:
+                raise BootstrapError(
+                    f"could not stage rank {rank.id} fabric netplan: "
+                    f"{stage.stderr.strip()}"
+                )
+            encoded_script = base64.b64encode(script.encode("utf-8")).decode("ascii")
+            remote_apply = (
+                f"printf '%s' {encoded_script} | base64 -d > "
+                "/tmp/sparkring-apply-fabric.sh && "
+                "chmod 700 /tmp/sparkring-apply-fabric.sh && "
+                "sudo /tmp/sparkring-apply-fabric.sh; "
+                "rc=$?; rm -f /tmp/sparkring-apply-fabric.sh; exit $rc"
+            )
+            result = _run(
+                ["ssh", "-t", rank.ssh_target, remote_apply], capture=False
+            )
+        if result.returncode:
+            raise BootstrapError(
+                f"rank {rank.id} fabric configuration failed; remaining ranks "
+                "were not changed"
+            )
+        verify = probe_local(rank.id, rank.ssh_target) if rank.id == 0 else probe_remote(
+            rank.id, rank.ssh_target
+        )
+        expected = {
+            port.interface: port.address for port in cluster.rank(rank.id).ring_ports
+        }
+        if verify.management_address != rank.management.address:
+            raise BootstrapError(
+                f"rank {rank.id} management address changed after netplan apply"
+            )
+        # The detailed address and MTU verdict is intentionally left to Doctor.
+        if set(expected) != set(verify.fabric_interfaces):
+            raise BootstrapError(f"rank {rank.id} fabric interfaces changed unexpectedly")

--- a/scripts/sparkring_cluster.py
+++ b/scripts/sparkring_cluster.py
@@ -1,0 +1,285 @@
+#!/usr/bin/env python3
+"""Model-independent SparkRing cluster inventory and validator.
+
+The cluster inventory is the first configuration a blank Spark installation
+needs. It contains only management access, the direct-cable topology, and the
+ConnectX-7/RoCE facts required by Ring Doctor. Runtime, model, cache, and
+serving configuration belong to deployment profiles and are deliberately
+absent here.
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import json
+import sys
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+try:
+    import yaml as _yaml
+except Exception as _exc:  # pragma: no cover - only without PyYAML
+    _yaml = None
+    _YAML_IMPORT_ERROR: Exception | None = _exc
+else:
+    _YAML_IMPORT_ERROR = None
+
+try:
+    from .sparkring_site import (
+        PreflightOptions,
+        Rank,
+        SiteConfigError,
+        Topology,
+        validate_site,
+    )
+except ImportError:  # Direct execution
+    from sparkring_site import (
+        PreflightOptions,
+        Rank,
+        SiteConfigError,
+        Topology,
+        validate_site,
+    )
+
+SCHEMA_ID = "sparkring-cluster/v1"
+SCHEMA_VERSION = 1
+
+
+class ClusterConfigError(ValueError):
+    """A cluster inventory is invalid."""
+
+
+@dataclasses.dataclass(frozen=True)
+class ClusterConfig:
+    schema_version: int
+    name: str
+    description: str
+    topology: Topology
+    ranks: tuple[Rank, ...]
+    preflight: PreflightOptions
+    source: str | None = None
+
+    def rank(self, rank_id: int) -> Rank:
+        for rank in self.ranks:
+            if rank.id == rank_id:
+                return rank
+        raise KeyError(rank_id)
+
+    @property
+    def head_rank(self) -> Rank:
+        return self.rank(0)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "cluster": {
+                "name": self.name,
+                "description": self.description,
+            },
+            "topology": {
+                "mtu": self.topology.mtu,
+                "link_speed_mbps": self.topology.link_speed_mbps,
+                "edges": [
+                    {
+                        "id": edge.id,
+                        "subnet": str(edge.subnet),
+                        "endpoints": list(edge.endpoints),
+                    }
+                    for edge in self.topology.edges
+                ],
+            },
+            "ranks": [
+                {
+                    "id": rank.id,
+                    "ssh_target": rank.ssh_target,
+                    "management": {
+                        "interface": rank.management.interface,
+                        "address": str(rank.management.address),
+                    },
+                    "ring_ports": [
+                        {
+                            "edge": port.edge,
+                            "interface": port.interface,
+                            "address": str(port.address),
+                            "rdma_device": port.rdma_device,
+                            "rdma_port": port.rdma_port,
+                            "roce_gid_index": port.roce_gid_index,
+                        }
+                        for port in rank.ring_ports
+                    ],
+                    "transport_peers": [
+                        {"rank": peer.rank, "address": str(peer.address)}
+                        for peer in rank.transport_peers
+                    ],
+                }
+                for rank in self.ranks
+            ],
+            "preflight": {
+                "ssh_timeout_seconds": self.preflight.ssh_timeout_seconds,
+                "required_free_ports": list(self.preflight.required_free_ports),
+            },
+        }
+
+    def summary_lines(self) -> list[str]:
+        lines = [
+            f"cluster     : {self.name} (schema {self.schema_version})",
+            f"description : {self.description}",
+            f"source      : {self.source or '<in-memory>'}",
+            f"topology    : closed {len(self.ranks)}-cycle, "
+            f"mtu={self.topology.mtu}, "
+            f"link={self.topology.link_speed_mbps} Mb/s",
+        ]
+        for edge in self.topology.edges:
+            left, right = edge.endpoints
+            left_port = next(
+                port for port in self.rank(left).ring_ports if port.edge == edge.id
+            )
+            right_port = next(
+                port for port in self.rank(right).ring_ports if port.edge == edge.id
+            )
+            lines.append(
+                f"  {edge.id:<10} {str(edge.subnet):<18} "
+                f"rank{left} {left_port.address} ({left_port.interface}/"
+                f"{left_port.rdma_key} gid{left_port.roce_gid_index}) <-> "
+                f"rank{right} {right_port.address} ({right_port.interface}/"
+                f"{right_port.rdma_key} gid{right_port.roce_gid_index})"
+            )
+        lines.append("ranks       :")
+        for rank in self.ranks:
+            lines.append(
+                f"  rank{rank.id} {rank.ssh_target:<28} "
+                f"mgmt {rank.management.interface}={rank.management.address}"
+            )
+        return lines
+
+
+def _expanded_site_document(document: Mapping[str, Any]) -> dict[str, Any]:
+    allowed = {"schema_version", "cluster", "topology", "ranks", "preflight"}
+    unknown = set(document) - allowed
+    missing = allowed - set(document)
+    if unknown:
+        raise ClusterConfigError(
+            "cluster inventory has unsupported key(s): " + ", ".join(sorted(unknown))
+        )
+    if missing:
+        raise ClusterConfigError(
+            "cluster inventory is missing key(s): " + ", ".join(sorted(missing))
+        )
+    cluster = document["cluster"]
+    if not isinstance(cluster, Mapping):
+        raise ClusterConfigError("cluster must be a mapping")
+    ranks = document["ranks"]
+    rank_count = len(ranks) if isinstance(ranks, list) else 1
+    return {
+        "schema_version": document["schema_version"],
+        "site": dict(cluster),
+        "topology": document["topology"],
+        "ranks": ranks,
+        "runtime": {
+            "container_image": "sparkring/cluster-inventory:local",
+            "container_image_digest": "sha256:" + "a1" * 32,
+            "model_path": "/var/lib/sparkring/cluster-inventory/model",
+            "model_repo": "sparkring/cluster-inventory",
+            "model_revision": "a1" * 20,
+            "checkpoint_sha256": "b2" * 32,
+        },
+        "serving": {
+            "tensor_parallel_size": rank_count,
+            "decode_context_parallel_size": 1,
+            "mtp_mode": "off",
+            "mtp_tokens": 0,
+            "max_model_len": 256,
+            "kv_cache_bytes_per_rank": 1 << 20,
+            "max_num_seqs": 1,
+            "master_rank": 0,
+            "api_port": 8000,
+            "master_port": 29500,
+        },
+        "paths": {
+            "jit_cache_dir": "/var/lib/sparkring/cluster-inventory/jit",
+            "context_cache_dir": "/var/lib/sparkring/cluster-inventory/context",
+            "evidence_dir": ".sparkring/evidence",
+            "min_free_bytes": {"jit_cache": 0, "context_cache": 0},
+        },
+        "artifacts": [],
+        "preflight": document["preflight"],
+    }
+
+
+def validate_cluster(
+    document: Any, source: str | None = None
+) -> ClusterConfig:
+    if not isinstance(document, Mapping):
+        raise ClusterConfigError("cluster inventory root must be a mapping")
+    if document.get("schema_version") != SCHEMA_VERSION:
+        raise ClusterConfigError(
+            f"schema_version must be {SCHEMA_VERSION}"
+        )
+    try:
+        site = validate_site(_expanded_site_document(document), source=source)
+    except SiteConfigError as exc:
+        raise ClusterConfigError(str(exc)) from exc
+    return ClusterConfig(
+        schema_version=site.schema_version,
+        name=site.name,
+        description=site.description,
+        topology=site.topology,
+        ranks=site.ranks,
+        preflight=site.preflight,
+        source=source,
+    )
+
+
+def parse_cluster_yaml(text: str, source: str | None = None) -> ClusterConfig:
+    if _yaml is None:
+        raise ClusterConfigError(
+            "PyYAML is required to read cluster inventories "
+            f"(import failed with: {_YAML_IMPORT_ERROR})"
+        )
+    try:
+        document = _yaml.safe_load(text)
+    except Exception as exc:
+        raise ClusterConfigError(f"could not parse YAML: {exc}") from None
+    return validate_cluster(document, source=source)
+
+
+def load_cluster(path: str | Path) -> ClusterConfig:
+    resolved = Path(path)
+    try:
+        text = resolved.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise ClusterConfigError(f"could not read {resolved}: {exc}") from exc
+    return parse_cluster_yaml(text, source=str(resolved))
+
+
+def write_cluster(config: ClusterConfig, path: str | Path) -> None:
+    if _yaml is None:  # pragma: no cover
+        raise ClusterConfigError("PyYAML is required to write cluster inventories")
+    destination = Path(path)
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    destination.write_text(
+        _yaml.safe_dump(config.to_dict(), sort_keys=False), encoding="utf-8"
+    )
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Validate a SparkRing cluster inventory")
+    parser.add_argument("path")
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args(argv)
+    try:
+        cluster = load_cluster(args.path)
+    except ClusterConfigError as exc:
+        print(f"INVALID CLUSTER: {exc}", file=sys.stderr)
+        return 1
+    if args.json:
+        print(json.dumps(cluster.to_dict(), indent=2, sort_keys=True))
+    else:
+        print("\n".join(cluster.summary_lines()))
+        print(f"\nOK: {args.path} is a valid SparkRing cluster inventory")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/sparkring_diagnostics.py
+++ b/scripts/sparkring_diagnostics.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Shared diagnostic receipt types for SparkRing operator tooling.
+
+The receipt is the stable seam between check implementations and consumers.
+Ring Doctor, preflight, cable qualification, text renderers, saved evidence,
+and AI-assisted analysis can all describe results without sharing their probe
+or evaluation implementations.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import enum
+import time
+from collections import Counter
+from typing import Any, Sequence
+
+SCHEMA = "sparkring-diagnostics/v1"
+
+
+class CheckStatus(str, enum.Enum):
+    """One check outcome; absence of evidence is never reported as a pass."""
+
+    PASS = "pass"
+    FAIL = "fail"
+    UNKNOWN = "unknown"
+    SKIPPED = "skipped"
+
+
+@dataclasses.dataclass(frozen=True)
+class DiagnosticCheck:
+    """One attributable result with the evidence supporting its status."""
+
+    check_id: str
+    status: CheckStatus
+    scope: str
+    subject: str
+    summary: str
+    evidence: str
+    node: str | None = None
+    source: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        value = dataclasses.asdict(self)
+        value["status"] = self.status.value
+        return value
+
+
+def build_receipt(
+    checks: Sequence[DiagnosticCheck],
+    *,
+    generated_at: str | None = None,
+    source: str,
+) -> dict[str, Any]:
+    """Build a versioned receipt without interpreting unknown as success."""
+    counts = Counter(check.status.value for check in checks)
+    passed = bool(checks) and all(check.status is CheckStatus.PASS for check in checks)
+    return {
+        "schema": SCHEMA,
+        "generated_at": generated_at
+        or time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "source": source,
+        "passed": passed,
+        "totals": {
+            status.value: counts.get(status.value, 0) for status in CheckStatus
+        },
+        "checks": [check.to_dict() for check in checks],
+    }

--- a/scripts/sparkring_site.py
+++ b/scripts/sparkring_site.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 """SparkRing site configuration: loader and fail-closed validator.
 
-A "site" is one four-node ring: the ranks, the four 200GbE cables that join
-them, the control-channel rendezvous addresses, the pinned runtime, and the
-paths and artifacts every rank must agree on.  ``scripts/config/site.yaml``
+A "site" is one supported ring: the ranks, the 200GbE cables that join them,
+the control-channel rendezvous addresses, the pinned runtime, and the paths
+and artifacts every rank must agree on. ``scripts/config/site.yaml``
 (copied from ``exl3-r7-site.example.yaml``) is the single source of truth for the
 public tooling; ``scripts/preflight.py`` is driven entirely by it.
 
@@ -15,8 +15,8 @@ Design rules:
   hardware.
 * **No third-party dependencies** beyond PyYAML.  If PyYAML is missing the
   error says so plainly instead of surfacing as an ImportError traceback.
-* **Structure, not just types.**  The four ring edges must form a single closed
-  4-cycle through all four ranks, each edge must be claimed exactly once by
+* **Structure, not just types.** The ring edges must form one closed cycle
+  through all configured ranks, each edge must be claimed exactly once by
   each of its two endpoints, and every address must live in its own edge's /24.
   A mis-cabled or half-edited config fails here rather than at collective init.
 
@@ -55,7 +55,7 @@ SCHEMA_VERSION = 1
 # Accepted ranges.  These are deliberately wide enough for hardware that is
 # not a DGX Spark, and narrow enough that a typo (mtu: 90000, tp: 400) fails.
 # --------------------------------------------------------------------------
-RANK_IDS = (0, 1, 2, 3)
+SUPPORTED_RING_SIZES = (4, 6)
 RING_PORTS_PER_RANK = 2
 EDGE_PREFIX_LENGTH = 24
 
@@ -374,6 +374,10 @@ class Topology:
     edges: tuple[Edge, ...]
 
     @property
+    def rank_ids(self) -> tuple[int, ...]:
+        return tuple(sorted({rank for edge in self.edges for rank in edge.endpoints}))
+
+    @property
     def jumbo_payload_bytes(self) -> int:
         """ICMP payload that exactly fills ``mtu`` (20B IP + 8B ICMP header)."""
         return self.mtu - 28
@@ -614,7 +618,7 @@ class SiteConfig:
             f"description : {self.description}",
             f"source      : {self.source or '<in-memory>'}",
             "",
-            f"topology    : closed 4-cycle, mtu={self.topology.mtu}, "
+            f"topology    : closed {len(self.ranks)}-cycle, mtu={self.topology.mtu}, "
             f"link={self.topology.link_speed_mbps} Mb/s, "
             f"jumbo payload={self.topology.jumbo_payload_bytes}B",
         ]
@@ -688,12 +692,14 @@ def _validate_topology(raw: Any) -> Topology:
     speed = _integer(data, "topology", "link_speed_mbps", LINK_SPEED_RANGE)
 
     edges_raw = _sequence(data["edges"], "topology.edges")
-    if len(edges_raw) != len(RANK_IDS):
+    if len(edges_raw) not in SUPPORTED_RING_SIZES:
         raise SiteConfigError(
             "topology.edges",
-            f"a four-node ring has exactly {len(RANK_IDS)} edges, "
-            f"got {len(edges_raw)}",
+            "a supported ring has exactly "
+            + " or ".join(str(size) for size in SUPPORTED_RING_SIZES)
+            + f" edges, got {len(edges_raw)}",
         )
+    rank_ids = tuple(range(len(edges_raw)))
 
     edges: list[Edge] = []
     seen_ids: dict[str, int] = {}
@@ -742,10 +748,10 @@ def _validate_topology(raw: Any) -> Topology:
                     f"{where}.endpoints[{position}]",
                     f"expected a rank id integer, got {type(value).__name__}",
                 )
-            if value not in RANK_IDS:
+            if value not in rank_ids:
                 raise SiteConfigError(
                     f"{where}.endpoints[{position}]",
-                    f"rank id {value} is not one of {list(RANK_IDS)}",
+                    f"rank id {value} is not one of {list(rank_ids)}",
                 )
             endpoints.append(value)
         if endpoints[0] == endpoints[1]:
@@ -766,18 +772,22 @@ def _validate_topology(raw: Any) -> Topology:
                  endpoints=(endpoints[0], endpoints[1]))
         )
 
-    _require_single_cycle(edges)
+    _require_single_cycle(edges, rank_ids)
     return Topology(mtu=mtu, link_speed_mbps=speed, edges=tuple(edges))
 
 
-def _require_single_cycle(edges: Sequence[Edge]) -> None:
+def _require_single_cycle(
+    edges: Sequence[Edge], rank_ids: Sequence[int] | None = None
+) -> None:
     """Reject any edge set that is not one closed cycle through all ranks."""
-    degree: dict[int, list[Edge]] = {rank_id: [] for rank_id in RANK_IDS}
+    if rank_ids is None:
+        rank_ids = tuple(range(len(edges)))
+    degree: dict[int, list[Edge]] = {rank_id: [] for rank_id in rank_ids}
     for edge in edges:
         for endpoint in edge.endpoints:
             degree[endpoint].append(edge)
 
-    for rank_id in RANK_IDS:
+    for rank_id in rank_ids:
         incident = degree[rank_id]
         if len(incident) != RING_PORTS_PER_RANK:
             raise SiteConfigError(
@@ -788,7 +798,7 @@ def _require_single_cycle(edges: Sequence[Edge]) -> None:
                 f"{RING_PORTS_PER_RANK}",
             )
 
-    start = RANK_IDS[0]
+    start = rank_ids[0]
     current = start
     used: set[str] = set()
     visited = [start]
@@ -804,14 +814,14 @@ def _require_single_cycle(edges: Sequence[Edge]) -> None:
         visited.append(current)
 
     closed = current == start and len(used) == len(edges)
-    covered = set(visited) == set(RANK_IDS)
+    covered = set(visited) == set(rank_ids)
     if not (closed and covered):
         raise SiteConfigError(
             "topology.edges",
-            "edges do not form a single closed ring through all four ranks; "
+            f"edges do not form a single closed ring through all {len(rank_ids)} ranks; "
             f"walking from rank {start} visited {visited} using "
             f"{sorted(used)}. Check the endpoint pairs - a ring is "
-            "0-1, 1-2, 2-3, 3-0 (in any labelling), not two disjoint pairs.",
+            "each rank must have exactly two neighbours in one connected cycle.",
         )
 
 
@@ -853,10 +863,11 @@ def _validate_ring_port(raw: Any, where: str, topology: Topology) -> RingPort:
 
 def _validate_ranks(raw: Any, topology: Topology) -> tuple[Rank, ...]:
     entries = _sequence(raw, "ranks")
-    if len(entries) != len(RANK_IDS):
+    rank_ids = topology.rank_ids
+    if len(entries) != len(rank_ids):
         raise SiteConfigError(
             "ranks",
-            f"expected exactly {len(RANK_IDS)} ranks, got {len(entries)}",
+            f"expected exactly {len(rank_ids)} ranks, got {len(entries)}",
         )
 
     ranks: list[Rank] = []
@@ -875,10 +886,10 @@ def _validate_ranks(raw: Any, topology: Topology) -> tuple[Rank, ...]:
                 f"{where}.id",
                 f"expected an integer rank id, got {type(raw_id).__name__}",
             )
-        if raw_id not in RANK_IDS:
+        if raw_id not in rank_ids:
             raise SiteConfigError(
                 f"{where}.id",
-                f"rank id {raw_id} is not one of {list(RANK_IDS)}",
+                f"rank id {raw_id} is not one of {list(rank_ids)}",
             )
         if raw_id in seen_ids:
             raise SiteConfigError(
@@ -962,10 +973,10 @@ def _validate_ranks(raw: Any, topology: Topology) -> tuple[Rank, ...]:
                     f"expected an integer rank id, "
                     f"got {type(peer_rank).__name__}",
                 )
-            if peer_rank not in RANK_IDS:
+            if peer_rank not in rank_ids:
                 raise SiteConfigError(
                     f"{peer_where}.rank",
-                    f"rank id {peer_rank} is not one of {list(RANK_IDS)}",
+                    f"rank id {peer_rank} is not one of {list(rank_ids)}",
                 )
             if peer_rank == raw_id:
                 raise SiteConfigError(
@@ -1000,7 +1011,7 @@ def _validate_ranks(raw: Any, topology: Topology) -> tuple[Rank, ...]:
         )
 
     ranks.sort(key=lambda entry: entry.id)
-    missing = sorted(set(RANK_IDS) - set(seen_ids))
+    missing = sorted(set(rank_ids) - set(seen_ids))
     if missing:
         raise SiteConfigError(
             "ranks", "missing rank id(s): " + ", ".join(str(x) for x in missing)
@@ -1232,7 +1243,7 @@ def _validate_serving(raw: Any) -> Serving:
             "serving.mtp_tokens",
             f"must be at least 1 when mtp_mode is {mode!r}, got {tokens}",
         )
-    master_rank = _integer(data, "serving", "master_rank", (0, max(RANK_IDS)))
+    master_rank = _integer(data, "serving", "master_rank", (0, TP_RANGE[1] - 1))
     api_port = _integer(data, "serving", "api_port", PORT_RANGE)
     master_port = _integer(data, "serving", "master_port", PORT_RANGE)
     if api_port == master_port:

--- a/scripts/test_preflight.py
+++ b/scripts/test_preflight.py
@@ -18,6 +18,7 @@ import sys
 from pathlib import Path
 
 import pytest
+import yaml
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
@@ -38,7 +39,8 @@ from preflight import (  # noqa: E402
     run_preflight,
     summarise,
 )
-from sparkring_site import ipv4_mapped_gid, load_site  # noqa: E402
+from sparkring_site import ipv4_mapped_gid, load_site, validate_site  # noqa: E402
+from test_sparkring_site import six_ring_document  # noqa: E402
 
 EXAMPLE_PATH = (
     Path(__file__).resolve().parent / "config" / "exl3-r7-site.example.yaml"
@@ -725,6 +727,20 @@ def test_run_preflight_covers_every_rank(site):
     assert exit_code_for(results) == 0
 
 
+def test_run_preflight_covers_all_six_ring_ranks():
+    document = yaml.safe_load(EXAMPLE_PATH.read_text(encoding="utf-8"))
+    six_site = validate_site(six_ring_document(document))
+    runner = healthy_runner(six_site)
+
+    results = run_preflight(six_site, runner, scope="fabric")
+    evidence = build_evidence(six_site, results, scope="fabric")
+
+    assert {result.rank for result in results} == set(range(6))
+    assert len(runner.commands) == 6
+    assert exit_code_for(results) == 0
+    assert [entry["rank"] for entry in evidence["ranks"]] == list(range(6))
+
+
 def test_fabric_scope_emits_only_connectivity_and_ring_checks(site):
     runner = FakeRunner({
         rank.ssh_target: CommandResult(
@@ -827,6 +843,9 @@ def test_evidence_shape_on_success(site):
     assert evidence["failed_check_ids"] == []
     assert evidence["failed_ranks"] == []
     assert evidence["known_check_ids"] == list(CHECK_IDS)
+    assert evidence["diagnostics"]["schema"] == "sparkring-diagnostics/v1"
+    assert evidence["diagnostics"]["passed"] is True
+    assert evidence["diagnostics"]["generated_at"] == evidence["generated_at"]
     assert [entry["rank"] for entry in evidence["ranks"]] == [0, 1, 2, 3]
     for entry in evidence["ranks"]:
         for check in entry["checks"]:

--- a/scripts/test_ring_doctor.py
+++ b/scripts/test_ring_doctor.py
@@ -4,29 +4,43 @@ from __future__ import annotations
 
 import ipaddress
 import unittest
+from pathlib import Path
 
 from scripts.ring_doctor import (
     FABRIC_INTERFACES,
     UNAVAILABLE,
     CommandResult,
+    ControllerIdentity,
     InterfaceState,
+    ManagementGuard,
     NodeObservation,
+    NodePlan,
     NodeSpec,
+    ProposedRoute,
+    _build_parser,
+    _load_inputs,
+    _unit_program,
     build_plans,
+    build_diagnostic_checks,
+    build_management_guards,
     build_probe_command,
     diagnose,
     diagnose_launch_endpoints,
     diagnose_wifi_resilience,
     discover_nodes,
+    discovery_sufficient,
     docker_user_accepts,
     infer_adjacency,
     infer_topology,
+    enforce_controller_location,
     parse_all_addresses,
     parse_brief_addresses,
     parse_route_get,
     parse_wifi_observation,
+    apply_plans,
     select_route,
     validate_cycle,
+    validate_plan_management_safety,
 )
 
 IF0, IF1 = FABRIC_INTERFACES
@@ -97,6 +111,18 @@ def synthetic_cycle() -> dict[str, NodeObservation]:
     }
 
 
+def synthetic_six_cycle() -> dict[str, NodeObservation]:
+    size = 6
+    return {
+        f"r{rank}": observation(
+            f"r{rank}",
+            f"{IF0} UP 10.30.{rank}.{rank + 10}/24\n"
+            f"{IF1} UP 10.30.{(rank - 1) % size}.{rank + 100}/24",
+        )
+        for rank in range(size)
+    }
+
+
 def probe_output(
     hostname: str,
     addresses: str,
@@ -135,18 +161,259 @@ class FakeDiscoveryRunner:
         self.outputs = outputs
         self.down = down
         self.calls: list[tuple[str, str | None]] = []
+        self.commands: list[tuple[str, str]] = []
 
     def run(
         self, target: str, command: str, proxy_jump: str | None = None
     ) -> CommandResult:
-        del command
         self.calls.append((target, proxy_jump))
+        self.commands.append((target, command))
         if target in self.down:
             return CommandResult(False, detail="SSH exited 255: connection timed out")
         return CommandResult(True, stdout=self.outputs[target])
 
 
+class SiteConfigInputTests(unittest.TestCase):
+    SITE = Path(__file__).parent / "config" / "exl3-r7-site.example.yaml"
+
+    def test_site_supplies_canonical_nodes_interfaces_and_launch_endpoints(self) -> None:
+        args = _build_parser().parse_args(["--site", str(self.SITE)])
+
+        loaded = _load_inputs(args)
+        specs = loaded.specs
+
+        self.assertEqual([spec.name for spec in specs], ["rank0", "rank1", "rank2", "rank3"])
+        self.assertEqual(specs[0].target, "operator@198.18.1.10")
+        self.assertEqual(specs[0].fabric_interfaces, ("eth1", "eth2"))
+        self.assertEqual(specs[0].socket_interfaces, ("eth0",))
+        self.assertEqual(loaded.interfaces, ("eth1", "eth2"))
+        self.assertEqual(loaded.timeout, 45)
+        self.assertEqual(
+            loaded.rendezvous_address, ipaddress.ip_address("198.18.1.10")
+        )
+        self.assertIsNotNone(loaded.site)
+
+    def test_site_rejects_a_second_cluster_description(self) -> None:
+        args = _build_parser().parse_args(
+            ["--site", str(self.SITE), "--node", "operator@rank0"]
+        )
+
+        with self.assertRaisesRegex(ValueError, "--site cannot be combined with --node"):
+            _load_inputs(args)
+
+    def test_discovery_uses_each_nodes_site_defined_interface_names(self) -> None:
+        specs = (
+            NodeSpec("r0", "operator@r0", fabric_interfaces=("cx0a", "cx0b")),
+            NodeSpec("r1", "operator@r1", fabric_interfaces=("cx1a", "cx1b")),
+        )
+        outputs = {
+            "operator@r0": probe_output(
+                "spark-r0", "cx0a UP 10.0.1.10/24\ncx0b UP 10.0.4.10/24"
+            ).replace(IF0, "cx0a").replace(IF1, "cx0b"),
+            "operator@r1": probe_output(
+                "spark-r1", "cx1a UP 10.0.2.11/24\ncx1b UP 10.0.1.11/24"
+            ).replace(IF0, "cx1a").replace(IF1, "cx1b"),
+        }
+        runner = FakeDiscoveryRunner(outputs, set())
+
+        observations = discover_nodes(specs, runner)
+
+        commands = dict(runner.commands)
+        self.assertIn("cx0a", commands["operator@r0"])
+        self.assertNotIn("cx1a", commands["operator@r0"])
+        self.assertIn("cx1a", commands["operator@r1"])
+        self.assertEqual(set(observations["r0"].interfaces), {"cx0a", "cx0b"})
+        self.assertEqual(set(observations["r1"].interfaces), {"cx1a", "cx1b"})
+
+    def test_controller_defaults_to_head_and_worker_requires_recovery_flag(self) -> None:
+        loaded = _load_inputs(
+            _build_parser().parse_args(["--site", str(self.SITE)])
+        )
+        head = ControllerIdentity(
+            frozenset(), frozenset({ipaddress.ip_address("198.18.1.10")})
+        )
+        worker = ControllerIdentity(
+            frozenset(), frozenset({ipaddress.ip_address("198.18.1.12")})
+        )
+
+        self.assertEqual(
+            enforce_controller_location(loaded, allow_worker=False, identity=head),
+            "rank0",
+        )
+        with self.assertRaisesRegex(ValueError, "--allow-worker-controller"):
+            enforce_controller_location(loaded, allow_worker=False, identity=worker)
+        self.assertEqual(
+            enforce_controller_location(loaded, allow_worker=True, identity=worker),
+            "rank2",
+        )
+
+    def test_worker_override_never_allows_an_external_controller(self) -> None:
+        loaded = _load_inputs(
+            _build_parser().parse_args(["--site", str(self.SITE)])
+        )
+        external = ControllerIdentity(
+            frozenset({"operator-laptop"}),
+            frozenset({ipaddress.ip_address("203.0.114.50")}),
+        )
+
+        with self.assertRaisesRegex(ValueError, "configured Spark"):
+            enforce_controller_location(loaded, allow_worker=True, identity=external)
+
+
+class DiagnosticReceiptAdapterTests(unittest.TestCase):
+    def test_healthy_topology_produces_affirmative_shared_check(self) -> None:
+        topology = infer_topology(synthetic_cycle())
+
+        checks = build_diagnostic_checks(topology, [])
+
+        self.assertEqual(checks[0].check_id, "fabric-topology-cycle")
+        self.assertEqual(checks[0].status.value, "pass")
+
+    def test_warning_is_unknown_not_a_pass(self) -> None:
+        topology = infer_topology(synthetic_cycle())
+        findings = diagnose_wifi_resilience(
+            [NodeSpec("r0", "operator@r0")],
+            {
+                "r0": observation(
+                    "r0",
+                    f"{IF0} UP 10.0.1.10/24\n{IF1} UP 10.0.4.10/24",
+                    wifi=UNAVAILABLE,
+                )
+            },
+        )
+
+        checks = build_diagnostic_checks(topology, findings)
+
+        self.assertEqual(checks[-1].status.value, "unknown")
+
+
+class ManagementRepairSafetyTests(unittest.TestCase):
+    def guarded_observation(self) -> NodeObservation:
+        return observation(
+            "r0",
+            f"{IF0} UP 10.0.1.10/24\n{IF1} UP 10.0.4.10/24",
+            socket_interfaces=("eth0",),
+            host_addresses=(
+                f"{IF0} UP 10.0.1.10/24\n"
+                f"{IF1} UP 10.0.4.10/24\n"
+                "eth0 UP 192.0.2.10/24"
+            ),
+        )
+
+    def test_management_guard_requires_distinct_addressed_interface(self) -> None:
+        guarded = self.guarded_observation()
+        guards, findings = build_management_guards([guarded.spec], {"r0": guarded})
+
+        self.assertEqual(findings, [])
+        self.assertEqual(guards["r0"].address_map(), {"eth0": ["192.0.2.10/24"]})
+
+        unguarded = observation(
+            "r0", f"{IF0} UP 10.0.1.10/24\n{IF1} UP 10.0.4.10/24"
+        )
+        guards, findings = build_management_guards(
+            [unguarded.spec], {"r0": unguarded}
+        )
+        self.assertEqual(guards, {})
+        self.assertEqual(findings[0].code, "management-guard-unconfigured")
+
+    def test_plan_overlapping_management_subnet_is_rejected(self) -> None:
+        guarded = self.guarded_observation()
+        guard = ManagementGuard(
+            "r0", (guarded.host_interfaces["eth0"],)
+        )
+        plan = NodePlan(
+            "r0",
+            routes=[
+                ProposedRoute(
+                    ipaddress.ip_network("192.0.2.0/24"),
+                    ipaddress.ip_address("10.0.1.11"),
+                    IF0,
+                    ("r0", "r1"),
+                )
+            ],
+        )
+
+        reason = validate_plan_management_safety(guarded, plan, guard)
+
+        self.assertIn("contains a management address", reason or "")
+
+    def test_apply_checks_management_before_and_after_each_change(self) -> None:
+        guarded = self.guarded_observation()
+        guard = ManagementGuard("r0", (guarded.host_interfaces["eth0"],))
+        plan = NodePlan(
+            "r0",
+            routes=[
+                ProposedRoute(
+                    ipaddress.ip_network("10.0.2.0/24"),
+                    ipaddress.ip_address("10.0.1.11"),
+                    IF0,
+                    ("r0", "r1"),
+                )
+            ],
+        )
+
+        class ApplyRunner:
+            def __init__(self) -> None:
+                self.commands: list[str] = []
+
+            def run(self, target, command, proxy_jump=None):
+                self.commands.append(command)
+                return CommandResult(True)
+
+        runner = ApplyRunner()
+        findings = apply_plans(
+            {"r0": guarded}, {"r0": plan}, {"r0": guard}, runner
+        )
+
+        self.assertEqual(findings, [])
+        self.assertEqual(len(runner.commands), 1)
+        self.assertGreaterEqual(runner.commands[0].count("192.0.2.10/24"), 2)
+        self.assertIn("ip route replace 10.0.2.0/24", runner.commands[0])
+
+    def test_boot_program_checks_management_after_every_change(self) -> None:
+        guarded = self.guarded_observation()
+        guard = ManagementGuard("r0", (guarded.host_interfaces["eth0"],))
+        plan = NodePlan(
+            "r0",
+            routes=[
+                ProposedRoute(
+                    ipaddress.ip_network("10.0.2.0/24"),
+                    ipaddress.ip_address("10.0.1.11"),
+                    IF0,
+                    ("r0", "r1"),
+                )
+            ],
+            relay_directions={(IF0, IF1)},
+        )
+
+        program = _unit_program(guarded, plan, guard)
+
+        self.assertIn("EXPECTED_MANAGEMENT = {'eth0': ['192.0.2.10/24']}", program)
+        self.assertGreaterEqual(program.count("require_management()"), 5)
+
+
 class AddressAndTopologyTests(unittest.TestCase):
+    def test_six_node_cycle_infers_routes_for_every_remote_edge(self) -> None:
+        observations = synthetic_six_cycle()
+
+        topology = infer_topology(observations)
+        plans = build_plans(observations, topology)
+
+        self.assertTrue(topology.valid_cycle, topology.reason)
+        self.assertEqual(len(topology.cycle), 6)
+        self.assertTrue(
+            discovery_sufficient(
+                [observation.spec for observation in observations.values()],
+                observations,
+                topology,
+            )
+        )
+        for plan in plans.values():
+            self.assertEqual(len(plan.routes), 4)
+            self.assertEqual(
+                plan.relay_directions, {(IF0, IF1), (IF1, IF0)}
+            )
+
     def test_adjacency_inference_from_real_brief_address_fixture(self) -> None:
         observations = {
             "r0": observation(

--- a/scripts/test_spark_doctor.py
+++ b/scripts/test_spark_doctor.py
@@ -1,0 +1,42 @@
+"""Offline tests for single-Spark host diagnosis."""
+
+from scripts.spark_doctor import CommandResult, run_host_checks
+
+
+class HealthyRunner:
+    def run(self, argv):
+        command = tuple(argv)
+        if command[:2] == ("nvidia-smi", "-L"):
+            return CommandResult(0, "GPU 0: NVIDIA GB10\n")
+        if command == ("ibdev2netdev",):
+            return CommandResult(
+                0,
+                "rocep1s0f0 port 1 ==> enp1s0f0np0 (Down)\n"
+                "rocep1s0f1 port 1 ==> enp1s0f1np1 (Down)\n",
+            )
+        if command[:2] == ("sh", "-c") and "lspci" in command[2]:
+            return CommandResult(0, "Mellanox Technologies ConnectX-7\n")
+        if command[:2] == ("systemctl", "is-enabled"):
+            return CommandResult(0, "enabled\n")
+        return CommandResult(0, "ok\n")
+
+
+def test_telemetry_is_reported_without_overriding_consent_policy():
+    checks = run_host_checks(HealthyRunner())
+
+    assert all(check.status.value == "pass" for check in checks)
+    telemetry = next(
+        check for check in checks if check.check_id == "HOST.NVIDIA_TELEMETRY"
+    )
+    assert telemetry.evidence == "is-enabled=enabled"
+
+
+def test_telemetry_can_be_required_disabled():
+    checks = run_host_checks(
+        HealthyRunner(), require_telemetry_disabled=True
+    )
+
+    telemetry = next(
+        check for check in checks if check.check_id == "HOST.NVIDIA_TELEMETRY"
+    )
+    assert telemetry.status.value == "fail"

--- a/scripts/test_sparkring_bootstrap.py
+++ b/scripts/test_sparkring_bootstrap.py
@@ -1,0 +1,159 @@
+"""Offline tests for blank-Spark cluster bootstrap."""
+
+from __future__ import annotations
+
+import ipaddress
+import json
+
+import pytest
+
+from scripts.sparkring_bootstrap import (
+    BootstrapError,
+    DEFAULT_INTERFACES,
+    DEFAULT_RDMA_DEVICES,
+    NodeFacts,
+    _network_apply_script,
+    _parse_probe,
+    authorize_local_key,
+    build_cluster_document,
+    parse_target,
+    render_rank_netplan,
+)
+from scripts.sparkring_cluster import validate_cluster
+
+
+def facts(size: int) -> list[NodeFacts]:
+    return [
+        NodeFacts(
+            rank=rank,
+            target=f"user{rank}@192.0.2.{rank + 10}",
+            hostname=f"spark-{rank}",
+            management_interface="enP7s7",
+            management_address=ipaddress.ip_address(f"192.0.2.{rank + 10}"),
+            fabric_interfaces=DEFAULT_INTERFACES,
+            rdma_devices=DEFAULT_RDMA_DEVICES,
+        )
+        for rank in range(size)
+    ]
+
+
+@pytest.mark.parametrize("size", [4, 6])
+def test_generated_inventory_is_a_complete_cycle(size):
+    document = build_cluster_document(
+        facts(size), name=f"ring-{size}", fabric_supernet="198.18.0.0/21"
+    )
+
+    cluster = validate_cluster(document)
+
+    assert len(cluster.ranks) == size
+    assert len(cluster.topology.edges) == size
+    for rank in cluster.ranks:
+        assert len(rank.ring_ports) == 2
+        assert len(rank.neighbour_ranks) == 2
+        assert rank.management.interface not in {
+            port.interface for port in rank.ring_ports
+        }
+
+
+def test_standard_port_orientation_connects_f0_to_next_ranks_f1():
+    cluster = validate_cluster(
+        build_cluster_document(
+            facts(4), name="orientation", fabric_supernet="198.18.0.0/21"
+        )
+    )
+
+    edge = cluster.topology.by_id("r0-r1")
+    rank0 = next(port for port in cluster.rank(0).ring_ports if port.edge == edge.id)
+    rank1 = next(port for port in cluster.rank(1).ring_ports if port.edge == edge.id)
+
+    assert rank0.interface == "enp1s0f0np0"
+    assert rank0.rdma_device == "rocep1s0f0"
+    assert rank1.interface == "enp1s0f1np1"
+    assert rank1.rdma_device == "rocep1s0f1"
+    assert rank0.address == ipaddress.ip_address("198.18.0.10")
+    assert rank1.address == ipaddress.ip_address("198.18.0.11")
+
+
+def test_management_overlap_is_rejected():
+    with pytest.raises(BootstrapError, match="overlaps a management address"):
+        build_cluster_document(
+            facts(4), name="overlap", fabric_supernet="192.0.0.0/21"
+        )
+
+
+def test_target_requires_username_and_literal_ipv4():
+    assert parse_target("operator@192.0.2.10") == (
+        "operator",
+        ipaddress.ip_address("192.0.2.10"),
+    )
+    with pytest.raises(BootstrapError, match="username@IPv4"):
+        parse_target("spark-r1")
+
+
+def test_probe_identifies_management_and_cx7_mapping():
+    rows = [
+        {
+            "ifname": "enP7s7",
+            "addr_info": [{"family": "inet", "local": "192.0.2.10"}],
+        },
+        {"ifname": "enp1s0f0np0", "addr_info": []},
+        {"ifname": "enp1s0f1np1", "addr_info": []},
+    ]
+    output = (
+        "spark-zero\n__SPARKRING_ADDR__\n"
+        + json.dumps(rows)
+        + "\n__SPARKRING_RDMA__\n"
+        + "rocep1s0f0 port 1 ==> enp1s0f0np0 (Down)\n"
+        + "rocep1s0f1 port 1 ==> enp1s0f1np1 (Down)\n"
+    )
+
+    observed = _parse_probe(
+        0, "operator@192.0.2.10", ipaddress.ip_address("192.0.2.10"), output
+    )
+
+    assert observed.hostname == "spark-zero"
+    assert observed.management_interface == "enP7s7"
+    assert observed.fabric_interfaces == DEFAULT_INTERFACES
+
+
+def test_generated_netplan_contains_only_fabric_interfaces():
+    cluster = validate_cluster(
+        build_cluster_document(
+            facts(4), name="netplan", fabric_supernet="198.18.0.0/21"
+        )
+    )
+
+    text = render_rank_netplan(cluster, 0)
+
+    assert "enp1s0f0np0:" in text
+    assert "enp1s0f1np1:" in text
+    assert "enP7s7" not in text
+    assert "198.18.0.10/24" in text
+    assert "198.18.3.11/24" in text
+    assert "mtu: 9000" in text
+
+    apply_script = _network_apply_script(cluster, 0)
+    assert "rollback()" in apply_script
+    assert "if ! netplan apply" in apply_script
+    assert "ip -4 -o addr show dev enP7s7" in apply_script
+
+
+def test_head_self_authorization_is_idempotent_and_preserves_existing_keys(tmp_path):
+    public = tmp_path / "bootstrap.pub"
+    key = "ssh-ed25519 QkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkI= bootstrap@spark"
+    public.write_text(key + "\n", encoding="utf-8")
+    ssh_dir = tmp_path / ".ssh"
+    ssh_dir.mkdir()
+    authorized = ssh_dir / "authorized_keys"
+    authorized.write_text(
+        "ssh-ed25519 Q0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0M= existing@spark\n",
+        encoding="utf-8",
+    )
+
+    authorize_local_key(public, ssh_dir=ssh_dir)
+    authorize_local_key(public, ssh_dir=ssh_dir)
+
+    lines = authorized.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 2
+    assert lines.count(key) == 1
+    assert any(ssh_dir.glob("authorized_keys.before-sparkring-*"))

--- a/scripts/test_sparkring_cli.py
+++ b/scripts/test_sparkring_cli.py
@@ -1,0 +1,103 @@
+"""Offline tests for the top-level SparkRing operator command."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest import mock
+
+from scripts import sparkring
+
+
+def test_doctor_forwards_cluster_and_remaining_flags():
+    with mock.patch.object(sparkring.ring_doctor, "main", return_value=0) as doctor:
+        result = sparkring.main(
+            ["doctor", "--cluster", "/tmp/cluster.yaml", "--verify", "--json"]
+        )
+
+    assert result == 0
+    doctor.assert_called_once_with(
+        ["--cluster", str(Path("/tmp/cluster.yaml")), "--verify", "--json"]
+    )
+
+
+def test_cluster_init_prints_plan_before_initialising(capsys):
+    fake = mock.Mock()
+    fake.summary_lines.return_value = ["cluster: test"]
+    with mock.patch.object(sparkring, "initialise_cluster", return_value=fake) as init:
+        result = sparkring.main(
+            [
+                "cluster",
+                "init",
+                "--size",
+                "4",
+                "--head",
+                "user@192.0.2.10",
+                "--node",
+                "user@192.0.2.11",
+                "--node",
+                "user@192.0.2.12",
+                "--node",
+                "user@192.0.2.13",
+                "--skip-enroll",
+                "--yes",
+                "--output",
+                "/tmp/cluster.yaml",
+            ]
+        )
+
+    assert result == 0
+    assert "SparkRing cluster initialization plan" in capsys.readouterr().out
+    assert init.call_args.kwargs["size"] == 4
+    assert init.call_args.kwargs["enroll"] is False
+
+
+def test_cluster_init_rejects_wrong_worker_count(capsys):
+    with mock.patch("builtins.input", return_value=""):
+        result = sparkring.main(
+            [
+                "cluster",
+                "init",
+                "--size",
+                "4",
+                "--head",
+                "user@192.0.2.10",
+                "--node",
+                "user@192.0.2.11",
+                "--node",
+                "user@192.0.2.12",
+                "--skip-enroll",
+                "--yes",
+            ]
+        )
+
+    assert result == 2
+    assert "username@IPv4" in capsys.readouterr().err
+
+
+def test_cluster_configure_is_plan_only_without_apply(tmp_path, capsys):
+    path = tmp_path / "cluster.yaml"
+    with mock.patch.object(sparkring, "load_cluster") as load:
+        cluster = mock.Mock()
+        cluster.ranks = [mock.Mock(id=0, ssh_target="user@192.0.2.10")]
+        load.return_value = cluster
+        with mock.patch.object(
+            sparkring, "render_rank_netplan", return_value="network: {}\n"
+        ):
+            with mock.patch.object(sparkring, "apply_fabric_network") as apply:
+                result = sparkring.main(
+                    ["cluster", "configure", "--cluster", str(path)]
+                )
+
+    assert result == 0
+    assert "Plan only; no node was changed" in capsys.readouterr().out
+    apply.assert_not_called()
+
+
+def test_host_check_forwards_privacy_policy_flag():
+    with mock.patch.object(sparkring.spark_doctor, "main", return_value=0) as host:
+        result = sparkring.main(
+            ["host", "check", "--require-telemetry-disabled", "--json"]
+        )
+
+    assert result == 0
+    host.assert_called_once_with(["--json", "--require-telemetry-disabled"])

--- a/scripts/test_sparkring_cluster.py
+++ b/scripts/test_sparkring_cluster.py
@@ -1,0 +1,107 @@
+"""Offline contract tests for model-independent cluster inventories."""
+
+from __future__ import annotations
+
+import copy
+from pathlib import Path
+
+import pytest
+import yaml
+
+from scripts.sparkring_cluster import (
+    ClusterConfigError,
+    parse_cluster_yaml,
+    validate_cluster,
+    write_cluster,
+)
+from scripts.ring_doctor import _build_parser, _load_inputs
+from scripts.test_sparkring_site import six_ring_document
+
+EXAMPLE = Path(__file__).parent / "config" / "exl3-r7-site.example.yaml"
+
+
+def cluster_document(site_document: dict) -> dict:
+    return {
+        "schema_version": site_document["schema_version"],
+        "cluster": copy.deepcopy(site_document["site"]),
+        "topology": copy.deepcopy(site_document["topology"]),
+        "ranks": copy.deepcopy(site_document["ranks"]),
+        "preflight": copy.deepcopy(site_document["preflight"]),
+    }
+
+
+@pytest.fixture()
+def four_document() -> dict:
+    return cluster_document(yaml.safe_load(EXAMPLE.read_text(encoding="utf-8")))
+
+
+def test_four_ring_needs_no_runtime_or_model_configuration(four_document):
+    cluster = validate_cluster(four_document, source="cluster.yaml")
+
+    assert cluster.source == "cluster.yaml"
+    assert len(cluster.ranks) == 4
+    assert cluster.head_rank.id == 0
+    assert "runtime" not in cluster.to_dict()
+    assert "serving" not in cluster.to_dict()
+
+
+def test_six_ring_validates_through_same_inventory(four_document):
+    site_shape = {
+        **four_document,
+        "site": four_document["cluster"],
+        "runtime": {},
+        "serving": {},
+        "paths": {},
+        "artifacts": [],
+    }
+    six = six_ring_document(site_shape)
+    document = cluster_document(six)
+
+    cluster = validate_cluster(document)
+
+    assert [rank.id for rank in cluster.ranks] == list(range(6))
+    assert len(cluster.topology.edges) == 6
+
+
+def test_yaml_round_trip_preserves_canonical_shape(four_document):
+    first = validate_cluster(four_document)
+    second = parse_cluster_yaml(yaml.safe_dump(first.to_dict(), sort_keys=False))
+
+    assert second.to_dict() == first.to_dict()
+
+
+def test_model_fields_are_rejected_from_cluster_inventory(four_document):
+    four_document["runtime"] = {"container_image": "not allowed"}
+
+    with pytest.raises(ClusterConfigError, match="unsupported key.*runtime"):
+        validate_cluster(four_document)
+
+
+def test_five_ring_remains_unsupported(four_document):
+    four_document["topology"]["edges"].append(
+        {
+            "id": "extra",
+            "subnet": "10.99.0.0/24",
+            "endpoints": [0, 1],
+        }
+    )
+
+    with pytest.raises(ClusterConfigError, match="exactly 4 or 6 edges"):
+        validate_cluster(four_document)
+
+
+def test_ring_doctor_loads_cluster_without_a_deployment_site(four_document, tmp_path):
+    cluster = validate_cluster(four_document)
+    path = tmp_path / "cluster.yaml"
+    write_cluster(cluster, path)
+
+    loaded = _load_inputs(
+        _build_parser().parse_args(["--cluster", str(path)])
+    )
+
+    assert loaded.cluster is not None
+    assert loaded.site is None
+    assert loaded.rendezvous_address == cluster.head_rank.management.address
+    assert [spec.name for spec in loaded.specs] == [
+        "rank0", "rank1", "rank2", "rank3"
+    ]

--- a/scripts/test_sparkring_diagnostics.py
+++ b/scripts/test_sparkring_diagnostics.py
@@ -1,0 +1,54 @@
+"""Contract tests for the shared SparkRing diagnostic receipt."""
+
+from scripts.sparkring_diagnostics import (
+    SCHEMA,
+    CheckStatus,
+    DiagnosticCheck,
+    build_receipt,
+)
+
+
+def check(status: CheckStatus) -> DiagnosticCheck:
+    return DiagnosticCheck(
+        check_id="RING.EXAMPLE",
+        status=status,
+        scope="fabric",
+        subject="rank0:eth1",
+        summary="Example check.",
+        evidence="observed=true",
+        node="rank0",
+        source="test",
+    )
+
+
+def test_receipt_passes_only_when_every_check_passes():
+    passed = build_receipt(
+        [check(CheckStatus.PASS)],
+        generated_at="2026-08-24T00:00:00Z",
+        source="test",
+    )
+    unknown = build_receipt(
+        [check(CheckStatus.PASS), check(CheckStatus.UNKNOWN)],
+        generated_at="2026-08-24T00:00:00Z",
+        source="test",
+    )
+
+    assert passed["schema"] == SCHEMA
+    assert passed["passed"] is True
+    assert passed["totals"] == {
+        "pass": 1,
+        "fail": 0,
+        "unknown": 0,
+        "skipped": 0,
+    }
+    assert unknown["passed"] is False
+    assert unknown["totals"]["unknown"] == 1
+
+
+def test_empty_receipt_is_not_positive_evidence():
+    receipt = build_receipt(
+        [], generated_at="2026-08-24T00:00:00Z", source="test"
+    )
+
+    assert receipt["passed"] is False
+    assert receipt["checks"] == []

--- a/scripts/test_sparkring_site.py
+++ b/scripts/test_sparkring_site.py
@@ -65,6 +65,65 @@ def document(example_document: dict) -> dict:
     return result
 
 
+def six_ring_document(base: dict) -> dict:
+    """Return a complete six-rank cycle derived from the shipped four-ring."""
+    result = copy.deepcopy(base)
+    size = 6
+    result["site"] = {
+        "name": "six-ring-test",
+        "description": "Offline six-rank SparkRing validation fixture.",
+    }
+    result["topology"]["edges"] = [
+        {
+            "id": f"r{rank}-r{(rank + 1) % size}",
+            "subnet": f"10.20.{rank}.0/24",
+            "endpoints": [rank, (rank + 1) % size],
+        }
+        for rank in range(size)
+    ]
+    ranks = []
+    for rank in range(size):
+        previous = (rank - 1) % size
+        following = (rank + 1) % size
+        ranks.append(
+            {
+                "id": rank,
+                "ssh_target": f"operator@192.0.2.{rank + 10}",
+                "management": {
+                    "interface": "eth0",
+                    "address": f"192.0.2.{rank + 10}",
+                },
+                "ring_ports": [
+                    {
+                        "edge": f"r{previous}-r{rank}",
+                        "interface": "eth1",
+                        "address": f"10.20.{previous}.{rank + 100}",
+                        "rdma_device": "mlx5_0",
+                        "rdma_port": 1,
+                        "roce_gid_index": 3,
+                    },
+                    {
+                        "edge": f"r{rank}-r{following}",
+                        "interface": "eth2",
+                        "address": f"10.20.{rank}.{rank + 10}",
+                        "rdma_device": "mlx5_1",
+                        "rdma_port": 1,
+                        "roce_gid_index": 3,
+                    },
+                ],
+                "transport_peers": [
+                    {"rank": previous, "address": f"192.0.2.{previous + 10}"},
+                    {"rank": following, "address": f"192.0.2.{following + 10}"},
+                ],
+            }
+        )
+    result["ranks"] = ranks
+    result["serving"]["tensor_parallel_size"] = size
+    result["serving"]["decode_context_parallel_size"] = 1
+    result["serving"]["master_rank"] = 0
+    return result
+
+
 # ==========================================================================
 # Happy path
 # ==========================================================================
@@ -102,6 +161,30 @@ def test_example_has_four_edges_each_with_two_ring_ports():
             claims[port.edge].append(rank.id)
     for edge in site.topology.edges:
         assert sorted(claims[edge.id]) == sorted(edge.endpoints)
+
+
+def test_six_rank_ring_loads_and_resolves_every_neighbour(document):
+    site = validate_site(six_ring_document(document))
+
+    assert site.topology.rank_ids == (0, 1, 2, 3, 4, 5)
+    assert len(site.topology.edges) == 6
+    assert len(site.ranks) == 6
+    for rank in site.ranks:
+        assert len(rank.ring_ports) == 2
+        assert len(rank.neighbour_ranks) == 2
+        assert {peer.rank for peer in rank.transport_peers} == set(
+            rank.neighbour_ranks
+        )
+        for port in rank.ring_ports:
+            assert port.peer_address is not None
+
+
+def test_five_rank_ring_is_rejected_as_unsupported(document):
+    candidate = six_ring_document(document)
+    candidate["topology"]["edges"] = candidate["topology"]["edges"][:5]
+
+    with pytest.raises(SiteConfigError, match="exactly 4 or 6 edges"):
+        validate_site(candidate)
 
 
 def test_peer_addresses_are_resolved_for_every_ring_port():
@@ -379,7 +462,7 @@ CASES: list[tuple[str, object, str, str]] = [
         lambda d: d["topology"].__setitem__(
             "edges", d["topology"]["edges"][:3]
         ),
-        "topology.edges", "exactly 4 edges",
+        "topology.edges", "exactly 4 or 6 edges",
     ),
     (
         "topology-duplicate-edge-id",


### PR DESCRIPTION
## Summary
- add a blank-Spark installer and top-level `sparkring` CLI
- add read-only single-host checks, verified SSH enrollment, and model-independent 4/6-ring inventories
- add fabric-only netplan planning/application with management rollback
- deepen Ring Doctor with shared receipts, canonical fabric preflight, worker-controller recovery, and fail-closed management guards

## Validation
- 1,849 tests passed; 9 skipped on the rebased branch
- Ruff and `bash -n bootstrap.sh` passed
- live DGX4 host check: 9/9 passed
- live DGX4 model-free Ring Doctor: 88/88 passed with full reachability and management guards ready
- live enrollment/discovery path passed; network apply remained plan-only on the already-configured stack

## Coordination
PR #116 also edits `README.md`. Merge #116 first, then refresh this branch against `main` and rerun CI before merging.