### PR TITLE
Honor the DFlash draft load config

### DIFF
--- a/runtime/glm53-flash-adaptive-mtp-python-overlay/Containerfile
+++ b/runtime/glm53-flash-adaptive-mtp-python-overlay/Containerfile
@@ -83,6 +83,17 @@ RUN python3 "${PYTHON_OVERLAY_ROOT}/overlay_contract.py" \
       verify-files \
       --root /usr/local/lib/python3.12/dist-packages \
       --stage target
+COPY bundle/runtime/patches/010-dflash-draft-load-config.patch \
+  ${PYTHON_OVERLAY_ROOT}/patches/010-dflash-draft-load-config.patch
+RUN root=/usr/local/lib/python3.12/dist-packages; \
+    target="${root}/vllm/v1/worker/gpu/spec_decode/dflash/utils.py"; \
+    before="$(sha256sum "${target}" | cut -d' ' -f1)"; \
+    printf 'dflash_loader_preimage_sha256=%s\n' "${before}"; \
+    test "${before}" = 2301c8199b73ed893dfbd3ae14ad125816f100b2d2ed034215b1f2d9aa2c23c5; \
+    patch --batch --forward -p1 -d "${root}" \
+      < "${PYTHON_OVERLAY_ROOT}/patches/010-dflash-draft-load-config.patch"; \
+    test "$(sha256sum "${target}" | cut -d' ' -f1)" = \
+      98acbae2b3bb4482d83f9637c163ce7c92707ccdf6561b7e431f23337f151cf4
 
 COPY --from=b12x-wheel /out/wheels/ /opt/sparkring/wheelhouse/
 RUN uv pip install --system --reinstall --no-deps \
@@ -164,6 +175,8 @@ LABEL org.opencontainers.image.title="SparkRing GLM-5.3 adaptive-MTP Python over
       org.sparkring.vllm.python.commit="${VLLM_PYTHON_COMMIT}" \
       org.sparkring.vllm.python.tree="${VLLM_PYTHON_TREE}" \
       org.sparkring.vllm.python-overlay-manifest-sha256="${OVERLAY_MANIFEST_SHA256}" \
+      org.sparkring.vllm.dflash-draft-loader-patch-sha256="39b567013ee7aed79f63200ed460129587933dc77fb430decdf19f78178de279" \
+      org.sparkring.vllm.dflash-draft-loader-postimage-sha256="98acbae2b3bb4482d83f9637c163ce7c92707ccdf6561b7e431f23337f151cf4" \
       org.sparkring.vllm.native-elf-manifest-sha256="${NATIVE_ELF_MANIFEST_SHA256}" \
       org.sparkring.vllm.native-dispatch-manifest-sha256="${NATIVE_DISPATCH_MANIFEST_SHA256}" \
       org.jovian.b12x.commit="${B12X_COMMIT}" \

--- a/runtime/glm53-flash-adaptive-mtp-python-overlay/README.md
+++ b/runtime/glm53-flash-adaptive-mtp-python-overlay/README.md
@@ -53,6 +53,25 @@ commits into a temporary build context, builds a pure B12X wheel and the
 SparkCache CUDA placement library, creates the composed image, and writes a local
 receipt. It does not push an image or contact serving hosts.
 
+## External DFlash loader separation
+
+Status: **implemented, not qualified**. The composed vLLM runtime passes
+`SpeculativeConfig.draft_load_config` to the DFlash model loader. An external
+BF16 DFlash2 checkpoint can therefore retain the standard safetensors loader
+while the NVFP4 target uses fastsafetensors:
+
+```text
+--load-format fastsafetensors
+--speculative-config '{"method":"dflash","model":"/mtp-draft","num_speculative_tokens":7,"draft_tensor_parallel_size":4,"kv_cache_dtype":"auto","draft_sample_method":"probabilistic","rejection_sample_method":"standard","draft_load_config":{"load_format":"safetensors"}}'
+```
+
+Mount the exact external checkpoint read-only at `/mtp-draft`. The draft
+loader config is optional: omitting it inherits the target `LoadConfig`, which
+means both models use fastsafetensors under the command above. The separated
+configuration requires `fastsafetensors==0.3.3` for the target and no
+InstantTensor mount or environment setting. Four-rank model loading,
+generation, draft counters, and peak device memory remain unqualified.
+
 ## Resolve and inspect the four-rank plan
 
 Copy the sanitized site template outside version control and replace its

