### PR TITLE
Align GLM-5.3 quickstarts with exact SparkCache contracts

### DIFF
--- a/docs/GLM53_B12X_KDA_ADAPTIVE_MTP_SPARKCACHE_TP4_QUICKSTART.md
+++ b/docs/GLM53_B12X_KDA_ADAPTIVE_MTP_SPARKCACHE_TP4_QUICKSTART.md
@@ -2,9 +2,10 @@
 
 Status: **implemented, not qualified**. This guide builds vLLM commit
 `0b67266a0f37d6146a8403fb8482403c62f412d5` and the SparkCache overlay from
-commit `5d571018de5b63a9a90e5c11e6d6e86bbff4a957`, Git tree
-`e864ed9ad64f771188fdb59aa9738e348134d636`, for four DGX Spark systems at
-TP4/DCP1.
+commit `5ec6a9953ad5d39120298bbfc26e95a6fa4b1dc3`, Git tree
+`94c236b9dfbf5f70075eb47877fd9caaa5d8c249`, for four DGX Spark systems at
+TP4/DCP1. The adaptive-MTP composition has GPU-free contract coverage but no
+four-rank persistent-restore or performance qualification.
 
 The serving profile uses embedded MTP with maximum depth five, initial depth
 three, and a 32-step acceptance window. Fastsafetensors uses queue size one.
@@ -26,7 +27,7 @@ storage. Clone both repositories beside each other:
 git clone https://github.com/FujitsuPolycom/sparkring.git sparkring
 git -C sparkring checkout --detach <revision-containing-this-guide>
 git clone https://github.com/FujitsuPolycom/sparkcache.git sparkcache
-git -C sparkcache checkout --detach 5d571018de5b63a9a90e5c11e6d6e86bbff4a957
+git -C sparkcache checkout --detach 5ec6a9953ad5d39120298bbfc26e95a6fa4b1dc3
 
 IMAGE='sparkring-glm53-runtime:b12x-kda-adaptive-mtp-0b67266a-arm64' \
 BUILD_RECEIPT="$PWD/glm53-b12x-kda-adaptive-mtp-runtime-receipt.json" \
@@ -39,8 +40,8 @@ python sparkcache/deploy/glm53_flash/build_image.py \
   --containerfile deploy/glm53_flash/Containerfile.b12x-kda-adaptive-mtp \
   --base-image "${runtime_image}" \
   --base-image-id "${runtime_image_id}" \
-  --source-sha256 f7c0565521fddeff7085e4cc08043cb8d1e2bde33abc67f83b8608a162d05b88 \
-  --sparkcache-revision 5d571018de5b63a9a90e5c11e6d6e86bbff4a957 \
+  --source-sha256 bc238f96e550c7ec27d4081dd1f2e741d404aaf5c8572d89ccc5e76812be4d63 \
+  --sparkcache-revision 5ec6a9953ad5d39120298bbfc26e95a6fa4b1dc3 \
   --output-image sparkring-glm53-sparkcache:b12x-kda-adaptive-mtp-0b67266a-arm64
 ```
 
@@ -58,7 +59,9 @@ test "${#cuda_placement_sha256}" -eq 64
 The runtime builder verifies the complete first-parent vLLM history from
 `da4d7be` through adaptive MTP and the three live-tensor B12X KDA commits. The
 SparkCache build verifies LF Linux preimages, four exact patches, and eleven
-postimage source files.
+postimage source files. The pinned SparkCache source accepts the canonical
+`spark_cache_cuda_*` keys in the profile directly; no legacy-key translation
+is part of this composition.
 
 ## Resolve the TP4 profile
 
@@ -84,6 +87,10 @@ loader queue, source identities, or attestation command.
 
 The one-shot clear token is recorded only after a successful SparkCache-owned
 cache removal. Restarting this unchanged profile does not clear again.
+
+`--prefill-schedule-interval` is not part of this implemented profile. Test
+interval `8` as a separate research-only profile so its mixed prefill/decode
+tradeoff cannot be confused with adaptive-MTP or SparkCache results.
 
 ## Verify and launch
 

--- a/docs/GLM53_DFLASH7_PYTHON_OVERLAY_SPARKCACHE_TP4_QUICKSTART.md
+++ b/docs/GLM53_DFLASH7_PYTHON_OVERLAY_SPARKCACHE_TP4_QUICKSTART.md
@@ -1,9 +1,14 @@
 # Serve GLM-5.3 with external DFlash7 and the exact Python-overlay runtime
 
-Status: **implemented**, not qualified. The image builder, profile resolver,
-and four-rank dry-run contract pass without GPUs. No image digest from this
-path has completed TP4/DCP1 model loading, semantic generation, SparkCache
-store/restart/restore, or concurrency qualification.
+Status: **implemented**. The image builder, profile resolver, and four-rank
+dry-run contract pass without GPUs. Local image ID
+`sha256:eef863d8bc578815a80b0e2d9f0d745102b6363415225101fd92171a2e5a55cb`
+is **qualified** only for the TP4/DCP1 startup, health, semantic generation,
+arbitrary page-boundary replay, and 131,072- and 262,144-token restore cases
+in the
+[bounded validation record](../performance/records/glm53-flash/dflash7-python-overlay-pr30-live-validation.md).
+The exact image has no retained C2/C8/C16 or DFlash response-quality evidence.
+A rebuilt image has a different identity and requires its own live checks.
 
 ## Runtime contract
 
@@ -57,7 +62,7 @@ Two profiles share the same image and DFlash7 cache identity:
 | Profile | Status | Loader behavior |
 |---|---|---|
 | `glm53-flash-dflash7-python-overlay-safetensors-sparkcache-tp4-dcp1.example.json` | **implemented**, not qualified | Uses global safetensors for target and draft. This follows the qualified-compatible loader shape but still requires live qualification on the composed 0b image. |
-| `glm53-flash-dflash7-python-overlay-fastsafetensors-sparkcache-tp4-dcp1.example.json` | **implemented**, not qualified | Uses global fastsafetensors with queue size one for the target and `draft_load_config={"load_format":"safetensors"}` for DFlash. |
+| `glm53-flash-dflash7-python-overlay-fastsafetensors-sparkcache-tp4-dcp1.example.json` | **qualified** only for the recorded image and bounded cases | Uses global fastsafetensors with queue size one for the target and `draft_load_config={"load_format":"safetensors"}` for DFlash. |
 
 The image applies an exact-input vLLM patch that passes
 `SpeculativeConfig.draft_load_config` to the DFlash model loader. The image
@@ -65,10 +70,13 @@ receipt verifies patch SHA-256
 `39b567013ee7aed79f63200ed460129587933dc77fb430decdf19f78178de279` and
 postimage SHA-256
 `98acbae2b3bb4482d83f9637c163ce7c92707ccdf6561b7e431f23337f151cf4`.
-Both profiles remain unqualified until live four-rank gates pass.
+The all-safetensors profile remains unqualified. The fastsafetensors result
+belongs only to the image ID and cases named above; it does not transfer to a
+rebuild.
 
-SparkCache PR #26 accepts the canonical CUDA keys used by both profiles. No
-local PR25 compatibility profile or legacy-key rewrite is part of this path.
+SparkCache commit `5ec6a9953ad5d39120298bbfc26e95a6fa4b1dc3`
+accepts the canonical CUDA keys used by both profiles. No legacy-key rewrite
+is part of this path.
 
 ## Resolve the profile and inspect the plan
 
@@ -79,7 +87,7 @@ device, host path, and image identity. Select one profile template:
 ```bash
 receipt="$PWD/glm53-dflash7-python-overlay-image-receipt.json"
 image='sparkring-glm53-sparkcache:dflash7-vllm-python-0b67266-native-da4d7be-b12x-b1d541f-arm64'
-profile_template='scripts/config/glm53-flash-dflash7-python-overlay-safetensors-sparkcache-tp4-dcp1.example.json'
+profile_template='scripts/config/glm53-flash-dflash7-python-overlay-fastsafetensors-sparkcache-tp4-dcp1.example.json'
 
 python scripts/prepare_glm53_dflash7_python_overlay_profile.py \
   --profile-template "$profile_template" \
@@ -101,22 +109,73 @@ python scripts/sparkring_generic_launcher.py \
 
 `plan` is offline. Inspect every rank action before a lifecycle command.
 
