### PR TITLE
Configure supported launchers from validated operator inputs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,7 +50,7 @@ SparkRing supports three model families across eight deployment profiles:
 Qwen3.8-27B with SparkCache is Pending. No composition recipe or live cache
 evidence is published for that combination.
 
-Six-Spark GLM and KIMI profiles are in dev and are not part of the supported
+Six-Spark GLM and KIMI work is research-only and is not part of the supported
 repository surface.
 
 Maintained Python trees are `spark_transport/`, `runtime/`, `scripts/`, and
@@ -72,7 +72,7 @@ choosing one.
 | Qwen runtime/source pins and model identities | `runtime/qwen38/pins.json`, then `recipes/qwen38-27b-exl3-k5k6{,-pair}.json` |
 | Public Python overlay allowlist | `runtime/public-overlay-files.json` |
 | R7 site and candidate templates | `scripts/config/exl3-r7-site.example.yaml`, `scripts/config/exl3-r7-candidate.example.json` |
-| DeepSeek per-rank environment | `scripts/config/deepseek-v4-flash-0731.env.example` |
+| DeepSeek two-rank and four-rank environments | `scripts/config/deepseek-v4-flash-0731-pair.env.example`, `scripts/config/deepseek-v4-flash-0731.env.example` |
 | Qwen3.8-27B pair environment | `scripts/config/qwen38-27b-exl3-k5k6-pair.env.example` |
 | Qwen3.8-27B four-rank environment | `scripts/config/qwen38-27b-exl3-k5k6.env.example` |
 | Performance claim requirements | `performance/README.md` |
@@ -117,8 +117,9 @@ produces a content-manifested bundle from the explicit allowlist in
 Use `scripts/config/exl3-r7-site.example.yaml` and
 `scripts/config/exl3-r7-candidate.example.json` as sanitized R7 inputs. Keep
 resolved site addresses, image identities, host paths, and credentials out of
-version control. Use `scripts/config/deepseek-v4-flash-0731.env.example` only
-as a per-rank environment template for DeepSeek-V4-Flash-0731.
+version control. Use `scripts/config/deepseek-v4-flash-0731-pair.env.example`
+for a two-rank pair and `scripts/config/deepseek-v4-flash-0731.env.example` for
+a four-rank cycle.
 
 Use the topology-specific Qwen environment in `scripts/config/` with the image
 built by `runtime/qwen38/build-image.sh`, as described in

--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@
 inference-serving stack for switchless clusters of NVIDIA DGX 'Spark' systems
 powered by the GB10 Grace Blackwell Superchip.
 
-SparkRing supports GB10 pairs, four-node rings, and Six-node rings (in dev).
+SparkRing supports GB10 pairs and four-node rings. Six-node ring work is
+research-only.
 
 Models run as tensor-parallel deployments over the direct fabric without an
 external Ethernet or InfiniBand switch. [SIRCL](https://github.com/FujitsuPolycom/sparkring/blob/main/docs/SIRCL.md) provides custom RDMA collectives
@@ -38,7 +39,8 @@ profile is selected.
 - **4× DGX Spark — physical ring.** Models: GLM-5.2 EXL3 3.5-bpw,
   DeepSeek-V4-Flash-0731, and Qwen3.8-27B EXL3 K5/K6. GLM and DeepSeek are
   compatible with SparkCache; Qwen SparkCache support is Pending.
-- **6× DGX Spark — physical ring.** **In dev. Target models: GLM | KIMI.**
+- **6× DGX Spark — physical ring.** **Research-only.** GLM and KIMI profiles
+  are not part of the supported repository surface.
 
 ## Profiles
 

--- a/docs/DEEPSEEK_V4_FLASH_QUICKSTART.md
+++ b/docs/DEEPSEEK_V4_FLASH_QUICKSTART.md
@@ -2,10 +2,27 @@
 
 Deploy DeepSeek-V4-Flash across directly cabled DGX Sparks in either of two
 topologies: **two tensor-parallel ranks on a cabled pair**, or **four on a
-cycle**. Both setups have been benchmarked. The measured pair used
+cycle**.
+
+**Status: implemented.** The env-driven launchers at
+[`scripts/deepseek_v4_pair_serve.sh`](../scripts/deepseek_v4_pair_serve.sh) and
+[`scripts/deepseek_v4_cycle_serve.sh`](../scripts/deepseek_v4_cycle_serve.sh)
+have offline contract coverage. Equivalent two-rank and four-rank serving
+arguments have served requests with benchmark image
+`ghcr.io/fujitsupolycom/gb10-vllm-serving@sha256:6fc26fdad81a18f0fff67ce0a05f6d90165625ea2e1cac8a6f39bfb462017028`
+under the checkpoint conditions below. The published image selected by the
+`deepseek_v4_flash_0731_hardened_serving_image` key in
+[`runtime/faststart-lock.json`](../runtime/faststart-lock.json) has not completed an exact
+post-publication pull-and-replay on either topology, so the profiles are not
+qualified for general use or for 1,048,576-token output quality. The recorded
+pair throughput used
 `deepseek-ai/DeepSeek-V4-Flash-DSpark@913f0657a874f76844e2e91cbe706dbcaceeb6d7`;
-the measured cycle used
+the recorded cycle throughput used
 `deepseek-ai/DeepSeek-V4-Flash-0731@7872f01b1d1fe23eabc4c98b48bffcef5a386062`.
+The pair package has the same configuration and tensor index as plain 0731,
+but different weight payloads. The measurements therefore establish launch
+behavior and conditional throughput, not exact checkpoint scaling or output
+quality.
 
 The machine-readable serving contracts are
 [`recipes/deepseek-v4-flash-0731-pair.json`](../recipes/deepseek-v4-flash-0731-pair.json)
@@ -13,9 +30,8 @@ for the pair and
 [`recipes/deepseek-v4-flash-0731.json`](../recipes/deepseek-v4-flash-0731.json)
 for the cycle.
 
-Both public recipes use the plain 0731 package and serve a 1,048,576-token
-request length. The measured TP2 result used the DSpark package named above;
-its configuration and tensor index match, while its weight payloads differ.
+Both public recipes use the plain 0731 package and configure a
+1,048,576-token request limit.
 
 | | Two-Spark pair | Four-Spark cycle |
 |---|---|---|
@@ -24,15 +40,15 @@ its configuration and tensor index match, while its weight payloads differ.
 | Weights resident per rank | 80.97 GiB | 40.82 GiB |
 | `--tensor-parallel-size` / `--nnodes` | 2 | 4 |
 | `--kv-cache-memory-bytes` | 17179869184 (16 GiB) | 17179869184 (16 GiB) |
-| Context / Seq / Batch | 1M, 32, 4096 | 1M, 32, 4096 |
+| Request limit / sequences / scheduler tokens | 1M / 32 / 4096 | 1M / 32 / 4096 |
 | Environment template | `deepseek-v4-flash-0731-pair.env.example` | `deepseek-v4-flash-0731.env.example` |
 
 `--max-model-len 1048576`, `--max-num-seqs 32`, `--max-num-batched-tokens
 4096`, `--block-size 256`, and the 16 GiB reservation are the settings used by
 both base topologies.
 
-Both commands explicitly enable asynchronous scheduling and retain complete
-input-length reservation before admission:
+Both commands explicitly enable asynchronous scheduling and reserve each
+request's complete input length before admission:
 
 ```text
 --async-scheduling --scheduler-reserve-full-isl
@@ -64,23 +80,38 @@ docker pull ghcr.io/fujitsupolycom/gb10-vllm-serving@sha256:827a8e8c5749b78529cc
 This is the `deepseek_v4_flash_0731_hardened_serving_image.manifest_digest`
 pinned by
 [`runtime/faststart-lock.json`](../runtime/faststart-lock.json). The image
-registers `DeepseekV4ForCausalLM` and adds malformed-DSML recovery plus the K5
-sparse-row/native top-k repairs. Override its inherited GLM-specific entrypoint
-as shown below. The prior generic `serving_image` digest remains available as
-the rollback image and continues to serve the GLM profiles.
+registers `DeepseekV4ForCausalLM` and repairs malformed speculative-model
+metadata plus five-token sparse-row/native top-k execution. The launch commands
+override its GLM-specific entrypoint. The generic image used to roll back GLM
+profiles is pinned by the `serving_image` key in
+[`runtime/faststart-lock.json`](../runtime/faststart-lock.json).
 
 Copy the environment template for your topology to one local file per rank.
 
-For a pair, replace `<FABRIC_IFNAME>`, `<RANK_FABRIC_IP>`, and `<GID_INDEX>`.
-Both ranks name the same interface when the pair is cabled cage 0 to cage 0:
+For a pair, fill the rank, rank-0 rendezvous address, model/cache host paths,
+fabric interface, rank fabric address, and GID index. Both ranks normally name
+the same interface when the pair is cabled cage 0 to cage 0. Keep the serving
+defaults unchanged for the first launch:
 
 ```bash
+# Run on the rank 0 / API host.
 cp scripts/config/deepseek-v4-flash-0731-pair.env.example /path/to/rank-0.env
+
+# Run on the rank 1 / worker host.
 cp scripts/config/deepseek-v4-flash-0731-pair.env.example /path/to/rank-1.env
 ```
 
-For a cycle, replace `<NCCL_SOCKET_IFNAME>` and `<RANK_FABRIC_IP>`. Even ranks
-use cage 0 (`enp1s0f0np0`) and odd ranks use cage 1 (`enp1s0f1np1`):
+Create the cache directory named by `CACHE_HOST_PATH` on each host before
+validation. It must be writable by the account running Docker:
+
+```bash
+mkdir -p /absolute/path/to/deepseek-cache
+test -w /absolute/path/to/deepseek-cache
+```
+
+For a cycle, resolve the rank/rendezvous values, model/cache host paths,
+serving values, `<NCCL_SOCKET_IFNAME>`, and `<RANK_FABRIC_IP>`. Even ranks use
+cage 0 (`enp1s0f0np0`) and odd ranks use cage 1 (`enp1s0f1np1`):
 
 ```bash
 cp scripts/config/deepseek-v4-flash-0731.env.example /path/to/rank-0.env
@@ -89,16 +120,36 @@ cp scripts/config/deepseek-v4-flash-0731.env.example /path/to/rank-2.env
 cp scripts/config/deepseek-v4-flash-0731.env.example /path/to/rank-3.env
 ```
 
+Create the `CACHE_HOST_PATH` directory recorded in each cycle rank env before
+running `deepseek_v4_cycle_serve.sh --check`.
+
 The templates' `LD_PRELOAD`, `VLLM_NCCL_SO_PATH`, and `NCCL_*` values are
-required by the published image. Do not use a GLM profile environment file, and
+required by the image selected by the
+`deepseek_v4_flash_0731_hardened_serving_image` lock key. Do not use a GLM
+profile environment file, and
 do not use the cycle template on a pair: its transport settings name two host
 channel adapters, enable subnet-aware routing, and skip tree connect, none of
 which applies when the two ranks are directly adjacent.
 
-The `<GID_INDEX>` placeholder in the pair template is the RoCE GID index for
-that interface's IPv4 address. `show_gids` lists them. Do not copy a value from
-another deployment; the correct index depends on the RoCE version and the
-address configured on the host.
+The pair template is the single operator input for the pair launcher. It
+contains the host model/cache mounts, API and rendezvous ports, speculative
+depth, request limit, sequence ceiling, and scheduler token budget in addition
+to the container environment. Rank 0 and rank 1 may use different local model
+and cache paths, but the mounted model bytes and all serving values must agree.
+
+Use these rank-specific values; keep the serving values below them identical:
+
+| Variable | Rank 0 / API host | Rank 1 / worker host |
+|---|---|---|
+| `NODE_RANK` | `0` | `1` |
+| `MASTER_ADDR` | rank 0 fabric address | same rank 0 fabric address |
+| `VLLM_HOST_IP` | rank 0 fabric address | rank 1 fabric address |
+| `MODEL_HOST_PATH` | local model directory | local directory with identical model bytes |
+| `CACHE_HOST_PATH` | local writable cache directory | local writable cache directory |
+
+The `<GID_INDEX>` placeholder is the RoCE GID index for that interface's IPv4
+address. `show_gids` lists them. Do not copy a value from another deployment;
+the correct index depends on the RoCE version and host address.
 
 ## 2. Launch one rank per host
 
@@ -108,75 +159,84 @@ recompiles its just-in-time kernels from scratch.
 
 ### Two-Spark pair
 
-Set `RANK` to `0` or `1` on the corresponding host, and `RANK0_FABRIC_ADDR` to
-rank 0's fabric address. Rank 0 serves the API; rank 1 must use `--headless`.
+The pair launcher checks the resolved environment, host paths, API and
+rendezvous ports, direct-pair NCCL settings, and positive serving limits before
+constructing Docker arguments. `--check` is offline and prints the exact
+command without creating a container. Run it on both hosts:
 
 ```bash
-docker run -d --name deepseek-v4-flash-r"$RANK" \
-  --network host --ipc host --shm-size 16g --gpus all \
-  --ulimit memlock=-1:-1 --device /dev/infiniband \
-  -v /path/to/deepseek-v4-flash-0731:/models/deepseek-v4-flash-0731:ro \
-  -v /path/to/jit-cache:/cache \
-  --env-file /path/to/rank-"$RANK".env \
-  --entrypoint /opt/venv/bin/vllm \
-  ghcr.io/fujitsupolycom/gb10-vllm-serving@sha256:827a8e8c5749b78529cc0015dd174e1b19a0accc116bc142282f8b75428f98bd \
-  serve /models/deepseek-v4-flash-0731 \
-  --tensor-parallel-size 2 --nnodes 2 --node-rank "$RANK" \
-  --master-addr "$RANK0_FABRIC_ADDR" --master-port 29500 \
-  --distributed-executor-backend mp \
-  --dtype bfloat16 \
-  --max-model-len 1048576 \
-  --max-num-seqs 32 \
-  --max-num-batched-tokens 4096 \
-  --async-scheduling --scheduler-reserve-full-isl \
-  --gpu-memory-utilization 0.70 \
-  --kv-cache-memory-bytes 17179869184 \
-  --kv-cache-dtype fp8_ds_mla \
-  --block-size 256 \
-  --tokenizer-mode deepseek_v4 \
-  --kernel-config '{"enable_cutedsl_warmup": false}' \
-  --enable-auto-tool-choice --tool-call-parser deepseek_v4 \
-  --speculative-config '{"method": "dspark",
-    "num_speculative_tokens": 5, "moe_backend": "b12x"}' \
-  --served-model-name deepseek-v4-flash-0731 \
-  $([ "$RANK" -eq 0 ] && echo "--host 0.0.0.0 --port 8000" || echo "--headless")
+scripts/deepseek_v4_pair_serve.sh --check /path/to/rank-0.env
+scripts/deepseek_v4_pair_serve.sh --check /path/to/rank-1.env
 ```
+
+Each check covers one rank. Compare the printed `MAX_MODEL_LEN`,
+`MAX_NUM_SEQS`, `MAX_NUM_BATCHED_TOKENS`, and `NUM_SPECULATIVE_TOKENS` values
+on both hosts before launching; matching values do not verify that model bytes
+are identical.
+
+Start rank 1 first, then rank 0. `--run` refuses to replace an existing
+container; remove an existing container intentionally before a relaunch.
+
+```bash
+# Rank 1 / worker host
+scripts/deepseek_v4_pair_serve.sh --run /path/to/rank-1.env
+docker logs -f deepseek-v4-flash-r1
+
+# Rank 0 / API host
+scripts/deepseek_v4_pair_serve.sh --run /path/to/rank-0.env
+docker logs -f deepseek-v4-flash-r0
+```
+
+The pair environment exposes these operator-facing settings and uses the
+defaults recorded in
+[`recipes/deepseek-v4-flash-0731-pair.json`](../recipes/deepseek-v4-flash-0731-pair.json):
+
+| Variable | Default | Purpose |
+|---|---:|---|
+| `MODEL_HOST_PATH` | required | Read-only host model directory mounted at the fixed container model path |
+| `CACHE_HOST_PATH` | required | Writable parent for persistent JIT/compiler caches mounted at `/cache` |
+| `API_PORT` | 8000 | Rank-0 OpenAI-compatible API port |
+| `NUM_SPECULATIVE_TOKENS` | 5 | DSpark proposal depth |
+| `MAX_MODEL_LEN` | 1048576 | Per-request token limit |
+| `MAX_NUM_SEQS` | 32 | Scheduler admission ceiling |
+| `MAX_NUM_BATCHED_TOKENS` | 4096 | Scheduler budget and chunked-prefill size |
+
+The launcher uses `--ipc host --shm-size 16g`. Host IPC makes the host's
+`/dev/shm` allocation authoritative, so changing the declaration from 16 GiB
+to 64 GiB does not enlarge shared memory. Compare `df -h /dev/shm` on the host
+and inside the running container when diagnosing shared-memory pressure.
 
 ### Four-Spark cycle
 
-Set `RANK` to `0`, `1`, `2`, or `3` on the corresponding host. Rank 0 serves the
-API; the other ranks must use `--headless`. The command is identical to the
-pair's except for the parallelism flags and the key-value reservation:
+The cycle launcher consumes one resolved
+`deepseek-v4-flash-0731.env.example` copy per rank and exposes the same model,
+cache, port, speculation, context, sequence, and scheduler settings as the pair
+launcher. Validate all four ranks and compare their printed serving values:
 
 ```bash