--- a/runtime/glm53-flash-adaptive-mtp-python-overlay/overlay_contract.py
+++ b/runtime/glm53-flash-adaptive-mtp-python-overlay/overlay_contract.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import ast
 import hashlib
 import importlib.metadata
 import inspect
@@ -116,6 +117,118 @@ def final_file_hashes(pins: dict[str, Any]) -> dict[str, str]:
             patch["postimage_sha256"], f"{target} patch postimage"
         )
     return result
+
+
+def validate_dflash_loader_source(source: str) -> None:
+    """Require DFlash to pass its optional draft LoadConfig to get_model."""
+
+    tree = ast.parse(source)
+    function = next(
+        (
+            node
+            for node in tree.body
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+            and node.name == "load_dflash_model"
+        ),
+        None,
+    )
+    if function is None:
+        raise ContractError("DFlash loader source omits load_dflash_model")
+    calls = [
+        node
+        for node in ast.walk(function)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "get_model"
+    ]
+    if len(calls) != 1:
+        raise ContractError("DFlash loader must contain exactly one get_model call")
+    keyword = next(
+        (item for item in calls[0].keywords if item.arg == "load_config"),
+        None,
+    )
+    value = None if keyword is None else keyword.value
+    if not (
+        isinstance(value, ast.Attribute)
+        and value.attr == "draft_load_config"
+        and isinstance(value.value, ast.Name)
+        and value.value.id == "speculative_config"
+    ):
+        raise ContractError(
+            "DFlash get_model must consume speculative_config.draft_load_config"
+        )
+
+
+def validate_optional_load_config_fallback(source: str) -> None:
+    """Require get_model(None) to retain the enclosing vLLM LoadConfig."""
+
+    tree = ast.parse(source)
+    function = next(
+        (
+            node
+            for node in tree.body
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+            and node.name == "get_model"
+        ),
+        None,
+    )
+    if function is None:
+        raise ContractError("model-loader source omits get_model")
+    calls = [
+        node
+        for node in ast.walk(function)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "get_model_loader"
+    ]
+    if len(calls) != 1 or len(calls[0].args) != 1:
+        raise ContractError("get_model must select exactly one model loader")
+    selected = calls[0].args[0]
+    if not (
+        isinstance(selected, ast.BoolOp)
+        and isinstance(selected.op, ast.Or)
+        and len(selected.values) == 2
+        and isinstance(selected.values[0], ast.Name)
+        and selected.values[0].id == "load_config"
+        and isinstance(selected.values[1], ast.Attribute)
+        and selected.values[1].attr == "load_config"
+        and isinstance(selected.values[1].value, ast.Name)
+        and selected.values[1].value.id == "vllm_config"
+    ):
+        raise ContractError(
+            "get_model must fall back from a missing draft LoadConfig to "
+            "vllm_config.load_config"
+        )
+
+
+def verify_vllm_runtime_patch_files(
+    root: Path,
+    pins: dict[str, Any],
+) -> list[dict[str, str]]:
+    """Verify installed runtime-patch postimages and loader semantics."""
+
+    verified = []
+    for record in pins["vllm"].get("runtime_patches", ()):
+        relative = safe_relative_path(record["target"])
+        path = root / relative
+        observed = sha256_file(path)
+        if observed != record["postimage_sha256"]:
+            raise ContractError(
+                f"vLLM runtime patch postimage mismatch for {relative}: "
+                f"expected {record['postimage_sha256']}, got {observed}"
+            )
+        compile(path.read_bytes(), str(path), "exec")
+        if relative.as_posix() == "vllm/v1/worker/gpu/spec_decode/dflash/utils.py":
+            validate_dflash_loader_source(path.read_text(encoding="utf-8"))
+        verified.append(
+            {
+                "path": relative.as_posix(),
+                "sha256": observed,
+            }
+        )
+    loader = root / "vllm/model_executor/model_loader/__init__.py"
+    validate_optional_load_config_fallback(loader.read_text(encoding="utf-8"))
+    return verified
 
 
 def verify_overlay_files(
@@ -372,12 +485,14 @@ def composed_report(
     verified = verify_overlay_files(root, manifest, stage="final", pins=pins)
     compile_overlay_files(root, manifest)
     verify_retained_native(site_root, console_script, base_record)
+    runtime_patches = verify_vllm_runtime_patch_files(root, pins)
     return {
         "schema": "sparkring-glm53-public-python-overlay-verification/v1",
         "status": "implemented",
         "vllm_python_files_verified": len(verified),
         "vllm_python_commit": pins["vllm"]["python_commit"],
         "vllm_native_commit": pins["vllm"]["native_commit"],
+        "vllm_runtime_patches": runtime_patches,
         "b12x": verify_b12x_contract(pins),
         "dependencies": verify_dependencies(pins),
         "native_elf_manifest_sha256": base_record["native_elf_manifest_sha256"],

--- a/runtime/glm53-flash-adaptive-mtp-python-overlay/patches/010-dflash-draft-load-config.patch
+++ b/runtime/glm53-flash-adaptive-mtp-python-overlay/patches/010-dflash-draft-load-config.patch
@@ -1,0 +1,13 @@
+diff --git a/vllm/v1/worker/gpu/spec_decode/dflash/utils.py b/vllm/v1/worker/gpu/spec_decode/dflash/utils.py
+index b9e6ea02f..84c7d54ac 100644
+--- a/vllm/v1/worker/gpu/spec_decode/dflash/utils.py
++++ b/vllm/v1/worker/gpu/spec_decode/dflash/utils.py
+@@ -46,5 +46,7 @@ def load_dflash_model(target_model: nn.Module, vllm_config: VllmConfig) -> nn.M
+     )
+     with set_model_tag("dflash_head"):
+         dflash_model = get_model(
+-            vllm_config=draft_vllm_config, model_config=draft_model_config
++            vllm_config=draft_vllm_config,
++            model_config=draft_model_config,
++            load_config=speculative_config.draft_load_config,
+         )

--- a/runtime/glm53-flash-adaptive-mtp-python-overlay/pins.json
+++ b/runtime/glm53-flash-adaptive-mtp-python-overlay/pins.json
@@ -28,6 +28,17 @@
     "python_tree": "ba9484ccb33aa56e90ff2f447f15ca9b9da97639",
     "overlay_manifest": "runtime/glm53-flash-adaptive-mtp-python-overlay/vllm-python-overlay.json",
     "overlay_manifest_sha256": "e5e528288b173399611a4930fecc4182b7208bc1564881d52ca5d2c5c4ae0f6a",
+    "runtime_patches": [
+      {
+        "status": "implemented",
+        "path": "runtime/glm53-flash-adaptive-mtp-python-overlay/patches/010-dflash-draft-load-config.patch",
+        "target": "vllm/v1/worker/gpu/spec_decode/dflash/utils.py",
+        "sha256": "39b567013ee7aed79f63200ed460129587933dc77fb430decdf19f78178de279",
+        "preimage_sha256": "2301c8199b73ed893dfbd3ae14ad125816f100b2d2ed034215b1f2d9aa2c23c5",
+        "postimage_sha256": "98acbae2b3bb4482d83f9637c163ce7c92707ccdf6561b7e431f23337f151cf4",
+        "contract": "DFlash passes SpeculativeConfig.draft_load_config to get_model; None retains the target LoadConfig fallback."
+      }
+    ],
     "native_source_objects": {
       "csrc": "9ada29088768f1bc08dadd2eed3c9738eb9ac8a1",
       "cmake": "5e5bbdbe1c1b3a479656d8d6a41cc32a1982c43d",

--- a/runtime/glm53-flash-adaptive-mtp-python-overlay/prepare_context.py
+++ b/runtime/glm53-flash-adaptive-mtp-python-overlay/prepare_context.py
@@ -72,6 +72,7 @@ def clone_detached(
     destination.mkdir(parents=True)
     run(("git", "init", "--quiet", str(destination)))
     run(("git", "-C", str(destination), "config", "core.autocrlf", "false"))
+    run(("git", "-C", str(destination), "config", "core.longpaths", "true"))
     run(("git", "-C", str(destination), "remote", "add", "origin", repository))
     run(
         (
@@ -172,6 +173,39 @@ def verify_vllm_lineage(
             raise PrepareError(f"vLLM base blob mismatch: {path}")
 
 
+def verify_vllm_runtime_patches(
+    source: Path,
+    pins: dict[str, Any],
+    patch_root: Path,
+) -> None:
+    """Verify each exact-input runtime patch and restore the clean source."""
+
+    for record in pins["vllm"].get("runtime_patches", ()):
+        patch = patch_root / Path(record["path"]).name
+        target = source / record["target"]
+        if sha256_file(patch) != record["sha256"]:
+            raise PrepareError(f"vLLM runtime patch mismatch: {record['path']}")
+        if sha256_file(target) != record["preimage_sha256"]:
+            raise PrepareError(
+                f"vLLM runtime patch preimage mismatch: {record['target']}"
+            )
+        run(("git", "-C", str(source), "apply", "--check", str(patch)))
+        run(("git", "-C", str(source), "apply", str(patch)))
+        try:
+            observed = sha256_file(target)
+            if observed != record["postimage_sha256"]:
+                raise PrepareError(
+                    f"vLLM runtime patch postimage mismatch: {record['target']}"
+                )
+        finally:
+            run(("git", "-C", str(source), "apply", "--reverse", str(patch)))
+    verify_git_source(
+        source,
+        commit=pins["vllm"]["python_commit"],
+        tree=pins["vllm"]["python_tree"],
+    )
+
+
 def copy_overlay(source: Path, destination: Path, manifest: dict[str, Any]) -> None:
     target = manifest["target"]["commit"]
     for record in manifest["files"]:
@@ -241,6 +275,8 @@ def prepare(output: Path, *, repository_root: Path = ROOT) -> dict[str, Any]:
     )
     verify_vllm_lineage(vllm, pins, manifest)
     copy_overlay(vllm, overlay, manifest)
+    patch_root = HERE / "patches"
+    verify_vllm_runtime_patches(vllm, pins, patch_root)
 
     b12x = sources / "b12x"
     clone_detached(
@@ -283,6 +319,11 @@ def prepare(output: Path, *, repository_root: Path = ROOT) -> dict[str, Any]:
         "README.md",
     ):
         copy_file(HERE / filename, runtime / filename)
+    runtime_patches = []
+    for patch in pins["vllm"].get("runtime_patches", ()):
+        name = Path(patch["path"]).name
+        copy_file(patch_root / name, runtime / "patches" / name)
+        runtime_patches.append(f"bundle/runtime/patches/{name}")
     copy_file(repository_root / "LICENSE", runtime / "SparkRing-LICENSE")
 
     receipt_inputs = tuple(
@@ -297,7 +338,7 @@ def prepare(output: Path, *, repository_root: Path = ROOT) -> dict[str, Any]:
             "README.md",
             "SparkRing-LICENSE",
         )
-    )
+    ) + tuple(runtime_patches)
     receipt = {
         "schema": RECEIPT_SCHEMA,
         "status": "implemented",
@@ -318,6 +359,7 @@ def prepare(output: Path, *, repository_root: Path = ROOT) -> dict[str, Any]:
                 "source_tree_sha256": observed_sparkcache,
             },
         },
+        "vllm_runtime_patches": pins["vllm"].get("runtime_patches", []),
         "files": {relative: sha256_file(output / relative) for relative in receipt_inputs},
     }
     (output / "receipt.json").write_text(
@@ -344,6 +386,15 @@ def verify_context(context: Path) -> dict[str, Any]:
         tree=pins["vllm"]["python_tree"],
     )
     verify_vllm_lineage(context / "bundle/sources/vllm", pins, manifest)
+    if receipt.get("vllm_runtime_patches") != pins["vllm"].get(
+        "runtime_patches", []
+    ):
+        raise PrepareError("prepared context vLLM runtime patch receipt differs")
+    verify_vllm_runtime_patches(
+        context / "bundle/sources/vllm",
+        pins,
+        context / "bundle/runtime/patches",
+    )
     verify_git_source(
         context / "bundle/sources/b12x",
         commit=pins["b12x"]["commit"],

--- a/runtime/glm53-flash-adaptive-mtp-python-overlay/test_public_python_overlay.py
+++ b/runtime/glm53-flash-adaptive-mtp-python-overlay/test_public_python_overlay.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import hashlib
 import importlib.util
 import json
+import re
 from dataclasses import dataclass
 from pathlib import Path
 from types import SimpleNamespace
@@ -13,6 +14,7 @@ import pytest
 HERE = Path(__file__).resolve().parent
 PINS = HERE / "pins.json"
 MANIFEST = HERE / "vllm-python-overlay.json"
+DFLASH_PATCH = HERE / "patches/010-dflash-draft-load-config.patch"
 
 
 def _module(name: str, path: Path):
@@ -25,6 +27,7 @@ def _module(name: str, path: Path):
 
 contract = _module("glm53_public_python_overlay_contract", HERE / "overlay_contract.py")
 verify = _module("glm53_public_python_overlay_verify", HERE / "verify_image.py")
+prepare = _module("glm53_public_python_overlay_prepare", HERE / "prepare_context.py")
 
 
 def test_overlay_pins_public_base_and_mixed_vllm_provenance() -> None:
@@ -70,6 +73,93 @@ def test_overlay_manifest_is_the_exact_31_file_python_delta() -> None:
     assert hashlib.sha256(MANIFEST.read_bytes()).hexdigest() == pins["vllm"][
         "overlay_manifest_sha256"
     ]
+
+
+def test_dflash_loader_patch_binds_exact_0b_preimage_and_postimage() -> None:
+    pins = json.loads(PINS.read_text(encoding="utf-8"))
+    assert pins["vllm"]["runtime_patches"] == [
+        {
+            "status": "implemented",
+            "path": (
+                "runtime/glm53-flash-adaptive-mtp-python-overlay/patches/"
+                "010-dflash-draft-load-config.patch"
+            ),
+            "target": "vllm/v1/worker/gpu/spec_decode/dflash/utils.py",
+            "sha256": "39b567013ee7aed79f63200ed460129587933dc77fb430decdf19f78178de279",
+            "preimage_sha256": (
+                "2301c8199b73ed893dfbd3ae14ad125816f100b2d2ed034215b1f2d9aa2c23c5"
+            ),
+            "postimage_sha256": (
+                "98acbae2b3bb4482d83f9637c163ce7c92707ccdf6561b7e431f23337f151cf4"
+            ),
+            "contract": (
+                "DFlash passes SpeculativeConfig.draft_load_config to get_model; "
+                "None retains the target LoadConfig fallback."
+            ),
+        }
+    ]
+    assert prepare.sha256_file(DFLASH_PATCH) == pins["vllm"]["runtime_patches"][
+        0
+    ]["sha256"]
+
+
+def test_dflash_loader_contract_honors_explicit_draft_load_config() -> None:
+    contract.validate_dflash_loader_source(
+        """
+def load_dflash_model(target_model, vllm_config):
+    speculative_config = vllm_config.speculative_config
+    return get_model(
+        vllm_config=vllm_config,
+        model_config=speculative_config.draft_model_config,
+        load_config=speculative_config.draft_load_config,
+    )
+"""
+    )
+
+
+def test_dflash_loader_contract_rejects_an_ignored_draft_load_config() -> None:
+    with pytest.raises(contract.ContractError, match="draft_load_config"):
+        contract.validate_dflash_loader_source(
+            """
+def load_dflash_model(target_model, vllm_config):
+    speculative_config = vllm_config.speculative_config
+    return get_model(
+        vllm_config=vllm_config,
+        model_config=speculative_config.draft_model_config,
+    )
+"""
+        )
+
+
+def test_missing_draft_load_config_uses_the_target_load_config_fallback() -> None:
+    contract.validate_optional_load_config_fallback(
+        """
+def get_model(*, vllm_config, load_config=None):
+    loader = get_model_loader(load_config or vllm_config.load_config)
+    return loader.load_model()
+"""
+    )
+
+    with pytest.raises(contract.ContractError, match="fall back"):
+        contract.validate_optional_load_config_fallback(
+            """
+def get_model(*, vllm_config, load_config=None):
+    loader = get_model_loader(vllm_config.load_config)
+    return loader.load_model()
+"""
+        )
+
+
+def test_documented_dflash_config_separates_target_and_draft_loaders() -> None:
+    guide = (HERE / "README.md").read_text(encoding="utf-8")
+    match = re.search(r"--speculative-config '([^']+)'", guide)
+    assert match is not None
+    speculative = json.loads(match.group(1))
+    assert "--load-format fastsafetensors" in guide
+    assert speculative["method"] == "dflash"
+    assert speculative["model"] == "/mtp-draft"
+    assert speculative["num_speculative_tokens"] == 7
+    assert speculative["draft_load_config"] == {"load_format": "safetensors"}
 
 
 def test_native_build_inputs_are_identical_git_objects() -> None:
@@ -168,20 +258,23 @@ def test_image_verifier_reads_the_clean_sparkcache_source_receipt() -> None:
 
 def test_build_prepares_context_below_the_temporary_workspace() -> None:
     script = (HERE / "build-image.sh").read_text(encoding="utf-8")
+    preparer = (HERE / "prepare_context.py").read_text(encoding="utf-8")
     assert 'workspace="$(mktemp -d)"' in script
     assert 'context="${workspace}/context"' in script
     assert 'rm -rf -- "${workspace}"' in script
+    assert '"core.longpaths", "true"' in preparer
 
 
 def test_sparkcache_patches_and_contract_run_after_the_python_overlay() -> None:
     recipe = (HERE / "Containerfile").read_text(encoding="utf-8")
     overlay = recipe.index("COPY bundle/vllm-overlay/")
     patch_020 = recipe.index("020-sparkcache-vmm-exemption.patch")
+    dflash_patch = recipe.index("010-dflash-draft-load-config.patch")
     patch_030 = recipe.index("030-sparkcache-hma-load-failure.patch")
     patch_040 = recipe.index("040-sparkcache-shared-prefix-lease.patch")
     patch_041 = recipe.index("041-sparkcache-shared-prefix-attach.patch")
     lease = recipe.index("verify_lease_contract.py")
-    assert overlay < patch_020 < patch_030 < patch_040 < patch_041 < lease
+    assert overlay < dflash_patch < patch_020 < patch_030 < patch_040 < patch_041 < lease
 
 
 def test_output_labels_do_not_claim_a_source_built_0b_wheel() -> None:
@@ -194,3 +287,9 @@ def test_output_labels_do_not_claim_a_source_built_0b_wheel() -> None:
     assert labels["org.jovian.vllm.commit"] != labels[
         "org.sparkring.vllm.python.commit"
     ]
+    assert labels["org.sparkring.vllm.dflash-draft-loader-patch-sha256"] == (
+        "39b567013ee7aed79f63200ed460129587933dc77fb430decdf19f78178de279"
+    )
+    assert labels["org.sparkring.vllm.dflash-draft-loader-postimage-sha256"] == (
+        "98acbae2b3bb4482d83f9637c163ce7c92707ccdf6561b7e431f23337f151cf4"
+    )

--- a/runtime/glm53-flash-adaptive-mtp-python-overlay/verify_image.py
+++ b/runtime/glm53-flash-adaptive-mtp-python-overlay/verify_image.py
@@ -87,7 +87,7 @@ def validate_base(document: dict[str, Any], pins: dict[str, Any]) -> None:
 
 
 def expected_output_labels(pins: dict[str, Any]) -> dict[str, str]:
-    return {
+    labels = {
         "org.opencontainers.image.base.name": pins["public_base"]["reference"],
         "org.sparkring.base.image-id": pins["public_base"]["image_id"],
         "org.sparkring.vllm.native.commit": pins["vllm"]["native_commit"],
@@ -110,6 +110,17 @@ def expected_output_labels(pins: dict[str, Any]) -> dict[str, str]:
         ],
         "org.sparkcache.deployment-profile": "glm53-flash-adaptive-mtp-python-overlay",
     }
+    runtime_patches = pins["vllm"].get("runtime_patches", ())
+    if len(runtime_patches) != 1:
+        raise VerifyError("runtime contract requires one DFlash loader patch")
+    patch = runtime_patches[0]
+    labels["org.sparkring.vllm.dflash-draft-loader-patch-sha256"] = patch[
+        "sha256"
+    ]
+    labels["org.sparkring.vllm.dflash-draft-loader-postimage-sha256"] = patch[
+        "postimage_sha256"
+    ]
+    return labels
 
 
 def validate_output(document: dict[str, Any], pins: dict[str, Any]) -> None:
@@ -202,6 +213,15 @@ def verify_image(engine: str, image: str, pins_path: Path = PINS) -> dict[str, A
     artifacts = artifact_probe(engine, image)
     if runtime.get("vllm_python_files_verified") != 31:
         raise VerifyError("runtime did not verify all 31 vLLM Python overlay files")
+    expected_runtime_patches = [
+        {
+            "path": record["target"],
+            "sha256": record["postimage_sha256"],
+        }
+        for record in pins["vllm"].get("runtime_patches", ())
+    ]
+    if runtime.get("vllm_runtime_patches") != expected_runtime_patches:
+        raise VerifyError("runtime did not verify the DFlash draft-loader patch")
     if artifacts["sparkcache_contract_sha256"] != pins["sparkcache"]["contract"]["sha256"]:
         raise VerifyError("installed SparkCache lease contract differs from its pin")
     if artifacts["sparkcache_source_tree_sha256"] != pins["sparkcache"][

--- a/scripts/config/glm53-flash-public-python-overlay-mtp5-adaptive-fastsafetensors-sparkcache-tp4-dcp1.example.json
+++ b/scripts/config/glm53-flash-public-python-overlay-mtp5-adaptive-fastsafetensors-sparkcache-tp4-dcp1.example.json
@@ -137,6 +137,8 @@
     "org.sparkring.vllm.python.commit": "0b67266a0f37d6146a8403fb8482403c62f412d5",
     "org.sparkring.vllm.python.tree": "ba9484ccb33aa56e90ff2f447f15ca9b9da97639",
     "org.sparkring.vllm.python-overlay-manifest-sha256": "e5e528288b173399611a4930fecc4182b7208bc1564881d52ca5d2c5c4ae0f6a",
+    "org.sparkring.vllm.dflash-draft-loader-patch-sha256": "39b567013ee7aed79f63200ed460129587933dc77fb430decdf19f78178de279",
+    "org.sparkring.vllm.dflash-draft-loader-postimage-sha256": "98acbae2b3bb4482d83f9637c163ce7c92707ccdf6561b7e431f23337f151cf4",
     "org.sparkring.vllm.native-elf-manifest-sha256": "REPLACE_WITH_VLLM_NATIVE_ELF_MANIFEST_SHA256",
     "org.sparkring.vllm.native-dispatch-manifest-sha256": "REPLACE_WITH_VLLM_NATIVE_DISPATCH_MANIFEST_SHA256",
     "org.sparkring.b12x.tree": "c69cdec1c59a08e8e0e549f930fa8abcfb5134ae",

--- a/scripts/prepare_glm53_public_python_overlay_profile.py
+++ b/scripts/prepare_glm53_public_python_overlay_profile.py
@@ -47,6 +47,12 @@ B12X_TREE = "c69cdec1c59a08e8e0e549f930fa8abcfb5134ae"
 OVERLAY_MANIFEST_SHA256 = (
     "e5e528288b173399611a4930fecc4182b7208bc1564881d52ca5d2c5c4ae0f6a"
 )
+DFLASH_LOADER_PATCH_SHA256 = (
+    "39b567013ee7aed79f63200ed460129587933dc77fb430decdf19f78178de279"
+)
+DFLASH_LOADER_POSTIMAGE_SHA256 = (
+    "98acbae2b3bb4482d83f9637c163ce7c92707ccdf6561b7e431f23337f151cf4"
+)
 SPARKCACHE_COMMIT = "5d571018de5b63a9a90e5c11e6d6e86bbff4a957"
 SPARKCACHE_TREE = "e864ed9ad64f771188fdb59aa9738e348134d636"
 SPARKCACHE_SOURCE_SHA256 = (
@@ -208,6 +214,12 @@ def resolve(
         "org.sparkring.vllm.python.commit": VLLM_PYTHON_COMMIT,
         "org.sparkring.vllm.python.tree": VLLM_PYTHON_TREE,
         "org.sparkring.vllm.python-overlay-manifest-sha256": OVERLAY_MANIFEST_SHA256,
+        "org.sparkring.vllm.dflash-draft-loader-patch-sha256": (
+            DFLASH_LOADER_PATCH_SHA256
+        ),
+        "org.sparkring.vllm.dflash-draft-loader-postimage-sha256": (
+            DFLASH_LOADER_POSTIMAGE_SHA256
+        ),
         "org.jovian.b12x.commit": B12X_COMMIT,
         "org.sparkring.b12x.tree": B12X_TREE,
         "org.opencontainers.image.base.name": PUBLIC_BASE,

--- a/scripts/test_prepare_glm53_public_python_overlay_profile.py
+++ b/scripts/test_prepare_glm53_public_python_overlay_profile.py
@@ -10,6 +10,8 @@ import yaml
 import sparkring_generic_launcher as launcher
 from prepare_glm53_public_python_overlay_profile import (
     B12X_COMMIT,
+    DFLASH_LOADER_PATCH_SHA256,
+    DFLASH_LOADER_POSTIMAGE_SHA256,
     LEASE_CONTRACT_SHA256,
     MTP_CACHE_IDENTITY_SHA256,
     OVERLAY_MANIFEST_SHA256,
@@ -129,6 +131,12 @@ def test_resolver_requires_mixed_provenance_and_all_artifact_hashes() -> None:
     assert labels["org.opencontainers.image.base.name"] == PUBLIC_BASE
     assert labels["org.sparkring.vllm.python-overlay-manifest-sha256"] == (
         OVERLAY_MANIFEST_SHA256
+    )
+    assert labels["org.sparkring.vllm.dflash-draft-loader-patch-sha256"] == (
+        DFLASH_LOADER_PATCH_SHA256
+    )
+    assert labels["org.sparkring.vllm.dflash-draft-loader-postimage-sha256"] == (
+        DFLASH_LOADER_POSTIMAGE_SHA256
     )
     assert labels["org.sparkring.vllm.native-elf-manifest-sha256"] == NATIVE_ELF
     assert labels["org.sparkring.vllm.native-dispatch-manifest-sha256"] == (


### PR DESCRIPTION
## Resulting behavior

The composed vLLM `0b67266a0f37d6146a8403fb8482403c62f412d5` runtime passes `SpeculativeConfig.draft_load_config` into the DFlash `get_model()` call. A profile can therefore keep global target loading on fastsafetensors while loading the external BF16 DFlash2 checkpoint with standard safetensors.

The exact configuration shape is:

```text
--load-format fastsafetensors
--speculative-config '{"method":"dflash","model":"/mtp-draft","num_speculative_tokens":7,"draft_tensor_parallel_size":4,"kv_cache_dtype":"auto","draft_sample_method":"probabilistic","rejection_sample_method":"standard","draft_load_config":{"load_format":"safetensors"}}'
```

`draft_load_config` remains optional. When it is absent or `null`, vLLM's existing `get_model(load_config or vllm_config.load_config)` rule retains the global target loader for the draft.

## Exact source contract

- vLLM commit: `0b67266a0f37d6146a8403fb8482403c62f412d5`
- vLLM tree: `ba9484ccb33aa56e90ff2f447f15ca9b9da97639`
- target: `vllm/v1/worker/gpu/spec_decode/dflash/utils.py`
- preimage SHA-256: `2301c8199b73ed893dfbd3ae14ad125816f100b2d2ed034215b1f2d9aa2c23c5`
- patch SHA-256: `39b567013ee7aed79f63200ed460129587933dc77fb430decdf19f78178de279`
- postimage SHA-256: `98acbae2b3bb4482d83f9637c163ce7c92707ccdf6561b7e431f23337f151cf4`

The source preparer applies and reverses the patch against the immutable vLLM checkout to prove both byte boundaries. The prepared-context receipt, image labels, composed verifier, and profile label requirements bind the patch and postimage. GPU-free AST checks reject a DFlash loader that ignores `draft_load_config` and reject a model-loader implementation that loses the `None` fallback.

## Compatibility

This draft was created from exact SparkRing #131 commit `a7e5a70af1b7cb329651712a449c60f54b1d0ae5`. The #131 branch later added unrelated README commit `56b3a8f77d5b35a63bb97c213a73d34e5c178db6`; that commit is deliberately not folded into this exact-base branch.

No vLLM, B12X, SparkCache, NCCL, model, or image source commit changed. Existing MTP profile identity fields and SparkCache cache identity are unchanged. Cache namespace impact: **none**.

No image was built or published. No service or serving host was contacted or changed.

## Validation

- Focused runtime, resolver, terminology, and launcher tests: 42 passed.
- DFlash runtime and resolver tests: 23 passed.
- Fresh source-context preparation followed by independent receipt verification: passed.
- Ruff, JSON parsing, Python compilation, Bash syntax, and diff checks: passed.
- Maintained exact-base suite: 1,935 passed, 9 skipped, 1 inherited README assertion failure. The later #131 commit named above addresses that unrelated assertion outside this requested base.