+## Start and observe the four-rank service
+
+Run the strict placeholder check before starting containers:
+
+```bash
+python scripts/preflight.py \
+  --site /path/to/glm53-dflash7-site.yaml \
+  --strict-placeholders \
+  --json /path/to/glm53-dflash7-preflight.json
+```
+
+Starting the profile replaces the named four-rank deployment:
+
+```bash
+python scripts/sparkring_generic_launcher.py \
+  --site /path/to/glm53-dflash7-site.yaml \
+  --profile /path/to/glm53-dflash7-profile.json \
+  --execute \
+  --confirmation START_GLM53_FLASH_DFLASH7_PYTHON_OVERLAY_FASTSAFETENSORS_TP4 \
+  start
+```
+
+Tail rank zero from another terminal:
+
+```bash
+ssh operator@rank0.example.net \
+  'docker logs --follow --tail 120 glm53-flash-dflash7-python-overlay-fastsafetensors-sparkcache-tp4-r0 2>&1'
+```
+
+Wait for health and send a bounded generation smoke request with the model name from
+the selected profile:
+
+```bash
+api_endpoint='http://rank0.example.net:8015'
+served_model='glm-5.3-flash-nvfp4-dflash7-python-overlay-0b67266-on-da4d7be-b12x-b1d541f-tp4'
+until curl --fail --silent "${api_endpoint}/health" >/dev/null; do sleep 5; done
+curl --fail --silent --show-error "${api_endpoint}/v1/completions" \
+  -H 'Content-Type: application/json' \
+  -d "{\"model\":\"${served_model}\",\"prompt\":\"The capital of France is\",\"max_tokens\":16,\"temperature\":0}"
+```
+
+The configured `spark_cache_clear_once` value is a durable operation token,
+not a permanent clear-on-start switch. SparkCache removes its owned cache
+content, writes the token's completion marker only after successful removal,
+and treats later starts with the same token as no-ops. Change the token only
+when another intentional cache reset is required.
+
+`--prefill-schedule-interval` is not part of the qualified DFlash7 profile.
+Test interval `8` in a separate research-only profile so its mixed
+prefill/decode tradeoff is measured independently.
+
 ## Cache namespace impact
 
 The external DFlash weights SHA-256 is stored as
 `spark_cache_draft_checkpoint_sha256`. It cannot share entries with embedded
 MTP profiles. `tail-cow-v1` also separates these entries from snapshot-v1
 manifests. The two target-loader profiles share a namespace because loader
-choice does not change target or draft model state; each profile uses a
-different cache root and one-shot clear token while qualification is pending.
+choice does not change target or draft model state. Each template uses a
+different cache root and one-shot clear token so loader observations remain
+isolated.
 