-docker run -d --name deepseek-v4-flash-r"$RANK" \
-  --network host --ipc host --shm-size 16g --gpus all \
-  --ulimit memlock=-1:-1 --device /dev/infiniband \
-  -v /path/to/deepseek-v4-flash-0731:/models/deepseek-v4-flash-0731:ro \
-  -v /path/to/jit-cache:/cache \
-  --env-file /path/to/rank-"$RANK".env \
-  --entrypoint /opt/venv/bin/vllm \
-  ghcr.io/fujitsupolycom/gb10-vllm-serving@sha256:827a8e8c5749b78529cc0015dd174e1b19a0accc116bc142282f8b75428f98bd \
-  serve /models/deepseek-v4-flash-0731 \
-  --tensor-parallel-size 4 --nnodes 4 --node-rank "$RANK" \
-  --master-addr "$RANK0_FABRIC_ADDR" --master-port 29500 \
-  --distributed-executor-backend mp \
-  --dtype bfloat16 \
-  --max-model-len 1048576 \
-  --max-num-seqs 32 \
-  --max-num-batched-tokens 4096 \
-  --async-scheduling --scheduler-reserve-full-isl \
-  --gpu-memory-utilization 0.70 \
-  --kv-cache-memory-bytes 17179869184 \
-  --kv-cache-dtype fp8_ds_mla \
-  --block-size 256 \
-  --tokenizer-mode deepseek_v4 \
-  --kernel-config '{"enable_cutedsl_warmup": false}' \
-  --enable-auto-tool-choice --tool-call-parser deepseek_v4 \
-  --speculative-config '{"method": "dspark",
-    "num_speculative_tokens": 5, "moe_backend": "b12x"}' \
-  --served-model-name deepseek-v4-flash-0731 \
-  $([ "$RANK" -eq 0 ] && echo "--host 0.0.0.0 --port 8000" || echo "--headless")
+scripts/deepseek_v4_cycle_serve.sh --check /path/to/rank-0.env
+scripts/deepseek_v4_cycle_serve.sh --check /path/to/rank-1.env
+scripts/deepseek_v4_cycle_serve.sh --check /path/to/rank-2.env
+scripts/deepseek_v4_cycle_serve.sh --check /path/to/rank-3.env
+```
+
+Start worker ranks 1-3 first, then rank 0:
+
+```bash
+# Run on the corresponding worker hosts.
+scripts/deepseek_v4_cycle_serve.sh --run /path/to/rank-1.env
+scripts/deepseek_v4_cycle_serve.sh --run /path/to/rank-2.env
+scripts/deepseek_v4_cycle_serve.sh --run /path/to/rank-3.env
+
+# Run on the API host after all workers are waiting for rendezvous.
+scripts/deepseek_v4_cycle_serve.sh --run /path/to/rank-0.env
+```
+
+Follow the container for the rank on each host, for example:
+
+```bash
+docker logs -f deepseek-v4-flash-r1
+docker logs -f deepseek-v4-flash-r0
 ```
 
 `--kv-cache-dtype fp8_ds_mla` is required in both topologies: it declares the
@@ -189,11 +249,15 @@ substitute generic `fp8`.
 `--max-num-batched-tokens` are not independent. Changing one alone will
 usually fail or waste memory.
 
+For the pair, change `MAX_MODEL_LEN`, `MAX_NUM_SEQS`, and
+`MAX_NUM_BATCHED_TOKENS` in its environment file and rerun the launcher's
+`--check` mode. The four-Spark workflow uses explicit CLI configuration.
+
 **Set `--max-num-batched-tokens` explicitly.** The normalized comparison target
-uses 4096 in every DeepSeek base and SparkCache profile. A historical pair run
-with 8192 measured higher C32 throughput, but it is not the default because it
-would make the base and cache comparison change two variables. The 4096 target
-was measured in the C1/C2/C4/C8/C16/C32 campaign below.
+uses 4096 in every DeepSeek base and SparkCache profile. A recorded pair run
+with 8192 measured higher throughput at concurrency 32, but the base and cache
+comparison uses 4096 so the scheduler budget remains controlled. The
+measurement records cover concurrency levels 1, 2, 4, 8, 16, and 32.
 
 **A longer request limit is close to free; a larger pool is not.** This model
 has bounded cache groups whose cost per sequence is fixed, so per-token pool
@@ -204,10 +268,9 @@ memory.
 
 **Sequence count and speculation depth inflate the per-request floor.** The
 engine refuses to start unless the pool can hold one full-length request. The
-32-sequence target retains the bounded sequence count while the pair reservation
-increases to 16 GiB. The normalized pair reported a 2,198,756-token pool and
-2.10x full-length capacity. A separate cycle gate must record its pool and free
-memory before a concurrency campaign begins.
+32-sequence pair profile uses a 16 GiB reservation. The recorded pair reported
+a 2,198,756-token pool and 2.10x full-length capacity. A four-Spark concurrency
+measurement must record its pool and free memory before load generation.
 
 **`--kv-cache-memory-bytes` disables the memory-utilization guard.** The engine
 states this explicitly: it "skipped memory profiling. This does not respect the
@@ -218,8 +281,8 @@ exhausting the node.
 
 Check free memory after a launch rather than trusting the flag. The normalized
 pair had only 4.9–6.0 GiB available per node and used swap. The roughly 50 GB
-cycle observation came from a historical configuration, not the normalized
-block-256, batch-4096 target.
+cycle observation used settings other than the block-256, batch-4096
+configuration recorded here.
 A node driven to 2-3 GB free with swap in use is one long prefill away from
 having its engine core killed, and on this platform severe memory exhaustion
 can leave a host answering ICMP while refusing to complete any new connection,
@@ -228,9 +291,14 @@ recoverable only by a power cycle.
 ## 4. Verify rank 0
 
 Wait for the API health endpoint, then issue a deterministic chat request.
+Read the configured port from the rank-0 environment so a non-default
+`API_PORT` is verified correctly.
 
 ```bash
-curl -s localhost:8000/v1/chat/completions \
+api_port=$(sed -n 's/^API_PORT=//p' /path/to/rank-0.env)
+curl --fail "http://localhost:$api_port/health"
+curl "http://localhost:$api_port/v1/models"
+curl -s "http://localhost:$api_port/v1/chat/completions" \
   -H 'Content-Type: application/json' \
   -d '{"model":"deepseek-v4-flash-0731",
        "messages":[{"role":"user","content":"What is 17 * 23?"}],
@@ -245,9 +313,10 @@ bought.
 ## Measured
 
 Both cache-disabled base setups were measured with the sampling settings in
-their benchmark records. C1/C2 use at least five accepted observations per context; every
-other applicable decode cell uses at least three. Decode values below are mean
-aggregate generated tok/s.
+their benchmark records. Concurrency levels 1 and 2 use at least five accepted
+observations per context; every other applicable decode cell uses at least
+three. Table headings `C1` through `C32` denote concurrent request counts.
+Decode values are mean aggregate generated tokens per second.
 
 The DSpark package used by TP2 has the same model configuration, tokenizer
 configuration, and tensor index as the plain 0731 package used by TP4. Its 48
@@ -284,7 +353,7 @@ exact same-weight TP2-versus-TP4 scaling test.
 
 The full records report mean, standard deviation, N, Coding Peak, exclusions,
 and source-receipt hashes. Synthetic sustained text changes DSpark acceptance,
-so even five-observation cells retain meaningful variance.
+so five-observation cells have meaningful variance.
 
 The profile remains collective-latency-sensitive: the model issues two
 all-reduces per layer across 43 layers, and each token waits on synchronous
@@ -312,30 +381,33 @@ single-host multi-GPU profiles and are not worth carrying here.
 
 Each topology has separate results recorded in its serving contract.
 
-A diagnostic plain-0731 TP4/K5 deployment built from this runtime lane was
-exercised on 2026-08-24: 100 consecutive max-reasoning strict streamed tool
-calls passed, followed by cold tool calls at approximately 98K and 262K prompt
-tokens. No raw DSML/control tokens or server-error responses were observed. The run did
-not attest the published digest, so both TP4/K5 and TP2/K5 still need an exact
-post-publication pull-and-replay. These correctness checks do not replace the
-throughput tables below.
+A diagnostic four-rank tensor-parallel deployment of plain 0731 with five
+DSpark proposal tokens was exercised on 2026-08-24: 100 consecutive
+maximum-reasoning strict streamed tool calls passed, followed by cold tool
+calls at approximately 98K and 262K prompt tokens. No raw speculative-model
+control tokens or server-error responses were observed. The run did not attest
+an image digest, so both the two-rank and four-rank five-token profiles
+require an exact post-publication pull-and-replay. These correctness checks are
+separate from the throughput tables in this document.
 
-The two-Spark launch was exercised on 2026-08-21 on two directly cabled Sparks:
+The two-Spark launch used benchmark image
+`ghcr.io/fujitsupolycom/gb10-vllm-serving@sha256:6fc26fdad81a18f0fff67ce0a05f6d90165625ea2e1cac8a6f39bfb462017028`
+on 2026-08-21 on two directly cabled Sparks:
 both ranks rendezvoused, a deterministic completion, an emitted tool call and a
 34-tool chat request returned coherent output with no leaked markers, and DSpark
 speculation ran at depth 5 with a 2.76 mean acceptance length. It mounted only
-the checkpoint and a cache directory, so the published image needs no source
+the checkpoint and a cache directory, so that benchmark image needs no source
 overlay.
 
-The four-Spark launch was exercised on 2026-08-21 against the same pinned
-image: all four ranks rendezvoused, each loading 40.82 GiB of weights, a
+The four-Spark launch used the same benchmark image digest on 2026-08-21: all
+four ranks rendezvoused, each loading 40.82 GiB of weights, a
 deterministic completion and an emitted tool call were correct, and DSpark
 speculation ran at depth 5 with a 3.06 mean acceptance length.
 
-The historical throughput figures are client-observed on the stated prompt and
+The throughput figures are client-observed on the stated prompt and
 generation lengths. The normalized TP2 table is isolated-server sustained
 decode and standalone prefill. Neither dataset measures output quality or
-qualifies the setup for general use. The normal launch uses
+qualifies the setup for general use. The documented launch uses
 patched NCCL from the environment template; SIRCL width-4096 graph collectives
 are research-only and are not part of this quickstart. See
 [the profile record](profiles/DEEPSEEK_V4_FLASH_0731.md) and
@@ -343,7 +415,7 @@ are research-only and are not part of this quickstart. See
 
 The offline-only [four-Spark SIRCL A/B plan](DEEPSEEK_V4_FLASH_SIRCL_AB.md)
 validates both transport arms against this quickstart's machine-readable
-recipe, applies the research experiment's 4,096-token batch budget to both
-arms, and preserves its model, memory, scheduler-mode, and five-token DSpark
+recipe, applies a 4,096-token batch budget to both arms, and uses the same
+model, memory, scheduler mode, and five-token DSpark
 contract. The plan has no execution mode and does not promote SIRCL into this
 quickstart.

--- a/docs/DEEPSEEK_V4_FLASH_QUICKSTART.md
+++ b/docs/DEEPSEEK_V4_FLASH_QUICKSTART.md
@@ -381,37 +381,18 @@ single-host multi-GPU profiles and are not worth carrying here.
 
 ## What these results cover
 
-Each topology has separate results recorded in its serving contract.
+Each topology has separate results recorded in its serving contract. The
+reported throughput values are client-observed for the prompt and generation
+lengths named by each record. The two-rank matrix uses isolated-server
+sustained decode and standalone prefill. Neither dataset measures output
+quality or qualifies an untested image, checkpoint, topology, or request
+shape.
 
-A diagnostic four-rank tensor-parallel deployment of plain 0731 with five
-DSpark proposal tokens was exercised on 2026-08-24: 100 consecutive
-maximum-reasoning strict streamed tool calls passed, followed by cold tool
-calls at approximately 98K and 262K prompt tokens. No raw speculative-model
-control tokens or server-error responses were observed. The run did not attest
-an image digest, so both the two-rank and four-rank five-token profiles
-require an exact post-publication pull-and-replay. These correctness checks are
-separate from the throughput tables in this document.
-
-The two-Spark launch used benchmark image
-`ghcr.io/fujitsupolycom/gb10-vllm-serving@sha256:6fc26fdad81a18f0fff67ce0a05f6d90165625ea2e1cac8a6f39bfb462017028`
-on 2026-08-21 on two directly cabled Sparks:
-both ranks rendezvoused, a deterministic completion, an emitted tool call and a
-34-tool chat request returned coherent output with no leaked markers, and DSpark
-speculation ran at depth 5 with a 2.76 mean acceptance length. It mounted only
-the checkpoint and a cache directory, so that benchmark image needs no source
-overlay.
-
-The four-Spark launch used the same benchmark image digest on 2026-08-21: all
-four ranks rendezvoused, each loading 40.82 GiB of weights, a
-deterministic completion and an emitted tool call were correct, and DSpark
-speculation ran at depth 5 with a 3.06 mean acceptance length.
-
-The throughput figures are client-observed on the stated prompt and
-generation lengths. The normalized TP2 table is isolated-server sustained
-decode and standalone prefill. Neither dataset measures output quality or
-qualifies the setup for general use. The documented launch uses
-patched NCCL from the environment template; SIRCL width-4096 graph collectives
-are research-only and are not part of this quickstart. See
+The documented launch uses patched NCCL from the selected topology-specific
+environment template. SIRCL width-4096 graph collectives are research-only and
+are not part of this quickstart. Diagnostic tool-call evidence, benchmark
+image identities, acceptance lengths, dates, and published-digest replay
+requirements are retained in
 [the profile record](profiles/DEEPSEEK_V4_FLASH_0731.md) and
 [results](RESULTS.md).
 

--- a/docs/DEEPSEEK_V4_FLASH_QUICKSTART.md
+++ b/docs/DEEPSEEK_V4_FLASH_QUICKSTART.md
@@ -251,7 +251,9 @@ usually fail or waste memory.
 
 For the pair, change `MAX_MODEL_LEN`, `MAX_NUM_SEQS`, and
 `MAX_NUM_BATCHED_TOKENS` in its environment file and rerun the launcher's
-`--check` mode. The four-Spark workflow uses explicit CLI configuration.
+`--check` mode. For the four-Spark cycle, change the same values in every
+rank's `deepseek-v4-flash-0731.env.example` copy, confirm that they match, and
+rerun `deepseek_v4_cycle_serve.sh --check` on every rank.
 
 **Set `--max-num-batched-tokens` explicitly.** The normalized comparison target
 uses 4096 in every DeepSeek base and SparkCache profile. A recorded pair run

--- a/docs/QWEN38_27B_EXL3_K5K6_PAIR_QUICKSTART.md
+++ b/docs/QWEN38_27B_EXL3_K5K6_PAIR_QUICKSTART.md
@@ -196,11 +196,12 @@ docker logs --follow "qwen38-dgx2-${ATTEMPT_ID}-r0"
 The ready service must report all of these:
 
 - TP world size 2 and one worker per rank;
-- `max_seq_len=1048576` and `kv_cache_dtype=fp8`;
+- `max_seq_len` equal to `MAX_MODEL_LEN` and `kv_cache_dtype=fp8`;
 - `draft_sample_method=probabilistic` in the resolved speculative config;
 - NCCL connected over the selected RoCEv2 GID;
 - `Application startup complete` on rank 0; and
-- `/v1/models` advertising `qwen38` with `max_model_len` 1,048,576.
+- `/v1/models` advertising `qwen38` with `max_model_len` equal to
+  `MAX_MODEL_LEN`.
 
 ## 7. Run bounded functional checks
 

--- a/docs/QWEN38_27B_EXL3_K5K6_PAIR_QUICKSTART.md
+++ b/docs/QWEN38_27B_EXL3_K5K6_PAIR_QUICKSTART.md
@@ -114,34 +114,49 @@ cp scripts/config/qwen38-27b-exl3-k5k6-pair.env.example \
   "$HOME/qwen38/config/rank.env"
 ```
 
-Replace all four placeholders in each rank's file. The pair template names
-one HCA, disables subnet-aware routing, and leaves the NCCL channel count and
-algorithm at library defaults. Do not use the four-Spark cycle template: its
-two-HCA routing, forced Ring algorithm, four-channel pin and tree skip describe
-a different topology.
+Resolve every placeholder in each rank's file. In addition to the direct-link
+interface, address, HCA, and GID, the file records rank/rendezvous values, host
+model/cache/log paths, API/master ports, speculative depth, request limit,
+sequence limit, and scheduler budget. The pair template names one HCA,
+disables subnet-aware routing, and leaves NCCL channel count and algorithm at
+library defaults. Do not use the four-Spark cycle template: its two-HCA
+routing, Ring algorithm, four-channel pin, and tree skip describe a different
+topology.
 
 Review the resolved file and confirm it contains no `REPLACE_WITH_` or angle
 bracket placeholders.
 
+Create the configured writable directories and verify the model mount source:
+
+```bash
+# shellcheck disable=SC1090
+. "$HOME/qwen38/config/rank.env"
+export -n LD_PRELOAD
+mkdir -p "$CACHE_HOST_PATH" "$LOG_HOST_PATH"
+test -d "$MODEL_HOST_PATH"
+test -w "$CACHE_HOST_PATH" && test -w "$LOG_HOST_PATH"
+```
+
 ## 5. Run the no-start preflight
 
-Set the site values separately on each rank:
+Read the host mounts and rank settings from the resolved env file:
 
 ```bash
 IMAGE=sparkring-qwen38:arm64-sm121
