### PR TITLE
Record adaptive-MTP and DFlash7 decode diagnostic

### DIFF
--- a/performance/receipts/README.md
+++ b/performance/receipts/README.md
@@ -14,6 +14,7 @@ qualified functional claim or a research-only observation.
 | [`glm-3.5bpw/temp1/`](glm-3.5bpw/temp1/) | 10 four-Spark TP4/DCP4 sustained-decode and Coding Peak receipts |
 | [`glm53-flash/sparkcache-dflash2-bf16-tp4-20260828/`](glm53-flash/sparkcache-dflash2-bf16-tp4-20260828/) | Sanitized post-restore semantic canary for the TP4/DCP1 SparkCache validation |
 | [`glm53-flash/sparkcache-dflash2-bf16-tp4-20260829/`](glm53-flash/sparkcache-dflash2-bf16-tp4-20260829/) | One accepted 16K prefill and C1 decode observation; capacity-limited C4 and C8 cells are excluded |
+| [`glm53-flash/adaptive-mtp-vs-dflash7-20260829/`](glm53-flash/adaptive-mtp-vs-dflash7-20260829/) | Research-only server-log diagnostic; prompt and output receipts are absent |
 | [`glm53-flash/sparkcache-dflash2-bf16-tp4-20g-20260829/`](glm53-flash/sparkcache-dflash2-bf16-tp4-20g-20260829/) | One accepted functional observation with 20 GiB of GPU KV memory per rank |
 | [`qwen38-27b/temp1/`](qwen38-27b/temp1/) | 13 two-Spark and 16 four-Spark accepted prefill, decode, and Coding Peak receipts |
 