-[SparkCache pull request #30](https://github.com/FujitsuPolycom/sparkcache/pull/30)
-combines canonical CUDA configuration names, replacement of a partial terminal
-HMA page when an authenticated cache boundary falls inside that page, and an
-eight-worker reader for authenticated page-delta chunks. The reader preserves
-manifest descriptor order after concurrent reads.
-Moving from SparkCache commit
-`5d571018de5b63a9a90e5c11e6d6e86bbff4a957` to the pinned commit
+The pinned SparkCache source combines canonical CUDA configuration names,
+replacement of a partial terminal HMA page when an authenticated cache
+boundary falls inside that page, and an eight-worker reader for authenticated
+page-delta chunks. The reader preserves manifest descriptor order after
+concurrent reads. Moving from SparkCache commit
+`5d571018de5b63a9a90e5c11e6d6e86bbff4a957` to
 `5ec6a9953ad5d39120298bbfc26e95a6fa4b1dc3` does not change the namespace.
 Checkpoint identities, page-delta wire schemas, record vocabulary, digest
 salts, parallel geometry, vLLM patches, the lease contract, and the CUDA

--- a/performance/receipts/glm53-flash/dflash7-python-overlay-pr30/validation.json
+++ b/performance/receipts/glm53-flash/dflash7-python-overlay-pr30/validation.json
@@ -1,0 +1,120 @@
+{
+  "schema": "sparkring-glm53-dflash7-pr30-live-validation/v1",
+  "status": {
+    "artifact_construction": "implemented",
+    "startup_health": "qualified",
+    "semantic_generation": "qualified",
+    "arbitrary_page_boundary_restore": "qualified",
+    "persistent_128k_restore": "qualified",
+    "persistent_256k_restore_correctness": "qualified",
+    "persistent_256k_restore_performance": "research-only",
+    "shared_prefix_concurrency": "unsupported",
+    "dflash_response_quality": "unsupported"
+  },
+  "artifact": {
+    "image": "sparkring-glm53-sparkcache:dflash7-vllm-python-0b67266-native-da4d7be-b12x-b1d541f-pr30-clean-arm64",
+    "image_id": "sha256:eef863d8bc578815a80b0e2d9f0d745102b6363415225101fd92171a2e5a55cb",
+    "published_digest": null,
+    "oci_revision_label": "b7a7265c62c1df05b17d1221d8fd0c97c54240d1",
+    "vllm_native_revision": "da4d7be6c97434f6942292ed8abbf4b32dc44355",
+    "vllm_python_revision": "0b67266a0f37d6146a8403fb8482403c62f412d5",
+    "vllm_python_tree": "ba9484ccb33aa56e90ff2f447f15ca9b9da97639",
+    "b12x_revision": "b1d541f9e71a35f030d45fae437630fff7507c2a",
+    "b12x_tree": "c69cdec1c59a08e8e0e549f930fa8abcfb5134ae",
+    "sparkcache_revision": "5ec6a9953ad5d39120298bbfc26e95a6fa4b1dc3",
+    "sparkcache_tree": "94c236b9dfbf5f70075eb47877fd9caaa5d8c249",
+    "sparkcache_source_sha256": "bc238f96e550c7ec27d4081dd1f2e741d404aaf5c8572d89ccc5e76812be4d63",
+    "cuda_placement_library_sha256": "d57509052b73853bcc8e3c3f47bb81748d87b9cbd8d908fc20d4c79a09aa400c",
+    "source_receipt_sha256": "497b068d4fb789499c540ea5ccc1638ff6d31a7a871b706f61f2a8b64606d88d",
+    "dflash_loader_patch_sha256": "39b567013ee7aed79f63200ed460129587933dc77fb430decdf19f78178de279",
+    "dflash_loader_postimage_sha256": "98acbae2b3bb4482d83f9637c163ce7c92707ccdf6561b7e431f23337f151cf4"
+  },
+  "conditions": {
+    "observed_at_utc": "2026-08-30T05:32:01Z/2026-08-30T05:40:04Z",
+    "hardware": "four NVIDIA DGX Spark systems",
+    "topology": {
+      "tensor_parallel_size": 4,
+      "decode_context_parallel_size": 1,
+      "pipeline_parallel_size": 1
+    },
+    "served_model": "glm-5.3-flash-nvfp4-dflash7-python-overlay-0b67266-on-da4d7be-b12x-b1d541f-tp4",
+    "target_loader": "fastsafetensors",
+    "target_loader_queue_size": 1,
+    "draft_loader": "safetensors",
+    "draft_method": "dflash",
+    "draft_tokens": 7,
+    "draft_tensor_parallel_size": 4,
+    "kv_cache_dtype": "fp8",
+    "kv_cache_bytes_per_rank": 21474836480,
+    "vllm_block_size_tokens": 256,
+    "max_num_seqs": 32,
+    "sparkcache_publication_schema": "tail-cow-v1",
+    "sparkcache_effective_publication_schema": "page-tail-cow-v1",
+    "sparkcache_config_schema": "canonical-v1",
+    "sparkcache_cuda_restore_io_workers": 8,
+    "sparkcache_load_threads": 2
+  },
+  "measurements": {
+    "startup": {
+      "target_fastsafetensors_seconds": 53.93,
+      "draft_safetensors_seconds": 4.85,
+      "total_model_load_seconds": 64.375343,
+      "ready_seconds_approx": 146.0,
+      "healthy_ranks": 4,
+      "restart_count_by_rank": [0, 0, 0, 0],
+      "oom_killed_by_rank": [false, false, false, false]
+    },
+    "clear_once": {
+      "worker_result": "already completed",
+      "scheduler_result": "already completed"
+    },
+    "arbitrary_page_boundary_restore": {
+      "base_tokens": 7168,
+      "restored_tokens": 12032,
+      "rank_0_end_to_end_milliseconds": 487.657,
+      "rank_0_read_milliseconds": 402.873,
+      "rank_0_h2d_submit_milliseconds": 52.12,
+      "rank_0_cuda_sync_milliseconds": 16.698,
+      "chunk_count": 47,
+      "connector_outcome": "verified"
+    },
+    "persistent_restore_128k": {
+      "restored_tokens": 131072,
+      "completion_token": 13,
+      "rank_restore_milliseconds": {
+        "0": 151.4,
+        "1": 123.6,
+        "2": 130.6,
+        "3": 138.8
+      }
+    },
+    "persistent_restore_256k": {
+      "restored_tokens": 262144,
+      "prime_request_seconds": 67.164,
+      "prime_completion_token": 916,
+      "replay_completion_token": 916,
+      "replay_wall_seconds": 7.835,
+      "rank_restore_milliseconds": {
+        "0": 5842.1,
+        "1": 7217.9,
+        "2": 6208.7,
+        "3": 7121.6
+      },
+      "rank_0_page_bytes": 1575821491,
+      "rank_0_chunk_count": 1024,
+      "rank_0_read_milliseconds": 4437.355,
+      "rank_0_h2d_submit_milliseconds": 961.72,
+      "rank_0_cuda_sync_milliseconds": 313.987
+    }
+  },
+  "limitations": [
+    "The exact image has no retained C2, C8, or C16 shared-prefix wave on this SparkCache revision.",
+    "The 262144-token result is one prime and one committed replay; it has no variability estimate.",
+    "The 1024-object page-delta layout makes the 262144-token restore a correctness result, not a performance qualification.",
+    "The first 262144-token replay began before all-rank manifest visibility and recomputed the unavailable tail; only the replay after committed visibility is reported as a restore.",
+    "No scored DFlash response-quality benchmark was run.",
+    "Sanitized raw HTTP response bodies and a complete command transcript were not retained with this record.",
+    "The image has no published OCI digest and exists only on the observed deployment hosts.",
+    "The prefill schedule interval was not changed from the profile default."
+  ]
+}

--- a/performance/records/glm53-flash/dflash7-python-overlay-pr30-live-validation.md
+++ b/performance/records/glm53-flash/dflash7-python-overlay-pr30-live-validation.md
@@ -1,0 +1,83 @@
+# GLM-5.3 DFlash7 with SparkCache bounded validation
+
+Status: **qualified** only for the startup, health, semantic generation, and
+exact SparkCache restore cases described below. The 262,144-token restore
+latency is **research-only**. Shared-prefix concurrency and DFlash response
+quality are **unsupported** by this record.
+
+## Conditions
+
+- Four NVIDIA DGX Spark systems at TP4/DCP1/PP1.
+- Local image ID
+  `sha256:eef863d8bc578815a80b0e2d9f0d745102b6363415225101fd92171a2e5a55cb`
+  on every rank. The image has no published OCI digest.
+- SparkRing image revision
+  `b7a7265c62c1df05b17d1221d8fd0c97c54240d1`; retained vLLM native commit
+  `da4d7be6c97434f6942292ed8abbf4b32dc44355`; vLLM Python commit
+  `0b67266a0f37d6146a8403fb8482403c62f412d5`; B12X commit
+  `b1d541f9e71a35f030d45fae437630fff7507c2a`.
+- SparkCache commit `5ec6a9953ad5d39120298bbfc26e95a6fa4b1dc3`, Git tree
+  `94c236b9dfbf5f70075eb47877fd9caaa5d8c249`, and deployable-source SHA-256
+  `bc238f96e550c7ec27d4081dd1f2e741d404aaf5c8572d89ccc5e76812be4d63`.
+- GLM-5.3 NVFP4 target loaded with fastsafetensors queue size one. The external
+  BF16 DFlash checkpoint loaded with safetensors. Serving used seven draft
+  tokens, draft TP4, FP8 KV, 32 sequences, and 256-token vLLM blocks.
+- SparkCache used `tail-cow-v1`, resolved to `page-tail-cow-v1` for opaque GLM
+  pages, with the canonical CUDA configuration keys, eight storage-read
+  workers, and two request-placement lanes.
+
+The machine-readable artifact identities, observations, and limitations are
+in
+[`validation.json`](../../receipts/glm53-flash/dflash7-python-overlay-pr30/validation.json).
+
+## Measurement
+
+Startup values came from the target-loader, draft-loader, model-runner, and API
+readiness logs. Container inspection checked the same complete image ID on all
+four ranks, running state, restart count, and the runtime OOM flag.
+
+Restore values came from each rank's SparkCache completion log. The client
+observed the same completion token after the 131,072-token prime and replay,
+and the same completion token after the 262,144-token prime and committed
+replay. The first 262,144-token replay began before all-rank manifest
+visibility and recomputed the unavailable tail; it is not counted as a cache
+restore. Each reported shape has one retained observation and no variability
+estimate.
+
+## Result
+
+| Gate or measurement | Observed result |
+|---|---|
+| Target fastsafetensors load | 53.93 seconds |
+| Draft safetensors load | 4.85 seconds |
+| Total model load | 64.375 seconds |
+| API readiness | approximately 146 seconds after container start |
+| Four-rank health | four running containers; restart counts `0,0,0,0`; OOM flags `false,false,false,false` |
+| One-shot cache reset | scheduler and worker reported that the configured operation token had already completed; no repeated removal occurred |
+| Arbitrary page boundary | 7,168-token base followed by verified 12,032-token restore; rank-zero total 487.657 ms; 47 objects |
+| Persistent 131,072-token restore | prime and replay completion token 13; rank range 123.6-151.4 ms |
+| Persistent 262,144-token restore | prime and replay completion token 916; 7.835-second request; rank range 5,842.1-7,217.9 ms |
+| Rank-zero 262,144-token phases | 1,024 objects; 4,437.355 ms read; 961.720 ms CUDA submission; 313.987 ms CUDA synchronization |
+
+## Conclusion
+
+The exact four-rank image loaded the target and external draft, remained
+healthy, continued generation, and restored the authenticated arbitrary-page,
+131,072-token, and 262,144-token cases without changing their observed
+completion tokens. Those bounded cases are qualified for correctness. The
+large restore is too slow to support a performance claim.
+
+## Limitations
+
+- This SparkCache revision has no retained C2, C8, or C16 shared-prefix wave on
+  the exact image. Concurrency observations from another image do not qualify
+  this artifact.
+- The 262,144-token result is one prime and one committed replay.
+- The 1,024-object physical layout dominates large page-delta restore. A
+  macro-object layout requires separate implementation and qualification.
+- No scored DFlash response-quality benchmark was run.
+- Sanitized raw HTTP bodies and a complete command transcript were not
+  retained with this record.
+- The image exists only on the observed hosts and cannot be pulled by digest.
+- `--prefill-schedule-interval 8` was not part of the recorded profile and
+  requires an independent research-only mixed-traffic test.

--- a/performance/records/glm53-flash/test_dflash7_pr30_live_validation.py
+++ b/performance/records/glm53-flash/test_dflash7_pr30_live_validation.py
@@ -1,0 +1,91 @@
+"""Validate the bounded GLM-5.3 DFlash7 SparkCache record."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[3]
+RECEIPT_PATH = (
+    ROOT
+    / "performance"
+    / "receipts"
+    / "glm53-flash"
+    / "dflash7-python-overlay-pr30"
+    / "validation.json"
+)
+RECORD_PATH = (
+    ROOT
+    / "performance"
+    / "records"
+    / "glm53-flash"
+    / "dflash7-python-overlay-pr30-live-validation.md"
+)
+
+
+def _receipt() -> dict[str, object]:
+    return json.loads(RECEIPT_PATH.read_text(encoding="utf-8"))
+
+
+def test_receipt_binds_the_exact_image_and_runtime_sources() -> None:
+    receipt = _receipt()
+    assert receipt["schema"] == "sparkring-glm53-dflash7-pr30-live-validation/v1"
+    artifact = receipt["artifact"]
+    assert artifact["image_id"] == (
+        "sha256:eef863d8bc578815a80b0e2d9f0d745102b6363415225101fd92171a2e5a55cb"
+    )
+    assert artifact["published_digest"] is None
+    assert artifact["sparkcache_revision"] == (
+        "5ec6a9953ad5d39120298bbfc26e95a6fa4b1dc3"
+    )
+    assert artifact["sparkcache_tree"] == (
+        "94c236b9dfbf5f70075eb47877fd9caaa5d8c249"
+    )
+
+
+def test_status_does_not_transfer_concurrency_or_quality() -> None:
+    status = _receipt()["status"]
+    assert status["startup_health"] == "qualified"
+    assert status["persistent_128k_restore"] == "qualified"
+    assert status["persistent_256k_restore_correctness"] == "qualified"
+    assert status["persistent_256k_restore_performance"] == "research-only"
+    assert status["shared_prefix_concurrency"] == "unsupported"
+    assert status["dflash_response_quality"] == "unsupported"
+
+
+def test_receipt_preserves_loader_health_and_restore_observations() -> None:
+    measurements = _receipt()["measurements"]
+    assert measurements["startup"]["target_fastsafetensors_seconds"] == 53.93
+    assert measurements["startup"]["draft_safetensors_seconds"] == 4.85
+    assert measurements["startup"]["restart_count_by_rank"] == [0, 0, 0, 0]
+    assert measurements["startup"]["oom_killed_by_rank"] == [
+        False,
+        False,
+        False,
+        False,
+    ]
+    assert measurements["arbitrary_page_boundary_restore"]["chunk_count"] == 47
+    restore_128k = measurements["persistent_restore_128k"]
+    assert restore_128k["restored_tokens"] == 131072
+    assert restore_128k["completion_token"] == 13
+    restore_256k = measurements["persistent_restore_256k"]
+    assert restore_256k["restored_tokens"] == 262144
+    assert restore_256k["prime_completion_token"] == 916
+    assert restore_256k["replay_completion_token"] == 916
+    assert restore_256k["rank_0_chunk_count"] == 1024
+
+
+def test_record_has_required_evidence_sections_and_scope() -> None:
+    record = RECORD_PATH.read_text(encoding="utf-8")
+    for heading in (
+        "## Conditions",
+        "## Measurement",
+        "## Result",
+        "## Conclusion",
+        "## Limitations",
+    ):
+        assert heading in record
+    assert "Concurrency observations from another image do not qualify" in record
+    assert "macro-object layout" in record
+    assert "prefill-schedule-interval 8" in record

--- a/runtime/glm53-flash-adaptive-mtp-python-overlay/README.md
+++ b/runtime/glm53-flash-adaptive-mtp-python-overlay/README.md
@@ -27,13 +27,15 @@ image is not described as a source-built vLLM 0b67266 wheel.
 
 The SparkCache source that routes reconstructed opaque pages through the SM121
 placement library is commit
-`5d571018de5b63a9a90e5c11e6d6e86bbff4a957`, Git tree
-`e864ed9ad64f771188fdb59aa9738e348134d636`. The builder verifies clean
+`5ec6a9953ad5d39120298bbfc26e95a6fa4b1dc3`, Git tree
+`94c236b9dfbf5f70075eb47877fd9caaa5d8c249`. The builder verifies clean
 deployable-source SHA-256
-`f7c0565521fddeff7085e4cc08043cb8d1e2bde33abc67f83b8608a162d05b88`
+`bc238f96e550c7ec27d4081dd1f2e741d404aaf5c8572d89ccc5e76812be4d63`
 before generating the SparkCache CUDA placement library. It applies the VMM exemption,
 load-failure recovery, shared-prefix retention, and follower-attachment
-patches in order, then runs the eleven-file lease-contract verifier. The test
+patches in order, then runs the eleven-file lease-contract verifier. The
+pinned source accepts the canonical `spark_cache_cuda_*` configuration keys
+used by the profile. The test
 profile selects `spark_cache_publication_schema=tail-cow-v1`, which maps opaque
 GLM page storage to the distinct `page-tail-cow-v1` cache namespace.
 

--- a/runtime/glm53-flash-adaptive-mtp-python-overlay/pins.json
+++ b/runtime/glm53-flash-adaptive-mtp-python-overlay/pins.json
@@ -77,9 +77,17 @@
   },
   "sparkcache": {
     "repository": "https://github.com/FujitsuPolycom/sparkcache.git",
-    "commit": "5d571018de5b63a9a90e5c11e6d6e86bbff4a957",
-    "tree": "e864ed9ad64f771188fdb59aa9738e348134d636",
-    "source_tree_sha256": "f7c0565521fddeff7085e4cc08043cb8d1e2bde33abc67f83b8608a162d05b88",
+    "commit": "5ec6a9953ad5d39120298bbfc26e95a6fa4b1dc3",
+    "tree": "94c236b9dfbf5f70075eb47877fd9caaa5d8c249",
+    "source_tree_sha256": "bc238f96e550c7ec27d4081dd1f2e741d404aaf5c8572d89ccc5e76812be4d63",
+    "cuda_config_schema": "canonical-v1",
+    "canonical_cuda_config_keys": [
+      "spark_cache_cuda_restore",
+      "spark_cache_cuda_placement_library",
+      "spark_cache_cuda_placement_library_sha256",
+      "spark_cache_cuda_placement_arena_bytes",
+      "spark_cache_cuda_restore_io_workers"
+    ],
     "contract": {
       "path": "sparkcache/runtime_patches/vllm-kv-block-lease-contract-glm53-b12x-kda-adaptive-mtp.json",
       "sha256": "6defde9551cbb586fd09bb2d3020495531b6573397875a767eaae1dbad126024",

--- a/runtime/glm53-flash-adaptive-mtp-python-overlay/test_public_python_overlay.py
+++ b/runtime/glm53-flash-adaptive-mtp-python-overlay/test_public_python_overlay.py
@@ -51,12 +51,13 @@ def test_overlay_pins_public_base_and_mixed_vllm_provenance() -> None:
     assert pins["b12x"]["commit"] != pins["b12x"]["base_commit"]
     sparkcache = pins["sparkcache"]
     assert sparkcache["commit"] == (
-        "5d571018de5b63a9a90e5c11e6d6e86bbff4a957"
+        "5ec6a9953ad5d39120298bbfc26e95a6fa4b1dc3"
     )
-    assert sparkcache["tree"] == "e864ed9ad64f771188fdb59aa9738e348134d636"
+    assert sparkcache["tree"] == "94c236b9dfbf5f70075eb47877fd9caaa5d8c249"
     assert sparkcache["source_tree_sha256"] == (
-        "f7c0565521fddeff7085e4cc08043cb8d1e2bde33abc67f83b8608a162d05b88"
+        "bc238f96e550c7ec27d4081dd1f2e741d404aaf5c8572d89ccc5e76812be4d63"
     )
+    assert sparkcache["cuda_config_schema"] == "canonical-v1"
     assert pins["dependencies"]["torch"] == "2.13.0+cu130"
 
 

--- a/runtime/glm53-flash-b12x-kda-adaptive-mtp/README.md
+++ b/runtime/glm53-flash-b12x-kda-adaptive-mtp/README.md
@@ -33,9 +33,11 @@ SparkCache restore, shared-prefix concurrency, and fatal-log checks require a
 separate four-rank receipt.
 
 The matching SparkCache CUDA placement source is commit
-`5d571018de5b63a9a90e5c11e6d6e86bbff4a957`, Git tree
-`e864ed9ad64f771188fdb59aa9738e348134d636`, with clean deployable-source
-SHA-256 `f7c0565521fddeff7085e4cc08043cb8d1e2bde33abc67f83b8608a162d05b88`.
+`5ec6a9953ad5d39120298bbfc26e95a6fa4b1dc3`, Git tree
+`94c236b9dfbf5f70075eb47877fd9caaa5d8c249`, with clean deployable-source
+SHA-256 `bc238f96e550c7ec27d4081dd1f2e741d404aaf5c8572d89ccc5e76812be4d63`.
+That source accepts the profile's canonical `spark_cache_cuda_*` keys
+directly.
 Its Linux-byte-exact vLLM contract is
 `vllm-kv-block-lease-contract-glm53-b12x-kda-adaptive-mtp.json`. The
 runtime-bound embedded-MTP identity prevents this profile from reusing e105

--- a/runtime/glm53-flash-b12x-kda-adaptive-mtp/pins.json
+++ b/runtime/glm53-flash-b12x-kda-adaptive-mtp/pins.json
@@ -104,9 +104,17 @@
   },
   "sparkcache": {
     "repository": "https://github.com/FujitsuPolycom/sparkcache",
-    "commit": "5d571018de5b63a9a90e5c11e6d6e86bbff4a957",
-    "tree": "e864ed9ad64f771188fdb59aa9738e348134d636",
-    "source_tree_sha256": "f7c0565521fddeff7085e4cc08043cb8d1e2bde33abc67f83b8608a162d05b88",
+    "commit": "5ec6a9953ad5d39120298bbfc26e95a6fa4b1dc3",
+    "tree": "94c236b9dfbf5f70075eb47877fd9caaa5d8c249",
+    "source_tree_sha256": "bc238f96e550c7ec27d4081dd1f2e741d404aaf5c8572d89ccc5e76812be4d63",
+    "cuda_config_schema": "canonical-v1",
+    "canonical_cuda_config_keys": [
+      "spark_cache_cuda_restore",
+      "spark_cache_cuda_placement_library",
+      "spark_cache_cuda_placement_library_sha256",
+      "spark_cache_cuda_placement_arena_bytes",
+      "spark_cache_cuda_restore_io_workers"
+    ],
     "lease_contract": "sparkcache/runtime_patches/vllm-kv-block-lease-contract-glm53-b12x-kda-adaptive-mtp.json",
     "lease_contract_sha256": "6defde9551cbb586fd09bb2d3020495531b6573397875a767eaae1dbad126024",
     "overlay_containerfile": "deploy/glm53_flash/Containerfile.b12x-kda-adaptive-mtp",

--- a/runtime/glm53-flash-b12x-kda-adaptive-mtp/test_glm53_b12x_kda_adaptive_mtp_contract.py
+++ b/runtime/glm53-flash-b12x-kda-adaptive-mtp/test_glm53_b12x_kda_adaptive_mtp_contract.py
@@ -8,10 +8,10 @@ from unittest import mock
 
 HERE = Path(__file__).resolve().parent
 PINS = HERE / "pins.json"
-SPARKCACHE_COMMIT = "5d571018de5b63a9a90e5c11e6d6e86bbff4a957"
-SPARKCACHE_TREE = "e864ed9ad64f771188fdb59aa9738e348134d636"
+SPARKCACHE_COMMIT = "5ec6a9953ad5d39120298bbfc26e95a6fa4b1dc3"
+SPARKCACHE_TREE = "94c236b9dfbf5f70075eb47877fd9caaa5d8c249"
 SPARKCACHE_SOURCE_SHA256 = (
-    "f7c0565521fddeff7085e4cc08043cb8d1e2bde33abc67f83b8608a162d05b88"
+    "bc238f96e550c7ec27d4081dd1f2e741d404aaf5c8572d89ccc5e76812be4d63"
 )
 OVERLAY_CONTAINERFILE_SHA256 = (
     "8e2377d034ba80b059f9a4387a6590a08e205313568ee1382e0e25342f8c5d40"
@@ -52,6 +52,14 @@ def test_glm53_b12x_kda_adaptive_mtp_source_build_is_exact_and_unqualified() -> 
     assert sparkcache["commit"] == SPARKCACHE_COMMIT
     assert sparkcache["tree"] == SPARKCACHE_TREE
     assert sparkcache["source_tree_sha256"] == SPARKCACHE_SOURCE_SHA256
+    assert sparkcache["cuda_config_schema"] == "canonical-v1"
+    assert set(sparkcache["canonical_cuda_config_keys"]) == {
+        "spark_cache_cuda_restore",
+        "spark_cache_cuda_placement_library",
+        "spark_cache_cuda_placement_library_sha256",
+        "spark_cache_cuda_placement_arena_bytes",
+        "spark_cache_cuda_restore_io_workers",
+    }
     assert (
         sparkcache["overlay_containerfile_sha256"]
         == OVERLAY_CONTAINERFILE_SHA256

--- a/runtime/glm53-flash-dflash7-python-overlay/README.md
+++ b/runtime/glm53-flash-dflash7-python-overlay/README.md
@@ -1,8 +1,12 @@
 # GLM-5.3 DFlash7 public-base Python overlay
 
-Status: **implemented**, not qualified. The builder constructs and verifies an
-ARM64 image but no image digest from this path has completed four-rank serving
-qualification.
+Status: **implemented**. The builder constructs and verifies an ARM64 image.
+Local image ID
+`sha256:eef863d8bc578815a80b0e2d9f0d745102b6363415225101fd92171a2e5a55cb`
+is **qualified** only for the bounded four-rank cases recorded in
+`performance/records/glm53-flash/dflash7-python-overlay-pr30-live-validation.md`.
+Qualification does not transfer to a rebuild or to the all-safetensors
+profile.
 
 The image combines these exact roles:
 
@@ -42,20 +46,21 @@ operator-mounted and are verified by the runtime profile.
 
 Two executable profiles use external DFlash at depth seven and TP4, FP8 target
 KV, 256-token vLLM blocks, 32 sequences, and SparkCache page-tail copy-on-write
-publication with CUDA restore. Both are implemented but unqualified on the
-composed 0b image. The conservative profile uses global safetensors. The mixed
-profile uses global fastsafetensors for the target and an exact
-`draft_load_config` selecting safetensors for DFlash. The image applies and
+publication with CUDA restore. The all-safetensors profile is implemented but
+unqualified. The mixed-loader profile is qualified only for the exact image
+and bounded cases named above. The conservative profile uses global
+safetensors. The mixed profile uses global fastsafetensors for the target and
+an exact `draft_load_config` selecting safetensors for DFlash. The image applies and
 verifies the draft-loader patch before installing SparkCache patches. See
 `docs/GLM53_DFLASH7_PYTHON_OVERLAY_SPARKCACHE_TP4_QUICKSTART.md`.
 
 The SparkCache source accepts the canonical CUDA configuration keys directly.
-No PR25 compatibility profile or legacy-key translation is required by these
+No legacy-key compatibility profile or translation is required by these
 profiles.
 
-The pinned SparkCache source from
-[pull request #30](https://github.com/FujitsuPolycom/sparkcache/pull/30)
-accepts canonical CUDA configuration keys, replaces a partial terminal HMA
+The pinned SparkCache source at
+`5ec6a9953ad5d39120298bbfc26e95a6fa4b1dc3` accepts canonical CUDA
+configuration keys, replaces a partial terminal HMA
 page when the authenticated cache boundary falls inside that page, and reads
 authenticated page-delta chunks with a bounded eight-worker pool while
 preserving descriptor order. It does not change cache identity, page-tail wire

--- a/runtime/glm53-flash-dflash7-python-overlay/pins.json
+++ b/runtime/glm53-flash-dflash7-python-overlay/pins.json
@@ -1,7 +1,7 @@
 {
   "schema": "sparkring-glm53-public-python-overlay/v1",
   "status": "implemented",
-  "qualification": "The DFlash7 image builder and offline verifier are implemented. The resulting image is unsupported for serving until an immutable digest passes four-rank TP4/DCP1 target and external-draft loading, semantic generation, SparkCache store and restore, failure-recovery, and concurrency checks.",
+  "qualification": "The DFlash7 image builder and offline verifier are implemented. An image is unsupported for serving until its exact immutable identity passes four-rank TP4/DCP1 target and external-draft loading, semantic generation, SparkCache store and restore, and failure-recovery checks. Local image ID sha256:eef863d8bc578815a80b0e2d9f0d745102b6363415225101fd92171a2e5a55cb has bounded startup, health, semantic-generation, and restore qualification; it has no retained shared-prefix concurrency or DFlash response-quality qualification.",
   "platform": "linux/arm64",
   "public_base": {
     "reference": "ghcr.io/fujitsupolycom/sparkring-glm53-runtime@sha256:864adfe68f458223e186a19844ac80c7adc7365e5db1f25e109b85fc19850dcd",

--- a/scripts/config/glm53-flash-b12x-kda-mtp5-adaptive-fastsafetensors-sparkcache-tp4-dcp1.example.json
+++ b/scripts/config/glm53-flash-b12x-kda-mtp5-adaptive-fastsafetensors-sparkcache-tp4-dcp1.example.json
@@ -111,9 +111,9 @@
     "weight_loader": "fastsafetensors",
     "weight_loader_queue_size": "1",
     "weight_loader_tp_nogds": "true",
-    "sparkcache_source_sha256": "f7c0565521fddeff7085e4cc08043cb8d1e2bde33abc67f83b8608a162d05b88",
-    "sparkcache_source_revision": "5d571018de5b63a9a90e5c11e6d6e86bbff4a957",
-    "sparkcache_source_tree": "e864ed9ad64f771188fdb59aa9738e348134d636",
+    "sparkcache_source_sha256": "bc238f96e550c7ec27d4081dd1f2e741d404aaf5c8572d89ccc5e76812be4d63",
+    "sparkcache_source_revision": "5ec6a9953ad5d39120298bbfc26e95a6fa4b1dc3",
+    "sparkcache_source_tree": "94c236b9dfbf5f70075eb47877fd9caaa5d8c249",
     "vllm_revision": "0b67266a0f37d6146a8403fb8482403c62f412d5"
   },
   "required_image_labels": {
@@ -123,10 +123,10 @@
     "org.jovian.vllm.commit": "0b67266a0f37d6146a8403fb8482403c62f412d5",
     "org.sparkcache.deployment-profile": "glm53-flash-b12x-kda-adaptive-mtp-source-built",
     "org.opencontainers.image.base.name": "REPLACE_WITH_B12X_KDA_ADAPTIVE_MTP_RUNTIME_IMAGE",
-    "org.opencontainers.image.revision": "5d571018de5b63a9a90e5c11e6d6e86bbff4a957",
+    "org.opencontainers.image.revision": "5ec6a9953ad5d39120298bbfc26e95a6fa4b1dc3",
     "org.sparkcache.parent-image-id": "sha256:0000000000000000000000000000000000000000000000000000000000000000",
-    "org.sparkcache.source-revision": "5d571018de5b63a9a90e5c11e6d6e86bbff4a957",
-    "org.sparkcache.source-sha256": "f7c0565521fddeff7085e4cc08043cb8d1e2bde33abc67f83b8608a162d05b88",
+    "org.sparkcache.source-revision": "5ec6a9953ad5d39120298bbfc26e95a6fa4b1dc3",
+    "org.sparkcache.source-sha256": "bc238f96e550c7ec27d4081dd1f2e741d404aaf5c8572d89ccc5e76812be4d63",
     "org.sparkring.nccl.commit": "73cf112295c33aee2b895f329f592f2a9b4b0f97",
     "org.sparkring.nccl.patch-sha256": "6709063fa1c25055ae77a9397dea5d89643f8211d25e7990bdd11597d08c0dde",
     "org.sparkring.nccl.patched-tree": "abdeb053b94c3f6d472cd55ae2b79ca821299009"
@@ -134,6 +134,6 @@
   "attestation_hook": [
     "/bin/sh",
     "-ec",
-    "test -f /models/target/config.json && test -f /models/target/model.safetensors.index.json && test \"$(sha256sum /models/target/config.json | cut -d ' ' -f1)\" = 676382abd1e90a6c85f0c8f33d45441ecd45fd514fd7b63ce5610e732d8e4996 && test \"$(sha256sum /models/target/model.safetensors.index.json | cut -d ' ' -f1)\" = 0d1d9e6b226e76520e182de10d4e7194cc885c5cb1bf885bb90de1916ce312cb && test \"$(sha256sum /opt/sparkring/nccl/libnccl.so.2 | cut -d ' ' -f1)\" = 5f1c3f10d5ace66d4ba584415bbfe42b6ac1a0a9116a3b81dcbe50516ad924b3 && test \"$(python3 -c 'import importlib.util, pathlib; spec = importlib.util.spec_from_file_location(\"source_identity\", \"/opt/sparkcache-source-identity.py\"); module = importlib.util.module_from_spec(spec); spec.loader.exec_module(module); print(module.source_tree_sha256(pathlib.Path(\"/opt/sparkcache-src/sparkcache\")))')\" = f7c0565521fddeff7085e4cc08043cb8d1e2bde33abc67f83b8608a162d05b88 && test \"$(sha256sum /opt/sparkcache-src/sparkcache/runtime_patches/vllm-kv-block-lease-contract-glm53-b12x-kda-adaptive-mtp.json | cut -d ' ' -f1)\" = 6defde9551cbb586fd09bb2d3020495531b6573397875a767eaae1dbad126024 && test \"$(sha256sum /usr/local/lib/python3.12/dist-packages/vllm/config/vllm.py | cut -d ' ' -f1)\" = 9f64f5041f7f9d953e9f6bc53de8733b3eb4035c0753056a1f646346702a0994 && test \"$(sha256sum /opt/sparkcache-src/sparkcache/native/build-cuda/libspark_cache_placement.so | cut -d ' ' -f1)\" = REPLACE_WITH_CUDA_PLACEMENT_LIBRARY_SHA256 && python3 /opt/sparkcache-src/sparkcache/runtime_patches/verify_lease_contract.py --vllm-root /usr/local/lib/python3.12/dist-packages --contract /opt/sparkcache-src/sparkcache/runtime_patches/vllm-kv-block-lease-contract-glm53-b12x-kda-adaptive-mtp.json"
+    "test -f /models/target/config.json && test -f /models/target/model.safetensors.index.json && test \"$(sha256sum /models/target/config.json | cut -d ' ' -f1)\" = 676382abd1e90a6c85f0c8f33d45441ecd45fd514fd7b63ce5610e732d8e4996 && test \"$(sha256sum /models/target/model.safetensors.index.json | cut -d ' ' -f1)\" = 0d1d9e6b226e76520e182de10d4e7194cc885c5cb1bf885bb90de1916ce312cb && test \"$(sha256sum /opt/sparkring/nccl/libnccl.so.2 | cut -d ' ' -f1)\" = 5f1c3f10d5ace66d4ba584415bbfe42b6ac1a0a9116a3b81dcbe50516ad924b3 && test \"$(python3 -c 'import importlib.util, pathlib; spec = importlib.util.spec_from_file_location(\"source_identity\", \"/opt/sparkcache-source-identity.py\"); module = importlib.util.module_from_spec(spec); spec.loader.exec_module(module); print(module.source_tree_sha256(pathlib.Path(\"/opt/sparkcache-src/sparkcache\")))')\" = bc238f96e550c7ec27d4081dd1f2e741d404aaf5c8572d89ccc5e76812be4d63 && test \"$(sha256sum /opt/sparkcache-src/sparkcache/runtime_patches/vllm-kv-block-lease-contract-glm53-b12x-kda-adaptive-mtp.json | cut -d ' ' -f1)\" = 6defde9551cbb586fd09bb2d3020495531b6573397875a767eaae1dbad126024 && test \"$(sha256sum /usr/local/lib/python3.12/dist-packages/vllm/config/vllm.py | cut -d ' ' -f1)\" = 9f64f5041f7f9d953e9f6bc53de8733b3eb4035c0753056a1f646346702a0994 && test \"$(sha256sum /opt/sparkcache-src/sparkcache/native/build-cuda/libspark_cache_placement.so | cut -d ' ' -f1)\" = REPLACE_WITH_CUDA_PLACEMENT_LIBRARY_SHA256 && python3 /opt/sparkcache-src/sparkcache/runtime_patches/verify_lease_contract.py --vllm-root /usr/local/lib/python3.12/dist-packages --contract /opt/sparkcache-src/sparkcache/runtime_patches/vllm-kv-block-lease-contract-glm53-b12x-kda-adaptive-mtp.json"
   ]
 }

--- a/scripts/config/glm53-flash-public-python-overlay-mtp5-adaptive-fastsafetensors-sparkcache-tp4-dcp1.example.json
+++ b/scripts/config/glm53-flash-public-python-overlay-mtp5-adaptive-fastsafetensors-sparkcache-tp4-dcp1.example.json
@@ -118,9 +118,9 @@
     "weight_loader_tp_nogds": "true",
     "sparkcache_publication_schema": "tail-cow-v1",
     "sparkcache_effective_publication_schema": "page-tail-cow-v1",
-    "sparkcache_source_sha256": "f7c0565521fddeff7085e4cc08043cb8d1e2bde33abc67f83b8608a162d05b88",
-    "sparkcache_source_revision": "5d571018de5b63a9a90e5c11e6d6e86bbff4a957",
-    "sparkcache_source_tree": "e864ed9ad64f771188fdb59aa9738e348134d636",
+    "sparkcache_source_sha256": "bc238f96e550c7ec27d4081dd1f2e741d404aaf5c8572d89ccc5e76812be4d63",
+    "sparkcache_source_revision": "5ec6a9953ad5d39120298bbfc26e95a6fa4b1dc3",
+    "sparkcache_source_tree": "94c236b9dfbf5f70075eb47877fd9caaa5d8c249",
     "vllm_native_revision": "da4d7be6c97434f6942292ed8abbf4b32dc44355",
     "vllm_python_revision": "0b67266a0f37d6146a8403fb8482403c62f412d5",
     "vllm_python_tree": "ba9484ccb33aa56e90ff2f447f15ca9b9da97639",
@@ -146,9 +146,9 @@
     "org.sparkring.base.image-id": "sha256:7e8c0ebcb2001efb4cdab0ec9d20d53972e62db3688230044e22e61ffb1d35d5",
     "org.sparkcache.deployment-profile": "glm53-flash-adaptive-mtp-python-overlay",
     "org.sparkcache.cuda-placement-library-sha256": "REPLACE_WITH_CUDA_PLACEMENT_LIBRARY_SHA256",
-    "org.sparkcache.source-revision": "5d571018de5b63a9a90e5c11e6d6e86bbff4a957",
-    "org.sparkcache.source-tree": "e864ed9ad64f771188fdb59aa9738e348134d636",
-    "org.sparkcache.source-sha256": "f7c0565521fddeff7085e4cc08043cb8d1e2bde33abc67f83b8608a162d05b88",
+    "org.sparkcache.source-revision": "5ec6a9953ad5d39120298bbfc26e95a6fa4b1dc3",
+    "org.sparkcache.source-tree": "94c236b9dfbf5f70075eb47877fd9caaa5d8c249",
+    "org.sparkcache.source-sha256": "bc238f96e550c7ec27d4081dd1f2e741d404aaf5c8572d89ccc5e76812be4d63",
     "org.sparkcache.vllm-contract-sha256": "6defde9551cbb586fd09bb2d3020495531b6573397875a767eaae1dbad126024",
     "org.sparkring.source-receipt-sha256": "REPLACE_WITH_SOURCE_RECEIPT_SHA256",
     "org.sparkring.nccl.commit": "73cf112295c33aee2b895f329f592f2a9b4b0f97",
@@ -158,6 +158,6 @@
   "attestation_hook": [
     "/bin/sh",
     "-ec",
-    "test -f /models/target/config.json && test -f /models/target/model.safetensors.index.json && test \"$(sha256sum /models/target/config.json | cut -d ' ' -f1)\" = 676382abd1e90a6c85f0c8f33d45441ecd45fd514fd7b63ce5610e732d8e4996 && test \"$(sha256sum /models/target/model.safetensors.index.json | cut -d ' ' -f1)\" = 0d1d9e6b226e76520e182de10d4e7194cc885c5cb1bf885bb90de1916ce312cb && test \"$(sha256sum /opt/sparkring/nccl/libnccl.so.2 | cut -d ' ' -f1)\" = 5f1c3f10d5ace66d4ba584415bbfe42b6ac1a0a9116a3b81dcbe50516ad924b3 && grep -q '\"tail-cow-v1\"' /opt/sparkcache-src/sparkcache/spark_context_cache_config.py && test \"$(sha256sum /opt/sparkring/runtime/python-overlay/vllm-python-overlay.json | cut -d ' ' -f1)\" = e5e528288b173399611a4930fecc4182b7208bc1564881d52ca5d2c5c4ae0f6a && test \"$(sha256sum /opt/sparkring/runtime/python-overlay/source-receipt.json | cut -d ' ' -f1)\" = REPLACE_WITH_SOURCE_RECEIPT_SHA256 && test \"$(python3 -c 'import json; print(json.load(open(\"/opt/sparkring/runtime/python-overlay/retained-native.json\", encoding=\"utf-8\"))[\"native_elf_manifest_sha256\"])')\" = REPLACE_WITH_VLLM_NATIVE_ELF_MANIFEST_SHA256 && test \"$(python3 -c 'import json; print(json.load(open(\"/opt/sparkring/runtime/python-overlay/retained-native.json\", encoding=\"utf-8\"))[\"native_dispatch_manifest_sha256\"])')\" = REPLACE_WITH_VLLM_NATIVE_DISPATCH_MANIFEST_SHA256 && test \"$(cat /opt/sparkring/runtime/python-overlay/sparkcache-source-tree.sha256)\" = f7c0565521fddeff7085e4cc08043cb8d1e2bde33abc67f83b8608a162d05b88 && test \"$(sha256sum /opt/sparkcache-src/sparkcache/runtime_patches/vllm-kv-block-lease-contract-glm53-b12x-kda-adaptive-mtp.json | cut -d ' ' -f1)\" = 6defde9551cbb586fd09bb2d3020495531b6573397875a767eaae1dbad126024 && test \"$(sha256sum /opt/sparkcache-src/sparkcache/native/build-cuda/libspark_cache_placement.so | cut -d ' ' -f1)\" = REPLACE_WITH_CUDA_PLACEMENT_LIBRARY_SHA256 && python3 /opt/sparkcache-src/sparkcache/runtime_patches/verify_lease_contract.py --vllm-root /usr/local/lib/python3.12/dist-packages --contract /opt/sparkcache-src/sparkcache/runtime_patches/vllm-kv-block-lease-contract-glm53-b12x-kda-adaptive-mtp.json"
+    "test -f /models/target/config.json && test -f /models/target/model.safetensors.index.json && test \"$(sha256sum /models/target/config.json | cut -d ' ' -f1)\" = 676382abd1e90a6c85f0c8f33d45441ecd45fd514fd7b63ce5610e732d8e4996 && test \"$(sha256sum /models/target/model.safetensors.index.json | cut -d ' ' -f1)\" = 0d1d9e6b226e76520e182de10d4e7194cc885c5cb1bf885bb90de1916ce312cb && test \"$(sha256sum /opt/sparkring/nccl/libnccl.so.2 | cut -d ' ' -f1)\" = 5f1c3f10d5ace66d4ba584415bbfe42b6ac1a0a9116a3b81dcbe50516ad924b3 && grep -q '\"tail-cow-v1\"' /opt/sparkcache-src/sparkcache/spark_context_cache_config.py && test \"$(sha256sum /opt/sparkring/runtime/python-overlay/vllm-python-overlay.json | cut -d ' ' -f1)\" = e5e528288b173399611a4930fecc4182b7208bc1564881d52ca5d2c5c4ae0f6a && test \"$(sha256sum /opt/sparkring/runtime/python-overlay/source-receipt.json | cut -d ' ' -f1)\" = REPLACE_WITH_SOURCE_RECEIPT_SHA256 && test \"$(python3 -c 'import json; print(json.load(open(\"/opt/sparkring/runtime/python-overlay/retained-native.json\", encoding=\"utf-8\"))[\"native_elf_manifest_sha256\"])')\" = REPLACE_WITH_VLLM_NATIVE_ELF_MANIFEST_SHA256 && test \"$(python3 -c 'import json; print(json.load(open(\"/opt/sparkring/runtime/python-overlay/retained-native.json\", encoding=\"utf-8\"))[\"native_dispatch_manifest_sha256\"])')\" = REPLACE_WITH_VLLM_NATIVE_DISPATCH_MANIFEST_SHA256 && test \"$(cat /opt/sparkring/runtime/python-overlay/sparkcache-source-tree.sha256)\" = bc238f96e550c7ec27d4081dd1f2e741d404aaf5c8572d89ccc5e76812be4d63 && test \"$(sha256sum /opt/sparkcache-src/sparkcache/runtime_patches/vllm-kv-block-lease-contract-glm53-b12x-kda-adaptive-mtp.json | cut -d ' ' -f1)\" = 6defde9551cbb586fd09bb2d3020495531b6573397875a767eaae1dbad126024 && test \"$(sha256sum /opt/sparkcache-src/sparkcache/native/build-cuda/libspark_cache_placement.so | cut -d ' ' -f1)\" = REPLACE_WITH_CUDA_PLACEMENT_LIBRARY_SHA256 && python3 /opt/sparkcache-src/sparkcache/runtime_patches/verify_lease_contract.py --vllm-root /usr/local/lib/python3.12/dist-packages --contract /opt/sparkcache-src/sparkcache/runtime_patches/vllm-kv-block-lease-contract-glm53-b12x-kda-adaptive-mtp.json"
   ]
 }

--- a/scripts/prepare_glm53_b12x_kda_adaptive_mtp_profile.py
+++ b/scripts/prepare_glm53_b12x_kda_adaptive_mtp_profile.py
@@ -24,10 +24,10 @@ CUDA_PLACEMENT_PLACEHOLDER = "REPLACE_WITH_CUDA_PLACEMENT_LIBRARY_SHA256"
 LEGACY_PLACEMENT_PLACEHOLDER = "REPLACE_WITH_NATIVE_LIBRARY_SHA256"
 IMAGE_PLACEHOLDER = "REPLACE_WITH_B12X_KDA_ADAPTIVE_MTP_SPARKCACHE_IMAGE"
 PARENT_PLACEHOLDER = "REPLACE_WITH_B12X_KDA_ADAPTIVE_MTP_RUNTIME_IMAGE"
-SPARKCACHE_COMMIT = "5d571018de5b63a9a90e5c11e6d6e86bbff4a957"
-SPARKCACHE_TREE = "e864ed9ad64f771188fdb59aa9738e348134d636"
+SPARKCACHE_COMMIT = "5ec6a9953ad5d39120298bbfc26e95a6fa4b1dc3"
+SPARKCACHE_TREE = "94c236b9dfbf5f70075eb47877fd9caaa5d8c249"
 SPARKCACHE_SOURCE_SHA256 = (
-    "f7c0565521fddeff7085e4cc08043cb8d1e2bde33abc67f83b8608a162d05b88"
+    "bc238f96e550c7ec27d4081dd1f2e741d404aaf5c8572d89ccc5e76812be4d63"
 )
 LEASE_CONTRACT_SHA256 = (
     "6defde9551cbb586fd09bb2d3020495531b6573397875a767eaae1dbad126024"
@@ -132,6 +132,23 @@ def resolve(
         raise ResolveError("adaptive MTP observation window must be 32")
     if profile.get("environment", {}).get("VLLM_FASTSAFETENSORS_QUEUE_SIZE") != "1":
         raise ResolveError("fastsafetensors queue size must be one")
+    transfer = json.loads(_argument(profile, "--kv-transfer-config"))
+    transfer_extra = transfer.get("kv_connector_extra_config", {})
+    canonical_cuda_keys = {
+        "spark_cache_cuda_restore",
+        "spark_cache_cuda_placement_library",
+        "spark_cache_cuda_placement_library_sha256",
+        "spark_cache_cuda_placement_arena_bytes",
+        "spark_cache_cuda_restore_io_workers",
+    }
+    missing_cuda_keys = canonical_cuda_keys.difference(transfer_extra)
+    if missing_cuda_keys:
+        raise ResolveError(
+            "profile omits canonical SparkCache CUDA keys: "
+            + ", ".join(sorted(missing_cuda_keys))
+        )
+    if any(name.startswith("spark_cache_native_") for name in transfer_extra):
+        raise ResolveError("profile may not use legacy SparkCache native keys")
     attestation = " ".join(str(value) for value in profile.get("attestation_hook", []))
     if SPARKCACHE_SOURCE_SHA256 not in attestation:
         raise ResolveError("profile does not attest the integrated SparkCache source")

--- a/scripts/prepare_glm53_public_python_overlay_profile.py
+++ b/scripts/prepare_glm53_public_python_overlay_profile.py
@@ -53,10 +53,10 @@ DFLASH_LOADER_PATCH_SHA256 = (
 DFLASH_LOADER_POSTIMAGE_SHA256 = (
     "98acbae2b3bb4482d83f9637c163ce7c92707ccdf6561b7e431f23337f151cf4"
 )
-SPARKCACHE_COMMIT = "5d571018de5b63a9a90e5c11e6d6e86bbff4a957"
-SPARKCACHE_TREE = "e864ed9ad64f771188fdb59aa9738e348134d636"
+SPARKCACHE_COMMIT = "5ec6a9953ad5d39120298bbfc26e95a6fa4b1dc3"
+SPARKCACHE_TREE = "94c236b9dfbf5f70075eb47877fd9caaa5d8c249"
 SPARKCACHE_SOURCE_SHA256 = (
-    "f7c0565521fddeff7085e4cc08043cb8d1e2bde33abc67f83b8608a162d05b88"
+    "bc238f96e550c7ec27d4081dd1f2e741d404aaf5c8572d89ccc5e76812be4d63"
 )
 LEASE_CONTRACT_SHA256 = (
     "6defde9551cbb586fd09bb2d3020495531b6573397875a767eaae1dbad126024"
@@ -206,6 +206,21 @@ def resolve(
     transfer_extra = transfer.get("kv_connector_extra_config", {})
     if transfer_extra.get("spark_cache_publication_schema") != "tail-cow-v1":
         raise ResolveError("opaque page-tail publication requires tail-cow-v1")
+    canonical_cuda_keys = {
+        "spark_cache_cuda_restore",
+        "spark_cache_cuda_placement_library",
+        "spark_cache_cuda_placement_library_sha256",
+        "spark_cache_cuda_placement_arena_bytes",
+        "spark_cache_cuda_restore_io_workers",
+    }
+    missing_cuda_keys = canonical_cuda_keys.difference(transfer_extra)
+    if missing_cuda_keys:
+        raise ResolveError(
+            "profile omits canonical SparkCache CUDA keys: "
+            + ", ".join(sorted(missing_cuda_keys))
+        )
+    if any(name.startswith("spark_cache_native_") for name in transfer_extra):
+        raise ResolveError("profile may not use legacy SparkCache native keys")
 
     labels = profile.get("required_image_labels", {})
     fixed_labels = {

--- a/scripts/test_prepare_glm53_b12x_kda_adaptive_mtp_profile.py
+++ b/scripts/test_prepare_glm53_b12x_kda_adaptive_mtp_profile.py
@@ -162,6 +162,18 @@ def test_resolver_rejects_runtime_or_loader_identity_drift() -> None:
     with pytest.raises(ResolveError, match="queue size must be one"):
         resolve(changed, copy.deepcopy(site), **arguments)
 
+    changed = copy.deepcopy(profile)
+    transfer = json.loads(_argument(changed, "--kv-transfer-config"))
+    transfer["kv_connector_extra_config"].pop(
+        "spark_cache_cuda_restore_io_workers"
+    )
+    changed_args = changed["extra_vllm_args"]
+    changed_args[changed_args.index("--kv-transfer-config") + 1] = json.dumps(
+        transfer, separators=(",", ":")
+    )
+    with pytest.raises(ResolveError, match="omits canonical SparkCache CUDA keys"):
+        resolve(changed, copy.deepcopy(site), **arguments)
+
 
 def test_resolver_normalizes_legacy_cuda_restore_aliases_and_rejects_conflicts() -> None:
     profile = json.loads(PROFILE.read_text(encoding="utf-8"))

--- a/scripts/test_prepare_glm53_dflash7_python_overlay_profile.py
+++ b/scripts/test_prepare_glm53_dflash7_python_overlay_profile.py
@@ -261,11 +261,17 @@ def test_quickstart_names_both_loader_statuses_and_exact_builder() -> None:
     guide = GUIDE.read_text(encoding="utf-8")
     assert "runtime/glm53-flash-dflash7-python-overlay/build-image.sh" in guide
     assert FAST.name in guide and SAFE.name in guide
-    assert "implemented" in guide and "not qualified" in guide
+    assert "implemented" in guide and "qualified" in guide
+    assert "sha256:eef863d8bc578815a80b0e2d9f0d745102b6363415225101fd92171a2e5a55cb" in guide
     assert DFLASH_WEIGHTS_SHA256 in guide
     assert DFLASH_LOADER_PATCH_SHA256 in guide
     assert "does not change the namespace" in guide
-    assert "PR25 compatibility profile" in guide
+    assert "No legacy-key rewrite" in guide
     assert "DeepEP" in guide
     assert "ModelOpt" in guide
     assert "FP8 KV" in guide
+    assert "START_GLM53_FLASH_DFLASH7_PYTHON_OVERLAY_FASTSAFETENSORS_TP4" in guide
+    assert "docker logs --follow --tail 120" in guide
+    assert "spark_cache_clear_once" in guide
+    assert "prefill-schedule-interval" in guide
+    assert FAST.name in guide.split("profile_template=", 1)[1].splitlines()[0]

--- a/scripts/test_prepare_glm53_public_python_overlay_profile.py
+++ b/scripts/test_prepare_glm53_public_python_overlay_profile.py
@@ -147,7 +147,7 @@ def test_resolver_requires_mixed_provenance_and_all_artifact_hashes() -> None:
     )
     assert "org.sparkcache.native-library-sha256" not in labels
     assert labels["org.sparkcache.source-tree"] == (
-        "e864ed9ad64f771188fdb59aa9738e348134d636"
+        "94c236b9dfbf5f70075eb47877fd9caaa5d8c249"
     )
     assert labels["org.sparkcache.vllm-contract-sha256"] == LEASE_CONTRACT_SHA256
     assert labels["org.sparkring.source-receipt-sha256"] == SOURCE_RECEIPT
@@ -181,6 +181,18 @@ def test_resolver_rejects_snapshot_publication_or_source_built_labels() -> None:
     changed = copy.deepcopy(profile)
     changed["required_image_labels"]["org.jovian.vllm.commit"] = VLLM_PYTHON_COMMIT
     with pytest.raises(ResolveError, match="org.jovian.vllm.commit"):
+        resolve(changed, copy.deepcopy(site), **arguments)
+
+    changed = copy.deepcopy(profile)
+    transfer = json.loads(_argument(changed, "--kv-transfer-config"))
+    transfer["kv_connector_extra_config"].pop(
+        "spark_cache_cuda_restore_io_workers"
+    )
+    changed_args = changed["extra_vllm_args"]
+    changed_args[changed_args.index("--kv-transfer-config") + 1] = json.dumps(
+        transfer, separators=(",", ":")
+    )
+    with pytest.raises(ResolveError, match="omits canonical SparkCache CUDA keys"):
         resolve(changed, copy.deepcopy(site), **arguments)
 
     changed = copy.deepcopy(profile)


### PR DESCRIPTION
## Resulting behavior

The adaptive-MTP image builders, executable profiles, resolvers, and quickstart now bind SparkCache commit `5ec6a9953ad5d39120298bbfc26e95a6fa4b1dc3`, tree `94c236b9dfbf5f70075eb47877fd9caaa5d8c249`, and deployable-source SHA-256 `bc238f96e550c7ec27d4081dd1f2e741d404aaf5c8572d89ccc5e76812be4d63`. This is the same SparkCache source contract used by the DFlash7 composition in the base branch. Resolvers require the complete canonical `spark_cache_cuda_*` configuration and reject incomplete or ambiguous configuration.

The DFlash7 quickstart selects the fastsafetensors target profile, includes strict preflight, start, rank-zero log tail, health, and generation-smoke commands, and explains the one-shot cache-removal token. A bounded evidence record binds the observed four-rank result to local image ID `sha256:eef863d8bc578815a80b0e2d9f0d745102b6363415225101fd92171a2e5a55cb`.

`--prefill-schedule-interval 8` is recorded as a separate research-only mixed-traffic test. It is not added to either serving profile.

## Status

- DFlash7 image construction: implemented.
- Exact local DFlash7 image: qualified only for recorded startup, health, continued generation, arbitrary page-boundary replay, and 131,072- and 262,144-token restore correctness.
- DFlash7 shared-prefix C2/C8/C16 on the exact image: unsupported by the retained record. Concurrency results from another image do not transfer.
- DFlash7 response quality and 262,144-token restore performance: unsupported and research-only, respectively.
- Adaptive MTP with SparkCache: implemented and GPU-free tested; four-rank persistent restore and performance remain unqualified.

## Technical reason

The adaptive profiles used canonical SparkCache CUDA keys while their builders pinned a source revision that did not accept those names directly. Advancing the source contract makes the documented command path executable without an undocumented legacy-key rewrite.

## Compatibility

The SparkCache pin advance does not change cache identity wire fields, digest salts, 256-token logical geometry, stored schemas, vLLM patch bytes, the lease contract, or the CUDA placement ABI. Compatible `page-tail-cow-v1` entries remain eligible. The adaptive and DFlash profiles retain distinct model, draft, cache-root, and one-shot-clear identities. No public serving default changes.

## Validation

- Maintained repository suite: 1,979 passed, 9 skipped.
- Focused runtime, resolver, quickstart, and evidence suite: 56 passed.
- Ruff over maintained Python trees: passed.
- JSON parsing and `git diff --check`: passed.

This draft is stacked on PR #143 and should be rebased or merged after that runtime contract is accepted.