### PR TITLE
Expose hash-proven recurrent replay boundaries

### DIFF
--- a/runtime/glm53-flash-adaptive-mtp-python-overlay/Containerfile
+++ b/runtime/glm53-flash-adaptive-mtp-python-overlay/Containerfile
@@ -85,6 +85,10 @@ RUN python3 "${PYTHON_OVERLAY_ROOT}/overlay_contract.py" \
       --stage target
 COPY bundle/runtime/patches/010-dflash-draft-load-config.patch \
   ${PYTHON_OVERLAY_ROOT}/patches/010-dflash-draft-load-config.patch
+COPY bundle/runtime/patches/011-recurrent-boundary-contract.patch \
+  ${PYTHON_OVERLAY_ROOT}/patches/011-recurrent-boundary-contract.patch
+COPY bundle/runtime/patches/012-recurrent-boundary-contract-tests.patch \
+  ${PYTHON_OVERLAY_ROOT}/patches/012-recurrent-boundary-contract-tests.patch
 RUN root=/usr/local/lib/python3.12/dist-packages; \
     target="${root}/vllm/v1/worker/gpu/spec_decode/dflash/utils.py"; \
     before="$(sha256sum "${target}" | cut -d' ' -f1)"; \
@@ -150,6 +154,19 @@ RUN set -eu; \
     python3 /opt/sparkcache-src/sparkcache/runtime_patches/verify_lease_contract.py \
       --vllm-root "${root}" \
       --contract /opt/sparkcache-src/sparkcache/runtime_patches/vllm-kv-block-lease-contract-glm53-b12x-kda-adaptive-mtp.json; \
+    recurrent_patch="${PYTHON_OVERLAY_ROOT}/patches/011-recurrent-boundary-contract.patch"; \
+    recurrent_tests="${PYTHON_OVERLAY_ROOT}/patches/012-recurrent-boundary-contract-tests.patch"; \
+    test "$(sha256sum "${recurrent_patch}" | cut -d' ' -f1)" = 5a6561a5bbab990dcd03bfd6a485ea26c3b5a578c2fd61b76305767b16dbfba0; \
+    test "$(sha256sum "${recurrent_tests}" | cut -d' ' -f1)" = 4a23f25b540760aa3f793427017e3ee39605e60de7af1b851cbbd6cc0faeddec; \
+    test "$(sha256sum "${root}/vllm/v1/core/kv_cache_manager.py" | cut -d' ' -f1)" = ee03dc9ce2b720c0be6e9f572d23580ba96eff68fe3406250557e83071654af0; \
+    test "$(sha256sum "${root}/vllm/v1/core/sched/output.py" | cut -d' ' -f1)" = 65235eba652e5a3ccee18bf3cbfeac9bf4da8fb9c61e961580f612cfb7e593bc; \
+    test "$(sha256sum "${root}/vllm/v1/core/sched/scheduler.py" | cut -d' ' -f1)" = 6d397c97f31e67a75efc01b5ddd89fa58db425de14fa43965ef2d6146b6b9bdb; \
+    test "$(sha256sum "${root}/vllm/v1/core/single_type_kv_cache_manager.py" | cut -d' ' -f1)" = e4b1c5c38b63b708fd55aa40a9ab0d008b266d006a63dcfcef55890ac1371cb8; \
+    patch --batch --forward -p1 -d "${root}" < "${recurrent_patch}"; \
+    test "$(sha256sum "${root}/vllm/v1/core/kv_cache_manager.py" | cut -d' ' -f1)" = c5b83d382c96b2bf8c466a993ed77123a14a971e2661797128533319388d0b5f; \
+    test "$(sha256sum "${root}/vllm/v1/core/sched/output.py" | cut -d' ' -f1)" = 9911b3f9d21815a185285852b5a6176e5484e1ab0ff5c30f7caaa68ea0fab543; \
+    test "$(sha256sum "${root}/vllm/v1/core/sched/scheduler.py" | cut -d' ' -f1)" = 260f36ce8fabf70c193b20009ea465eea7b1b6c8e9fb72f2307a01ba8fcf7b2a; \
+    test "$(sha256sum "${root}/vllm/v1/core/single_type_kv_cache_manager.py" | cut -d' ' -f1)" = f67a1850a7e0288baaa6d42e7ec55b22b09c156720767e23acaabedcae333c8a; \
     python3 "${PYTHON_OVERLAY_ROOT}/overlay_contract.py" \
       --pins "${PYTHON_OVERLAY_ROOT}/pins.json" \
       --manifest "${PYTHON_OVERLAY_ROOT}/vllm-python-overlay.json" \
@@ -177,6 +194,7 @@ LABEL org.opencontainers.image.title="SparkRing GLM-5.3 adaptive-MTP Python over
       org.sparkring.vllm.python-overlay-manifest-sha256="${OVERLAY_MANIFEST_SHA256}" \
       org.sparkring.vllm.dflash-draft-loader-patch-sha256="39b567013ee7aed79f63200ed460129587933dc77fb430decdf19f78178de279" \
       org.sparkring.vllm.dflash-draft-loader-postimage-sha256="98acbae2b3bb4482d83f9637c163ce7c92707ccdf6561b7e431f23337f151cf4" \
+      org.sparkring.vllm.recurrent-boundary-patch-sha256="5a6561a5bbab990dcd03bfd6a485ea26c3b5a578c2fd61b76305767b16dbfba0" \
       org.sparkring.vllm.native-elf-manifest-sha256="${NATIVE_ELF_MANIFEST_SHA256}" \
       org.sparkring.vllm.native-dispatch-manifest-sha256="${NATIVE_DISPATCH_MANIFEST_SHA256}" \
       org.jovian.b12x.commit="${B12X_COMMIT}" \
@@ -185,6 +203,6 @@ LABEL org.opencontainers.image.title="SparkRing GLM-5.3 adaptive-MTP Python over
       org.sparkcache.source-tree="${SPARKCACHE_TREE}" \
       org.sparkcache.source-sha256="${SPARKCACHE_SOURCE_SHA256}" \
       org.sparkcache.cuda-placement-library-sha256="${SPARKCACHE_CUDA_PLACEMENT_SHA256}" \
-      org.sparkcache.vllm-contract-sha256="6defde9551cbb586fd09bb2d3020495531b6573397875a767eaae1dbad126024" \
+      org.sparkcache.vllm-contract-sha256="45d7a92b38b836a4f829f02df85e339cfeea860e1080e4663a8340af6c125125" \
       org.sparkcache.deployment-profile="glm53-flash-adaptive-mtp-python-overlay" \
       org.sparkring.source-receipt-sha256="${SOURCE_RECEIPT_SHA256}"

--- a/runtime/glm53-flash-adaptive-mtp-python-overlay/README.md
+++ b/runtime/glm53-flash-adaptive-mtp-python-overlay/README.md
@@ -25,12 +25,21 @@ files. Construction fails if any retained artifact changes. The output labels
 identify the retained native commit and overlaid Python commit separately; the
 image is not described as a source-built vLLM 0b67266 wheel.
 
+The composed vLLM source also provides the opt-in
+`SchedulerOutput.recurrent_boundary_blocks` interface for connectors that need
+the exact Mamba replay-boundary state. Entries are emitted only after the block
+hash proves both the KV group and token boundary. Partial-tail copy-on-write
+handoffs remain backward compatible. Aligned handoffs require the connector to
+advertise `supports_recurrent_boundary_blocks`; other connectors retain no
+additional recurrent page. Pins live through the worker execution fence and
+are released during request cleanup.
+
 The SparkCache source that routes reconstructed opaque pages through the SM121
 placement library is commit
