### PR TITLE
scripts: add deep-context NIAH boundary probe

### DIFF
--- a/scripts/niah_boundary_probe.py
+++ b/scripts/niah_boundary_probe.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Deep-context NIAH boundary probe for SparkRing-style GLM lanes.
+
+Finds the largest prompt depth an OpenAI-compatible endpoint serves cleanly.
+One request at a time: builds a synthetic 4 chars/token log archive with an
+8-digit verification needle at a configurable depth fraction, issues it, and
+classifies the outcome:
+
+  PASS           needle retrieved, request completed (finish=stop)
+  NEEDLE-MISS    prompt processed but needle not retrievable
+  TIMEOUT        wall deadline hit first
+
+The request runs in a background thread while the main thread samples the
+engine's Prometheus counter (`vllm:prompt_tokens_total` on <api>/metrics).
+Probe an IDLE lane: under concurrent load the global counter advances from
+unrelated traffic and the counter signal degrades to the wall deadline.
+
+Example:
+    DSPARK_API_KEY is read from the environment by default (--api-key to override)
+    python3 niah_boundary_probe.py --api http://<rank-0>:8015 \
+        --model GLM-5.3-Flash-Ring --depth 400000 --frac 0.5 --deadline 300
+
+Multiple boundary walks can be driven by hashing same-seed depths, e.g.:
+    for d in 100000 200000 300000 350000 375000 400000 450000; do
+        python3 niah_boundary_probe.py --api ... --model ... --depth $d; done
+
+Exit codes: 0 pass, 2 needle miss, 4 timeout, 5 request error.
+"""
+import argparse
+import json
+import os
+import random
+import sys
+import threading
+import time
+import urllib.error
+import urllib.request
+
+NOUNS = ("router switch daemon ledger cipher packet kernel socket buffer "
+         "index shard replica cursor token lease quorum").split()
+VERBS = ("reconciles validates rotates flushes replays throttles mirrors "
+         "audits caches evicts signs verifies").split()
+ADJS = ("stale nightly regional encrypted ephemeral durable inbound signed "
+        "pending archived").split()
+
+ARGS = None
+
+
+def build_archive(rng, target_tokens):
+    def sentence(i):
+        return (f"Record {i}: the {rng.choice(ADJS)} {rng.choice(NOUNS)} "
+                f"{rng.choice(VERBS)} the {rng.choice(ADJS)} {rng.choice(NOUNS)}.")
+    lines, size, n = [], 0, 0
+    while size < target_tokens * 4:
+        s = sentence(n)
+        lines.append(s)
+        size += len(s) + 1
+        n += 1
+    code = f"{rng.randint(10000000, 99999999)}"
+    needle = ("\n\nIMPORTANT SECRET VERIFICATION CODE: " + code + "\n"
+              "Remember this code, it will be requested later.\n\n")
+    at = max(1, int(len(lines) * ARGS.frac))
+    body = "\n".join(lines[:at]) + needle + "\n".join(lines[at:])
+    prompt = ("The following is a long log archive. Read it carefully.\n\n" + body +
+              "\n\nWhat is the IMPORTANT SECRET VERIFICATION CODE from the log? "
+              "Respond with ONLY the 8-digit code and nothing else.")
+    return prompt, code
+
+
+def prompt_counter(metrics_url):
+    try:
+        for line in urllib.request.urlopen(metrics_url, timeout=8).read().decode().split("\n"):
+            if line.startswith("vllm:prompt_tokens_total{"):
+                return int(float(line.split()[-1]))
+    except Exception:
+        return None
+    return None
+
+
+def main():
+    rng = random.Random(ARGS.seed)
+    prompt, code = build_archive(rng, ARGS.depth)
+    headers = {"Content-Type": "application/json"}
+    if ARGS.api_key:
+        headers["Authorization"] = "Bearer " + ARGS.api_key
+    metrics = ARGS.api.rstrip("/") + "/metrics"
+
+    # background thread for the request; main thread runs the watchdog
+    box = {}
+
+    def request():
+        try:
+            payload = {
+                "model": ARGS.model,
+                "messages": [{"role": "user", "content": prompt}],
+                "temperature": 0.0,
+                "max_tokens": 256,
+            }
+            req = urllib.request.Request(
+                ARGS.api.rstrip("/") + "/v1/chat/completions",
+                data=json.dumps(payload).encode(), headers=headers)
+            # generous inner timeout; the watchdog is the effective limiter
+            box["data"] = json.load(urllib.request.urlopen(req, timeout=ARGS.deadline + 300))
+        except urllib.error.HTTPError as e:
+            box["http_error"] = e.code
+        except Exception as e:
+            box["request_error"] = str(e)
+
+    before = prompt_counter(metrics)
+    print(f"prompt_counter_before={before}", flush=True)
+    t0 = time.time()
+    thread = threading.Thread(target=request, daemon=True)
+    thread.start()
+    last = before
+    stuck = 0
+    while time.time() - t0 < ARGS.deadline:
+        thread.join(timeout=20)
+        if not thread.is_alive():
+            break
+        cur = prompt_counter(metrics)
+        print(f"t={time.time()-t0:.0f}s counter={cur}", flush=True)
+        if cur is None or cur == last:
+            stuck += 1
+        else:
+            stuck, last = 0, cur
+        if ARGS.stall_ticks and stuck >= ARGS.stall_ticks:
+            print("STALL: prompt counter frozen while a request is admitted "
+                  "(deep prefill wedge signature)", flush=True)
+            sys.exit(3)
+
+    thread.join(timeout=60)
+    elapsed = time.time() - t0
+    if "http_error" in box:
+        print(f"HTTPError {box['http_error']} after {elapsed:.1f}s "
+              "(admission rejection is the expected behavior above the cap)",
+              flush=True)
+        sys.exit(5)
+    if "request_error" in box:
+        print(f"request error: {box['request_error']}", flush=True)
+        sys.exit(5)
+    if "data" not in box:
+        print(f"TIMEOUT after {elapsed:.1f}s (deadline={ARGS.deadline}s)", flush=True)
+        sys.exit(4)
+    data = box["data"]
+    text = (data.get("choices") or [{}])[0].get("message", {}).get("content", "")
+    finish = (data.get("choices") or [{}])[0].get("finish_reason")
+    usage = data.get("usage", {})
+    present = code in text
+    print(f"elapsed={elapsed:.1f}s prompt_tokens={usage.get('prompt_tokens', '?')} "
+          f"completion={usage.get('completion_tokens', '?')} "
+          f"finish={finish} needle_present={present} code={code}", flush=True)
+
+    if present and finish == "stop":
+        print("verdict=PASS", flush=True)
+        sys.exit(0)
+    print("verdict=NEEDLE-MISS", flush=True)
+    sys.exit(2)
+
+
+if __name__ == "__main__":
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--api", required=True, help="OpenAI-compatible base URL of the rank-0 head")
+    ap.add_argument("--model", required=True)
+    ap.add_argument("--depth", type=int, required=True, help="target prompt tokens")
+    ap.add_argument("--frac", type=float, default=0.5, help="needle position fraction 0..1")
+    ap.add_argument("--deadline", type=int, default=900, help="wall deadline seconds")
+    ap.add_argument("--stall-ticks", type=int, default=4,
+                    help="counter-frozen ticks (polls run at the 20s join cadence) before STALL exit; 0 disables")
+    ap.add_argument("--seed", type=int, default=424242)
+    ap.add_argument("--api-key", default=os.environ.get("DSPARK_API_KEY", ""),
+                    help="bearer key (default $DSPARK_API_KEY)")
+    ARGS = ap.parse_args()
+    main()

--- a/scripts/niah_boundary_probe.py
+++ b/scripts/niah_boundary_probe.py
@@ -10,11 +10,21 @@ classifies the outcome:
   PASS           needle retrieved, request completed (finish=stop)
   NEEDLE-MISS    prompt processed but needle not retrievable
   TIMEOUT        wall deadline hit first
+  STALL          opt-in watchdog: prompt counter frozen while admitted
 
-The request runs in a background thread while the main thread samples the
-engine's Prometheus counter (`vllm:prompt_tokens_total` on <api>/metrics).
-Probe an IDLE lane: under concurrent load the global counter advances from
-unrelated traffic and the counter signal degrades to the wall deadline.
+The request runs in a background thread. By default the wall deadline is
+the authoritative limiter; the prompt-counter watchdog is opt-in via
+--stall-ticks N: it samples the engine's Prometheus counter
+(`vllm:prompt_tokens_total` on <api>/metrics) from the main thread and
+reports the deep prefill wedge signature only after the counter stays
+frozen for N polls. Trust that signal only on an IDLE lane: under
+concurrent load the global counter advances from unrelated traffic, and
+this vLLM runtime may leave the counter unchanged until a healthy long
+prefill completes, so watchdog-off is the default.
+
+--depth is an approximate prompt-token target: the 4 chars/token archive
+construction is tokenizer-dependent, and the measured prompt size is the
+final `usage.prompt_tokens` value reported with the verdict.
 
 Example:
     DSPARK_API_KEY is read from the environment by default (--api-key to override)
@@ -25,7 +35,7 @@ Multiple boundary walks can be driven by hashing same-seed depths, e.g.:
     for d in 100000 200000 300000 350000 375000 400000 450000; do
         python3 niah_boundary_probe.py --api ... --model ... --depth $d; done
 
-Exit codes: 0 pass, 2 needle miss, 4 timeout, 5 request error.
+Exit codes: 0 pass, 2 needle miss, 3 stall (opt-in watchdog), 4 timeout, 5 request error.
 """
 import argparse
 import json
