### PR TITLE
Explain container package roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,20 @@ launches Ring Doctor before any model profile is selected.
 ## Resources
 
 - [Supported models and profiles](#profiles)
+- [Container image roles](#container-images)
 - [Benchmark results](#benchmark-results)
 - [Deployment prerequisites](docs/PREREQUISITES.md) — then choose a profile quickstart below
+
+## Container images
+
+| Package | Purpose | When to use it |
+|---|---|---|
+| [`sparkring-glm53-sparkcache`](https://github.com/users/FujitsuPolycom/packages/container/package/sparkring-glm53-sparkcache) | Published GLM-5.3 R8 operator image. One image supports SparkCache-enabled and vLLM-only launches. | Use the immutable digest from the [GLM-5.3 quickstart](docs/GLM53_JJ_R8_GB10_SPARKCACHE_TP4_QUICKSTART.md). |
+| [`sparkring-glm53-runtime`](https://github.com/users/FujitsuPolycom/packages/container/package/sparkring-glm53-runtime) | Source-pinned GLM-5.3 runtime bases used to construct later operator images. | Use only when a source-build procedure names an exact digest. |
+| [`gb10-vllm-serving`](https://github.com/users/FujitsuPolycom/packages/container/package/gb10-vllm-serving) | Profile-specific GB10 serving images, including published DeepSeek inputs. | Use only when a model profile names an exact digest. |
+
+Package tags are convenient labels, not reproducible identities. Deployment
+guides use immutable digests.
 
 ## Profiles
 

--- a/docs/GLM53_JJ_R8_GB10_SPARKCACHE_TP4_QUICKSTART.md
+++ b/docs/GLM53_JJ_R8_GB10_SPARKCACHE_TP4_QUICKSTART.md
@@ -23,6 +23,10 @@ local image ID: sha256:b3a13d8003e7de30d7737fd33c8307404e506ba570240819ec7eb4f5c
 platform: linux/arm64
 ```
 
+Use the `sparkring-glm53-sparkcache` package for this procedure. The
+`sparkring-glm53-runtime` and `gb10-vllm-serving` packages are build or
+profile inputs and are not substitutes for the operator image below.
+
 Pull and verify the immutable image on rank 0:
 
 ```bash


### PR DESCRIPTION
## Result

SparkRing's front page maps every connected container package to its technical role. The published `sparkring-glm53-sparkcache` package is identified as the GLM-5.3 R8 operator image for both SparkCache-enabled and vLLM-only launches. `sparkring-glm53-runtime` is identified as a source-build input, and `gb10-vllm-serving` is identified as a profile-specific GB10 image family.

The GLM-5.3 quickstart explicitly rejects the two supporting package families as substitutes for its immutable operator image.

The GHCR package `sparkring-glm53-sparkcache` has also been migrated from the SparkCache repository association to SparkRing. Its public visibility, versions, immutable digest, and pull behavior are unchanged.

## Compatibility

Documentation and package navigation change only. Image bytes, tags, digests, model artifacts, launch defaults, SparkCache identity, and runtime behavior are unchanged.

## Validation

- 39 focused tests passed.
- Ruff passed.
- `git diff --check` passed.
- GitHub reports the package repository source as `FujitsuPolycom/sparkring`.
- The SparkRing repository sidebar lists all three container packages.
- The published immutable manifest still resolves to image ID `sha256:b3a13d8003e7de30d7737fd33c8307404e506ba570240819ec7eb4f5c611400f`.