-`5d571018de5b63a9a90e5c11e6d6e86bbff4a957`, Git tree
-`e864ed9ad64f771188fdb59aa9738e348134d636`. The builder verifies clean
+`9e779c32b285e00577a7829a75192069d12685dc`, Git tree
+`4df3ea1435241a688e6d44345687414605131450`. The builder verifies clean
 deployable-source SHA-256
-`f7c0565521fddeff7085e4cc08043cb8d1e2bde33abc67f83b8608a162d05b88`
+`01cc59bf2c45af60f02813b771a484e65829e4f464eb27aa1756ca7067c82c9f`
 before generating the SparkCache CUDA placement library. It applies the VMM exemption,
 load-failure recovery, shared-prefix retention, and follower-attachment
 patches in order, then runs the eleven-file lease-contract verifier. The test

--- a/runtime/glm53-flash-adaptive-mtp-python-overlay/overlay_contract.py
+++ b/runtime/glm53-flash-adaptive-mtp-python-overlay/overlay_contract.py
@@ -116,6 +116,13 @@ def final_file_hashes(pins: dict[str, Any]) -> dict[str, str]:
         result[target] = _sha256(
             patch["postimage_sha256"], f"{target} patch postimage"
         )
+    for patch in pins["vllm"].get("composed_runtime_patches", ()):
+        for target_record in patch["targets"]:
+            target = safe_relative_path(target_record["path"]).as_posix()
+            result[target] = _sha256(
+                target_record["postimage_sha256"],
+                f"{target} composed patch postimage",
+            )
     return result
 
 
@@ -201,6 +208,62 @@ def validate_optional_load_config_fallback(source: str) -> None:
         )
 
 
+def validate_recurrent_boundary_sources(root: Path) -> None:
+    """Require exact-boundary selection and the SchedulerOutput hand-off."""
+
+    output_source = (root / "vllm/v1/core/sched/output.py").read_text(
+        encoding="utf-8"
+    )
+    scheduler_source = (root / "vllm/v1/core/sched/scheduler.py").read_text(
+        encoding="utf-8"
+    )
+    manager_source = (
+        root / "vllm/v1/core/single_type_kv_cache_manager.py"
+    ).read_text(encoding="utf-8")
+    cache_source = (root / "vllm/v1/core/kv_cache_manager.py").read_text(
+        encoding="utf-8"
+    )
+    required = {
+        "SchedulerOutput field": (
+            "recurrent_boundary_blocks: "
+            "dict[str, list[tuple[int, int, int]]] | None = None",
+            output_source,
+        ),
+        "scheduler hand-off": (
+            "recurrent_boundary_blocks=pending_recurrent_boundary_blocks",
+            scheduler_source,
+        ),
+        "connector capability gate": (
+            '"supports_recurrent_boundary_blocks"',
+            scheduler_source,
+        ),
+        "consumer-compatible free fence": (
+            "kv_transfer_config.is_kv_consumer",
+            scheduler_source,
+        ),
+        "overlapping-step free fence": (
+            "multiple_inflight_batches and (",
+            scheduler_source,
+        ),
+        "prompt-minus-one replay rule": (
+            "(request.num_prompt_tokens - 1) // self.block_pool.hash_block_size",
+            manager_source,
+        ),
+        "exact token-boundary proof": (
+            "block.block_hash_num_tokens != replay_boundary",
+            manager_source,
+        ),
+        "exact group proof": (
+            "get_group_id(block.block_hash) != self.kv_cache_group_id",
+            manager_source,
+        ),
+        "request-lifetime pin": ("self._pin_recurrent_boundary", cache_source),
+    }
+    for label, (fragment, source) in required.items():
+        if fragment not in source:
+            raise ContractError(f"recurrent-boundary source omits {label}")
+
+
 def verify_vllm_runtime_patch_files(
     root: Path,
     pins: dict[str, Any],
@@ -226,6 +289,20 @@ def verify_vllm_runtime_patch_files(
                 "sha256": observed,
             }
         )
+    for record in pins["vllm"].get("composed_runtime_patches", ()):
+        for target_record in record["targets"]:
+            relative = safe_relative_path(target_record["path"])
+            path = root / relative
+            observed = sha256_file(path)
+            if observed != target_record["postimage_sha256"]:
+                raise ContractError(
+                    f"vLLM composed patch postimage mismatch for {relative}: "
+                    f"expected {target_record['postimage_sha256']}, got {observed}"
+                )
+            compile(path.read_bytes(), str(path), "exec")
+            verified.append({"path": relative.as_posix(), "sha256": observed})
+    if pins["vllm"].get("composed_runtime_patches"):
+        validate_recurrent_boundary_sources(root)
     loader = root / "vllm/model_executor/model_loader/__init__.py"
     validate_optional_load_config_fallback(loader.read_text(encoding="utf-8"))
     return verified