-MODEL_DIR="$HOME/qwen38/model/Qwen3.8-27B-EXL3-K5K6-hydrated"
 ENV_FILE="$HOME/qwen38/config/rank.env"
-CACHE_DIR="$HOME/qwen38/cache"
-LOG_DIR="$HOME/qwen38/logs"
-RANK=0                         # 1 on the follower
-RANK0_RENDEZVOUS_ADDR=<rank-0-direct-link-ip>
+# shellcheck disable=SC1090
+. "$ENV_FILE"
+# Do not apply the container's NCCL preload to host commands.
+export -n LD_PRELOAD
+MODEL_DIR="$MODEL_HOST_PATH"
+CACHE_DIR="$CACHE_HOST_PATH"
+LOG_DIR="$LOG_HOST_PATH"
 
 docker run --rm --network host --ipc host --shm-size 16g --gpus all \
   --ulimit memlock=-1:-1 --cap-add IPC_LOCK --device /dev/infiniband \
   -v "$MODEL_DIR:/ws/model/Qwen3.8-27B-EXL3-K5K6-hydrated:ro" \
   -v "$CACHE_DIR:/ws/cache" -v "$LOG_DIR:/ws/logs" \
   -v "$ENV_FILE:/ws/rank.env:ro" \
-  -e RANK="$RANK" -e RANK0_RENDEZVOUS_ADDR="$RANK0_RENDEZVOUS_ADDR" \
   --entrypoint /ws/qwen38_dgx2_serve.sh \
   "$IMAGE" --check
 ```
@@ -166,7 +181,6 @@ docker run -d --name "$CONTAINER" \
   -v "$MODEL_DIR:/ws/model/Qwen3.8-27B-EXL3-K5K6-hydrated:ro" \
   -v "$CACHE_DIR:/ws/cache" -v "$LOG_DIR:/ws/logs" \
   -v "$ENV_FILE:/ws/rank.env:ro" \
-  -e RANK="$RANK" -e RANK0_RENDEZVOUS_ADDR="$RANK0_RENDEZVOUS_ADDR" \
   --label org.sparkring.profile=qwen38-27b-exl3-k5k6-pair \
   --label org.sparkring.attempt="$ATTEMPT_ID" \
   --entrypoint /ws/qwen38_dgx2_serve.sh \
@@ -194,9 +208,9 @@ From the checkout or another machine that can reach rank 0:
 
 ```bash
 python scripts/qwen38_smoke.py \
-  --endpoint http://<rank-0-management-address>:8000 \
+  --endpoint "http://<rank-0-management-address>:$API_PORT" \
   --model qwen38 \
-  --expected-max-model-len 1048576 \
+  --expected-max-model-len "$MAX_MODEL_LEN" \
   --timeout 180 \
   --output "$HOME/qwen38/logs/qwen38-smoke-${ATTEMPT_ID}.json"
 ```

--- a/docs/QWEN38_27B_EXL3_K5K6_QUICKSTART.md
+++ b/docs/QWEN38_27B_EXL3_K5K6_QUICKSTART.md
@@ -305,7 +305,8 @@ sequence limit, and scheduler budget in addition to these topology values:
   this rank.
 
 The management LAN must permit mutual TCP between ranks. vLLM's multi-node
-`mp` executor uses dynamic worker ports in addition to rendezvous port 29500.
+`mp` executor uses dynamic worker ports in addition to the rendezvous port
+configured by `MASTER_PORT`.
 The environment uses management only for process/bootstrap traffic; model
 collectives use the two RoCE devices.
 
@@ -351,9 +352,9 @@ nvidia-smi
 ss -ltn
 ```
 
-Do not continue while another model stack owns the GPU or rank-0 ports 8000
-and 29500. Then run the same container and mounts as the real launch, but pass
-`--check`:
+Do not continue while another model stack owns the GPU or either rank-0 port
+configured by `API_PORT` and `MASTER_PORT`. Then run the same container and
+mounts as the serving launch, but pass `--check`:
 
 ```bash
 docker run --rm \
@@ -412,11 +413,12 @@ CONTAINER_ID=$(docker run -d --name "$CONTAINER" \
 printf '%s\n' "$CONTAINER_ID" > "$ID_FILE"
 ```
 
-Rank 0 listens on port 8000. Ranks 1-3 run headless. The launcher carries the
-complete serving command, including TP4/DCP1, the 1,048,576-token request limit,
-64 sequences, the 8,192-token scheduler budget, FP8 KV, native aligned prefix
-caching, probabilistic Qwen MTP3 with standard rejection, FP8 EXL3 prefill,
-and full-decode CUDA graphs.
+Rank 0 listens on `API_PORT`. Ranks 1-3 run headless. The launcher carries the
+complete serving command, including TP4/DCP1; the request, sequence, scheduler,
+and speculative-token limits configured by `MAX_MODEL_LEN`, `MAX_NUM_SEQS`,
+`MAX_NUM_BATCHED_TOKENS`, and `NUM_SPECULATIVE_TOKENS`; FP8 KV; native aligned
+prefix caching; probabilistic Qwen speculation with standard rejection; FP8
+EXL3 prefill; and full-decode CUDA graphs.
 The tracked
 [`scripts/qwen38_dgx4_serve.sh`](../scripts/qwen38_dgx4_serve.sh) is baked at
 `/ws/qwen38_dgx4_serve.sh` by the image builder.
@@ -470,16 +472,20 @@ hash/preflight check to make a later attempt proceed.
 From a client that can reach rank 0:
 
 ```bash
+API_PORT=<API_PORT value from rank 0 environment>
+MAX_MODEL_LEN=<MAX_MODEL_LEN value from rank 0 environment>
 mkdir -p "$HOME/qwen38/logs"
 python scripts/qwen38_smoke.py \
-  --endpoint http://<rank0-management-ip>:8000 \
+  --endpoint "http://<rank0-management-ip>:$API_PORT" \
   --model qwen38 \
+  --expected-max-model-len "$MAX_MODEL_LEN" \
   --timeout 120 \
   --output "$HOME/qwen38/logs/qwen38-smoke-${ATTEMPT_ID}.json"
 ```
 
-The stdlib-only harness checks `/health`, model identity and the 1,048,576-token
-limit in `/v1/models`, repeated deterministic arithmetic, the `multiply(6,7)`
+The stdlib-only harness checks `/health`, model identity and the configured
+`MAX_MODEL_LEN` value in `/v1/models`, repeated deterministic arithmetic, the
+`multiply(6,7)`
 tool call, a tiny data-URL vision request, repeated-prefix output equality,
 and divergent shared-prefix suffixes. It
 compares stable message fields rather than API IDs or timestamps and returns
@@ -505,7 +511,7 @@ docker logs --tail 200 "$CONTAINER_ID"
 From the client, require rank 0 to remain healthy:
 
 ```bash
-curl -fsS http://<rank0-management-ip>:8000/health
+curl -fsS "http://<rank0-management-ip>:$API_PORT/health"
 ```
 
 ## 10. Stop or restart the exact deployment

--- a/docs/QWEN38_27B_EXL3_K5K6_QUICKSTART.md
+++ b/docs/QWEN38_27B_EXL3_K5K6_QUICKSTART.md
@@ -291,7 +291,9 @@ scp scripts/config/qwen38-27b-exl3-k5k6.env.example \
 Edit `$HOME/qwen38/config/rank.env` locally on each rank; do not reuse rank 0's
 resolved file on another rank.
 
-Replace all four placeholders:
+Resolve every placeholder. The env file contains the rank/rendezvous values,
+host model/cache/log paths, API/master ports, speculative depth, request limit,
+sequence limit, and scheduler budget in addition to these topology values:
 
 - `<RENDEZVOUS_IFNAME>`: the management interface used by vLLM, Gloo, and
   NCCL bootstrap TCP;
@@ -307,20 +309,33 @@ The management LAN must permit mutual TCP between ranks. vLLM's multi-node
 The environment uses management only for process/bootstrap traffic; model
 collectives use the two RoCE devices.
 
+Create the configured writable directories and verify the model mount source
+on every rank:
+
+```bash
+# shellcheck disable=SC1090
+. "$HOME/qwen38/config/rank.env"
+export -n LD_PRELOAD
+mkdir -p "$CACHE_HOST_PATH" "$LOG_HOST_PATH"
+test -d "$MODEL_HOST_PATH"
+test -w "$CACHE_HOST_PATH" && test -w "$LOG_HOST_PATH"
+```
+
 ## 6. Run the no-start local preflight
 
-Set these values separately on each host:
+Read the host mounts and rank settings from the resolved env file:
 
 ```bash
 IMAGE=sparkring-qwen38:arm64-sm121
-MODEL_PARENT="$HOME/qwen38/model"
-MODEL_DIR="$MODEL_PARENT/Qwen3.8-27B-EXL3-K5K6-hydrated"
 ATTEMPT_ID=<shared-deployment-id>
-RANK=<0-to-3>
-RANK0_RENDEZVOUS_ADDR=<rank0-management-ip>
 ENV_FILE="$HOME/qwen38/config/rank.env"
-CACHE_DIR="$HOME/qwen38/cache"
-LOG_DIR="$HOME/qwen38/logs"
+# shellcheck disable=SC1090
+. "$ENV_FILE"
+# Do not apply the container's NCCL preload to host commands.
+export -n LD_PRELOAD
+MODEL_DIR="$MODEL_HOST_PATH"
+CACHE_DIR="$CACHE_HOST_PATH"
+LOG_DIR="$LOG_HOST_PATH"
 
 case "$ATTEMPT_ID" in
   ''|*[!A-Za-z0-9_.-]*) echo "ATTEMPT_ID must match [A-Za-z0-9_.-]+" >&2; exit 1 ;;
@@ -348,8 +363,6 @@ docker run --rm \
   -v "$CACHE_DIR:/ws/cache" \
   -v "$LOG_DIR:/ws/logs" \
   -v "$ENV_FILE:/ws/rank.env:ro" \
-  -e RANK="$RANK" \
-  -e RANK0_RENDEZVOUS_ADDR="$RANK0_RENDEZVOUS_ADDR" \
   --label org.sparkring.profile=qwen38-27b-exl3-k5k6 \
   --label org.sparkring.attempt="$ATTEMPT_ID" \
   --label org.sparkring.rank="$RANK" \
@@ -391,8 +404,6 @@ CONTAINER_ID=$(docker run -d --name "$CONTAINER" \
   -v "$CACHE_DIR:/ws/cache" \
   -v "$LOG_DIR:/ws/logs" \
   -v "$ENV_FILE:/ws/rank.env:ro" \
-  -e RANK="$RANK" \
-  -e RANK0_RENDEZVOUS_ADDR="$RANK0_RENDEZVOUS_ADDR" \
   --label org.sparkring.profile=qwen38-27b-exl3-k5k6 \
   --label org.sparkring.attempt="$ATTEMPT_ID" \
   --label org.sparkring.rank="$RANK" \
@@ -416,8 +427,8 @@ Allow up to 15 minutes for first-start compilation and graph capture:
 
 ```bash
 timeout 900 bash -c \