@@ -86,7 +96,7 @@ def main():
         headers["Authorization"] = "Bearer " + ARGS.api_key
     metrics = ARGS.api.rstrip("/") + "/metrics"
 
-    # background thread for the request; main thread runs the watchdog
+    # background thread for the request; main thread samples the counter (watchdog is opt-in)
     box = {}
 
     def request():
@@ -100,7 +110,7 @@ def main():
             req = urllib.request.Request(
                 ARGS.api.rstrip("/") + "/v1/chat/completions",
                 data=json.dumps(payload).encode(), headers=headers)
-            # generous inner timeout; the watchdog is the effective limiter
+            # generous inner timeout; the wall deadline is the effective limiter by default
             box["data"] = json.load(urllib.request.urlopen(req, timeout=ARGS.deadline + 300))
         except urllib.error.HTTPError as e:
             box["http_error"] = e.code
@@ -162,11 +172,12 @@ if __name__ == "__main__":
     ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
     ap.add_argument("--api", required=True, help="OpenAI-compatible base URL of the rank-0 head")
     ap.add_argument("--model", required=True)
-    ap.add_argument("--depth", type=int, required=True, help="target prompt tokens")
+    ap.add_argument("--depth", type=int, required=True,
+                    help="approximate prompt-token target (tokenizer-dependent; the measured size is the response's usage.prompt_tokens)")
     ap.add_argument("--frac", type=float, default=0.5, help="needle position fraction 0..1")
     ap.add_argument("--deadline", type=int, default=900, help="wall deadline seconds")