--- a/runtime/glm53-flash-adaptive-mtp-python-overlay/patches/011-recurrent-boundary-contract.patch
+++ b/runtime/glm53-flash-adaptive-mtp-python-overlay/patches/011-recurrent-boundary-contract.patch
@@ -1,0 +1,246 @@
+diff --git a/vllm/v1/core/kv_cache_manager.py b/vllm/v1/core/kv_cache_manager.py
+index 645af9c87..80d4500ff 100644
+--- a/vllm/v1/core/kv_cache_manager.py
++++ b/vllm/v1/core/kv_cache_manager.py
+@@ -1155,13 +1155,66 @@ class KVCacheManager:
+                 block,
+                 boundary_tokens,
+             ) in mgr.take_pending_partial_tail_offloads():
+-                self.block_pool.touch((block,))
+-                self._partial_tail_pins.setdefault(req_id, []).append(block)
++                block = self._pin_recurrent_boundary(req_id, block, boundary_tokens)
+                 offloads.setdefault(req_id, []).append(
+                     (group_id, block.block_id, boundary_tokens)
+                 )
+         return offloads
+
++    def take_recurrent_boundary_blocks(
++        self,
++        partial_tail_offloads: dict[str, list[tuple[int, int, int]]] | None = None,
++    ) -> dict[str, list[tuple[int, int, int]]]:
++        """Drain hash-proven recurrent boundaries for connector metadata.
++
++        The returned union preserves the partial-tail entries already exposed
++        to connectors and adds full Mamba pages at the scheduler replay
++        boundary. Pins use the existing request-cleanup lifetime.
++        """
++        boundaries = {
++            req_id: list(entries)
++            for req_id, entries in (partial_tail_offloads or {}).items()
++        }
++        for mgr in self.coordinator.single_type_managers:
++            for (
++                req_id,
++                group_id,
++                block,
++                boundary_tokens,
++            ) in mgr.take_pending_aligned_recurrent_boundaries():
++                block = self._pin_recurrent_boundary(req_id, block, boundary_tokens)
++                entry = (group_id, block.block_id, boundary_tokens)
++                request_entries = boundaries.setdefault(req_id, [])
++                if entry not in request_entries:
++                    request_entries.append(entry)
++        return boundaries
++
++    def _pin_recurrent_boundary(
++        self,
++        request_id: str,
++        block: KVCacheBlock,
++        boundary_tokens: int,
++    ) -> KVCacheBlock:
++        """Pin one exact boundary without duplicating a prior hand-off."""
++        assert not block.is_null
++        assert block.block_hash is not None
++        assert block.block_hash_num_tokens == boundary_tokens
++        pins = self._partial_tail_pins.setdefault(request_id, [])
++        for pinned in pins:
++            if (
++                pinned.block_hash == block.block_hash
++                and pinned.block_hash_num_tokens == boundary_tokens
++            ):
++                return pinned
++        self.block_pool.touch((block,))
++        pins.append(block)
++        return block
++
++    def discard_aligned_recurrent_boundaries(self) -> None:
++        """Drop aligned hand-offs when the producer connector did not opt in."""
++        for mgr in self.coordinator.single_type_managers:
++            mgr.take_pending_aligned_recurrent_boundaries()
++
+     def new_step_starts(self) -> None:
+         """Notify the coordinator that a new step is starting."""
+         self.coordinator.new_step_starts()
+diff --git a/vllm/v1/core/sched/output.py b/vllm/v1/core/sched/output.py
+index ad09529e8..f3a363085 100644
+--- a/vllm/v1/core/sched/output.py
++++ b/vllm/v1/core/sched/output.py
+@@ -280,6 +280,13 @@ class SchedulerOutput:
+     # tail (mamba "align" CoW target). None unless partial hash hits are active.
+     partial_tail_offloads: dict[str, list[tuple[int, int, int]]] | None = None
+
++    # Hash-proven recurrent-state blocks for external KV connectors:
++    # {request_id: [(group_id, block_id, boundary_tokens), ...]}. The union
++    # includes full aligned Mamba pages and the partial-tail CoW targets above.
++    # Consumers opting into aligned boundaries must finish their worker-side
++    # snapshot before request cleanup releases the scheduler pin.
++    recurrent_boundary_blocks: dict[str, list[tuple[int, int, int]]] | None = None
++
+     # Dynamic speculative decoding: optimal K chosen by scheduler.
+     # Number of spec tokens to schedule for the next step.
+     num_spec_tokens_to_schedule: int | None = None
+diff --git a/vllm/v1/core/sched/scheduler.py b/vllm/v1/core/sched/scheduler.py
+index 562c240f4..3d1e13665 100644
+--- a/vllm/v1/core/sched/scheduler.py
++++ b/vllm/v1/core/sched/scheduler.py
+@@ -165,7 +165,14 @@ class Scheduler(SchedulerInterface):
+             # Connector can reallocate and fill those blocks via a load that
+             # isn't ordered against that write, so defer freeing them.
+             multiple_inflight_batches = self.vllm_config.max_concurrent_batches > 1
+-            if multiple_inflight_batches and kv_transfer_config.is_kv_consumer:
++            if multiple_inflight_batches and (
++                kv_transfer_config.is_kv_consumer
++                or bool(
++                    getattr(
++                        self.connector, "supports_recurrent_boundary_blocks", False
++                    )
++                )
++            ):
+                 self.defer_block_free = True
+
+             self.requires_kv_delivery = self.connector.requires_kv_delivery
+@@ -1331,6 +1338,7 @@ class Scheduler(SchedulerInterface):
+         # pin); the manager drops stale entries when the request's blocks are
+         # popped for free.
+         pending_partial_tail_offloads = None
++        pending_recurrent_boundary_blocks = None
+         if (
+             self.connector is not None
+             and self.vllm_config.kv_transfer_config is not None
+@@ -1339,6 +1347,19 @@ class Scheduler(SchedulerInterface):
+             pending_partial_tail_offloads = (
+                 self.kv_cache_manager.take_partial_tail_offloads() or None
+             )
++            if bool(
++                getattr(self.connector, "supports_recurrent_boundary_blocks", False)
++            ):
++                # Opting in requires the connector's worker snapshot to finish
++                # before request cleanup releases the boundary pins.
++                pending_recurrent_boundary_blocks = (
++                    self.kv_cache_manager.take_recurrent_boundary_blocks(
++                        pending_partial_tail_offloads
++                    )
++                    or None
++                )
++            else:
++                self.kv_cache_manager.discard_aligned_recurrent_boundaries()
+
+         kv_cache_block_copies, cow_retained_blocks = (
+             self.kv_cache_manager.take_kv_cache_block_copies()
+@@ -1391,6 +1412,7 @@ class Scheduler(SchedulerInterface):
+             new_block_ids_to_zero=self._get_new_block_ids_to_zero(),
+             kv_cache_block_copies=pending_kv_cache_block_copies,
+             partial_tail_offloads=pending_partial_tail_offloads,
++            recurrent_boundary_blocks=pending_recurrent_boundary_blocks,
+             num_spec_tokens_to_schedule=num_spec_tokens_to_schedule,
+             ec_manager_metadata=self.encoder_cache_manager.get_manager_metadata(),
+         )
+diff --git a/vllm/v1/core/single_type_kv_cache_manager.py b/vllm/v1/core/single_type_kv_cache_manager.py
+index ceb56a598..aef3efe8e 100644
+--- a/vllm/v1/core/single_type_kv_cache_manager.py
++++ b/vllm/v1/core/single_type_kv_cache_manager.py
+@@ -13,6 +13,7 @@ from vllm.v1.core.kv_cache_utils import (
+     BlockHashListWithBlockSize,
+     BlockHashWithGroupId,
+     KVCacheBlock,
++    get_group_id,
+     resolve_block_hashes,
+ )
+ from vllm.v1.kv_cache_interface import (
+@@ -121,6 +122,9 @@ class SingleTypeKVCacheManager(ABC):
+         self._pending_partial_tail_offloads: list[
+             tuple[str, int, KVCacheBlock, int]
+         ] = []
++        self._pending_aligned_recurrent_boundaries: list[
++            tuple[str, int, KVCacheBlock, int]
++        ] = []
+
+     @classmethod
+     def _get_num_evictable_blocks(cls, blocks: Sequence[KVCacheBlock]):
+@@ -399,6 +403,14 @@ class SingleTypeKVCacheManager(ABC):
+         self._pending_partial_tail_offloads = []
+         return pending
+
++    def take_pending_aligned_recurrent_boundaries(
++        self,
++    ) -> list[tuple[str, int, KVCacheBlock, int]]:
++        """Drain full-page Mamba boundary hand-offs."""
++        pending = self._pending_aligned_recurrent_boundaries
++        self._pending_aligned_recurrent_boundaries = []
++        return pending
++
+     def _apply_cow(
+         self,
+         request_id: str,
+@@ -1697,6 +1709,11 @@ class MambaManager(SingleTypeKVCacheManager):
+                 for entry in self._pending_partial_tail_offloads
+                 if entry[0] != request_id
+             ]
++            self._pending_aligned_recurrent_boundaries = [
++                entry
++                for entry in self._pending_aligned_recurrent_boundaries
++                if entry[0] != request_id
++            ]
+         return super().pop_blocks_for_free(request_id)
+
+     def get_num_skipped_tokens(self, num_computed_tokens: int) -> int:
+@@ -1720,6 +1737,7 @@ class MambaManager(SingleTypeKVCacheManager):
+             partial_hash = self._cache_partial_tail_block(request, num_tokens)
+             if partial_hash is not None:
+                 self.cached_blocks_this_step.add(partial_hash)
++            self._queue_aligned_recurrent_boundary(request, num_tokens)
+         if num_cached_blocks_after > num_cached_blocks_before:
+             for block in self.req_to_blocks[request.request_id][
+                 num_cached_blocks_before:num_cached_blocks_after
+@@ -1778,6 +1796,41 @@ class MambaManager(SingleTypeKVCacheManager):
+             self._producer_partial_tail_reqs[request.request_id] = num_tokens
+         return partial_hash
+
++    def _queue_aligned_recurrent_boundary(
++        self,
++        request: Request,
++        num_tokens: int,
++    ) -> None:
++        """Queue a full Mamba page only when its hash proves the replay boundary."""
++        if num_tokens <= 0 or num_tokens % self.block_size != 0:
++            return
++        replay_boundary = (
++            (request.num_prompt_tokens - 1) // self.block_pool.hash_block_size
++        ) * self.block_pool.hash_block_size
++        if num_tokens != replay_boundary:
++            return
++
++        block_idx = num_tokens // self.block_size - 1
++        blocks = self.req_to_blocks[request.request_id]
++        if block_idx >= len(blocks):
++            return
++        block = blocks[block_idx]
++        if (
++            block.is_null
++            or block.block_hash is None
++            or block.block_hash_num_tokens != replay_boundary
++            or get_group_id(block.block_hash) != self.kv_cache_group_id
++        ):
++            return
++        self._pending_aligned_recurrent_boundaries.append(
++            (
++                request.request_id,
++                self.kv_cache_group_id,
++                block,
++                replay_boundary,
++            )
++        )
++
+
+ class CrossAttentionManager(SingleTypeKVCacheManager):
+     """Manager for cross-attention KV cache in encoder-decoder models."""

--- a/runtime/glm53-flash-adaptive-mtp-python-overlay/patches/012-recurrent-boundary-contract-tests.patch
+++ b/runtime/glm53-flash-adaptive-mtp-python-overlay/patches/012-recurrent-boundary-contract-tests.patch
@@ -1,0 +1,166 @@
+diff --git a/tests/v1/core/prefix_cache/test_partial_prefix_cache_hits.py b/tests/v1/core/prefix_cache/test_partial_prefix_cache_hits.py
+index eff889b98..64d8409ae 100644
+--- a/tests/v1/core/prefix_cache/test_partial_prefix_cache_hits.py
++++ b/tests/v1/core/prefix_cache/test_partial_prefix_cache_hits.py
+@@ -4,6 +4,7 @@
+ "align") models: scheduler chunk splitting, partial tail registration, CoW
+ on partial hits, and same-step deferral."""
+
++import inspect
+ from math import lcm
+ from types import SimpleNamespace
+ from unittest.mock import MagicMock
+@@ -69,6 +70,14 @@ def test_capable_connector_uses_divergent_partial_hit_lookup():
+     manager.get_computed_blocks.assert_not_called()
+
+
++@pytest.mark.skip_global_cleanup
++def test_recurrent_boundary_capability_defers_overlapping_block_free():
++    source = inspect.getsource(Scheduler.__init__)
++    assert "multiple_inflight_batches and (" in source
++    assert "kv_transfer_config.is_kv_consumer" in source
++    assert '"supports_recurrent_boundary_blocks"' in source
++
++
+ def make_full_mamba_manager(
+     *,
+     dcp_world_size: int,
+@@ -856,6 +865,138 @@ def test_take_partial_tail_offloads_empty_without_partial_tail():
+     assert manager.take_partial_tail_offloads() == {}
+
+
++@pytest.mark.parametrize("prompt_tokens", [6992, 7168])
++@pytest.mark.skip_global_cleanup
++def test_aligned_recurrent_boundary_ignores_seven_speculative_slots(
++    prompt_tokens: int,
++):
++    """The GLM aligned boundary is selected by its exact hash, not by scanning
++    the later running and DFlash speculative slots."""
++    hash_block_size = 256
++    mamba_block_size = 2304
++    boundary_tokens = 6912
++    kv_cache_config = KVCacheConfig(
++        num_blocks=128,
++        kv_cache_tensors=[],
++        kv_cache_groups=[
++            KVCacheGroupSpec(
++                ["full"],
++                FullAttentionSpec(
++                    block_size=hash_block_size,
++                    num_kv_heads=1,
++                    head_size=1,
++                    dtype=torch.float32,
++                ),
++            ),
++            KVCacheGroupSpec(
++                ["mamba"],
++                MambaSpec(
++                    block_size=mamba_block_size,
++                    shapes=(1, 1),
++                    dtypes=(torch.float32,),
++                    mamba_cache_mode="align",
++                    num_speculative_blocks=7,
++                ),
++            ),
++        ],
++    )
++    manager = make_kv_cache_manager(
++        kv_cache_config=kv_cache_config,
++        max_model_len=8192,
++        enable_caching=True,
++        scheduler_block_size=mamba_block_size,
++        hash_block_size=hash_block_size,
++    )
++    request = make_request(
++        "aligned",
++        list(range(prompt_tokens)),
++        hash_block_size,
++        sha256,
++    )
++    computed_blocks, num_computed, _ = manager.get_computed_blocks(request)
++    assert manager.allocate_slots(
++        request, boundary_tokens, num_computed, computed_blocks
++    ) is not None
++
++    assert manager.take_partial_tail_offloads() == {}
++    boundaries = manager.take_recurrent_boundary_blocks()
++    assert list(boundaries) == ["aligned"]
++    assert len(boundaries["aligned"]) == 1
++    group_id, block_id, emitted_boundary = boundaries["aligned"][0]
++    assert (group_id, emitted_boundary) == (1, boundary_tokens)
++
++    mamba_blocks = manager.get_blocks("aligned").blocks[1]
++    assert len(mamba_blocks) == 3 + 7
++    boundary_block = mamba_blocks[2]
++    assert block_id == boundary_block.block_id
++    assert block_id not in {block.block_id for block in mamba_blocks[3:]}
++    assert boundary_block.block_hash_num_tokens == boundary_tokens
++    assert get_group_id(boundary_block.block_hash) == group_id
++
++    # Finish the prompt, then schedule one decode token. The second allocation
++    # runs remove_skipped_blocks, which nulls arithmetic slot 2. The hand-off
++    # must keep naming and pinning the exact cached boundary block rather than
++    # selecting a later running or speculative slot.
++    request.num_computed_tokens = boundary_tokens
++    assert manager.allocate_slots(
++        request, prompt_tokens - boundary_tokens
++    ) is not None
++    request.num_computed_tokens = prompt_tokens
++    request.append_output_token_ids([prompt_tokens])
++    assert manager.allocate_slots(request, 1) is not None
++
++    assert mamba_blocks[2].is_null
++    assert boundary_block.ref_cnt == 1
++    assert block_id not in {
++        block.block_id for block in mamba_blocks[3:] if not block.is_null
++    }
++    assert boundaries["aligned"] == [(1, block_id, boundary_tokens)]
++
++    manager.free(request)
++    assert boundary_block.ref_cnt == 0
++
++
++@pytest.mark.skip_global_cleanup
++def test_recurrent_boundary_union_preserves_partial_tail_handoff():
++    hash_block_size = 2
++    manager = make_full_mamba_manager(
++        dcp_world_size=1,
++        hash_block_size=hash_block_size,
++        full_block_size=hash_block_size,
++        mamba_block_size=2 * hash_block_size,
++    )
++    request = make_request("partial", [0, 0, 1, 1, 2, 2], 2, sha256)
++    computed_blocks, num_computed, _ = manager.get_computed_blocks(request)
++    assert manager.allocate_slots(
++        request, 6, num_computed, computed_blocks
++    ) is not None
++    request.num_computed_tokens = 6
++    request.append_output_token_ids([3])
++    assert manager.allocate_slots(request, 1) is not None
++
++    partial = manager.take_partial_tail_offloads()
++    assert manager.take_recurrent_boundary_blocks(partial) == partial
++
++
++@pytest.mark.skip_global_cleanup
++def test_aligned_recurrent_boundary_can_be_discarded_without_a_pin():
++    manager = make_full_mamba_manager(
++        dcp_world_size=1,
++        hash_block_size=2,
++        full_block_size=2,
++        mamba_block_size=4,
++    )
++    request = make_request("no-capability", [0, 0, 1, 1, 2], 2, sha256)
++    computed_blocks, num_computed, _ = manager.get_computed_blocks(request)
++    assert manager.allocate_slots(request, 4, num_computed, computed_blocks) is not None
++    boundary = manager.get_blocks("no-capability").blocks[1][0]
++    ref_cnt = boundary.ref_cnt
++
++    manager.discard_aligned_recurrent_boundaries()
++
++    assert manager.take_recurrent_boundary_blocks() == {}
++    assert boundary.ref_cnt == ref_cnt
++
+ def test_truncate_computed_blocks_preserves_sparse_prefix_positions():
+     """truncate_computed_blocks slices each group by its own block size,
+     keeps null placeholders in the retained prefix, and leaves the original

--- a/runtime/glm53-flash-adaptive-mtp-python-overlay/pins.json
+++ b/runtime/glm53-flash-adaptive-mtp-python-overlay/pins.json
@@ -39,6 +39,43 @@
         "contract": "DFlash passes SpeculativeConfig.draft_load_config to get_model; None retains the target LoadConfig fallback."
       }
     ],