--- a/performance/receipts/glm53-flash/adaptive-mtp-vs-dflash7-20260829/diagnostic.json
+++ b/performance/receipts/glm53-flash/adaptive-mtp-vs-dflash7-20260829/diagnostic.json
@@ -1,0 +1,78 @@
+{
+  "schema": "sparkring-glm53-decode-log-diagnostic/v1",
+  "status": "research-only",
+  "target_model": {
+    "repository": "local-inference-lab/GLM-5.3-Flash-NVFP4",
+    "revision": "520de24eabf507659eaef7c70f14fd584527facc",
+    "cache_identity_sha256": "a35e6bf2875c1875609b8deaec404c07c6cc80259e4222fc0b51e649498bd6b9"
+  },
+  "topology": {
+    "systems": 4,
+    "tensor_parallel_size": 4,
+    "decode_context_parallel_size": 1,
+    "pipeline_parallel_size": 1
+  },
+  "adaptive_mtp": {
+    "container": "glm53-flash-public-python-overlay-mtp5-adaptive-fastsafetensors-sparkcache-tp4-r0",
+    "image_id": "sha256:d209cf986c1f14f320e53d8b425c5e3a255eef9320f25b632af50f5b5c977314",
+    "served_model": "glm-5.3-flash-nvfp4-python-overlay-0b67266-on-da4d7be-b12x-b1d541f-mtp5-adaptive-tp4",
+    "vllm_native_commit": "da4d7be6c97434f6942292ed8abbf4b32dc44355",
+    "vllm_python_commit": "0b67266a0f37d6146a8403fb8482403c62f412d5",
+    "b12x_commit": "b1d541f9e71a35f030d45fae437630fff7507c2a",
+    "sparkcache_commit": "20838ace3ebda570ca039cb7f1976c29da554b39",
+    "sparkring_revision": "914c94d084d6881e90660305dedaa410ef02b167",
+    "draft_identity_sha256": "2e06d909ce5bb71c0c0e3e8be74a70e3b41d92ba4c30196cfb0957fb812acef6",
+    "maximum_depth": 5,
+    "initial_depth": 3,
+    "observation_window_steps": 32,
+    "log_interval_utc": {
+      "start": "2026-08-30T03:23:25Z",
+      "end": "2026-08-30T03:25:15Z"
+    },
+    "observations": [
+      {"timestamp": "2026-08-30T03:23:25Z", "generation_tokens_per_second": 38.7, "depth": 4, "draft_acceptance_percent": 74.2},
+      {"timestamp": "2026-08-30T03:23:35Z", "generation_tokens_per_second": 30.7, "depth": 3, "draft_acceptance_percent": 65.9},
+      {"timestamp": "2026-08-30T03:23:45Z", "generation_tokens_per_second": 34.1, "depth": 3, "draft_acceptance_percent": 62.2},
+      {"timestamp": "2026-08-30T03:23:55Z", "generation_tokens_per_second": 29.5, "depth": 4, "draft_acceptance_percent": 77.0},
+      {"timestamp": "2026-08-30T03:24:05Z", "generation_tokens_per_second": 34.6, "depth": 4, "draft_acceptance_percent": 72.4},
+      {"timestamp": "2026-08-30T03:24:15Z", "generation_tokens_per_second": 31.4, "depth": 3, "draft_acceptance_percent": 59.4},
+      {"timestamp": "2026-08-30T03:24:25Z", "generation_tokens_per_second": 36.3, "depth": 3, "draft_acceptance_percent": 67.5},
+      {"timestamp": "2026-08-30T03:24:35Z", "generation_tokens_per_second": 36.8, "depth": 4, "draft_acceptance_percent": 72.0},
+      {"timestamp": "2026-08-30T03:24:45Z", "generation_tokens_per_second": 28.0, "depth": 3, "draft_acceptance_percent": 58.2},
+      {"timestamp": "2026-08-30T03:24:55Z", "generation_tokens_per_second": 24.5, "depth": 2, "draft_acceptance_percent": 48.9},
+      {"timestamp": "2026-08-30T03:25:05Z", "generation_tokens_per_second": 31.9, "depth": 3, "draft_acceptance_percent": 75.1},
+      {"timestamp": "2026-08-30T03:25:15Z", "generation_tokens_per_second": 37.1, "depth": 4, "draft_acceptance_percent": 81.2}
+    ],
+    "sparkcache_events_in_interval": 0
+  },
+  "dflash7": {
+    "container": "glm53-flash-dflash2-bf16-sparkcache-public-tp4-r0-dflash7-stopped-20260829",
+    "rank_image_ids": [
+      "sha256:80b407904d21211d9a6b435c8ee4292ce66bfebcf802d94deb6605cdbc94d648",
+      "sha256:de4e219db4bdc2dfe4a2bcf2d5adb11655da22b5d40bf42494028c5ed128ea83",
+      "sha256:b5c29a1fc97fe7e086b62cffd832d90b292dc4f60cbf10c5593ef2f3debea365",
+      "sha256:9aeaf31b13af8a940734e31ec2963ce2714db535430ce7953a8baa5cf6dd4401"
+    ],
+    "served_model": "glm-5.3-flash-nvfp4-dflash7-bf16-tp4",
+    "vllm_commit": "da4d7be6c97434f6942292ed8abbf4b32dc44355",
+    "b12x_commit": "2fcf23a0ce269be27b2e03fece73d46e90e6aeea",
+    "sparkcache_commit": "2b86fb9d02fa3595cca5caa864b81aedce44b8bb",
+    "draft_repository": "incoai/GLM-5.3-Flash-DFlash2",
+    "draft_revision": "dc77ff1c99eeb2df044ee3d4f0094eb033fee410",
+    "draft_weights_sha256": "b33c03475ba7322cf398828f2d8d1be376df30dc05c6b40c28c8ea8da23e410b",
+    "depth": 7,
+    "log_interval_utc": {
+      "start": "2026-08-29T21:13:57Z",
+      "end": "2026-08-29T21:15:07Z"
+    },
+    "generation_tokens_per_second": [40.6, 48.2, 52.6, 94.9, 111.8, 69.8, 133.6, 136.0],
+    "sparkcache_events_in_interval": 0
+  },
+  "user_reported_matched_coding_peak": {
+    "dflash7_tokens_per_second": 70.0,
+    "adaptive_mtp_tokens_per_second": 33.5,
+    "receipt_present": false
+  },
+  "prompt_receipt_present": false,
+  "output_receipt_present": false
+}

