### PR TITLE
Default GLM-5.3 serving to DCP4 with 24 GiB KV

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,10 +51,10 @@ guides use immutable digests.
 
 | Profile | Deployment | Context | Seqs | Batch | KV / cache | Start here |
 |---|---|---:|---:|---:|---|---|
-| GLM-5.3 Flash NVFP4 + BF16 DFlash2 on Jovian Judgement R8 | 4 Sparks · TP4 with DCP1, DCP2, or DCP4 | 1M | 16 | 8,192 | FP8 KV: 26 GiB/rank at DCP1, 30 GiB/rank at DCP2/DCP4; optional SparkCache | [Quickstart](docs/GLM53_JJ_R8_GB10_SPARKCACHE_TP4_QUICKSTART.md) |
+| GLM-5.3 Flash NVFP4 + BF16 DFlash2 on Jovian Judgement R8 | 4 Sparks · TP4/DCP4 by default; DCP1 and DCP2 available | 1M | 16 | 8,192 | 24 GiB/rank FP8 KV; SparkCache enabled by default | [Quickstart](docs/GLM53_JJ_R8_GB10_SPARKCACHE_TP4_QUICKSTART.md) |
 
-The quickstart uses one Linux/ARM64 image for both caching modes. Set
-`SPARKCACHE_ENABLED=1` for persistent SparkCache plus vLLM prefix caching or
+The quickstart uses one Linux/ARM64 image for both caching modes. SparkCache is
+enabled by default. Set `SPARKCACHE_ENABLED=1` for persistent SparkCache plus vLLM prefix caching or
 `SPARKCACHE_ENABLED=0` for vLLM prefix caching alone. The image is published
 at
 `ghcr.io/fujitsupolycom/sparkring-glm53-sparkcache@sha256:380283a506aeb8f9d486a3c64cd738e44268c3cc21590913ea9e4685869f256a`.

--- a/docs/GLM53_JJ_R8_GB10_SPARKCACHE_TP4_QUICKSTART.md
+++ b/docs/GLM53_JJ_R8_GB10_SPARKCACHE_TP4_QUICKSTART.md
@@ -134,7 +134,7 @@ The default OpenAI-compatible model name is `glm-5.3-flash`. Override
 Choose the DCP degree with one line:
 
 ```bash
-DECODE_CONTEXT_PARALLEL_SIZE=1  # change to 2 or 4
+DECODE_CONTEXT_PARALLEL_SIZE=4  # change to 1 or 2
 ```
 
 The launcher selects the matching GLM KV geometry automatically:
@@ -143,12 +143,13 @@ The launcher selects the matching GLM KV geometry automatically:
 |---:|---:|---:|---:|
 | 1 | 1 token | disabled | 26 GiB |
 | 2 | 4 tokens | enabled | 30 GiB |
-| 4 | 4 tokens | enabled | 30 GiB |
+| 4 | 4 tokens | enabled | 24 GiB |
 
-The published image's DCP1 default completed a 942,898-token needle retrieval under the 1M
-request limit. The DCP2 and DCP4 defaults preserve their recorded capacity and
-restart-restore configurations. Set `KV_CACHE_MEMORY_BYTES` to a positive byte
-count to override the topology-aware `auto` policy.
+The published image's DCP1 profile completed a 942,898-token needle retrieval
+under the 1M request limit. The DCP2 and DCP4 validation records used 30 GiB
+per rank. The DCP4 operator default uses 24 GiB per rank to retain more
+host-memory headroom under concurrent serving. Set `KV_CACHE_MEMORY_BYTES` to
+a positive byte count to override the topology-aware `auto` policy.
 
 Choose persistent SparkCache or vLLM's GPU prefix cache alone without changing
 the image:

--- a/runtime/glm53-flash-jj-r8-gb10/README.md
+++ b/runtime/glm53-flash-jj-r8-gb10/README.md
@@ -32,11 +32,11 @@ The launcher defaults to:
 
 | Setting | Value |
 |---|---:|
-| topology | TP4/DCP1 |
+| topology | TP4/DCP4 |
 | maximum model length | 1,048,576 tokens |
 | batched-token budget | 8,192 tokens |
 | sequences | 16 |
-| FP8 KV allocation | 26 GiB for DCP1; 30 GiB for DCP2/DCP4 |
+| FP8 KV allocation | 24 GiB for the default DCP4 profile; 26 GiB for DCP1; 30 GiB for DCP2 |
 | DFlash2 depth | 7 |
 | SparkCache publication | complete `snapshot-v1` objects |
 