-    ap.add_argument("--stall-ticks", type=int, default=4,
-                    help="counter-frozen ticks (polls run at the 20s join cadence) before STALL exit; 0 disables")
+    ap.add_argument("--stall-ticks", type=int, default=0,
+                    help="opt-in stall watchdog: exit 3 after this many prompt-counter polls at the 20s cadence show no advance; 0 (default) disables it and the wall deadline is authoritative")
     ap.add_argument("--seed", type=int, default=424242)
     ap.add_argument("--api-key", default=os.environ.get("DSPARK_API_KEY", ""),
                     help="bearer key (default $DSPARK_API_KEY)")


### PR DESCRIPTION
Companion tooling for #151: a self-contained, stdlib-only probe that makes the
deep-context wedge boundary map reproducible in minutes on any GLM-5.3-Flash
ring lane.

**What it does**

- builds a deterministic synthetic log archive (4 chars/token) with an 8-digit
  verification needle at a configurable depth fraction (`--frac`); `--depth`
  is an approximate prompt-token target (tokenizer-dependent; the measured
  size is the response's `usage.prompt_tokens`)
- issues exactly one chat request (no concurrency) and classifies the outcome:
  `PASS` (needle retrieved, finish=stop) / `NEEDLE-MISS` / `TIMEOUT`
- runs the request in a background thread; the wall deadline is the
  authoritative limiter by default. The prompt-counter watchdog is opt-in
  (`--stall-ticks N`): while the request runs, the main thread samples the
  engine's `vllm:prompt_tokens_total` Prometheus counter and reports the deep
  prefill wedge signature only after the counter stays frozen for N polls
  (probe an idle lane; on this vLLM runtime the counter may stay unchanged
  until a healthy long prefill completes, hence watchdog-off is the default)
- treats a clean admission rejection (HTTP 4xx when `max_model_len` is the
  served cap) as an expected outcome (`exit 5` + message), which is how the
  boundary above the configured cap should surface

**What it found (data in #151)**

On our 4× DGX Spark GLM-5.3-Flash TP4/DCP1 ring: `max-num-batched-tokens 8192`
(the qualified default) wedges deterministically at ≥375k-token single-seq;
chunk 4096 verified clean to 450k at needle depths 0.1/0.5/0.9, 500k stalls
(client-cancellable), and beyond the served cap requests are refused cleanly in
~1 s.

**Usage**

```bash
python3 scripts/niah_boundary_probe.py --api http://<rank-0>:8015 \
  --model GLM-5.3-Flash-Ring --depth 400000 --frac 0.5 --deadline 300
```

Exit codes: 0 pass, 2 needle miss, 3 stall (opt-in watchdog), 4 timeout, 5 admission/request error.
Licensed Apache-2.0 to match the repo.