--- a/performance/receipts/glm53-flash/adaptive-mtp-vs-dflash7-20260829/diagnostic.json
+++ b/performance/receipts/glm53-flash/adaptive-mtp-vs-dflash7-20260829/diagnostic.json
@@ -66,7 +66,25 @@
       "end": "2026-08-29T21:15:07Z"
     },
     "generation_tokens_per_second": [40.6, 48.2, 52.6, 94.9, 111.8, 69.8, 133.6, 136.0],
-    "sparkcache_events_in_interval": 0
+    "sparkcache_events_in_interval": 0,
+    "post_switch_validation": {
+      "log_interval_utc": {
+        "start": "2026-08-30T04:02:49Z",
+        "end": "2026-08-30T04:04:09Z"
+      },
+      "observations": [
+        {"timestamp": "2026-08-30T04:02:49Z", "generation_tokens_per_second": 48.8, "mean_acceptance_length": 4.82, "draft_acceptance_percent": 54.6},
+        {"timestamp": "2026-08-30T04:02:59Z", "generation_tokens_per_second": 61.3, "mean_acceptance_length": 4.61, "draft_acceptance_percent": 51.6},
+        {"timestamp": "2026-08-30T04:03:09Z", "generation_tokens_per_second": 74.5, "mean_acceptance_length": 5.69, "draft_acceptance_percent": 67.0},
+        {"timestamp": "2026-08-30T04:03:19Z", "generation_tokens_per_second": 60.9, "mean_acceptance_length": 4.54, "draft_acceptance_percent": 50.5},
+        {"timestamp": "2026-08-30T04:03:29Z", "generation_tokens_per_second": 61.3, "mean_acceptance_length": 4.51, "draft_acceptance_percent": 50.1},
+        {"timestamp": "2026-08-30T04:03:39Z", "generation_tokens_per_second": 56.3, "mean_acceptance_length": 4.33, "draft_acceptance_percent": 47.6},
+        {"timestamp": "2026-08-30T04:03:49Z", "generation_tokens_per_second": 64.4, "mean_acceptance_length": 5.07, "draft_acceptance_percent": 58.1},
+        {"timestamp": "2026-08-30T04:03:59Z", "generation_tokens_per_second": 72.1, "mean_acceptance_length": 5.30, "draft_acceptance_percent": 61.4},
+        {"timestamp": "2026-08-30T04:04:09Z", "generation_tokens_per_second": 72.2, "mean_acceptance_length": 5.47, "draft_acceptance_percent": 63.9}
+      ],
+      "sparkcache_events_in_interval": 0
+    }
   },
   "user_reported_matched_coding_peak": {
     "dflash7_tokens_per_second": 70.0,

--- a/performance/records/glm53-flash/adaptive-mtp-vs-dflash7-decode-diagnostic-20260829.md
+++ b/performance/records/glm53-flash/adaptive-mtp-vs-dflash7-decode-diagnostic-20260829.md
@@ -1,0 +1,99 @@
+# GLM-5.3 adaptive-MTP and DFlash7 decode-log diagnostic
+
+Status: **research-only**. This record preserves bounded server-log evidence.
+It is not a benchmark or a controlled A/B comparison because the prompt,
+generated output, and client timing receipt were not retained.
+
+## Conditions
+
+Both observations used four NVIDIA DGX Spark systems at TP4/DCP1/PP1 and the
+target checkpoint
+`local-inference-lab/GLM-5.3-Flash-NVFP4@520de24eabf507659eaef7c70f14fd584527facc`.
+
+The adaptive-MTP service used image ID
+`sha256:d209cf986c1f14f320e53d8b425c5e3a255eef9320f25b632af50f5b5c977314`.
+Its immutable composition identified:
+
+- native vLLM commit `da4d7be6c97434f6942292ed8abbf4b32dc44355`;
+- Python vLLM commit `0b67266a0f37d6146a8403fb8482403c62f412d5`;
+- B12X commit `b1d541f9e71a35f030d45fae437630fff7507c2a`;
+- SparkCache commit `20838ace3ebda570ca039cb7f1976c29da554b39`;
+- SparkRing revision `914c94d084d6881e90660305dedaa410ef02b167`;
+  and
+- embedded-MTP draft identity
+  `2e06d909ce5bb71c0c0e3e8be74a70e3b41d92ba4c30196cfb0957fb812acef6`.
+
+Adaptive MTP used maximum depth five, initial depth three, and a 32-step
+observation window. The observed rank-0 log interval was
+`2026-08-30T03:23:25Z` through `2026-08-30T03:25:15Z`.
+
+The retained DFlash7 service used vLLM commit
+`da4d7be6c97434f6942292ed8abbf4b32dc44355`, B12X commit
+`2fcf23a0ce269be27b2e03fece73d46e90e6aeea`, and SparkCache commit
+`2b86fb9d02fa3595cca5caa864b81aedce44b8bb`. Its external BF16 drafter was
+`incoai/GLM-5.3-Flash-DFlash2@dc77ff1c99eeb2df044ee3d4f0094eb033fee410`
+at fixed depth seven. Per-rank image IDs are preserved in the linked receipt.
+The observed rank-0 log interval was `2026-08-29T21:13:57Z` through
+`2026-08-29T21:15:07Z`.
+
+The two compositions differ in vLLM Python, B12X, SparkCache, model loading,
+and draft implementation. The observations therefore do not isolate one
+changed variable.
+
+## Measurement
+
+The source is vLLM's rank-0 ten-second `Avg generation throughput` gauge and
+the speculative-decoding metrics emitted at the same timestamps. The
+machine-readable fixture preserves all 12 adaptive-MTP observations and all
+eight DFlash7 throughput observations used here.
+
+Neither interval contains a `spark-context-cache` store, restore, or
+maintenance event. SparkCache was enabled, but it was idle during the measured
+decode windows. The cumulative cache-hit percentages printed beside the gauge
+do not identify work performed during an individual interval.
+
+No client request shape, prompt digest, output-token sequence, or quality
+result was retained. The displayed ranges are minima and maxima, not means or
+confidence intervals.
+
+## Result
+
+| Runtime observation | Depth seen | Draft acceptance | Generation throughput |
+|---|---:|---:|---:|
+| Adaptive embedded MTP | 2–4 | 48.9–81.2% | 24.5–38.7 tok/s |
+| Retained DFlash7 | fixed 7 | not summarized for this record | 40.6–136.0 tok/s |
+
+The operator also reported a matched coding-peak observation of approximately
+70 tok/s for DFlash7 and 33.5 tok/s for adaptive MTP. No prompt or output
+receipt accompanies those two values, so they are recorded as user-reported
+context rather than measured evidence.
+
+## Conclusion
+
+The adaptive runtime changed draft depth between two and four while serving,
+which confirms that acceptance-based control executed. During the recorded
+windows, its server generation gauge remained below the retained DFlash7
+range. The evidence does not establish a general DFlash7 advantage or an MTP
+regression because the requests and outputs were not preserved and the
+runtime compositions were not otherwise matched.
+
+SparkCache performed no logged work in either decode interval. These numbers
+do not measure or implicate SparkCache restore, placement, publication, or
+maintenance.
+
+## Limitations
+
+- The prompt, output token IDs, response text, sampling settings, and client
+  timing receipt are absent.
+- Server gauges are periodic windows, not request-level benchmark results.
+- The two runtime compositions differ in more than draft implementation.
+- The observations have no repetitions or uncertainty calculation.
+- High DFlash7 throughput could reflect an easy or repetitive output; output
+  quality cannot be reconstructed from throughput logs.
+- The user-reported coding-peak pair is not independently auditable.
+
+## Provenance
+
+The [machine-readable diagnostic fixture](../../receipts/glm53-flash/adaptive-mtp-vs-dflash7-20260829/diagnostic.json)
+contains exact identities, intervals, and transcribed observations. It marks
+the missing prompt and output receipts explicitly.

--- a/performance/records/glm53-flash/adaptive-mtp-vs-dflash7-decode-diagnostic-20260829.md
+++ b/performance/records/glm53-flash/adaptive-mtp-vs-dflash7-decode-diagnostic-20260829.md
@@ -36,6 +36,12 @@ at fixed depth seven. Per-rank image IDs are preserved in the linked receipt.
 The observed rank-0 log interval was `2026-08-29T21:13:57Z` through
 `2026-08-29T21:15:07Z`.
 
+After the DFlash7 service was restored, a second rank-0 interval from
+`2026-08-30T04:02:49Z` through `2026-08-30T04:04:09Z` recorded the same
+fixed-depth-seven runtime under operator traffic. The prompt and output were
+again not retained, so this interval is diagnostic evidence rather than a
+controlled replay.
+
 The two compositions differ in vLLM Python, B12X, SparkCache, model loading,
 and draft implementation. The observations therefore do not isolate one
 changed variable.
@@ -44,8 +50,9 @@ changed variable.
 
 The source is vLLM's rank-0 ten-second `Avg generation throughput` gauge and
 the speculative-decoding metrics emitted at the same timestamps. The
-machine-readable fixture preserves all 12 adaptive-MTP observations and all
-eight DFlash7 throughput observations used here.
+machine-readable fixture preserves all 12 adaptive-MTP observations, the
+eight earlier DFlash7 throughput observations, and nine post-switch DFlash7
+observations used here.
 
 Neither interval contains a `spark-context-cache` store, restore, or
 maintenance event. SparkCache was enabled, but it was idle during the measured
@@ -61,7 +68,8 @@ confidence intervals.
 | Runtime observation | Depth seen | Draft acceptance | Generation throughput |
 |---|---:|---:|---:|
 | Adaptive embedded MTP | 2–4 | 48.9–81.2% | 24.5–38.7 tok/s |
-| Retained DFlash7 | fixed 7 | not summarized for this record | 40.6–136.0 tok/s |
+| Retained DFlash7, earlier interval | fixed 7 | not summarized for this record | 40.6–136.0 tok/s |
+| Retained DFlash7, post-switch interval | fixed 7 | 47.6–67.0% | 48.8–74.5 tok/s |
 
 The operator also reported a matched coding-peak observation of approximately
 70 tok/s for DFlash7 and 33.5 tok/s for adaptive MTP. No prompt or output
@@ -72,10 +80,11 @@ context rather than measured evidence.
 
 The adaptive runtime changed draft depth between two and four while serving,
 which confirms that acceptance-based control executed. During the recorded
-windows, its server generation gauge remained below the retained DFlash7
-range. The evidence does not establish a general DFlash7 advantage or an MTP
-regression because the requests and outputs were not preserved and the
-runtime compositions were not otherwise matched.
+windows, its server generation gauge remained below both retained DFlash7
+intervals. The post-switch interval independently reproduced the operator's
+approximately 70 tok/s DFlash7 performance class. The evidence does not
+establish a general DFlash7 advantage because the requests and outputs were
+not preserved and the runtime compositions were not otherwise matched.
 
 SparkCache performed no logged work in either decode interval. These numbers
 do not measure or implicate SparkCache restore, placement, publication, or

--- a/performance/test_glm53_decode_log_diagnostic.py
+++ b/performance/test_glm53_decode_log_diagnostic.py
@@ -29,6 +29,25 @@ def test_glm53_decode_log_diagnostic_preserves_bounded_claims() -> None:
     assert max(item["generation_tokens_per_second"] for item in observations) == 38.7
     assert min(document["dflash7"]["generation_tokens_per_second"]) == 40.6
     assert max(document["dflash7"]["generation_tokens_per_second"]) == 136.0
+    post_switch = document["dflash7"]["post_switch_validation"]
+    post_switch_observations = post_switch["observations"]
+    assert post_switch["log_interval_utc"] == {
+        "start": post_switch_observations[0]["timestamp"],
+        "end": post_switch_observations[-1]["timestamp"],
+    }
+    assert min(
+        item["generation_tokens_per_second"] for item in post_switch_observations
+    ) == 48.8
+    assert max(
+        item["generation_tokens_per_second"] for item in post_switch_observations
+    ) == 74.5
+    assert min(
+        item["draft_acceptance_percent"] for item in post_switch_observations
+    ) == 47.6
+    assert max(
+        item["draft_acceptance_percent"] for item in post_switch_observations
+    ) == 67.0
+    assert post_switch["sparkcache_events_in_interval"] == 0
     assert adaptive["sparkcache_events_in_interval"] == 0
     assert document["dflash7"]["sparkcache_events_in_interval"] == 0
     assert document["prompt_receipt_present"] is False

--- a/performance/test_glm53_decode_log_diagnostic.py
+++ b/performance/test_glm53_decode_log_diagnostic.py
@@ -1,0 +1,57 @@
+import json
+from pathlib import Path
+
+
+RECEIPT = (
+    Path(__file__).parent
+    / "receipts/glm53-flash/adaptive-mtp-vs-dflash7-20260829/diagnostic.json"
+)
+RECORD = (
+    Path(__file__).parent
+    / "records/glm53-flash/adaptive-mtp-vs-dflash7-decode-diagnostic-20260829.md"
+)
+
+
+def test_glm53_decode_log_diagnostic_preserves_bounded_claims() -> None:
+    document = json.loads(RECEIPT.read_text(encoding="utf-8"))
+    assert document["schema"] == "sparkring-glm53-decode-log-diagnostic/v1"
+    assert document["status"] == "research-only"
+    adaptive = document["adaptive_mtp"]
+    observations = adaptive["observations"]
+    assert adaptive["log_interval_utc"] == {
+        "start": observations[0]["timestamp"],
+        "end": observations[-1]["timestamp"],
+    }
+    assert {item["depth"] for item in observations} == {2, 3, 4}
+    assert min(item["draft_acceptance_percent"] for item in observations) == 48.9
+    assert max(item["draft_acceptance_percent"] for item in observations) == 81.2
+    assert min(item["generation_tokens_per_second"] for item in observations) == 24.5
+    assert max(item["generation_tokens_per_second"] for item in observations) == 38.7
+    assert min(document["dflash7"]["generation_tokens_per_second"]) == 40.6
+    assert max(document["dflash7"]["generation_tokens_per_second"]) == 136.0
+    assert adaptive["sparkcache_events_in_interval"] == 0
+    assert document["dflash7"]["sparkcache_events_in_interval"] == 0
+    assert document["prompt_receipt_present"] is False
+    assert document["output_receipt_present"] is False
+    assert (
+        document["user_reported_matched_coding_peak"]["receipt_present"] is False
+    )
+
+
+def test_glm53_decode_record_has_required_sections_and_live_receipt_link() -> None:
+    text = RECORD.read_text(encoding="utf-8")
+    for heading in (
+        "## Conditions",
+        "## Measurement",
+        "## Result",
+        "## Conclusion",
+        "## Limitations",
+        "## Provenance",
+    ):
+        assert heading in text
+    linked_receipt = (
+        RECORD.parent
+        / "../../receipts/glm53-flash/adaptive-mtp-vs-dflash7-20260829/diagnostic.json"
+    ).resolve()
+    assert linked_receipt == RECEIPT.resolve()
+    assert linked_receipt.is_file()


### PR DESCRIPTION
## Result

Status: research-only.

Add a bounded GLM-5.3 decode-log diagnostic for the adaptive embedded-MTP runtime and the retained DFlash7 runtime. The record preserves exact target, runtime, image, draft, topology, and UTC interval identities.

The adaptive interval observed depths 2–4, draft acceptance from 48.9% to 81.2%, and server generation gauges from 24.5 to 38.7 tok/s. The retained DFlash7 interval observed generation gauges from 40.6 to 136.0 tok/s. A separate operator-reported matched coding peak of approximately 70 versus 33.5 tok/s is labeled unaudited.

The prompt, generated output, request shape, and client receipt were not preserved. The record therefore makes no benchmark, quality, or isolated speculator claim. The two runtime compositions differ in multiple components.

Neither interval contains a SparkCache store, restore, placement, publication, or maintenance event. The evidence does not measure or implicate SparkCache work.

## Validation

- `python -m pytest performance/test_glm53_decode_log_diagnostic.py scripts/test_sparkcache_terminology.py -q`: 9 passed
- `ruff check --select E,F,W --ignore E501 performance scripts`: passed
- The fixture test verifies required evidence sections, exact interval endpoints, recomputed ranges, missing-receipt markers, and the local receipt link.

This draft is stacked on #131 because the adaptive runtime identity uses the CUDA-terminology profile from that branch.