--- a/runtime/glm53-flash-jj-r8-gb10/launch-rank.sh
+++ b/runtime/glm53-flash-jj-r8-gb10/launch-rank.sh
@@ -32,7 +32,7 @@ fi
 : "${SHM_SIZE:=32g}"
 : "${TENSOR_PARALLEL_SIZE:=4}"
 : "${PIPELINE_PARALLEL_SIZE:=1}"
-: "${DECODE_CONTEXT_PARALLEL_SIZE:=1}"
+: "${DECODE_CONTEXT_PARALLEL_SIZE:=4}"
 : "${CP_KV_CACHE_INTERLEAVE_SIZE:=auto}"
 : "${B12X_MLA_CKV_GATHER:=auto}"
 : "${B12X_MLA_CKV_GATHER_MAX_TOKENS:=524288}"
@@ -124,9 +124,12 @@ if [[ "${KV_CACHE_MEMORY_BYTES}" == auto ]]; then
   if (( DECODE_CONTEXT_PARALLEL_SIZE == 1 )); then
     # This reservation completed a 942,767-token request without host OOM.
     KV_CACHE_MEMORY_BYTES=27917287424
-  else
-    # DCP2 and DCP4 use the recorded 30 GiB capacity configuration.
+  elif (( DECODE_CONTEXT_PARALLEL_SIZE == 2 )); then
+    # DCP2 retains the recorded 30 GiB capacity configuration.
     KV_CACHE_MEMORY_BYTES=32212254720
+  else
+    # DCP4 uses 24 GiB to retain host-memory headroom under concurrent serving.
+    KV_CACHE_MEMORY_BYTES=25769803776
   fi
 else
   require_positive_uint KV_CACHE_MEMORY_BYTES