+    "composed_runtime_patches": [
+      {
+        "status": "implemented",
+        "path": "runtime/glm53-flash-adaptive-mtp-python-overlay/patches/011-recurrent-boundary-contract.patch",
+        "sha256": "5a6561a5bbab990dcd03bfd6a485ea26c3b5a578c2fd61b76305767b16dbfba0",
+        "contract": "SchedulerOutput.recurrent_boundary_blocks exposes only hash-proven aligned Mamba pages and partial-tail CoW targets; request cleanup releases their pins.",
+        "targets": [
+          {
+            "path": "vllm/v1/core/kv_cache_manager.py",
+            "preimage_sha256": "ee03dc9ce2b720c0be6e9f572d23580ba96eff68fe3406250557e83071654af0",
+            "postimage_sha256": "c5b83d382c96b2bf8c466a993ed77123a14a971e2661797128533319388d0b5f"
+          },
+          {
+            "path": "vllm/v1/core/sched/output.py",
+            "preimage_sha256": "65235eba652e5a3ccee18bf3cbfeac9bf4da8fb9c61e961580f612cfb7e593bc",
+            "postimage_sha256": "9911b3f9d21815a185285852b5a6176e5484e1ab0ff5c30f7caaa68ea0fab543"
+          },
+          {
+            "path": "vllm/v1/core/sched/scheduler.py",
+            "preimage_sha256": "6d397c97f31e67a75efc01b5ddd89fa58db425de14fa43965ef2d6146b6b9bdb",
+            "postimage_sha256": "260f36ce8fabf70c193b20009ea465eea7b1b6c8e9fb72f2307a01ba8fcf7b2a"
+          },
+          {
+            "path": "vllm/v1/core/single_type_kv_cache_manager.py",
+            "preimage_sha256": "e4b1c5c38b63b708fd55aa40a9ab0d008b266d006a63dcfcef55890ac1371cb8",
+            "postimage_sha256": "f67a1850a7e0288baaa6d42e7ec55b22b09c156720767e23acaabedcae333c8a"
+          }
+        ],
+        "test_patch": {
+          "path": "runtime/glm53-flash-adaptive-mtp-python-overlay/patches/012-recurrent-boundary-contract-tests.patch",
+          "sha256": "4a23f25b540760aa3f793427017e3ee39605e60de7af1b851cbbd6cc0faeddec",
+          "target": "tests/v1/core/prefix_cache/test_partial_prefix_cache_hits.py",
+          "preimage_sha256": "2f58e600fd39413b385b9e96b3c642a9ffb051bedcfc247a700fb532b35ec185",
+          "postimage_sha256": "9081e5b910a6712ed497ca6cf76abcf7aa911268c4b2c0e79dc8a89cc3a20daa"
+        }
+      }
+    ],
     "native_source_objects": {
       "csrc": "9ada29088768f1bc08dadd2eed3c9738eb9ac8a1",
       "cmake": "5e5bbdbe1c1b3a479656d8d6a41cc32a1982c43d",
@@ -77,12 +114,12 @@
   },
   "sparkcache": {
     "repository": "https://github.com/FujitsuPolycom/sparkcache.git",
-    "commit": "5d571018de5b63a9a90e5c11e6d6e86bbff4a957",
-    "tree": "e864ed9ad64f771188fdb59aa9738e348134d636",
-    "source_tree_sha256": "f7c0565521fddeff7085e4cc08043cb8d1e2bde33abc67f83b8608a162d05b88",
+    "commit": "9e779c32b285e00577a7829a75192069d12685dc",
+    "tree": "4df3ea1435241a688e6d44345687414605131450",
+    "source_tree_sha256": "01cc59bf2c45af60f02813b771a484e65829e4f464eb27aa1756ca7067c82c9f",
     "contract": {
       "path": "sparkcache/runtime_patches/vllm-kv-block-lease-contract-glm53-b12x-kda-adaptive-mtp.json",
-      "sha256": "6defde9551cbb586fd09bb2d3020495531b6573397875a767eaae1dbad126024",
+      "sha256": "45d7a92b38b836a4f829f02df85e339cfeea860e1080e4663a8340af6c125125",
       "files": 11
     },
     "patches": [

--- a/runtime/glm53-flash-adaptive-mtp-python-overlay/prepare_context.py
+++ b/runtime/glm53-flash-adaptive-mtp-python-overlay/prepare_context.py
@@ -206,6 +206,70 @@ def verify_vllm_runtime_patches(
     )
 
 
+def verify_composed_runtime_patches(
+    source: Path,
+    pins: dict[str, Any],
+    patch_root: Path,
+    sparkcache: Path,
+) -> None:
+    """Verify patches whose preimages include the SparkCache vLLM chain."""
+
+    applied_sparkcache: list[Path] = []
+    applied_composed: list[Path] = []
+    try:
+        for record in pins["sparkcache"]["patches"]:
+            patch = sparkcache / record["path"]
+            run(("git", "-C", str(source), "apply", str(patch)))
+            applied_sparkcache.append(patch)
+
+        for record in pins["vllm"].get("composed_runtime_patches", ()):
+            patch = patch_root / Path(record["path"]).name
+            if sha256_file(patch) != record["sha256"]:
+                raise PrepareError(f"vLLM composed patch mismatch: {record['path']}")
+            for target_record in record["targets"]:
+                target = source / target_record["path"]
+                if sha256_file(target) != target_record["preimage_sha256"]:
+                    raise PrepareError(
+                        "vLLM composed patch preimage mismatch: "
+                        f"{target_record['path']}"
+                    )
+            run(("git", "-C", str(source), "apply", "--check", str(patch)))
+            run(("git", "-C", str(source), "apply", str(patch)))
+            applied_composed.append(patch)
+            for target_record in record["targets"]:
+                target = source / target_record["path"]
+                if sha256_file(target) != target_record["postimage_sha256"]:
+                    raise PrepareError(
+                        "vLLM composed patch postimage mismatch: "
+                        f"{target_record['path']}"
+                    )
+
+            test_record = record["test_patch"]
+            test_patch = patch_root / Path(test_record["path"]).name
+            test_target = source / test_record["target"]
+            if sha256_file(test_patch) != test_record["sha256"]:
+                raise PrepareError("vLLM recurrent-boundary test patch mismatch")
+            if sha256_file(test_target) != test_record["preimage_sha256"]:
+                raise PrepareError("vLLM recurrent-boundary test preimage mismatch")
+            run(("git", "-C", str(source), "apply", "--check", str(test_patch)))
+            run(("git", "-C", str(source), "apply", str(test_patch)))
+            try:
+                if sha256_file(test_target) != test_record["postimage_sha256"]:
+                    raise PrepareError("vLLM recurrent-boundary test postimage mismatch")
+            finally:
+                run(("git", "-C", str(source), "apply", "--reverse", str(test_patch)))
+    finally:
+        for patch in reversed(applied_composed):
+            run(("git", "-C", str(source), "apply", "--reverse", str(patch)))
+        for patch in reversed(applied_sparkcache):
+            run(("git", "-C", str(source), "apply", "--reverse", str(patch)))
+    verify_git_source(
+        source,
+        commit=pins["vllm"]["python_commit"],
+        tree=pins["vllm"]["python_tree"],
+    )
+
+
 def copy_overlay(source: Path, destination: Path, manifest: dict[str, Any]) -> None:
     target = manifest["target"]["commit"]
     for record in manifest["files"]:
@@ -305,6 +369,7 @@ def prepare(output: Path, *, repository_root: Path = ROOT) -> dict[str, Any]:
         path = sparkcache / patch["path"]
         if sha256_file(path) != patch["sha256"]:
             raise PrepareError(f"SparkCache patch mismatch: {patch['path']}")
+    verify_composed_runtime_patches(vllm, pins, patch_root, sparkcache)
     contract = sparkcache / pins["sparkcache"]["contract"]["path"]
     if sha256_file(contract) != pins["sparkcache"]["contract"]["sha256"]:
         raise PrepareError("SparkCache vLLM contract differs from its pin")
@@ -320,7 +385,10 @@ def prepare(output: Path, *, repository_root: Path = ROOT) -> dict[str, Any]:
     ):
         copy_file(HERE / filename, runtime / filename)
     runtime_patches = []
-    for patch in pins["vllm"].get("runtime_patches", ()):
+    patch_records = list(pins["vllm"].get("runtime_patches", ()))
+    for patch in pins["vllm"].get("composed_runtime_patches", ()):
+        patch_records.extend((patch, patch["test_patch"]))
+    for patch in patch_records:
         name = Path(patch["path"]).name
         copy_file(patch_root / name, runtime / "patches" / name)
         runtime_patches.append(f"bundle/runtime/patches/{name}")
@@ -360,6 +428,9 @@ def prepare(output: Path, *, repository_root: Path = ROOT) -> dict[str, Any]:
             },
         },
         "vllm_runtime_patches": pins["vllm"].get("runtime_patches", []),