-  'until curl -fsS http://<rank0-management-ip>:8000/health >/dev/null; do sleep 5; done'
-curl -fsS http://<rank0-management-ip>:8000/v1/models
+  "until curl -fsS http://<rank0-management-ip>:$API_PORT/health >/dev/null; do sleep 5; done"
+curl -fsS "http://<rank0-management-ip>:$API_PORT/v1/models"
 ```
 
 On every rank, require the container to remain running and inspect its log:

--- a/recipes/deepseek-v4-flash-0731-pair.json
+++ b/recipes/deepseek-v4-flash-0731-pair.json
@@ -18,6 +18,9 @@
     "image_lock": "runtime/faststart-lock.json",
     "image_lock_entry": "deepseek_v4_flash_0731_hardened_serving_image",
     "environment_template": "scripts/config/deepseek-v4-flash-0731-pair.env.example",
+    "launcher": "scripts/deepseek_v4_pair_serve.sh",
+    "launcher_preflight_argument": "--check",
+    "launcher_run_argument": "--run",
     "entrypoint": "/opt/venv/bin/vllm"
   },
   "serving": {

--- a/recipes/deepseek-v4-flash-0731-pair.json
+++ b/recipes/deepseek-v4-flash-0731-pair.json
@@ -1,7 +1,7 @@
 {
   "schema": "sparkring-recipe/v1",
   "recipe_id": "deepseek-v4-flash-0731-pair",
-  "status": "candidate",
+  "status": "implemented",
   "hardware": {
     "platform": "linux/arm64",
     "cuda_arch": "sm_121",
@@ -50,7 +50,7 @@
     "max_num_batched_tokens": 4096,
     "async_scheduling": true,
     "scheduler_reserve_full_isl": true,
-    "sizing_note": "The candidate pair uses the 1048576-token context, 32-sequence limit, 4096-token scheduler budget, 256-token block size, and 16 GiB per-rank key-value reservation used by the benchmark campaign. Setting kv_cache_memory_bytes disables the gpu_memory_utilization guard, so free memory must be checked after launch rather than assumed."
+    "sizing_note": "The two-rank pair profile uses a 1048576-token request limit, 32-sequence limit, 4096-token scheduler budget, 256-token block size, and 16 GiB per-rank key-value reservation. Setting kv_cache_memory_bytes disables the gpu_memory_utilization guard, so free memory must be checked after launch rather than assumed."
   },
   "transport": {
     "difference_from_cycle": "A pair uses one host channel adapter per rank instead of two, so the cycle template's second adapter, subnet-aware routing, subnet prefix length, pinned channel counts, Ring algorithm selection and tree-connect skip are all removed. The tree-connect skip exists because a four-cycle contains non-adjacent rank pairs; the two ranks of a pair are directly adjacent.",
@@ -61,7 +61,7 @@
     "benchmark_runtime_image": "ghcr.io/fujitsupolycom/gb10-vllm-serving@sha256:6fc26fdad81a18f0fff67ce0a05f6d90165625ea2e1cac8a6f39bfb462017028",
     "conditions": "Two directly cabled NVIDIA DGX Sparks used benchmark_runtime_image, the serving settings above, and deepseek-ai/DeepSeek-V4-Flash-DSpark@913f0657a874f76844e2e91cbe706dbcaceeb6d7 instead of the recipe checkpoint: 1048576-token request limit, 32 sequences, 4096 batched tokens, 16 GiB key-value reservation per rank, block size 256, fp8_ds_mla, and DSpark depth 5. Prefill and sustained decode used temperature 1.0 and effective top-p 1.0 through 128K.",
     "result": "Both ranks rendezvoused and served the model. C1/C2 were measured with five accepted observations per context; every other applicable decode cell used at least three. At 16K, aggregate throughput measured 58.36 tok/s at C1, 77.65 at C2, 202.74 at C16, and 307.13 at C32. Coding Peak averaged 59.31 tok/s across five requests.",
-    "conclusion": "The normalized two-rank settings are live-benchmarked on benchmark_runtime_image with the starred DSpark checkpoint difference. The currently selected hardened runtime still needs an exact TP2 published-digest replay.",
+    "conclusion": "The recorded two-rank settings are live-benchmarked on benchmark_runtime_image with the stated DSpark checkpoint difference. The hardened runtime selected by runtime.image_lock_entry still needs an exact two-rank published-digest replay.",
     "limitations": [
       "The TP2 DSpark weight package differs from the plain 0731 package used by TP4, so TP2-versus-TP4 values are not an exact same-weight scaling comparison.",
       "The measurements apply to the recorded serving settings and checkpoint revision.",

--- a/recipes/deepseek-v4-flash-0731.json
+++ b/recipes/deepseek-v4-flash-0731.json
@@ -1,7 +1,7 @@
 {
   "schema": "sparkring-recipe/v1",
   "recipe_id": "deepseek-v4-flash-0731",
-  "status": "candidate",
+  "status": "implemented",
   "hardware": {
     "platform": "linux/arm64",
     "cuda_arch": "sm_121",
@@ -50,14 +50,14 @@
     "max_num_batched_tokens": 4096,
     "async_scheduling": true,
     "scheduler_reserve_full_isl": true,
-    "sizing_note": "The candidate cycle uses the 1048576-token context, 32-sequence limit, 4096-token scheduler budget, 256-token block size, and 16 GiB per-rank key-value reservation used by the benchmark campaign. Setting kv_cache_memory_bytes disables the gpu_memory_utilization guard, so free memory must be checked after launch rather than assumed."
+    "sizing_note": "The four-rank cycle profile uses a 1048576-token request limit, 32-sequence limit, 4096-token scheduler budget, 256-token block size, and 16 GiB per-rank key-value reservation. Setting kv_cache_memory_bytes disables the gpu_memory_utilization guard, so free memory must be checked after launch rather than assumed."
   },
   "evidence": {
     "status": "implemented",
     "benchmark_runtime_image": "ghcr.io/fujitsupolycom/gb10-vllm-serving@sha256:6fc26fdad81a18f0fff67ce0a05f6d90165625ea2e1cac8a6f39bfb462017028",
-    "conditions": "Historical live candidate evidence from four directly cabled DGX Sparks using the benchmark_runtime_image and deepseek-ai/DeepSeek-V4-Flash-0731@7872f01b1d1fe23eabc4c98b48bffcef5a386062: 1048576-token request limit, 32 sequences, 4096 batched tokens, 16 GiB key-value reservation per rank, block size 256, fp8_ds_mla, DSpark depth 5, asynchronous scheduling, full-input-length reservation, and patched NCCL. Prefill and sustained decode used temperature 1.0 and effective top-p 1.0 through 128K.",
+    "conditions": "Four directly cabled DGX Sparks used benchmark_runtime_image and deepseek-ai/DeepSeek-V4-Flash-0731@7872f01b1d1fe23eabc4c98b48bffcef5a386062 with a 1048576-token request limit, 32 sequences, 4096 batched tokens, 16 GiB key-value reservation per rank, block size 256, fp8_ds_mla, DSpark depth 5, asynchronous scheduling, full-input-length reservation, and patched NCCL. Prefill and sustained decode used temperature 1.0 and effective top-p 1.0 through 128K.",
     "result": "All four ranks rendezvoused and served the model. C1/C2 were measured with five accepted observations per context; every other applicable decode cell used at least three. At 16K, aggregate throughput measured 68.84 tok/s at C1, 139.01 at C2, 428.48 at C16, and 508.11 at C32. Coding Peak averaged 95.77 tok/s across fifteen requests.",
-    "conclusion": "The normalized four-rank settings are live-benchmarked on benchmark_runtime_image. The currently selected hardened runtime still needs an exact published-digest replay.",
+    "conclusion": "The recorded four-rank settings are live-benchmarked on benchmark_runtime_image. The hardened runtime selected by runtime.image_lock_entry still needs an exact published-digest replay.",
     "limitations": [
       "No SIRCL shadow-comparison window is qualified for width 4096.",
       "The TP4 plain 0731 weight package differs from the DSpark package used by TP2, so TP2-versus-TP4 values are not an exact same-weight scaling comparison.",

--- a/recipes/deepseek-v4-flash-0731.json
+++ b/recipes/deepseek-v4-flash-0731.json
@@ -18,6 +18,9 @@
     "image_lock": "runtime/faststart-lock.json",
     "image_lock_entry": "deepseek_v4_flash_0731_hardened_serving_image",
     "environment_template": "scripts/config/deepseek-v4-flash-0731.env.example",
+    "launcher": "scripts/deepseek_v4_cycle_serve.sh",
+    "launcher_preflight_argument": "--check",
+    "launcher_run_argument": "--run",
     "entrypoint": "/opt/venv/bin/vllm"
   },
   "serving": {

--- a/runtime/README.md
+++ b/runtime/README.md
@@ -77,10 +77,13 @@ python -m pytest runtime/exl3-r7 runtime/deepseek0731-gb10 runtime/qwen38 -q
 [`runtime/deepseek0731-gb10/`](deepseek0731-gb10/README.md) builds the
 DeepSeek-specific layer over the generic GB10 serving image. The lock records
 both the hardened image digest and the unchanged generic rollback digest. The
-per-rank container environment is defined in
-[`scripts/config/deepseek-v4-flash-0731.env.example`](../scripts/config/deepseek-v4-flash-0731.env.example).
-The environment template and immutable image digest must agree; neither
-substitutes for a four-rank serving qualification.
+per-rank container environments are defined by topology:
+[`scripts/config/deepseek-v4-flash-0731-pair.env.example`](../scripts/config/deepseek-v4-flash-0731-pair.env.example)
+for a two-rank pair and
+[`scripts/config/deepseek-v4-flash-0731.env.example`](../scripts/config/deepseek-v4-flash-0731.env.example)
+for a four-rank cycle. The selected environment template and immutable image
+digest must agree. Neither offline validation nor a successful launch on one
+topology qualifies the other topology.
 
 ## Scope and safety
 

--- a/scripts/config/README.md
+++ b/scripts/config/README.md
@@ -16,9 +16,24 @@ The R7 configuration is split by responsibility:
 | `exl3-r7-pins.json` | R7 model and runtime identity pins |
 
 Copy the site and candidate templates to local, untracked paths. Replace every
-placeholder with values for one appliance, then retain the resolved inputs and
+placeholder with values for one appliance, then record the resolved inputs and
 image identity with the resulting evidence. Do not commit host addresses,
 credentials, model files, local paths, or a locally produced image ID.
+
+The GLM configuration provides the operator-facing equivalent of the
+env-driven profiles:
+
+| Operator setting | Config field | Container use |
+|---|---|---|
+| Model host path | `model_host_path` and `runtime.model_path` | Read-only model mount |
+| JIT cache parent | `jit_cache_host_path` and `paths.jit_cache_dir` | `/cache/jit` |
+| Online EXL3 weight cache | `online_weight_cache_host_path` | `/cache/exl3-online` |
+| API/master ports | `serving.api_port`, `serving.master_port` | Rank-0 API and rendezvous |
+| MTP depth, context, sequences | `serving.mtp_tokens`, `serving.max_model_len`, `serving.max_num_seqs` | vLLM serving arguments |
+
+The profile generator owns the qualified scheduler-token budget; it is not a
+site override. SparkCache recipes inherit the model, cache, ports, and serving
+values from the generated GLM base profile.
 
 The site template is a declarative input for four directly connected ranks.
 The candidate template binds the selected image and model hashes to the
@@ -35,17 +50,28 @@ python -m pytest \
 
 ## DeepSeek-V4-Flash-0731
 
-`deepseek-v4-flash-0731.env.example` is the per-rank Docker environment file
-for DeepSeek-V4-Flash-0731. Copy it once per rank and replace:
+**Status: implemented.**
+
+`deepseek-v4-flash-0731-pair.env.example` is both the host launch contract and
+the container environment for the two-Spark profile. It is consumed by
+`scripts/deepseek_v4_pair_serve.sh`, which validates model/cache host paths,
+rank/rendezvous inputs, API and master ports, speculative depth, context,
+sequence count, scheduler budget, and pair transport before rendering or
+running Docker. Keep one resolved copy per rank outside version control.
+
+`deepseek-v4-flash-0731.env.example` is the corresponding host launch contract
+and container environment for the four-Spark cycle. It is consumed by
+`scripts/deepseek_v4_cycle_serve.sh`. Copy it once per rank and resolve:
 
 - `<NCCL_SOCKET_IFNAME>` with the rank's configured fabric interface;
 - `<RANK_FABRIC_IP>` with that interface's address.
 
-All other values are the common runtime contract. Keep each rank's resolved
-environment file local. The template configures the loader, patched NCCL,
-RoCE transport, B12X kernels, and local cache paths required by the pinned
-serving image. It does not supply a model path, launch command, registry
-credential, or serving acceptance result.
+The file also records model/cache host paths, API and master ports,
+speculative depth, context, sequence count, and scheduler budget. Keep each
+rank's resolved environment file local. Both DeepSeek env files map
+`CACHE_HOST_PATH` to `/cache`; their `/cache/jit` values are container paths
+and must remain unchanged. DeepSeek SparkCache recipes inherit these
+base-profile inputs.
 
 The template's immutable image digest is also represented in
 [`runtime/faststart-lock.json`](../../runtime/faststart-lock.json). If those
@@ -60,6 +86,13 @@ channel selection at library defaults and sets the long-context override used
 by the 1M static-YaRN launch. Follow
 [`docs/QWEN38_27B_EXL3_K5K6_PAIR_QUICKSTART.md`](../../docs/QWEN38_27B_EXL3_K5K6_PAIR_QUICKSTART.md).
 
+The pair env also records host model/cache/log paths, API and master ports,
+speculative depth, context, sequence count, and scheduler budget.
+`CACHE_HOST_PATH` is mounted at `/ws/cache`; the `/ws/cache/jit` values are
+container paths and must remain unchanged. `scripts/qwen38_dgx2_serve.sh`
+validates and consumes the serving values inside the prepared runtime
+container.
+
 `qwen38-27b-exl3-k5k6.env.example` is the per-rank environment for the
 four-Spark Qwen candidate. Copy it once per rank and replace:
 
@@ -73,9 +106,13 @@ The template combines the Qwen EXL3 graph/prefill settings with the
 four-Spark patched-NCCL cycle. Management carries rendezvous and random worker
 TCP ports; the RoCE devices carry collectives. The template assumes the
 Qwen image built by `runtime/qwen38/build-image.sh` supplies the immutable
-runtime under `/ws`; it does not supply the model, rank environment, a site
-address, or live evidence. Follow
+runtime under `/ws`. Host paths in the env select separately mounted model,
+cache, and log directories; they do not attest model bytes or provide live
+evidence. Follow
 [`docs/QWEN38_27B_EXL3_K5K6_QUICKSTART.md`](../../docs/QWEN38_27B_EXL3_K5K6_QUICKSTART.md).
+
+The cycle env uses the same host/cache/serving contract as the pair, with
+four-rank defaults from `recipes/qwen38-27b-exl3-k5k6.json`.
 
 ## DeepSeek SIRCL research overlay
 

--- a/scripts/config/README.md
+++ b/scripts/config/README.md
@@ -12,10 +12,10 @@ The R7 configuration is split by responsibility:
 | File | Role |
 |---|---|
 | `exl3-r7-site.example.yaml` | Four-rank site topology, host paths, and serving parameters |
-| `exl3-r7-candidate.example.json` | Candidate image identity, model hashes, transport selection, and enabled R7 options |
+| `exl3-r7-candidate.example.json` | Image identity, model hashes, transport selection, and enabled R7 options |
 | `exl3-r7-pins.json` | R7 model and runtime identity pins |
 
-Copy the site and candidate templates to local, untracked paths. Replace every
+Copy the site and image-identity templates to local, untracked paths. Replace every
 placeholder with values for one appliance, then record the resolved inputs and
 image identity with the resulting evidence. Do not commit host addresses,
 credentials, model files, local paths, or a locally produced image ID.
@@ -36,8 +36,9 @@ site override. SparkCache recipes inherit the model, cache, ports, and serving
 values from the generated GLM base profile.
 
 The site template is a declarative input for four directly connected ranks.
-The candidate template binds the selected image and model hashes to the
-transport and runtime options. Treat a mismatch between candidate, pins, and
+The image-identity template, `exl3-r7-candidate.example.json`, binds the
+selected image and model hashes to the transport and runtime options. Treat a
+mismatch between that template, pins, and
 the built image as a failed configuration, not a value to normalize manually.
 
 Run the focused offline tests after changing an R7 configuration contract:
@@ -94,7 +95,7 @@ validates and consumes the serving values inside the prepared runtime
 container.
 
 `qwen38-27b-exl3-k5k6.env.example` is the per-rank environment for the
-four-Spark Qwen candidate. Copy it once per rank and replace:
+implemented four-Spark Qwen profile. Copy it once per rank and replace:
 
 - `<RENDEZVOUS_IFNAME>` with the rank's management interface;
 - `<RANK_RENDEZVOUS_IP>` with that interface's address;
@@ -117,7 +118,7 @@ four-rank defaults from `recipes/qwen38-27b-exl3-k5k6.json`.
 ## DeepSeek SIRCL research overlay
 
 `deepseek-v4-flash-0731-sircl-research.env.example` is a second per-rank
-environment file for the research-only width-4096 SIRCL graph candidate. It
+environment file for the research-only width-4096 SIRCL graph overlay. It
 does not replace the canonical environment. Apply it after the canonical file
 only for an authorized matched A/B, and resolve both direct peer addresses
 against the device named beside each address. The offline plan and evidence

--- a/scripts/config/deepseek-v4-flash-0731-pair.env.example
+++ b/scripts/config/deepseek-v4-flash-0731-pair.env.example
@@ -1,7 +1,9 @@
-# Per-rank container environment for serving DeepSeek-V4-Flash-0731 on a
-# two-Spark pair, consumed by the docker run --env-file in
-# docs/DEEPSEEK_V4_FLASH_QUICKSTART.md. Copy to one file per rank and replace
-# the three placeholders; everything else is identical on both ranks.
+# Per-rank launch and container environment for serving
+# DeepSeek-V4-Flash-0731 on a two-Spark pair. Copy this file once per rank,
+# resolve every placeholder, then validate it before launching:
+#
+#   scripts/deepseek_v4_pair_serve.sh --check /path/to/rank-0.env
+#   scripts/deepseek_v4_pair_serve.sh --run /path/to/rank-0.env
 #
 #   <FABRIC_IFNAME>   the netdev carrying the direct cable between the two
 #                     hosts; the same name on both ranks when the pair is
@@ -19,8 +21,43 @@
 # skip that a four-cycle needs is unnecessary; and the channel counts are left
 # at the library default rather than pinned for a cycle.
 #
-# Every library path below exists in the published serving image; the loader
-# preload and the patched NCCL are required, and a worker aborts without them.
+# Every library path below exists in the image selected by the
+# deepseek_v4_flash_0731_hardened_serving_image key in
+# runtime/faststart-lock.json. The loader preload and patched NCCL are
+# required, and a worker aborts without them.
+
+# Host-side launch inputs. NODE_RANK and VLLM_HOST_IP differ between ranks;
+# MASTER_ADDR and the serving values must agree. Host paths may differ, but
+# they must expose identical model bytes and writable persistent caches.
+NODE_RANK=<NODE_RANK_0_OR_1>
+MASTER_ADDR=<RANK0_FABRIC_IP>
+MODEL_HOST_PATH=<ABSOLUTE_MODEL_DIRECTORY>
+
+# CACHE_HOST_PATH is a host directory mounted at /cache inside the container.
+# For example, CACHE_HOST_PATH=/cache/test stores the container caches at these
+# host paths:
+#
+#   /cache/test/jit
+#   /cache/test/jit/triton
+#   /cache/test/jit/vllm
+#
+# Leave XDG_CACHE_HOME, TRITON_CACHE_DIR, and VLLM_CACHE_ROOT unchanged below.
+# Their /cache paths are container paths mapped beneath CACHE_HOST_PATH on the
+# host; they are not additional host directories to configure.
+CACHE_HOST_PATH=<ABSOLUTE_CACHE_DIRECTORY>
+
+# Operator-tunable serving values. These defaults reproduce
+# recipes/deepseek-v4-flash-0731-pair.json.
+API_PORT=8000
+MASTER_PORT=29500
+NUM_SPECULATIVE_TOKENS=5
+MAX_MODEL_LEN=1048576
+MAX_NUM_SEQS=32
+MAX_NUM_BATCHED_TOKENS=4096
+
+# The launcher uses --ipc host. The host's /dev/shm size is authoritative;
+# changing a container --shm-size declaration does not enlarge host shared
+# memory. Check `df -h /dev/shm` on the host when diagnosing IPC pressure.
 
 LD_PRELOAD=/usr/local/cuda/compat/libcuda.so.1:/opt/sparkring/nccl/libnccl.so.2
 VLLM_NCCL_SO_PATH=/opt/sparkring/nccl/libnccl.so.2
@@ -87,6 +124,9 @@ SAFETENSORS_FAST_GPU=1
 OMP_NUM_THREADS=16
 HF_HOME=/root/.cache/huggingface
 HF_HUB_OFFLINE=1
+
+# Container-internal cache layout; configure the host location only through
+# CACHE_HOST_PATH above.
 XDG_CACHE_HOME=/cache/jit
 TRITON_CACHE_DIR=/cache/jit/triton
 VLLM_CACHE_ROOT=/cache/jit/vllm

--- a/scripts/config/deepseek-v4-flash-0731.env.example
+++ b/scripts/config/deepseek-v4-flash-0731.env.example
@@ -1,7 +1,9 @@
-# Per-rank container environment for serving DeepSeek-V4-Flash-0731 on the
-# four-Spark ring, consumed by the docker run --env-file in
-# docs/DEEPSEEK_V4_FLASH_QUICKSTART.md. Copy to one file per rank and replace
-# the two placeholders; everything else is identical on every rank.
+# Per-rank launch and container environment for serving
+# DeepSeek-V4-Flash-0731 on a four-Spark cycle. Copy this file once per rank,
+# resolve every placeholder, then validate it before launching:
+#
+#   scripts/deepseek_v4_cycle_serve.sh --check /path/to/rank-0.env
+#   scripts/deepseek_v4_cycle_serve.sh --run /path/to/rank-0.env
 #
 #   <NCCL_SOCKET_IFNAME>  the rank's cage-0 netdev on even ranks
 #                         (enp1s0f0np0) and cage-1 on odd ranks (enp1s0f1np1),
@@ -13,6 +15,32 @@
 # ghcr.io/fujitsupolycom/gb10-vllm-serving@sha256:827a8e8c5749b78529cc0015dd174e1b
 # 19a0accc116bc142282f8b75428f98bd; the loader preload and the patched
 # NCCL are required, and a worker aborts without them.
+
+# Host-side launch inputs. NODE_RANK and VLLM_HOST_IP differ between ranks;
+# MASTER_ADDR and the serving values must agree across all four ranks.
+NODE_RANK=<NODE_RANK_0_TO_3>
+MASTER_ADDR=<RANK0_FABRIC_IP>
+MODEL_HOST_PATH=<ABSOLUTE_MODEL_DIRECTORY>
+
+# CACHE_HOST_PATH is a host directory mounted at /cache inside the container.
+# For example, CACHE_HOST_PATH=/cache/deepseek-cycle stores the container
+# caches at these host paths:
+#
+#   /cache/deepseek-cycle/jit
+#   /cache/deepseek-cycle/jit/triton
+#   /cache/deepseek-cycle/jit/vllm
+#
+# Leave XDG_CACHE_HOME, TRITON_CACHE_DIR, and VLLM_CACHE_ROOT unchanged below.
+CACHE_HOST_PATH=<ABSOLUTE_CACHE_DIRECTORY>
+
+# Operator-tunable serving values. These defaults reproduce
+# recipes/deepseek-v4-flash-0731.json.
+API_PORT=8000
+MASTER_PORT=29500
+NUM_SPECULATIVE_TOKENS=5
+MAX_MODEL_LEN=1048576
+MAX_NUM_SEQS=32
+MAX_NUM_BATCHED_TOKENS=4096
 
 LD_PRELOAD=/usr/local/cuda/compat/libcuda.so.1:/opt/sparkring/nccl/libnccl.so.2
 VLLM_NCCL_SO_PATH=/opt/sparkring/nccl/libnccl.so.2
@@ -84,6 +112,9 @@ SAFETENSORS_FAST_GPU=1
 OMP_NUM_THREADS=16
 HF_HOME=/root/.cache/huggingface
 HF_HUB_OFFLINE=1
+
+# Container-internal cache layout; configure the host location only through
+# CACHE_HOST_PATH above.
 XDG_CACHE_HOME=/cache/jit
 TRITON_CACHE_DIR=/cache/jit/triton
 VLLM_CACHE_ROOT=/cache/jit/vllm

--- a/scripts/config/exl3-r7-site.example.yaml
+++ b/scripts/config/exl3-r7-site.example.yaml
@@ -19,7 +19,7 @@ schema_version: 1
 
 site:
   name: exl3-r7-4-node-ring
-  description: Example four-node DGX Spark ring for the R7 3.5-bpw candidate - REPLACE.
+  description: Example four-node DGX Spark ring for the R7 3.5-bpw serving profile - REPLACE.
 
 topology:
   mtu: 9000
@@ -147,7 +147,7 @@ runtime:
   model_revision: "9ab9579774cc432df91567a36f6e9e863e0d4c9f"
   checkpoint_sha256: 9fd852f69ed64442e31dce1cbc5fe7acd0a76bfb848e945d272fe98d00d0c9cd
 
-# R7 candidate serving contract: fixed MTP4, DCP4, 9.25 GB KV/rank, fp8_ds_mla.
+# R7 serving contract: fixed MTP4, DCP4, 9.25 GB KV/rank, fp8_ds_mla.
 # The MTP3 rollback uses mtp_tokens: 3 and kv_cache_bytes_per_rank: 9250000000.
 serving:
   tensor_parallel_size: 4

--- a/scripts/config/exl3-r7-site.example.yaml
+++ b/scripts/config/exl3-r7-site.example.yaml
@@ -140,6 +140,8 @@ runtime:
   container_image: sparkring/glm52-exl3-r7-3.5bpw:REPLACE
   # Replace with your local image ID (docker image inspect <ref> --format '{{.Id}}').
   container_image_digest: sha256:1111111111111111111111111111111111111111111111111111111111111111
+  # Absolute host model directory. The generated launcher mounts it read-only
+  # at the profile's fixed container model path.
   model_path: /models/glm52-exl3-r7-3.5bpw
   model_repo: brandonmusic/GLM-5.2-EXL3-TR3v4-3.5bpw-MTP78
   model_revision: "9ab9579774cc432df91567a36f6e9e863e0d4c9f"
@@ -160,6 +162,8 @@ serving:
   master_port: 29500
 
 paths:
+  # Host directories. The JIT path is mounted at /cache/jit. The context path
+  # stores external SparkCache state when a SparkCache recipe is selected.
   jit_cache_dir: /var/lib/sparkring/jit-cache
   context_cache_dir: /var/lib/sparkring/context-cache
   evidence_dir: ./evidence

--- a/scripts/config/qwen38-27b-exl3-k5k6-pair.env.example
+++ b/scripts/config/qwen38-27b-exl3-k5k6-pair.env.example
@@ -8,6 +8,32 @@
 #   <NCCL_IB_HCA>     the one RoCE device attached to the direct cable
 #   <GID_INDEX>       the RoCEv2 GID index encoding RANK_FABRIC_IP
 
+# Host launch inputs. RANK and VLLM_HOST_IP differ between ranks;
+# RANK0_RENDEZVOUS_ADDR and serving values must agree.
+RANK=<RANK_0_OR_1>
+RANK0_RENDEZVOUS_ADDR=<RANK0_FABRIC_IP>
+MODEL_HOST_PATH=<ABSOLUTE_MODEL_DIRECTORY>
+
+# CACHE_HOST_PATH is mounted at /ws/cache inside the runtime container. For
+# example, CACHE_HOST_PATH=/cache/qwen38-pair stores container caches at:
+#
+#   /cache/qwen38-pair/jit
+#   /cache/qwen38-pair/jit/triton
+#   /cache/qwen38-pair/jit/vllm
+#
+# Leave the /ws/cache variables below unchanged.
+CACHE_HOST_PATH=<ABSOLUTE_CACHE_DIRECTORY>
+LOG_HOST_PATH=<ABSOLUTE_LOG_DIRECTORY>
+
+# Operator-tunable serving values. These defaults reproduce
+# recipes/qwen38-27b-exl3-k5k6-pair.json.
+API_PORT=8000
+MASTER_PORT=29500
+NUM_SPECULATIVE_TOKENS=3
+MAX_MODEL_LEN=1048576
+MAX_NUM_SEQS=32
+MAX_NUM_BATCHED_TOKENS=8192
+
 LD_PRELOAD=/ws/nccl-patched/libnccl.so.2
 VLLM_NCCL_SO_PATH=/ws/nccl-patched/libnccl.so.2
 
@@ -38,6 +64,9 @@ CUDA_DEVICE_ORDER=PCI_BUS_ID
 CUDA_DEVICE_MAX_CONNECTIONS=32
 HF_HOME=/root/.cache/huggingface
 HF_HUB_OFFLINE=1
+
+# Container-internal cache layout; configure the host location only through
+# CACHE_HOST_PATH above.
 XDG_CACHE_HOME=/ws/cache/jit
 TRITON_CACHE_DIR=/ws/cache/jit/triton
 VLLM_CACHE_ROOT=/ws/cache/jit/vllm

--- a/scripts/config/qwen38-27b-exl3-k5k6.env.example
+++ b/scripts/config/qwen38-27b-exl3-k5k6.env.example
@@ -16,6 +16,32 @@
 # NCCL library must have SHA-256
 # e69a8c240f45d10166bcd901d99db78bb63147adda66e586d8dd505c6d608b54.
 
+# Host launch inputs. RANK and VLLM_HOST_IP differ between ranks;
+# RANK0_RENDEZVOUS_ADDR and serving values must agree across all four ranks.
+RANK=<RANK_0_TO_3>
+RANK0_RENDEZVOUS_ADDR=<RANK0_RENDEZVOUS_IP>
+MODEL_HOST_PATH=<ABSOLUTE_MODEL_DIRECTORY>
+
+# CACHE_HOST_PATH is mounted at /ws/cache inside the runtime container. For
+# example, CACHE_HOST_PATH=/cache/qwen38-cycle stores container caches at:
+#
+#   /cache/qwen38-cycle/jit
+#   /cache/qwen38-cycle/jit/triton
+#   /cache/qwen38-cycle/jit/vllm
+#
+# Leave the /ws/cache variables below unchanged.
+CACHE_HOST_PATH=<ABSOLUTE_CACHE_DIRECTORY>
+LOG_HOST_PATH=<ABSOLUTE_LOG_DIRECTORY>
+
+# Operator-tunable serving values. These defaults reproduce
+# recipes/qwen38-27b-exl3-k5k6.json.
+API_PORT=8000
+MASTER_PORT=29500
+NUM_SPECULATIVE_TOKENS=3
+MAX_MODEL_LEN=1048576
+MAX_NUM_SEQS=64
+MAX_NUM_BATCHED_TOKENS=8192
+
 LD_PRELOAD=/ws/nccl-patched/libnccl.so.2
 VLLM_NCCL_SO_PATH=/ws/nccl-patched/libnccl.so.2
 
@@ -51,6 +77,9 @@ CUDA_DEVICE_ORDER=PCI_BUS_ID
 CUDA_DEVICE_MAX_CONNECTIONS=32
 HF_HOME=/root/.cache/huggingface
 HF_HUB_OFFLINE=1
+
+# Container-internal cache layout; configure the host location only through
+# CACHE_HOST_PATH above.
 XDG_CACHE_HOME=/ws/cache/jit
 TRITON_CACHE_DIR=/ws/cache/jit/triton
 VLLM_CACHE_ROOT=/ws/cache/jit/vllm

--- a/scripts/deepseek_v4_cycle_serve.sh
+++ b/scripts/deepseek_v4_cycle_serve.sh
@@ -1,0 +1,210 @@
+#!/usr/bin/env bash
+# Validate or start one rank of the DeepSeek-V4-Flash-0731 four-Spark profile.
+# The per-rank env file is both the host launch contract and the container
+# environment, so operator-facing paths and serving values have one source.
+set -euo pipefail
+
+usage() {
+    echo "usage: deepseek_v4_cycle_serve.sh [--check|--run] ENV_FILE" >&2
+}
+
+die() {
+    echo "deepseek cycle launcher: $*" >&2
+    exit 20
+}
+
+case "$#" in
+    1) mode=--check; env_file=$1 ;;
+    2) mode=$1; env_file=$2 ;;
+    *) usage; exit 64 ;;
+esac
+case "$mode" in
+    --check|--run) ;;
+    *) usage; exit 64 ;;
+esac
+
+[ -f "$env_file" ] || die "environment file is missing: $env_file"
+env_file=$(cd "$(dirname "$env_file")" && pwd)/$(basename "$env_file")
+
+if grep -Ev '^[[:space:]]*(#|$)' "$env_file" \
+    | grep -Eq '<[A-Za-z0-9_]+>|REPLACE_WITH_'; then
+    die "environment file contains unresolved placeholders: $env_file"
+fi
+
+# shellcheck disable=SC1090
+. "$env_file"
+# Keep the container-only preload value available for validation without
+# exporting it to host commands such as grep and docker.
+export -n LD_PRELOAD
+
+require_value() {
+    local name=$1 value
+    value=${!name-}
+    [ -n "$value" ] || die "required value is empty: $name"
+}
+
+require_directory() {
+    local name=$1 value
+    value=${!name-}
+    case "$value" in
+        /*) ;;
+        *) die "$name must be an absolute host path: $value" ;;
+    esac
+    [ -d "$value" ] || die "$name directory does not exist: $value"
+}
+
+require_positive_integer() {
+    local name=$1 value
+    value=${!name-}
+    case "$value" in
+        ''|*[!0-9]*) die "$name must be a positive integer: $value" ;;
+    esac
+    [ "$((10#$value))" -gt 0 ] || die "$name must be greater than zero"
+}
+
+require_port() {
+    local name=$1 value
+    require_positive_integer "$name"
+    value=${!name-}
+    [ "$((10#$value))" -le 65535 ] || die "$name must be in 1..65535: $value"
+}
+
+for name in \
+    NODE_RANK MASTER_ADDR MODEL_HOST_PATH CACHE_HOST_PATH API_PORT MASTER_PORT \
+    NUM_SPECULATIVE_TOKENS MAX_MODEL_LEN MAX_NUM_SEQS MAX_NUM_BATCHED_TOKENS \
+    LD_PRELOAD VLLM_NCCL_SO_PATH NCCL_SOCKET_IFNAME GLOO_SOCKET_IFNAME \
+    VLLM_HOST_IP NCCL_NET NCCL_NET_PLUGIN NCCL_IB_DISABLE NCCL_IB_HCA \
+    NCCL_IB_GID_INDEX NCCL_IB_SUBNET_PREFIX_LEN \
+    NCCL_IB_SUBNET_AWARE_ROUTING NCCL_IB_MERGE_NICS NCCL_ALGO NCCL_PROTO \
+    NCCL_P2P_LEVEL NCCL_MIN_NCHANNELS NCCL_MAX_NCHANNELS NCCL_CROSS_NIC \
+    NCCL_CUMEM_ENABLE NCCL_SKIP_TREE_CONNECT NCCL_IGNORE_CPU_AFFINITY; do
+    require_value "$name"
+done
+
+case "$NODE_RANK" in
+    0|1|2|3) ;;
+    *) die "NODE_RANK must be 0, 1, 2, or 3: $NODE_RANK" ;;
+esac
+require_directory MODEL_HOST_PATH
+require_directory CACHE_HOST_PATH
+[ -r "$MODEL_HOST_PATH" ] || die "MODEL_HOST_PATH is not readable: $MODEL_HOST_PATH"
+[ -w "$CACHE_HOST_PATH" ] || die "CACHE_HOST_PATH is not writable: $CACHE_HOST_PATH"
+
+for name in NUM_SPECULATIVE_TOKENS MAX_MODEL_LEN MAX_NUM_SEQS \
+    MAX_NUM_BATCHED_TOKENS; do
+    require_positive_integer "$name"
+done
+require_port API_PORT
+require_port MASTER_PORT
+[ "$API_PORT" != "$MASTER_PORT" ] || die "API_PORT and MASTER_PORT must differ"
+
+[ "$NCCL_SOCKET_IFNAME" = "$GLOO_SOCKET_IFNAME" ] \
+    || die "NCCL_SOCKET_IFNAME and GLOO_SOCKET_IFNAME must match"
+[ "$NCCL_NET" = IB ] || die "NCCL_NET must be IB"
+[ "$NCCL_NET_PLUGIN" = none ] || die "NCCL_NET_PLUGIN must be none"
+[ "$NCCL_IB_DISABLE" = 0 ] || die "NCCL_IB_DISABLE must be 0"
+[ "$NCCL_IB_SUBNET_PREFIX_LEN" = 24 ] \
+    || die "NCCL_IB_SUBNET_PREFIX_LEN must be 24"
+[ "$NCCL_IB_SUBNET_AWARE_ROUTING" = 1 ] \
+    || die "cycle subnet-aware routing must be enabled"
+[ "$NCCL_IB_MERGE_NICS" = 0 ] || die "cycle NIC merging must be disabled"
+[ "$NCCL_ALGO" = Ring ] || die "NCCL_ALGO must be Ring"
+[ "$NCCL_PROTO" = LL,LL128,Simple ] \
+    || die "NCCL_PROTO must be LL,LL128,Simple"
+[ "$NCCL_P2P_LEVEL" = SYS ] || die "NCCL_P2P_LEVEL must be SYS"
+[ "$NCCL_MIN_NCHANNELS" = 4 ] || die "NCCL_MIN_NCHANNELS must be 4"
+[ "$NCCL_MAX_NCHANNELS" = 4 ] || die "NCCL_MAX_NCHANNELS must be 4"
+[ "$NCCL_CROSS_NIC" = 1 ] || die "NCCL_CROSS_NIC must be 1"
+[ "$NCCL_CUMEM_ENABLE" = 0 ] || die "NCCL_CUMEM_ENABLE must be 0"
+[ "$NCCL_SKIP_TREE_CONNECT" = 1 ] || die "NCCL_SKIP_TREE_CONNECT must be 1"
+[ "$NCCL_IGNORE_CPU_AFFINITY" = 1 ] \
+    || die "NCCL_IGNORE_CPU_AFFINITY must be 1"
+case ":$LD_PRELOAD:" in
+    *":$VLLM_NCCL_SO_PATH:"*) ;;
+    *) die "LD_PRELOAD must include VLLM_NCCL_SO_PATH ($VLLM_NCCL_SO_PATH)" ;;
+esac
+[ "$NODE_RANK" != 0 ] || [ "$MASTER_ADDR" = "$VLLM_HOST_IP" ] \
+    || die "rank-0 MASTER_ADDR must equal rank-0 VLLM_HOST_IP"
+
+IFS=',' read -r -a hca_specs <<< "$NCCL_IB_HCA"
+[ "${#hca_specs[@]}" = 2 ] \
+    || die "the cycle environment must name exactly two RoCE devices"
+[ "${hca_specs[0]}" != "${hca_specs[1]}" ] \
+    || die "the cycle environment must name two distinct RoCE devices"
+case "$NCCL_IB_GID_INDEX" in
+    ''|*[!0-9]*) die "NCCL_IB_GID_INDEX must be a decimal integer" ;;
+esac
+
+image=ghcr.io/fujitsupolycom/gb10-vllm-serving@sha256:827a8e8c5749b78529cc0015dd174e1b19a0accc116bc142282f8b75428f98bd
+container_name="deepseek-v4-flash-r$NODE_RANK"
+model_container_path=/models/deepseek-v4-flash-0731
+speculative_config=$(printf \
+    '{"method":"dspark","num_speculative_tokens":%s,"moe_backend":"b12x"}' \
+    "$NUM_SPECULATIVE_TOKENS")
+
+command=(
+    docker run -d
+    --name "$container_name"
+    --pull never
+    --network host
+    --ipc host
+    --shm-size 16g
+    --gpus all
+    --ulimit memlock=-1:-1
+    --device /dev/infiniband
+    -v "$MODEL_HOST_PATH:$model_container_path:ro"
+    -v "$CACHE_HOST_PATH:/cache"
+    --env-file "$env_file"
+    --entrypoint /opt/venv/bin/vllm
+    "$image"
+    serve "$model_container_path"
+    --tensor-parallel-size 4
+    --nnodes 4
+    --node-rank "$NODE_RANK"
+    --master-addr "$MASTER_ADDR"
+    --master-port "$MASTER_PORT"
+    --distributed-executor-backend mp
+    --dtype bfloat16
+    --max-model-len "$MAX_MODEL_LEN"
+    --max-num-seqs "$MAX_NUM_SEQS"
+    --max-num-batched-tokens "$MAX_NUM_BATCHED_TOKENS"
+    --async-scheduling
+    --scheduler-reserve-full-isl
+    --gpu-memory-utilization 0.70
+    --kv-cache-memory-bytes 17179869184
+    --kv-cache-dtype fp8_ds_mla
+    --block-size 256
+    --tokenizer-mode deepseek_v4
+    --kernel-config '{"enable_cutedsl_warmup":false}'
+    --enable-auto-tool-choice
+    --tool-call-parser deepseek_v4
+    --speculative-config "$speculative_config"
+    --served-model-name deepseek-v4-flash-0731
+)
+
+if [ "$NODE_RANK" = 0 ]; then
+    command+=(--host 0.0.0.0 --port "$API_PORT")
+else
+    command+=(--headless)
+fi
+
+printf "Local rank input checks passed.\n"
+printf '  rank: %s\n' "$NODE_RANK"
+printf '  model: %s\n' "$MODEL_HOST_PATH"
+printf '  cache: %s\n' "$CACHE_HOST_PATH"
+printf '  MAX_MODEL_LEN: %s\n' "$MAX_MODEL_LEN"
+printf '  MAX_NUM_SEQS: %s\n' "$MAX_NUM_SEQS"
+printf '  MAX_NUM_BATCHED_TOKENS: %s\n' "$MAX_NUM_BATCHED_TOKENS"
+printf '  NUM_SPECULATIVE_TOKENS: %s\n' "$NUM_SPECULATIVE_TOKENS"
+printf '  command:'
+printf ' %q' "${command[@]}"
+printf '\n'
+
+[ "$mode" = --run ] || exit 0
+command -v docker >/dev/null 2>&1 || die "docker is unavailable"
+docker image inspect "$image" >/dev/null 2>&1 \
+    || die "pinned image is not present; pull it before launching: $image"
+if docker container inspect "$container_name" >/dev/null 2>&1; then
+    die "container already exists; remove it intentionally before relaunch: $container_name"
+fi
+exec "${command[@]}"

--- a/scripts/deepseek_v4_pair_serve.sh
+++ b/scripts/deepseek_v4_pair_serve.sh
@@ -1,0 +1,201 @@
+#!/usr/bin/env bash
+# Validate or start one rank of the DeepSeek-V4-Flash-0731 two-Spark profile.
+# The per-rank env file is both the host launch contract and the container
+# environment, so operator-facing paths and serving values have one source.
+set -euo pipefail
+
+usage() {
+    echo "usage: deepseek_v4_pair_serve.sh [--check|--run] ENV_FILE" >&2
+}
+
+die() {
+    echo "deepseek pair launcher: $*" >&2
+    exit 20
+}
+
+case "$#" in
+    1) mode=--check; env_file=$1 ;;
+    2) mode=$1; env_file=$2 ;;
+    *) usage; exit 64 ;;
+esac
+case "$mode" in
+    --check|--run) ;;
+    *) usage; exit 64 ;;
+esac
+
+[ -f "$env_file" ] || die "environment file is missing: $env_file"
+env_file=$(cd "$(dirname "$env_file")" && pwd)/$(basename "$env_file")
+
+if grep -Ev '^[[:space:]]*(#|$)' "$env_file" \
+    | grep -Eq '<[A-Za-z0-9_]+>|REPLACE_WITH_'; then
+    die "environment file contains unresolved placeholders: $env_file"
+fi
+
+# shellcheck disable=SC1090
+. "$env_file"
+# Keep the container-only preload value available for validation without
+# exporting it to host commands such as grep and docker.
+export -n LD_PRELOAD
+
+require_value() {
+    local name=$1 value
+    value=${!name-}
+    [ -n "$value" ] || die "required value is empty: $name"
+}
+
+require_directory() {
+    local name=$1 value
+    value=${!name-}
+    case "$value" in
+        /*) ;;
+        *) die "$name must be an absolute host path: $value" ;;
+    esac
+    [ -d "$value" ] || die "$name directory does not exist: $value"
+}
+
+require_positive_integer() {
+    local name=$1 value
+    value=${!name-}
+    case "$value" in
+        ''|*[!0-9]*) die "$name must be a positive integer: $value" ;;
+    esac
+    [ "$((10#$value))" -gt 0 ] || die "$name must be greater than zero"
+}
+
+require_port() {
+    local name=$1 value
+    require_positive_integer "$name"
+    value=${!name-}
+    [ "$((10#$value))" -le 65535 ] || die "$name must be in 1..65535: $value"
+}
+
+for name in \
+    NODE_RANK MASTER_ADDR MODEL_HOST_PATH CACHE_HOST_PATH API_PORT MASTER_PORT \
+    NUM_SPECULATIVE_TOKENS MAX_MODEL_LEN MAX_NUM_SEQS MAX_NUM_BATCHED_TOKENS \
+    LD_PRELOAD VLLM_NCCL_SO_PATH NCCL_SOCKET_IFNAME GLOO_SOCKET_IFNAME \
+    VLLM_HOST_IP NCCL_NET NCCL_NET_PLUGIN NCCL_IB_DISABLE NCCL_IB_HCA \
+    NCCL_IB_GID_INDEX NCCL_IB_SUBNET_AWARE_ROUTING NCCL_IB_MERGE_NICS \
+    NCCL_PROTO NCCL_P2P_LEVEL NCCL_CROSS_NIC NCCL_CUMEM_ENABLE \
+    NCCL_IGNORE_CPU_AFFINITY; do
+    require_value "$name"
+done
+
+case "$NODE_RANK" in
+    0|1) ;;
+    *) die "NODE_RANK must be 0 or 1: $NODE_RANK" ;;
+esac
+require_directory MODEL_HOST_PATH
+require_directory CACHE_HOST_PATH
+[ -r "$MODEL_HOST_PATH" ] || die "MODEL_HOST_PATH is not readable: $MODEL_HOST_PATH"
+[ -w "$CACHE_HOST_PATH" ] || die "CACHE_HOST_PATH is not writable: $CACHE_HOST_PATH"
+
+for name in NUM_SPECULATIVE_TOKENS MAX_MODEL_LEN MAX_NUM_SEQS \
+    MAX_NUM_BATCHED_TOKENS; do
+    require_positive_integer "$name"
+done
+require_port API_PORT
+require_port MASTER_PORT
+[ "$API_PORT" != "$MASTER_PORT" ] || die "API_PORT and MASTER_PORT must differ"
+
+[ "$NCCL_SOCKET_IFNAME" = "$GLOO_SOCKET_IFNAME" ] \
+    || die "NCCL_SOCKET_IFNAME and GLOO_SOCKET_IFNAME must match on a pair"
+[ "$NCCL_NET" = IB ] || die "NCCL_NET must be IB"
+[ "$NCCL_NET_PLUGIN" = none ] || die "NCCL_NET_PLUGIN must be none"
+[ "$NCCL_IB_DISABLE" = 0 ] || die "NCCL_IB_DISABLE must be 0"
+[ "$NCCL_IB_SUBNET_AWARE_ROUTING" = 0 ] \
+    || die "pair subnet-aware routing must be disabled"
+[ "$NCCL_IB_MERGE_NICS" = 0 ] || die "pair NIC merging must be disabled"
+[ "$NCCL_PROTO" = LL,LL128,Simple ] \
+    || die "NCCL_PROTO must be LL,LL128,Simple"
+[ "$NCCL_P2P_LEVEL" = SYS ] || die "NCCL_P2P_LEVEL must be SYS"
+[ "$NCCL_CROSS_NIC" = 1 ] || die "NCCL_CROSS_NIC must be 1"
+[ "$NCCL_CUMEM_ENABLE" = 0 ] || die "NCCL_CUMEM_ENABLE must be 0"
+[ "$NCCL_IGNORE_CPU_AFFINITY" = 1 ] \
+    || die "NCCL_IGNORE_CPU_AFFINITY must be 1"
+case ":$LD_PRELOAD:" in
+    *":$VLLM_NCCL_SO_PATH:"*) ;;
+    *) die "LD_PRELOAD must include VLLM_NCCL_SO_PATH ($VLLM_NCCL_SO_PATH)" ;;
+esac
+[ "$NODE_RANK" != 0 ] || [ "$MASTER_ADDR" = "$VLLM_HOST_IP" ] \
+    || die "rank-0 MASTER_ADDR must equal rank-0 VLLM_HOST_IP"
+
+case "$NCCL_IB_HCA" in
+    *,*) die "the pair environment must name exactly one RoCE device" ;;
+esac
+case "$NCCL_IB_GID_INDEX" in
+    ''|*[!0-9]*) die "NCCL_IB_GID_INDEX must be a decimal integer" ;;
+esac
+
+image=ghcr.io/fujitsupolycom/gb10-vllm-serving@sha256:827a8e8c5749b78529cc0015dd174e1b19a0accc116bc142282f8b75428f98bd
+container_name="deepseek-v4-flash-r$NODE_RANK"
+model_container_path=/models/deepseek-v4-flash-0731
+speculative_config=$(printf \
+    '{"method":"dspark","num_speculative_tokens":%s,"moe_backend":"b12x"}' \
+    "$NUM_SPECULATIVE_TOKENS")
+
+command=(
+    docker run -d
+    --name "$container_name"
+    --pull never
+    --network host
+    --ipc host
+    --shm-size 16g
+    --gpus all
+    --ulimit memlock=-1:-1
+    --device /dev/infiniband
+    -v "$MODEL_HOST_PATH:$model_container_path:ro"
+    -v "$CACHE_HOST_PATH:/cache"
+    --env-file "$env_file"
+    --entrypoint /opt/venv/bin/vllm
+    "$image"
+    serve "$model_container_path"
+    --tensor-parallel-size 2
+    --nnodes 2
+    --node-rank "$NODE_RANK"
+    --master-addr "$MASTER_ADDR"
+    --master-port "$MASTER_PORT"
+    --distributed-executor-backend mp
+    --dtype bfloat16
+    --max-model-len "$MAX_MODEL_LEN"
+    --max-num-seqs "$MAX_NUM_SEQS"
+    --max-num-batched-tokens "$MAX_NUM_BATCHED_TOKENS"
+    --async-scheduling
+    --scheduler-reserve-full-isl
+    --gpu-memory-utilization 0.70
+    --kv-cache-memory-bytes 17179869184
+    --kv-cache-dtype fp8_ds_mla
+    --block-size 256
+    --tokenizer-mode deepseek_v4
+    --kernel-config '{"enable_cutedsl_warmup":false}'
+    --enable-auto-tool-choice
+    --tool-call-parser deepseek_v4
+    --speculative-config "$speculative_config"
+    --served-model-name deepseek-v4-flash-0731
+)
+
+if [ "$NODE_RANK" = 0 ]; then
+    command+=(--host 0.0.0.0 --port "$API_PORT")
+else
+    command+=(--headless)
+fi
+
+printf "Local rank input checks passed.\n"
+printf '  rank: %s\n' "$NODE_RANK"
+printf '  model: %s\n' "$MODEL_HOST_PATH"
+printf '  cache: %s\n' "$CACHE_HOST_PATH"
+printf '  MAX_MODEL_LEN: %s\n' "$MAX_MODEL_LEN"
+printf '  MAX_NUM_SEQS: %s\n' "$MAX_NUM_SEQS"
+printf '  MAX_NUM_BATCHED_TOKENS: %s\n' "$MAX_NUM_BATCHED_TOKENS"
+printf '  NUM_SPECULATIVE_TOKENS: %s\n' "$NUM_SPECULATIVE_TOKENS"
+printf '  command:'
+printf ' %q' "${command[@]}"
+printf '\n'
+
+[ "$mode" = --run ] || exit 0
+command -v docker >/dev/null 2>&1 || die "docker is unavailable"
+docker image inspect "$image" >/dev/null 2>&1 \
+    || die "pinned image is not present; pull it before launching: $image"
+if docker container inspect "$container_name" >/dev/null 2>&1; then
+    die "container already exists; remove it intentionally before relaunch: $container_name"
+fi
+exec "${command[@]}"

--- a/scripts/qwen38_dgx2_serve.sh
+++ b/scripts/qwen38_dgx2_serve.sh
@@ -28,19 +28,36 @@ check_sha256() {
     [ "$actual" = "$expected" ] || die "$label SHA-256 mismatch: expected $expected, got $actual"
 }
 
+case "${RANK-}" in
+    ''|0|1) ;;
+    *) die "RANK must be 0 or 1; got $RANK" ;;
+esac
+env_file=${QWEN_ENV_FILE:-/ws/rank.env}
+require_file "$env_file" "rank environment file is missing"
+if grep -Ev '^[[:space:]]*(#|$)' "$env_file" | grep -Eq '<[A-Za-z0-9_]+>|REPLACE_WITH_'; then
+    die "rank environment file contains unresolved placeholders: $env_file"
+fi
+set -a
+# shellcheck disable=SC1090
+. "$env_file"
+set +a
+
 rank=${RANK:-}
 case "$rank" in 0|1) ;; *) die "RANK must be 0 or 1; got ${rank:-empty}" ;; esac
 rank0_rendezvous_addr=${RANK0_RENDEZVOUS_ADDR:-}
 [ -n "$rank0_rendezvous_addr" ] || die "RANK0_RENDEZVOUS_ADDR is required"
 
-env_file=${QWEN_ENV_FILE:-/ws/rank.env}
 model_path=${QWEN_MODEL_PATH:-/ws/model/Qwen3.8-27B-EXL3-K5K6-hydrated}
 chat_template=${QWEN_CHAT_TEMPLATE:-/ws/chat_template_agentic.jinja}
 venv=${QWEN_VENV:-/ws/venv}
 infiniband_root=${QWEN_INFINIBAND_SYS_ROOT:-/sys/class/infiniband}
 infiniband_dev_root=${QWEN_INFINIBAND_DEV_ROOT:-/dev/infiniband}
-api_port=${QWEN_API_PORT:-8000}
-master_port=${QWEN_MASTER_PORT:-29500}
+api_port=${API_PORT:-${QWEN_API_PORT:-8000}}
+master_port=${MASTER_PORT:-${QWEN_MASTER_PORT:-29500}}
+num_speculative_tokens=${NUM_SPECULATIVE_TOKENS:-3}
+max_model_len=${MAX_MODEL_LEN:-1048576}
+max_num_seqs=${MAX_NUM_SEQS:-32}
+max_num_batched_tokens=${MAX_NUM_BATCHED_TOKENS:-8192}
 
 expected_manifest=7626d18481e7f995fd1d9ff211083b7fd57f044daba39e107fb29a48207f24c4
 expected_config=fbb105334da6554c10784ff1257fda5e3821d4d5426d64469cee2b2ad67ba2b3
@@ -51,15 +68,6 @@ expected_nccl=e69a8c240f45d10166bcd901d99db78bb63147adda66e586d8dd505c6d608b54
 for command_name in cut find grep ip pgrep printenv python3 sha256sum; do
     command -v "$command_name" >/dev/null 2>&1 || die "required command is unavailable: $command_name"
 done
-require_file "$env_file" "rank environment file is missing"
-if grep -Ev '^[[:space:]]*(#|$)' "$env_file" | grep -Eq '<[A-Za-z0-9_]+>|REPLACE_WITH_'; then
-    die "rank environment file contains unresolved placeholders: $env_file"
-fi
-set -a
-# shellcheck disable=SC1090
-. "$env_file"
-set +a
-
 for name in \
     LD_PRELOAD VLLM_NCCL_SO_PATH NCCL_SOCKET_IFNAME GLOO_SOCKET_IFNAME \
     VLLM_HOST_IP NCCL_NET NCCL_NET_PLUGIN NCCL_IB_DISABLE NCCL_IB_HCA \
@@ -69,6 +77,15 @@ for name in \
     VLLM_EXL3_PREFILL_FP8 VLLM_EXL3_PREFILL_RECONSTRUCT_M \
     VLLM_ALLOW_LONG_MAX_MODEL_LEN; do
     require_env "$name"
+done
+
+for value_name in num_speculative_tokens max_model_len max_num_seqs \
+    max_num_batched_tokens; do
+    value=${!value_name}
+    case "$value" in
+        ''|*[!0-9]*) die "$value_name must be a positive integer: $value" ;;
+    esac
+    [ "$((10#$value))" -gt 0 ] || die "$value_name must be greater than zero"
 done
 
 [ "$NCCL_SOCKET_IFNAME" = "$GLOO_SOCKET_IFNAME" ] || die "NCCL and Gloo interfaces differ"
@@ -181,7 +198,7 @@ fi
 endpoint=(--headless)
 [ "$rank" = 0 ] && endpoint=(--host 0.0.0.0 --port "$api_port")
 hf_overrides='{"text_config":{"rope_parameters":{"mrope_interleaved":true,"mrope_section":[11,11,10],"rope_type":"yarn","rope_theta":10000000,"partial_rotary_factor":0.25,"factor":4.0,"original_max_position_embeddings":262144}}}'
-speculation='{"method":"qwen3_5_mtp","num_speculative_tokens":3,"attention_backend":"TRITON_ATTN","draft_sample_method":"probabilistic","rejection_sample_method":"standard"}'
+speculation=$(printf '{"method":"qwen3_5_mtp","num_speculative_tokens":%s,"attention_backend":"TRITON_ATTN","draft_sample_method":"probabilistic","rejection_sample_method":"standard"}' "$num_speculative_tokens")
 
 command=(
     "$venv/bin/vllm" serve "$model_path"
@@ -190,8 +207,9 @@ command=(
     --nnodes 2 --node-rank "$rank"
     --master-addr "$rank0_rendezvous_addr" --master-port "$master_port"
     --distributed-executor-backend mp
-    --max-model-len 1048576 --hf-overrides "$hf_overrides"
-    --max-num-seqs 32 --max-num-batched-tokens 8192
+    --max-model-len "$max_model_len" --hf-overrides "$hf_overrides"
+    --max-num-seqs "$max_num_seqs"
+    --max-num-batched-tokens "$max_num_batched_tokens"
     --enable-chunked-prefill --async-scheduling --scheduler-reserve-full-isl
     --block-size 16 --gpu-memory-utilization 0.70 --kv-cache-dtype fp8
     --enable-prefix-caching --mamba-cache-mode align
@@ -206,6 +224,9 @@ command=(
 )
 
 printf 'qwen38 pair preflight passed for rank %s\n' "$rank"
+printf 'MAX_MODEL_LEN=%s MAX_NUM_SEQS=%s MAX_NUM_BATCHED_TOKENS=%s NUM_SPECULATIVE_TOKENS=%s\n' \
+    "$max_model_len" "$max_num_seqs" "$max_num_batched_tokens" \
+    "$num_speculative_tokens"
 printf 'resolved command:'
 printf ' %q' "${command[@]}"
 printf '\n'

--- a/scripts/qwen38_dgx4_serve.sh
+++ b/scripts/qwen38_dgx4_serve.sh
@@ -70,9 +70,23 @@ require_env_value() {
     esac
 }
 
+case "${RANK-}" in
+    ''|0|1|2|3) ;;
+    *) die "RANK must be 0, 1, 2, or 3; got $RANK" ;;
+esac
+env_file=${QWEN_ENV_FILE:-/ws/rank.env}
+require_file "$env_file" "rank environment file is missing"
+if grep -Ev '^[[:space:]]*(#|$)' "$env_file" | \
+    grep -Eq '<[A-Za-z0-9_]+>|REPLACE_WITH_'; then
+    die "rank environment file contains unresolved placeholders: $env_file"
+fi
+set -a
+# shellcheck disable=SC1090
+. "$env_file"
+set +a
+
 rank=${RANK:-}
 rank0_rendezvous_addr=${RANK0_RENDEZVOUS_ADDR:-}
-env_file=${QWEN_ENV_FILE:-/ws/rank.env}
 model_path=${QWEN_MODEL_PATH:-/ws/model/Qwen3.8-27B-EXL3-K5K6-hydrated}
 chat_template=${QWEN_CHAT_TEMPLATE:-/ws/chat_template_agentic.jinja}
 venv=${QWEN_VENV:-/ws/venv}
@@ -80,8 +94,12 @@ vllm_source=${QWEN_VLLM_SOURCE:-/ws/src/vllm-gg}
 exllamav3_source=${QWEN_EXLLAMAV3_SOURCE:-/ws/src/exllamav3}
 infiniband_dev_root=${QWEN_INFINIBAND_DEV_ROOT:-/dev/infiniband}
 infiniband_sys_root=${QWEN_INFINIBAND_SYS_ROOT:-/sys/class/infiniband}
-api_port=${QWEN_API_PORT:-8000}
-master_port=${QWEN_MASTER_PORT:-29500}
+api_port=${API_PORT:-${QWEN_API_PORT:-8000}}
+master_port=${MASTER_PORT:-${QWEN_MASTER_PORT:-29500}}
+num_speculative_tokens=${NUM_SPECULATIVE_TOKENS:-3}
+max_model_len=${MAX_MODEL_LEN:-1048576}
+max_num_seqs=${MAX_NUM_SEQS:-64}
+max_num_batched_tokens=${MAX_NUM_BATCHED_TOKENS:-8192}
 
 expected_vllm_commit=229effc810ee6b8112f661472f6aace4eb8c787d
 expected_exllamav3_commit=5f3c537ca9d89893d771256f5c43c93656553fbb
@@ -105,17 +123,6 @@ for command_name in awk cut git grep ip sha256sum; do
     require_command "$command_name"
 done
 
-require_file "$env_file" "rank environment file is missing"
-if grep -Ev '^[[:space:]]*(#|$)' "$env_file" | \
-    grep -Eq '<[A-Za-z0-9_]+>|REPLACE_WITH_'; then
-    die "rank environment file contains unresolved placeholders: $env_file"
-fi
-
-set -a
-# shellcheck disable=SC1090
-. "$env_file"
-set +a
-
 for name in \
     LD_PRELOAD VLLM_NCCL_SO_PATH NCCL_SOCKET_IFNAME GLOO_SOCKET_IFNAME \
     VLLM_HOST_IP NCCL_NET NCCL_NET_PLUGIN NCCL_IB_DISABLE NCCL_IB_HCA \
@@ -128,6 +135,15 @@ for name in \
     VLLM_EXL3_GRAPH_DECODE VLLM_EXL3_PREFILL_FP8 \
     VLLM_EXL3_PREFILL_RECONSTRUCT_M VLLM_ALLOW_LONG_MAX_MODEL_LEN; do
     require_env_value "$name"
+done
+
+for value_name in num_speculative_tokens max_model_len max_num_seqs \
+    max_num_batched_tokens; do
+    value=${!value_name}
+    case "$value" in
+        ''|*[!0-9]*) die "$value_name must be a positive integer: $value" ;;
+    esac
+    [ "$((10#$value))" -gt 0 ] || die "$value_name must be greater than zero"
 done
 
 [ "$NCCL_SOCKET_IFNAME" = "$GLOO_SOCKET_IFNAME" ] || {
@@ -380,7 +396,7 @@ if [ "$rank" = "0" ]; then
 fi
 
 hf_overrides='{"text_config":{"rope_parameters":{"mrope_interleaved":true,"mrope_section":[11,11,10],"rope_type":"yarn","rope_theta":10000000,"partial_rotary_factor":0.25,"factor":4.0,"original_max_position_embeddings":262144}}}'
-speculation='{"method":"qwen3_5_mtp","num_speculative_tokens":3,"attention_backend":"TRITON_ATTN","draft_sample_method":"probabilistic","rejection_sample_method":"standard"}'
+speculation=$(printf '{"method":"qwen3_5_mtp","num_speculative_tokens":%s,"attention_backend":"TRITON_ATTN","draft_sample_method":"probabilistic","rejection_sample_method":"standard"}' "$num_speculative_tokens")
 
 command=(
     "$venv/bin/vllm" serve "$model_path"
@@ -393,10 +409,10 @@ command=(
     --master-addr "$rank0_rendezvous_addr"
     --master-port "$master_port"
     --distributed-executor-backend mp
-    --max-model-len 1048576
+    --max-model-len "$max_model_len"
     --hf-overrides "$hf_overrides"
-    --max-num-seqs 64
-    --max-num-batched-tokens 8192
+    --max-num-seqs "$max_num_seqs"
+    --max-num-batched-tokens "$max_num_batched_tokens"
     --enable-chunked-prefill
     --async-scheduling
     --scheduler-reserve-full-isl
@@ -419,6 +435,9 @@ command=(
 
 printf 'qwen38 preflight passed for rank %s\n' "$rank"
 printf 'verified ExLlamaV3 ARM patch SHA-256: %s\n' "$expected_exllamav3_patch_sha256"
+printf 'MAX_MODEL_LEN=%s MAX_NUM_SEQS=%s MAX_NUM_BATCHED_TOKENS=%s NUM_SPECULATIVE_TOKENS=%s\n' \
+    "$max_model_len" "$max_num_seqs" "$max_num_batched_tokens" \
+    "$num_speculative_tokens"
 printf 'resolved command:'
 printf ' %q' "${command[@]}"
 printf '\n'

--- a/scripts/qwen38_dgx4_serve.sh
+++ b/scripts/qwen38_dgx4_serve.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Start one rank of the Qwen3.8-27B EXL3 K5/K6 four-Spark candidate.
+# Start one rank of the implemented Qwen3.8-27B EXL3 K5/K6 four-Spark profile.
 # Run inside the prepared runtime container on every rank. Rank 0 serves the
 # API; ranks 1-3 run headless workers. Pass --check to validate the complete
 # local rank contract and print the command without starting vLLM.

--- a/scripts/test_deepseek_v4_pair_launcher.py
+++ b/scripts/test_deepseek_v4_pair_launcher.py
@@ -1,0 +1,258 @@
+"""Offline contracts for the DeepSeek two-Spark env-driven launcher."""
+
+from __future__ import annotations
+
+import json
+import os
+import shlex
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+LAUNCHER = ROOT / "scripts" / "deepseek_v4_pair_serve.sh"
+TEMPLATE = ROOT / "scripts" / "config" / "deepseek-v4-flash-0731-pair.env.example"
+RECIPE = ROOT / "recipes" / "deepseek-v4-flash-0731-pair.json"
+CYCLE_LAUNCHER = ROOT / "scripts" / "deepseek_v4_cycle_serve.sh"
+CYCLE_TEMPLATE = ROOT / "scripts" / "config" / "deepseek-v4-flash-0731.env.example"
+CYCLE_RECIPE = ROOT / "recipes" / "deepseek-v4-flash-0731.json"
+
+
+def _bash_path(path: str | Path) -> str:
+    value = str(path)
+    if os.name != "nt":
+        return value
+    drive, tail = os.path.splitdrive(value)
+    assert drive, value
+    return f"/mnt/{drive[0].lower()}/{tail.lstrip('\\/').replace('\\', '/')}"
+
+
+def _run_launcher(
+    env_file: Path,
+    mode: str | None = "--check",
+    launcher: Path = LAUNCHER,
+) -> subprocess.CompletedProcess[str]:
+    arguments = [str(env_file)] if mode is None else [mode, str(env_file)]
+    if os.name != "nt":
+        command = ["bash", str(launcher), *arguments]
+    else:
+        rendered = " ".join(
+            shlex.quote(value)
+            for value in (
+                "bash",
+                _bash_path(launcher),
+                *([_bash_path(env_file)] if mode is None else [mode, _bash_path(env_file)]),
+            )
+        )
+        command = ["bash", "-lc", f"exec {rendered}"]
+    return subprocess.run(command, text=True, capture_output=True, check=False)
+
+
+def _env_values(path: Path) -> dict[str, str]:
+    values: dict[str, str] = {}
+    for raw_line in path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        key, value = line.split("=", 1)
+        values[key] = value
+    return values
+
+
+@pytest.fixture
+def pair_env(tmp_path: Path) -> Path:
+    model = tmp_path / "model"
+    cache = tmp_path / "cache"
+    model.mkdir()
+    cache.mkdir()
+    content = TEMPLATE.read_text(encoding="utf-8")
+    replacements = {
+        "<NODE_RANK_0_OR_1>": "0",
+        "<RANK0_FABRIC_IP>": "10.42.0.1",
+        "<ABSOLUTE_MODEL_DIRECTORY>": _bash_path(model),
+        "<ABSOLUTE_CACHE_DIRECTORY>": _bash_path(cache),
+        "<FABRIC_IFNAME>": "fabric0",
+        "<RANK_FABRIC_IP>": "10.42.0.1",
+        "<GID_INDEX>": "3",
+    }
+    for placeholder, value in replacements.items():
+        content = content.replace(placeholder, value)
+    env_file = tmp_path / "rank-0.env"
+    env_file.write_text(content, encoding="utf-8", newline="\n")
+    return env_file
+
+
+@pytest.fixture
+def cycle_env(tmp_path: Path) -> Path:
+    model = tmp_path / "model"
+    cache = tmp_path / "cache"
+    model.mkdir()
+    cache.mkdir()
+    content = CYCLE_TEMPLATE.read_text(encoding="utf-8")
+    replacements = {
+        "<NODE_RANK_0_TO_3>": "0",
+        "<RANK0_FABRIC_IP>": "10.43.0.1",
+        "<ABSOLUTE_MODEL_DIRECTORY>": _bash_path(model),
+        "<ABSOLUTE_CACHE_DIRECTORY>": _bash_path(cache),
+        "<NCCL_SOCKET_IFNAME>": "fabric0",
+        "<RANK_FABRIC_IP>": "10.43.0.1",
+    }
+    for placeholder, value in replacements.items():
+        content = content.replace(placeholder, value)
+    env_file = tmp_path / "rank-0.env"
+    env_file.write_text(content, encoding="utf-8", newline="\n")
+    return env_file
+
+
+def test_pair_env_defaults_match_recipe() -> None:
+    values = _env_values(TEMPLATE)
+    recipe = json.loads(RECIPE.read_text(encoding="utf-8"))
+    assert recipe["runtime"]["launcher"] == "scripts/deepseek_v4_pair_serve.sh"
+    serving = recipe["serving"]
+    assert int(values["API_PORT"]) == 8000
+    assert int(values["MASTER_PORT"]) == 29500
+    assert int(values["NUM_SPECULATIVE_TOKENS"]) == serving["speculation"][
+        "num_speculative_tokens"
+    ]
+    assert int(values["MAX_MODEL_LEN"]) == serving["max_model_len"]
+    assert int(values["MAX_NUM_SEQS"]) == serving["max_num_seqs"]
+    assert int(values["MAX_NUM_BATCHED_TOKENS"]) == serving[
+        "max_num_batched_tokens"
+    ]
+
+
+def test_pair_env_explains_host_cache_mapping() -> None:
+    source = TEMPLATE.read_text(encoding="utf-8")
+    assert "CACHE_HOST_PATH=/cache/test" in source
+    assert "/cache/test/jit/triton" in source
+    assert "Leave XDG_CACHE_HOME, TRITON_CACHE_DIR, and VLLM_CACHE_ROOT unchanged" in source
+    assert "configure the host location only through" in source
+
+
+def test_cycle_env_defaults_match_recipe() -> None:
+    values = _env_values(CYCLE_TEMPLATE)
+    recipe = json.loads(CYCLE_RECIPE.read_text(encoding="utf-8"))
+    assert recipe["runtime"]["launcher"] == "scripts/deepseek_v4_cycle_serve.sh"
+    serving = recipe["serving"]
+    assert int(values["NUM_SPECULATIVE_TOKENS"]) == serving["speculation"][
+        "num_speculative_tokens"
+    ]
+    assert int(values["MAX_MODEL_LEN"]) == serving["max_model_len"]
+    assert int(values["MAX_NUM_SEQS"]) == serving["max_num_seqs"]
+    assert int(values["MAX_NUM_BATCHED_TOKENS"]) == serving[
+        "max_num_batched_tokens"
+    ]
+
+
+def test_cycle_check_renders_operator_settings(cycle_env: Path) -> None:
+    result = _run_launcher(cycle_env, launcher=CYCLE_LAUNCHER)
+
+    assert result.returncode == 0, result.stderr
+    assert "--tensor-parallel-size 4" in result.stdout
+    assert "--nnodes 4" in result.stdout
+    assert "--node-rank 0" in result.stdout
+    assert "MAX_MODEL_LEN: 1048576" in result.stdout
+    assert "NUM_SPECULATIVE_TOKENS: 5" in result.stdout
+
+
+def test_cycle_rank_three_is_headless(cycle_env: Path) -> None:
+    content = cycle_env.read_text(encoding="utf-8")
+    content = content.replace("NODE_RANK=0", "NODE_RANK=3")
+    content = content.replace("VLLM_HOST_IP=10.43.0.1", "VLLM_HOST_IP=10.43.0.4")
+    cycle_env.write_text(content, encoding="utf-8", newline="\n")
+
+    result = _run_launcher(cycle_env, launcher=CYCLE_LAUNCHER)
+
+    assert result.returncode == 0, result.stderr
+    assert "--node-rank 3" in result.stdout
+    assert "--headless" in result.stdout
+
+
+def test_check_renders_every_operator_setting(pair_env: Path) -> None:
+    content = pair_env.read_text(encoding="utf-8")
+    content = content.replace("API_PORT=8000", "API_PORT=8123")
+    content = content.replace(
+        "NUM_SPECULATIVE_TOKENS=5", "NUM_SPECULATIVE_TOKENS=7"
+    )
+    content = content.replace("MAX_MODEL_LEN=1048576", "MAX_MODEL_LEN=262144")
+    content = content.replace("MAX_NUM_SEQS=32", "MAX_NUM_SEQS=12")
+    content = content.replace(
+        "MAX_NUM_BATCHED_TOKENS=4096", "MAX_NUM_BATCHED_TOKENS=8192"
+    )
+    pair_env.write_text(content, encoding="utf-8", newline="\n")
+
+    result = _run_launcher(pair_env)
+
+    assert result.returncode == 0, result.stderr
+    assert "MAX_MODEL_LEN: 262144" in result.stdout
+    assert "MAX_NUM_SEQS: 12" in result.stdout
+    assert "MAX_NUM_BATCHED_TOKENS: 8192" in result.stdout
+    assert "NUM_SPECULATIVE_TOKENS: 7" in result.stdout
+    assert "--max-model-len 262144" in result.stdout
+    assert "--max-num-seqs 12" in result.stdout
+    assert "--max-num-batched-tokens 8192" in result.stdout
+    assert "num_speculative_tokens" in result.stdout
+    assert "--port 8123" in result.stdout
+    assert f"{_bash_path(pair_env.parent / 'model')}" in result.stdout
+    assert f"{_bash_path(pair_env.parent / 'cache')}" in result.stdout
+
+
+def test_env_file_alone_defaults_to_check(pair_env: Path) -> None:
+    result = _run_launcher(pair_env, mode=None)
+
+    assert result.returncode == 0, result.stderr
+    assert "Local rank input checks passed." in result.stdout
+
+
+def test_rank_one_is_headless(pair_env: Path) -> None:
+    content = pair_env.read_text(encoding="utf-8").replace("NODE_RANK=0", "NODE_RANK=1")
+    content = content.replace("VLLM_HOST_IP=10.42.0.1", "VLLM_HOST_IP=10.42.0.2")
+    pair_env.write_text(content, encoding="utf-8", newline="\n")
+
+    result = _run_launcher(pair_env)
+
+    assert result.returncode == 0, result.stderr
+    assert "--node-rank 1" in result.stdout
+    assert "--headless" in result.stdout
+
+
+def test_unresolved_template_fails_before_launch(tmp_path: Path) -> None:
+    env_file = tmp_path / "rank.env"
+    env_file.write_text(TEMPLATE.read_text(encoding="utf-8"), encoding="utf-8")
+
+    result = _run_launcher(env_file)
+
+    assert result.returncode != 0
+    assert "unresolved placeholders" in result.stderr
+
+
+def test_invalid_serving_integer_fails(pair_env: Path) -> None:
+    content = pair_env.read_text(encoding="utf-8").replace(
+        "MAX_NUM_SEQS=32", "MAX_NUM_SEQS=0"
+    )
+    pair_env.write_text(content, encoding="utf-8", newline="\n")
+
+    result = _run_launcher(pair_env)
+
+    assert result.returncode != 0
+    assert "MAX_NUM_SEQS must be greater than zero" in result.stderr
+
+
+def test_rank_zero_requires_its_own_fabric_address(pair_env: Path) -> None:
+    content = pair_env.read_text(encoding="utf-8").replace(
+        "MASTER_ADDR=10.42.0.1", "MASTER_ADDR=10.42.0.9"
+    )
+    pair_env.write_text(content, encoding="utf-8", newline="\n")
+
+    result = _run_launcher(pair_env)
+
+    assert result.returncode != 0
+    assert "rank-0 MASTER_ADDR must equal rank-0 VLLM_HOST_IP" in result.stderr
+
+
+def test_launcher_uses_host_ipc_and_16g_shm_declaration() -> None:
+    source = LAUNCHER.read_text(encoding="utf-8")
+    assert "--ipc host" in source
+    assert "--shm-size 16g" in source

--- a/scripts/test_deepseek_v4_pair_launcher.py
+++ b/scripts/test_deepseek_v4_pair_launcher.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import shlex
 import subprocess
 from pathlib import Path
@@ -18,6 +19,7 @@ RECIPE = ROOT / "recipes" / "deepseek-v4-flash-0731-pair.json"
 CYCLE_LAUNCHER = ROOT / "scripts" / "deepseek_v4_cycle_serve.sh"
 CYCLE_TEMPLATE = ROOT / "scripts" / "config" / "deepseek-v4-flash-0731.env.example"
 CYCLE_RECIPE = ROOT / "recipes" / "deepseek-v4-flash-0731.json"
+RUNTIME_LOCK = ROOT / "runtime" / "faststart-lock.json"
 
 
 def _bash_path(path: str | Path) -> str:
@@ -59,6 +61,12 @@ def _env_values(path: Path) -> dict[str, str]:
         key, value = line.split("=", 1)
         values[key] = value
     return values
+
+
+def _launcher_image(path: Path) -> str:
+    match = re.search(r"^image=(\S+)$", path.read_text(encoding="utf-8"), re.MULTILINE)
+    assert match is not None
+    return match.group(1)
 
 
 @pytest.fixture
@@ -144,6 +152,15 @@ def test_cycle_env_defaults_match_recipe() -> None:
     assert int(values["MAX_NUM_BATCHED_TOKENS"]) == serving[
         "max_num_batched_tokens"
     ]
+
+
+def test_launchers_pin_the_hardened_image_from_the_runtime_lock() -> None:
+    lock = json.loads(RUNTIME_LOCK.read_text(encoding="utf-8"))
+    image = lock["deepseek_v4_flash_0731_hardened_serving_image"]
+    expected = f"{image['repository']}@{image['manifest_digest']}"
+
+    assert _launcher_image(LAUNCHER) == expected
+    assert _launcher_image(CYCLE_LAUNCHER) == expected
 
 
 def test_cycle_check_renders_operator_settings(cycle_env: Path) -> None:

--- a/scripts/test_qwen38_launcher_preflight.py
+++ b/scripts/test_qwen38_launcher_preflight.py
@@ -417,3 +417,27 @@ def test_explicit_run_mode_overrides_the_image_sleep_command(
     assert result.returncode == 0, result.stderr
     assert marker.exists()
     assert "--tensor-parallel-size\n4\n" in marker.read_text(encoding="utf-8")
+
+
+def test_env_serving_overrides_reach_the_vllm_command(
+    prepared_rank: tuple[dict[str, str], Path, Path],
+) -> None:
+    env, env_file, marker = prepared_rank
+    with env_file.open("a", encoding="utf-8", newline="\n") as stream:
+        stream.write(
+            "API_PORT=8123\n"
+            "NUM_SPECULATIVE_TOKENS=2\n"
+            "MAX_MODEL_LEN=262144\n"
+            "MAX_NUM_SEQS=12\n"
+            "MAX_NUM_BATCHED_TOKENS=4096\n"
+        )
+
+    result = _run_launcher(env, "--run")
+
+    assert result.returncode == 0, result.stderr
+    arguments = marker.read_text(encoding="utf-8")
+    assert "--port\n8123\n" in arguments
+    assert "--max-model-len\n262144\n" in arguments
+    assert "--max-num-seqs\n12\n" in arguments
+    assert "--max-num-batched-tokens\n4096\n" in arguments
+    assert '"num_speculative_tokens":2' in arguments

--- a/scripts/test_qwen38_pair_profile.py
+++ b/scripts/test_qwen38_pair_profile.py
@@ -20,6 +20,16 @@ def _recipe() -> dict:
     return json.loads(RECIPE.read_text(encoding="utf-8"))
 
 
+def _env_values() -> dict[str, str]:
+    values: dict[str, str] = {}
+    for raw_line in ENV.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if line and not line.startswith("#"):
+            key, value = line.split("=", 1)
+            values[key] = value
+    return values
+
+
 def test_pair_and_cycle_share_the_normalized_serving_contract() -> None:
     pair = _recipe()["serving"]
     cycle = json.loads(CYCLE_RECIPE.read_text(encoding="utf-8"))["serving"]
@@ -105,6 +115,22 @@ def test_pair_environment_is_single_hca_and_cache_free() -> None:
         assert forbidden not in text
 
 
+def test_pair_environment_operator_defaults_match_recipe() -> None:
+    values = _env_values()
+    serving = _recipe()["serving"]
+    assert int(values["API_PORT"]) == 8000
+    assert int(values["MASTER_PORT"]) == 29500
+    assert int(values["NUM_SPECULATIVE_TOKENS"]) == serving["speculation"][
+        "num_speculative_tokens"
+    ]
+    assert int(values["MAX_MODEL_LEN"]) == serving["max_model_len"]
+    assert int(values["MAX_NUM_SEQS"]) == serving["max_num_seqs"]
+    assert int(values["MAX_NUM_BATCHED_TOKENS"]) == serving[
+        "max_num_batched_tokens"
+    ]
+    assert "CACHE_HOST_PATH=/cache/qwen38-pair" in ENV.read_text(encoding="utf-8")
+
+
 def test_pair_launcher_matches_recipe_and_fails_closed() -> None:
     text = LAUNCHER.read_text(encoding="utf-8")
     for required in (
@@ -113,11 +139,15 @@ def test_pair_launcher_matches_recipe_and_fails_closed() -> None:
         "--decode-context-parallel-size 1",
         "--nnodes 2",
         "--distributed-executor-backend mp",
-        "--max-model-len 1048576",
-        "--max-num-seqs 32",
-        "--max-num-batched-tokens 8192",
+        'max_model_len=${MAX_MODEL_LEN:-1048576}',
+        'max_num_seqs=${MAX_NUM_SEQS:-32}',
+        'max_num_batched_tokens=${MAX_NUM_BATCHED_TOKENS:-8192}',
+        '--max-model-len "$max_model_len"',
+        '--max-num-seqs "$max_num_seqs"',
+        '--max-num-batched-tokens "$max_num_batched_tokens"',
         "--gpu-memory-utilization 0.70",
         "--kv-cache-dtype fp8",
+        'num_speculative_tokens=${NUM_SPECULATIVE_TOKENS:-3}',
         '"draft_sample_method":"probabilistic"',
         '"rejection_sample_method":"standard"',
         '"factor":4.0',
@@ -267,8 +297,11 @@ def test_quickstart_separates_normalized_and_shared_prefix_benchmarks() -> None:
     for required in (
         "runtime/qwen38/build-image.sh",
         "scripts/config/qwen38-27b-exl3-k5k6-pair.env.example",
+        'MODEL_DIR="$MODEL_HOST_PATH"',
+        'CACHE_DIR="$CACHE_HOST_PATH"',
+        'LOG_DIR="$LOG_HOST_PATH"',
         "/ws/qwen38_dgx2_serve.sh",
-        "--expected-max-model-len 1048576",
+        '--expected-max-model-len "$MAX_MODEL_LEN"',
         "temperature 1",
         "100% unique",
         "defer admission to the server",

--- a/scripts/test_qwen38_profile.py
+++ b/scripts/test_qwen38_profile.py
@@ -19,6 +19,16 @@ def _recipe() -> dict:
     return json.loads(RECIPE_PATH.read_text(encoding="utf-8"))
 
 
+def _env_values() -> dict[str, str]:
+    values: dict[str, str] = {}
+    for raw_line in ENV_PATH.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if line and not line.startswith("#"):
+            key, value = line.split("=", 1)
+            values[key] = value
+    return values
+
+
 def test_recipe_declares_the_four_spark_candidate() -> None:
     recipe = _recipe()
     assert recipe["schema"] == "sparkring-recipe/v1"
@@ -209,15 +219,36 @@ def test_environment_is_the_patched_nccl_cycle_without_model_foreign_knobs() -> 
         assert forbidden not in text
 
 
+def test_environment_operator_defaults_match_recipe() -> None:
+    values = _env_values()
+    serving = _recipe()["serving"]
+    assert int(values["API_PORT"]) == 8000
+    assert int(values["MASTER_PORT"]) == 29500
+    assert int(values["NUM_SPECULATIVE_TOKENS"]) == serving["speculation"][
+        "num_speculative_tokens"
+    ]
+    assert int(values["MAX_MODEL_LEN"]) == serving["max_model_len"]
+    assert int(values["MAX_NUM_SEQS"]) == serving["max_num_seqs"]
+    assert int(values["MAX_NUM_BATCHED_TOKENS"]) == serving[
+        "max_num_batched_tokens"
+    ]
+    assert "CACHE_HOST_PATH=/cache/qwen38-cycle" in ENV_PATH.read_text(
+        encoding="utf-8"
+    )
+
+
 def test_quickstart_command_matches_the_recipe() -> None:
     text = LAUNCHER_PATH.read_text(encoding="utf-8")
     for value in (
         "--tensor-parallel-size 4",
         "--nnodes 4",
         "--distributed-executor-backend mp",
-        "--max-model-len 1048576",
-        "--max-num-seqs 64",
-        "--max-num-batched-tokens 8192",
+        'max_model_len=${MAX_MODEL_LEN:-1048576}',
+        'max_num_seqs=${MAX_NUM_SEQS:-64}',
+        'max_num_batched_tokens=${MAX_NUM_BATCHED_TOKENS:-8192}',
+        '--max-model-len "$max_model_len"',
+        '--max-num-seqs "$max_num_seqs"',
+        '--max-num-batched-tokens "$max_num_batched_tokens"',
         "--enable-chunked-prefill",
         "--async-scheduling",
         "--scheduler-reserve-full-isl",
@@ -226,7 +257,7 @@ def test_quickstart_command_matches_the_recipe() -> None:
         "--enable-prefix-caching",
         "--mamba-cache-mode align",
         '"method":"qwen3_5_mtp"',
-        '"num_speculative_tokens":3',
+        'num_speculative_tokens=${NUM_SPECULATIVE_TOKENS:-3}',
         '"draft_sample_method":"probabilistic"',
         '"rejection_sample_method":"standard"',
         '"original_max_position_embeddings":262144',
@@ -252,8 +283,11 @@ def test_quickstart_command_matches_the_recipe() -> None:
         "--entrypoint /ws/venv/bin/hf",
         '"$IMAGE" --check',
         '"$IMAGE" --run',
-        "scripts/qwen38_smoke.py",
-        "ATTEMPT_ID must match [A-Za-z0-9_.-]+",
+            "scripts/qwen38_smoke.py",
+            'MODEL_DIR="$MODEL_HOST_PATH"',
+            'CACHE_DIR="$CACHE_HOST_PATH"',
+            'LOG_DIR="$LOG_HOST_PATH"',
+            "ATTEMPT_ID must match [A-Za-z0-9_.-]+",
         "container-id-${ATTEMPT_ID}-r${RANK}",
         "{{.State.Running}}",
         "/ws/runtime/source-receipt.json",
@@ -265,11 +299,9 @@ def test_quickstart_command_matches_the_recipe() -> None:
         "--ulimit memlock=-1:-1 --cap-add IPC_LOCK --device /dev/infiniband",
         '"$MODEL_DIR:/ws/model/Qwen3.8-27B-EXL3-K5K6-hydrated:ro"',
         '"$CACHE_DIR:/ws/cache"',
-        '"$LOG_DIR:/ws/logs"',
-        '"$ENV_FILE:/ws/rank.env:ro"',
-        '-e RANK="$RANK"',
-        '-e RANK0_RENDEZVOUS_ADDR="$RANK0_RENDEZVOUS_ADDR"',
-        "--label org.sparkring.profile=qwen38-27b-exl3-k5k6",
+            '"$LOG_DIR:/ws/logs"',
+            '"$ENV_FILE:/ws/rank.env:ro"',
+            "--label org.sparkring.profile=qwen38-27b-exl3-k5k6",
         "--entrypoint /ws/qwen38_dgx4_serve.sh",
     ):
         assert quickstart.count(shared_container_contract) == 2

--- a/scripts/test_qwen38_profile.py
+++ b/scripts/test_qwen38_profile.py
@@ -1,4 +1,4 @@
-"""GPU-free contracts for the Qwen3.8-27B four-Spark candidate profile."""
+"""GPU-free contracts for the implemented Qwen3.8-27B four-Spark profile."""
 
 from __future__ import annotations
 
@@ -29,7 +29,7 @@ def _env_values() -> dict[str, str]:
     return values
 
 
-def test_recipe_declares_the_four_spark_candidate() -> None:
+def test_recipe_declares_the_four_spark_profile() -> None:
     recipe = _recipe()
     assert recipe["schema"] == "sparkring-recipe/v1"
     assert recipe["recipe_id"] == "qwen38-27b-exl3-k5k6"


### PR DESCRIPTION
## Result

- Adds two-rank and four-rank DeepSeek launchers that validate per-rank environment contracts before rendering or starting containers.
- Makes supported DeepSeek and Qwen serving limits configurable through topology-specific sanitized inputs.
- Binds both DeepSeek launcher image literals to the canonical immutable digest in `runtime/faststart-lock.json` through an offline regression test.
- Documents pair and cycle inputs as separate canonical interfaces and routes dated diagnostic evidence to the profile record.

## Technical reason

Serving values previously appeared in multiple scripts and guides without one validated operator input per topology. The environment contracts now carry site-specific paths, ports, topology values, and supported serving limits while tests verify recipe and launcher agreement.

## Compatibility

The checked-in defaults preserve the recorded serving geometry and immutable image identity. The launchers have `implemented` status. Offline validation does not qualify Docker execution, CUDA, RDMA, cross-rank rendezvous, checkpoint bytes, or live serving. Existing benchmark results and their stated limitations are unchanged.

## Validation

- `ruff check --select E,F,W --ignore E501 spark_transport runtime scripts performance`
- `python -m pytest spark_transport runtime/exl3-r7 runtime/deepseek0731-gb10 runtime/qwen38 runtime/test_public_overlay.py performance/harnesses scripts -q -rs`
- Result: 1,878 passed, 9 environment-dependent skips