--- a/runtime/glm53-flash-jj-r8-gb10/pins.json
+++ b/runtime/glm53-flash-jj-r8-gb10/pins.json
@@ -56,7 +56,7 @@
     "kv_cache_bytes_per_rank": {
       "dcp1": 27917287424,
       "dcp2": 32212254720,
-      "dcp4": 32212254720
+      "dcp4": 25769803776
     },
     "full_ckv_gather_max_tokens": 524288,
     "dcp": {

--- a/runtime/glm53-flash-jj-r8-gb10/runtime.env.example
+++ b/runtime/glm53-flash-jj-r8-gb10/runtime.env.example
@@ -22,7 +22,7 @@ SHM_SIZE='32g'
 # Distributed topology.
 TENSOR_PARALLEL_SIZE=4
 PIPELINE_PARALLEL_SIZE=1
-DECODE_CONTEXT_PARALLEL_SIZE=1
+DECODE_CONTEXT_PARALLEL_SIZE=4
 # GLM-5.3 uses four-token KV interleaving for DCP2 and DCP4. `auto`
 # selects 1 for DCP1 and 4 for DCP2/DCP4.
 CP_KV_CACHE_INTERLEAVE_SIZE='auto'
@@ -37,8 +37,8 @@ MAX_MODEL_LEN=1048576
 MAX_NUM_SEQS=16
 MAX_NUM_BATCHED_TOKENS=8192
 PREFILL_SCHEDULE_INTERVAL=8
-# `auto` selects the deep-context DCP1 reservation or the recorded DCP2/DCP4
-# reservation. An explicit positive byte count overrides this policy.
+# `auto` selects 26 GiB for DCP1, 30 GiB for DCP2, or 24 GiB for DCP4. An
+# explicit positive byte count overrides this policy.
 KV_CACHE_MEMORY_BYTES='auto'
 GPU_MEMORY_UTILIZATION=0.80
 KV_CACHE_DTYPE='fp8'

--- a/runtime/glm53-flash-jj-r8-gb10/test_image_contract.py
+++ b/runtime/glm53-flash-jj-r8-gb10/test_image_contract.py
@@ -57,7 +57,7 @@ def test_pins_bind_effective_sources_and_operator_defaults() -> None:
     assert defaults["kv_cache_bytes_per_rank"] == {
         "dcp1": 27917287424,
         "dcp2": 32212254720,
-        "dcp4": 32212254720,
+        "dcp4": 25769803776,
     }
     assert defaults["full_ckv_gather_max_tokens"] == 524288
     assert defaults["dcp"] == {

--- a/runtime/glm53-flash-jj-r8-gb10/test_launcher_contract.py
+++ b/runtime/glm53-flash-jj-r8-gb10/test_launcher_contract.py
@@ -42,6 +42,7 @@ def test_environment_exposes_reproducible_r8_defaults() -> None:
     )
     assert values["MAX_MODEL_LEN"] == "1048576"
     assert values["SERVED_MODEL_NAME"] == "glm-5.3-flash"
+    assert values["DECODE_CONTEXT_PARALLEL_SIZE"] == "4"
     assert values["MAX_NUM_BATCHED_TOKENS"] == "8192"
     assert values["PREFILL_SCHEDULE_INTERVAL"] == "8"
     assert values["KV_CACHE_MEMORY_BYTES"] == "auto"
@@ -104,7 +105,7 @@ printf '%s  %s\n' "$hash" "$2"
     for dcp, interleave, gather, kv_bytes in (
         (1, "1", "0", "27917287424"),
         (2, "4", "1", "32212254720"),
-        (4, "4", "1", "32212254720"),
+        (4, "4", "1", "25769803776"),
     ):
         config = tmp_path / f"dcp{dcp}.env"
         config.write_text(
@@ -219,5 +220,5 @@ def test_public_r8_documents_use_portable_examples_and_resolving_links() -> None
 
     quickstart = documents[-1].read_text(encoding="utf-8")
     assert "sha256:380283a506aeb8f9d486a3c64cd738e44268c3cc21590913ea9e4685869f256a" in quickstart
-    assert "DECODE_CONTEXT_PARALLEL_SIZE=1  # change to 2 or 4" in quickstart
+    assert "DECODE_CONTEXT_PARALLEL_SIZE=4  # change to 1 or 2" in quickstart
     assert "fanout_image_archive.py" in quickstart

--- a/scripts/config/README.md
+++ b/scripts/config/README.md
@@ -54,9 +54,9 @@ python -m pytest \
 The operator template is
 [`runtime/glm53-flash-jj-r8-gb10/runtime.env.example`](../../runtime/glm53-flash-jj-r8-gb10/runtime.env.example).
 It configures one published Linux/ARM64 image for TP4 with DCP1, DCP2, or
-DCP4. Its defaults are a 1,048,576-token request limit, 16 sequences, an
-8,192-token batched-token budget, and FP8 KV allocations of 26 GiB/rank for
-DCP1 or 30 GiB/rank for DCP2/DCP4.
+DCP4. Its defaults are TP4/DCP4, a 1,048,576-token request limit, 16 sequences,
+an 8,192-token batched-token budget, scheduler interval 8, and a 24 GiB FP8 KV
+allocation per rank.
 
 `SPARKCACHE_ENABLED=1` enables persistent SparkCache plus vLLM prefix caching.
 `SPARKCACHE_ENABLED=0` omits the persistent connector and retains vLLM prefix

--- a/scripts/test_glm53_flash_profile.py
+++ b/scripts/test_glm53_flash_profile.py
@@ -413,7 +413,7 @@ def test_public_glm53_benchmark_is_sanitized_and_front_page_uses_r8() -> None:
 
     readme = README_PATH.read_text(encoding="utf-8")
     assert "GLM-5.3 Flash NVFP4 + BF16 DFlash2" in readme
-    assert "TP4 with DCP1, DCP2, or DCP4" in readme
+    assert "TP4/DCP4 by default; DCP1 and DCP2 available" in readme
     assert "942,898-token needle" in readme
     assert "GLM-5.3 Flash research observation" not in readme
     assert "IN PROGRESS" not in readme


### PR DESCRIPTION
## Result

The published GLM-5.3 Flash launcher now defaults to TP4/DCP4 with 24 GiB of FP8 KV per rank, an 8,192-token batched-prefill budget, scheduler interval 8, and SparkCache enabled. The topology-aware `auto` KV policy retains 26 GiB for DCP1 and 30 GiB for DCP2 while selecting 24 GiB for DCP4.

The root profile table, operator quickstart, runtime index, environment template, configuration index, source pins, and regression tests describe the same default. Existing DCP1 and DCP2 overrides remain supported.

The public image's retained DCP2/DCP4 validation record remains unchanged at its measured 30 GiB condition. The quickstart states that distinction instead of rewriting historical evidence.

## Compatibility

Image bytes, model artifacts, SparkCache identity, stored schemas, digest salts, and the 256-token logical cache geometry are unchanged. Existing environment files that explicitly set DCP or KV memory retain their configured values.

## Validation

- The exact public image started across four GB10 ranks with TP4/DCP4, 24 GiB FP8 KV per rank, DFlash2 depth 7, batch 8,192, scheduler interval 8, and SparkCache enabled.
- The live allocator exposed 4,321,618 KV tokens and approximately 4.12 simultaneous 1,048,576-token requests.
- Rank-0 API health returned HTTP 200.
- 39 focused CPU tests passed.
- Ruff passed.
- `git diff --check` passed.