+        "vllm_composed_runtime_patches": pins["vllm"].get(
+            "composed_runtime_patches", []
+        ),
         "files": {relative: sha256_file(output / relative) for relative in receipt_inputs},
     }
     (output / "receipt.json").write_text(
@@ -390,10 +461,20 @@ def verify_context(context: Path) -> dict[str, Any]:
         "runtime_patches", []
     ):
         raise PrepareError("prepared context vLLM runtime patch receipt differs")
+    if receipt.get("vllm_composed_runtime_patches") != pins["vllm"].get(
+        "composed_runtime_patches", []
+    ):
+        raise PrepareError("prepared context composed vLLM patch receipt differs")
     verify_vllm_runtime_patches(
         context / "bundle/sources/vllm",
         pins,
         context / "bundle/runtime/patches",
+    )
+    verify_composed_runtime_patches(
+        context / "bundle/sources/vllm",
+        pins,
+        context / "bundle/runtime/patches",
+        context / "bundle/sources/sparkcache",
     )
     verify_git_source(
         context / "bundle/sources/b12x",

--- a/runtime/glm53-flash-adaptive-mtp-python-overlay/test_public_python_overlay.py
+++ b/runtime/glm53-flash-adaptive-mtp-python-overlay/test_public_python_overlay.py
@@ -51,11 +51,14 @@ def test_overlay_pins_public_base_and_mixed_vllm_provenance() -> None:
     assert pins["b12x"]["commit"] != pins["b12x"]["base_commit"]
     sparkcache = pins["sparkcache"]
     assert sparkcache["commit"] == (
-        "5d571018de5b63a9a90e5c11e6d6e86bbff4a957"
+        "9e779c32b285e00577a7829a75192069d12685dc"
     )
-    assert sparkcache["tree"] == "e864ed9ad64f771188fdb59aa9738e348134d636"
+    assert sparkcache["tree"] == "4df3ea1435241a688e6d44345687414605131450"
     assert sparkcache["source_tree_sha256"] == (
-        "f7c0565521fddeff7085e4cc08043cb8d1e2bde33abc67f83b8608a162d05b88"
+        "01cc59bf2c45af60f02813b771a484e65829e4f464eb27aa1756ca7067c82c9f"
+    )
+    assert sparkcache["contract"]["sha256"] == (
+        "45d7a92b38b836a4f829f02df85e339cfeea860e1080e4663a8340af6c125125"
     )
     assert pins["dependencies"]["torch"] == "2.13.0+cu130"
 
@@ -101,6 +104,60 @@ def test_dflash_loader_patch_binds_exact_0b_preimage_and_postimage() -> None:
     assert prepare.sha256_file(DFLASH_PATCH) == pins["vllm"]["runtime_patches"][
         0
     ]["sha256"]
+
+
+def test_recurrent_boundary_patch_binds_composed_source_and_exact_tests() -> None:
+    pins = json.loads(PINS.read_text(encoding="utf-8"))
+    (record,) = pins["vllm"]["composed_runtime_patches"]
+    assert prepare.sha256_file(HERE / "patches" / Path(record["path"]).name) == (
+        record["sha256"]
+    )
+    test_record = record["test_patch"]
+    assert prepare.sha256_file(
+        HERE / "patches" / Path(test_record["path"]).name
+    ) == test_record["sha256"]
+    assert {target["path"] for target in record["targets"]} == {
+        "vllm/v1/core/kv_cache_manager.py",
+        "vllm/v1/core/sched/output.py",
+        "vllm/v1/core/sched/scheduler.py",
+        "vllm/v1/core/single_type_kv_cache_manager.py",
+    }
+
+
+def test_recurrent_boundary_source_validator_is_fail_closed(tmp_path: Path) -> None:
+    sources = {
+        "vllm/v1/core/sched/output.py": (
+            "recurrent_boundary_blocks: "
+            "dict[str, list[tuple[int, int, int]]] | None = None\n"
+        ),
+        "vllm/v1/core/sched/scheduler.py": (
+            "recurrent_boundary_blocks=pending_recurrent_boundary_blocks\n"
+            'getattr(self.connector, "supports_recurrent_boundary_blocks", False)\n'
+            "kv_transfer_config.is_kv_consumer\n"
+            "multiple_inflight_batches and (\n"
+        ),
+        "vllm/v1/core/single_type_kv_cache_manager.py": (
+            "(request.num_prompt_tokens - 1) // self.block_pool.hash_block_size\n"
+            "block.block_hash_num_tokens != replay_boundary\n"
+            "get_group_id(block.block_hash) != self.kv_cache_group_id\n"
+        ),
+        "vllm/v1/core/kv_cache_manager.py": "self._pin_recurrent_boundary\n",
+    }
+    for relative, source in sources.items():
+        path = tmp_path / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(source, encoding="utf-8")
+    contract.validate_recurrent_boundary_sources(tmp_path)
+
+    manager = tmp_path / "vllm/v1/core/single_type_kv_cache_manager.py"
+    manager.write_text(
+        sources["vllm/v1/core/single_type_kv_cache_manager.py"].replace(
+            "request.num_prompt_tokens - 1", "request.num_prompt_tokens"
+        ),
+        encoding="utf-8",
+    )
+    with pytest.raises(contract.ContractError, match="prompt-minus-one"):
+        contract.validate_recurrent_boundary_sources(tmp_path)
 
 
 def test_dflash_loader_contract_honors_explicit_draft_load_config() -> None:
@@ -274,7 +331,17 @@ def test_sparkcache_patches_and_contract_run_after_the_python_overlay() -> None:
     patch_040 = recipe.index("040-sparkcache-shared-prefix-lease.patch")
     patch_041 = recipe.index("041-sparkcache-shared-prefix-attach.patch")
     lease = recipe.index("verify_lease_contract.py")
-    assert overlay < dflash_patch < patch_020 < patch_030 < patch_040 < patch_041 < lease
+    recurrent = recipe.index("011-recurrent-boundary-contract.patch", lease)
+    assert (
+        overlay
+        < dflash_patch
+        < patch_020
+        < patch_030
+        < patch_040
+        < patch_041
+        < lease
+        < recurrent
+    )
 
 
 def test_output_labels_do_not_claim_a_source_built_0b_wheel() -> None:
@@ -292,4 +359,7 @@ def test_output_labels_do_not_claim_a_source_built_0b_wheel() -> None:
     )
     assert labels["org.sparkring.vllm.dflash-draft-loader-postimage-sha256"] == (
         "98acbae2b3bb4482d83f9637c163ce7c92707ccdf6561b7e431f23337f151cf4"
+    )
+    assert labels["org.sparkring.vllm.recurrent-boundary-patch-sha256"] == (
+        "5a6561a5bbab990dcd03bfd6a485ea26c3b5a578c2fd61b76305767b16dbfba0"
     )

--- a/runtime/glm53-flash-adaptive-mtp-python-overlay/verify_image.py
+++ b/runtime/glm53-flash-adaptive-mtp-python-overlay/verify_image.py
@@ -120,6 +120,12 @@ def expected_output_labels(pins: dict[str, Any]) -> dict[str, str]:
     labels["org.sparkring.vllm.dflash-draft-loader-postimage-sha256"] = patch[
         "postimage_sha256"
     ]
+    composed = pins["vllm"].get("composed_runtime_patches", ())
+    if len(composed) != 1:
+        raise VerifyError("runtime contract requires one recurrent-boundary patch")
+    labels["org.sparkring.vllm.recurrent-boundary-patch-sha256"] = composed[0][
+        "sha256"
+    ]
     cleanup = pins.get("runtime_cleanup", {}).get("deep_ep")
     if cleanup is not None:
         labels["org.sparkring.runtime.removed-deep-ep-distribution"] = (

--- a/runtime/glm53-flash-dflash7-python-overlay/README.md
+++ b/runtime/glm53-flash-dflash7-python-overlay/README.md
@@ -12,8 +12,8 @@ The image combines these exact roles:
   `0b67266a0f37d6146a8403fb8482403c62f412d5`;
 - B12X `b1d541f9e71a35f030d45fae437630fff7507c2a`;
 - SparkCache reconstructed-page placement source
-  `5d571018de5b63a9a90e5c11e6d6e86bbff4a957`, Git tree
-  `e864ed9ad64f771188fdb59aa9738e348134d636`;
+  `9e779c32b285e00577a7829a75192069d12685dc`, Git tree
+  `4df3ea1435241a688e6d44345687414605131450`;
 - external BF16 DFlash2 weights with SHA-256
   `b33c03475ba7322cf398828f2d8d1be376df30dc05c6b40c28c8ea8da23e410b`.
 
@@ -54,3 +54,32 @@ probes, disable the all-reduce RMS fusion, select language-model-only serving,
 and leave Torch thread selection unset. ModelOpt and FP8 KV warnings remain
 visible because they describe supported-runtime limitations rather than unused
 optional backends.
+
+## Recurrent replay-boundary hand-off
+
+Status: **implemented** in the vLLM overlay; unsupported until the selected KV
+connector explicitly advertises `supports_recurrent_boundary_blocks` and
+consumes the interface.
+
+`SchedulerOutput.recurrent_boundary_blocks` has this schema:
+
+```text
+dict[str, list[tuple[int, int, int]]] | None
+request_id -> [(group_id, block_id, boundary_tokens), ...]
+```
+
+Each entry identifies a Mamba `align` block whose prefix-cache hash covers
+exactly `boundary_tokens`. The replay boundary is the greatest 256-token hash
+boundary below the prompt end. A full 2,304-token recurrent page is admitted
+only when its stored hash token count and group ID both match that boundary.
+The scheduler never substitutes a later running-state or DFlash speculative
+slot. Existing partial-tail copy-on-write targets remain available through
+`partial_tail_offloads` and are also included in the new field.
+
+The scheduler pins an admitted block before worker execution. A connector that
+opts in must finish its worker-side snapshot before request cleanup; overlapping
+scheduler steps defer request-block recycling until their execution fence has
+completed. Request cleanup releases the pin, including cancellation paths.
+Connectors without the capability receive no aligned-boundary metadata and
+retain no additional recurrent block. The interface does not change
+SparkCache cache identities or on-disk namespaces.

--- a/runtime/glm53-flash-dflash7-python-overlay/pins.json
+++ b/runtime/glm53-flash-dflash7-python-overlay/pins.json
@@ -39,6 +39,43 @@
         "contract": "DFlash passes SpeculativeConfig.draft_load_config to get_model; None retains the target LoadConfig fallback."
       }
     ],
+    "composed_runtime_patches": [
+      {
+        "status": "implemented",
+        "path": "runtime/glm53-flash-adaptive-mtp-python-overlay/patches/011-recurrent-boundary-contract.patch",
+        "sha256": "5a6561a5bbab990dcd03bfd6a485ea26c3b5a578c2fd61b76305767b16dbfba0",
+        "contract": "SchedulerOutput.recurrent_boundary_blocks exposes only hash-proven aligned Mamba pages and partial-tail CoW targets; request cleanup releases their pins.",
+        "targets": [
+          {
+            "path": "vllm/v1/core/kv_cache_manager.py",
+            "preimage_sha256": "ee03dc9ce2b720c0be6e9f572d23580ba96eff68fe3406250557e83071654af0",
+            "postimage_sha256": "c5b83d382c96b2bf8c466a993ed77123a14a971e2661797128533319388d0b5f"
+          },
+          {
+            "path": "vllm/v1/core/sched/output.py",
+            "preimage_sha256": "65235eba652e5a3ccee18bf3cbfeac9bf4da8fb9c61e961580f612cfb7e593bc",
+            "postimage_sha256": "9911b3f9d21815a185285852b5a6176e5484e1ab0ff5c30f7caaa68ea0fab543"
+          },
+          {
+            "path": "vllm/v1/core/sched/scheduler.py",
+            "preimage_sha256": "6d397c97f31e67a75efc01b5ddd89fa58db425de14fa43965ef2d6146b6b9bdb",
+            "postimage_sha256": "260f36ce8fabf70c193b20009ea465eea7b1b6c8e9fb72f2307a01ba8fcf7b2a"
+          },
+          {
+            "path": "vllm/v1/core/single_type_kv_cache_manager.py",
+            "preimage_sha256": "e4b1c5c38b63b708fd55aa40a9ab0d008b266d006a63dcfcef55890ac1371cb8",
+            "postimage_sha256": "f67a1850a7e0288baaa6d42e7ec55b22b09c156720767e23acaabedcae333c8a"
+          }
+        ],
+        "test_patch": {
+          "path": "runtime/glm53-flash-adaptive-mtp-python-overlay/patches/012-recurrent-boundary-contract-tests.patch",
+          "sha256": "4a23f25b540760aa3f793427017e3ee39605e60de7af1b851cbbd6cc0faeddec",
+          "target": "tests/v1/core/prefix_cache/test_partial_prefix_cache_hits.py",
+          "preimage_sha256": "2f58e600fd39413b385b9e96b3c642a9ffb051bedcfc247a700fb532b35ec185",
+          "postimage_sha256": "9081e5b910a6712ed497ca6cf76abcf7aa911268c4b2c0e79dc8a89cc3a20daa"
+        }
+      }
+    ],
     "native_source_objects": {
       "csrc": "9ada29088768f1bc08dadd2eed3c9738eb9ac8a1",
       "cmake": "5e5bbdbe1c1b3a479656d8d6a41cc32a1982c43d",
@@ -77,12 +114,12 @@
   },
   "sparkcache": {
     "repository": "https://github.com/FujitsuPolycom/sparkcache.git",
-    "commit": "5d571018de5b63a9a90e5c11e6d6e86bbff4a957",
-    "tree": "e864ed9ad64f771188fdb59aa9738e348134d636",
-    "source_tree_sha256": "f7c0565521fddeff7085e4cc08043cb8d1e2bde33abc67f83b8608a162d05b88",
+    "commit": "9e779c32b285e00577a7829a75192069d12685dc",
+    "tree": "4df3ea1435241a688e6d44345687414605131450",
+    "source_tree_sha256": "01cc59bf2c45af60f02813b771a484e65829e4f464eb27aa1756ca7067c82c9f",
     "contract": {
       "path": "sparkcache/runtime_patches/vllm-kv-block-lease-contract-glm53-b12x-kda-adaptive-mtp.json",
-      "sha256": "6defde9551cbb586fd09bb2d3020495531b6573397875a767eaae1dbad126024",
+      "sha256": "45d7a92b38b836a4f829f02df85e339cfeea860e1080e4663a8340af6c125125",
       "files": 11
     },
     "patches": [

--- a/runtime/glm53-flash-dflash7-python-overlay/test_dflash7_python_overlay.py
+++ b/runtime/glm53-flash-dflash7-python-overlay/test_dflash7_python_overlay.py
@@ -38,7 +38,7 @@ def test_pins_bind_the_exact_dflash7_composition() -> None:
         "b1d541f9e71a35f030d45fae437630fff7507c2a"
     )
     assert pins["sparkcache"]["commit"] == (
-        "5d571018de5b63a9a90e5c11e6d6e86bbff4a957"
+        "9e779c32b285e00577a7829a75192069d12685dc"
     )
     workload = pins["workload"]
     assert workload["role"] == "external-dflash7"
@@ -94,6 +94,9 @@ def test_verifier_requires_the_dflash7_deployment_label() -> None:
     ]
     assert labels["org.sparkring.vllm.dflash-draft-loader-patch-sha256"] == (
         "39b567013ee7aed79f63200ed460129587933dc77fb430decdf19f78178de279"
+    )
+    assert labels["org.sparkring.vllm.recurrent-boundary-patch-sha256"] == (
+        "5a6561a5bbab990dcd03bfd6a485ea26c3b5a578c2fd61b76305767b16dbfba0"
     )
     assert labels["org.sparkring.runtime.removed-deep-ep-distribution"] == (
         "deep_ep==2.0.0+local"


### PR DESCRIPTION
## Resulting behavior

The exact vLLM `0b67266a0f37d6146a8403fb8482403c62f412d5` Python overlay exposes hash-proven recurrent replay boundaries to opt-in KV connectors:

```python
SchedulerOutput.recurrent_boundary_blocks: dict[str, list[tuple[int, int, int]]] | None
```

Each tuple is `(group_id, block_id, boundary_tokens)`. An aligned Mamba entry is emitted only when the physical block is non-null, its block hash belongs to the same KV group, and `block_hash_num_tokens` equals `floor((prompt_tokens - 1) / hash_block_size) * hash_block_size`. Later running state and seven DFlash verification slots are never scanned.

Connectors opt in through `supports_recurrent_boundary_blocks`. Existing `partial_tail_offloads` remains unchanged; its copy-on-write targets are also present in the generalized hand-off. Non-opt-in connectors discard aligned candidates without taking pins.

## Lifetime and failure behavior

Boundary pages are pinned through the existing request-cleanup lifetime. Overlapping producer batches defer block recycling when the connector advertises the capability, so preemption cannot recycle a handed-off page before worker execution and synchronous snapshot completion.

Request cleanup releases pins. The exact tests advance beyond the 6,912-token boundary until arithmetic slot 2 becomes null, prove the exported block remains distinct from seven later speculative slots, and verify cleanup returns its reference.

## Exact source identities

- Production patch SHA-256: `5a6561a5bbab990dcd03bfd6a485ea26c3b5a578c2fd61b76305767b16dbfba0`
- Exact-vLLM test patch SHA-256: `4a23f25b540760aa3f793427017e3ee39605e60de7af1b851cbbd6cc0faeddec`
- `kv_cache_manager.py`: `ee03dc9c…` → `c5b83d38…`
- `sched/output.py`: `65235eba…` → `9911b3f9…`
- `sched/scheduler.py`: `6d397c97…` → `260f36ce…`
- `single_type_kv_cache_manager.py`: `e4b1c5c3…` → `f67a1850…`

The builder pins SparkCache commit `9e779c32b285e00577a7829a75192069d12685dc`, tree `4df3ea1435241a688e6d44345687414605131450`, deployable source SHA-256 `01cc59bf2c45af60f02813b771a484e65829e4f464eb27aa1756ca7067c82c9f`, and lease-contract SHA-256 `45d7a92b38b836a4f829f02df85e339cfeea860e1080e4663a8340af6c125125`.

## Compatibility and stacking

Cache namespace impact: none. Persistent cache identities and schemas are unchanged.

This draft is stacked on SparkRing #139 at commit `2f94b8405b54658a6b54d9b3377570d320879c6f`. It consumes the capability implemented by [SparkCache draft #31](https://github.com/FujitsuPolycom/sparkcache/pull/31). Integration order is SparkCache #31, then this runtime overlay.

No image was built or published, and no service or host state was changed.

## Validation

- Exact composed-source verifier — passed
- Exact-vLLM focused tests — 5 passed
- Overlay tests — 27 passed
- `python -m pytest runtime -q` — 235 passed, 3 skipped
- `python -m ruff check .` — passed
- Local broad available-tree suite — 998 passed, 9 skipped, with one unrelated existing README assertion failure (`C4 and C8 were capacity-limited` is absent)`n- GitHub maintained-tree suite — 1,944 passed, 9 skipped, with the same inherited assertion failure already present on base draft #139