### PR TITLE
Feature the preferred GLM-5.3 DCP4 profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,14 +49,19 @@ guides use immutable digests.
 
 ### GLM-5.3 Flash
 
+All three profiles use the GLM-5.3 Flash NVFP4 target, BF16 DFlash2 at depth
+seven, FP8 KV, and the Jovian Judgement R8 runtime.
+
 | Profile | Deployment | Context | Seqs | Batch | KV / cache | Start here |
 |---|---|---:|---:|---:|---|---|
-| GLM-5.3 Flash NVFP4 + BF16 DFlash2 on Jovian Judgement R8 | 4 Sparks · TP4/DCP4 by default; DCP1 and DCP2 available | 1M | 16 | 8,192 | 24 GiB/rank FP8 KV; SparkCache enabled by default | [Quickstart](docs/GLM53_JJ_R8_GB10_SPARKCACHE_TP4_QUICKSTART.md) |
+| DCP1 | 4 Sparks · TP4/DCP1 | 1M | 16 | 8,192 | 26 GiB/rank; SparkCache enabled | [Quickstart](docs/GLM53_JJ_R8_GB10_SPARKCACHE_TP4_QUICKSTART.md) |
+| DCP2 | 4 Sparks · TP4/DCP2 | 1M | 16 | 8,192 | 30 GiB/rank; SparkCache enabled | [Quickstart](docs/GLM53_JJ_R8_GB10_SPARKCACHE_TP4_QUICKSTART.md) |
+| **DCP4 — preferred default** | **4 Sparks · TP4/DCP4** | **1M** | **16** | **8,192** | **24 GiB/rank; SparkCache enabled** | **[Quickstart](docs/GLM53_JJ_R8_GB10_SPARKCACHE_TP4_QUICKSTART.md)** |
 
-The quickstart uses one Linux/ARM64 image for both caching modes. SparkCache is
-enabled by default. Set `SPARKCACHE_ENABLED=1` for persistent SparkCache plus vLLM prefix caching or
-`SPARKCACHE_ENABLED=0` for vLLM prefix caching alone. The image is published
-at
+DCP4 is preferred because it provides the largest KV capacity while retaining
+host-memory headroom with the 24 GiB reservation. The quickstart uses one
+Linux/ARM64 image for every row and both caching modes. Set
+`SPARKCACHE_ENABLED=0` to use vLLM prefix caching alone. The image is published at
 `ghcr.io/fujitsupolycom/sparkring-glm53-sparkcache@sha256:380283a506aeb8f9d486a3c64cd738e44268c3cc21590913ea9e4685869f256a`.
 
 ### Other model profiles
@@ -86,6 +91,7 @@ temperature 1.0; decode values are aggregate throughput across active streams.
 
 | Profile | Prefill | C1 decode | C8 decode | Highest tested decode | Coding peak |
 |---|---:|---:|---:|---:|---:|
+| [GLM-5.3 Flash DCP4 preferred default · 4 Sparks](performance/records/glm53-flash/dcp4-24g-default-20260901.md) | 2,513 | 40.20 | 116.73 | C16: 168.39 | 71.67 |
 | [GLM-5.2 EXL3 3.5-bpw · 4 Sparks](performance/records/glm-3.5bpw/normalized-base-20260822.md) | 671 | 20.15 | 64.13 | C8: 64.13 | 25.39 |
 | [DeepSeek-V4-Flash DSpark · 2 Sparks](performance/records/deepseek-v4-flash/normalized-tp2-base-temp1-n5-20260823.md) | 1,926 | 58.36 | 162.69 | C32: 307.13 | 59.31 |
 | [DeepSeek-V4-Flash-0731 · 4 Sparks](performance/records/deepseek-v4-flash/normalized-tp4-base-temp1-n5-20260823.md) | 2,488 | 68.84 | 265.16 | C32: 508.11 | 95.77 |

--- a/docs/GLM53_JJ_R8_GB10_SPARKCACHE_TP4_QUICKSTART.md
+++ b/docs/GLM53_JJ_R8_GB10_SPARKCACHE_TP4_QUICKSTART.md
@@ -6,6 +6,10 @@ Linux/ARM64 image supports DCP1, DCP2, and DCP4. The default request limit is
 The operator can enable persistent SparkCache or use vLLM's GPU prefix cache
 alone without changing the image.
 
+The preferred launch is TP4/DCP4 with 24 GiB of FP8 KV per rank, scheduler
+interval eight, BF16 DFlash2 at depth seven, and SparkCache enabled. The
+environment template selects these values without additional overrides.
+
 The image does not contain model checkpoints. It mounts the exact
 [`local-inference-lab/GLM-5.3-Flash-NVFP4`](https://huggingface.co/local-inference-lab/GLM-5.3-Flash-NVFP4)
 target and the

--- a/docs/RESULTS.md
+++ b/docs/RESULTS.md
@@ -7,6 +7,7 @@ all active streams.
 
 | Profile | Prefill | C1 decode | C8 decode | Highest tested concurrency | Coding Peak |
 |---|---:|---:|---:|---:|---:|
+| GLM-5.3 Flash DCP4 preferred default, four Sparks | 2,513 | 40.20 | 116.73 | C16: 168.39 | 71.67 |
 | GLM-5.2 EXL3 3.5-bpw, four Sparks | 671 | 20.15 | 64.13 | C8: 64.13 | 25.39 |
 | DeepSeek-V4-Flash DSpark, two Sparks | 1,926 | 58.36 | 162.69 | C32: 307.13 | 59.31 |
 | DeepSeek-V4-Flash-0731, four Sparks | 2,488 | 68.84 | 265.16 | C32: 508.11 | 95.77 |
@@ -17,6 +18,7 @@ all active streams.
 
 | Profile | Results | Green matrix | Receipts |
 |---|---|---|---|
+| GLM-5.3 Flash DCP4 preferred default, four Sparks | [Bounded record](../performance/records/glm53-flash/dcp4-24g-default-20260901.md) | — | [Sanitized summary](../performance/receipts/glm53-flash/dcp4-24g-default-20260901/summary.json) |
 | GLM-5.2 EXL3 3.5-bpw, four Sparks | [Full record](../performance/records/glm-3.5bpw/normalized-base-20260822.md) | [Matrix image](../performance/records/glm-3.5bpw/normalized-base-20260822.png) | [Receipts](../performance/receipts/glm-3.5bpw/temp1/) |
 | DeepSeek-V4-Flash DSpark, two Sparks | [Full record](../performance/records/deepseek-v4-flash/normalized-tp2-base-temp1-n5-20260823.md) | [Matrix image](../performance/records/deepseek-v4-flash/normalized-tp2-base-temp1-n5-20260823.png) | [Receipts](../performance/receipts/deepseek-v4-flash/temp1/) |
 | DeepSeek-V4-Flash-0731, four Sparks | [Full record](../performance/records/deepseek-v4-flash/normalized-tp4-base-temp1-n5-20260823.md) | [Matrix image](../performance/records/deepseek-v4-flash/normalized-tp4-base-temp1-n5-20260823.png) | [Receipts](../performance/receipts/deepseek-v4-flash/temp1/20260823-tp4/) |

--- a/performance/receipts/glm53-flash/dcp4-24g-default-20260901/summary.json
+++ b/performance/receipts/glm53-flash/dcp4-24g-default-20260901/summary.json
@@ -1,0 +1,56 @@
+{
+  "schema": "sparkring-benchmark-summary/v1",
+  "status": "research-only",
+  "conditions": {
+    "image": "ghcr.io/fujitsupolycom/sparkring-glm53-sparkcache@sha256:380283a506aeb8f9d486a3c64cd738e44268c3cc21590913ea9e4685869f256a",
+    "image_id": "sha256:b3a13d8003e7de30d7737fd33c8307404e506ba570240819ec7eb4f5c611400f",
+    "target": "local-inference-lab/GLM-5.3-Flash-NVFP4@520de24eabf507659eaef7c70f14fd584527facc",
+    "draft": "incoai/GLM-5.3-Flash-DFlash2@dc77ff1c99eeb2df044ee3d4f0094eb033fee410",
+    "tensor_parallel_size": 4,
+    "decode_context_parallel_size": 4,
+    "kv_cache_dtype": "fp8",
+    "kv_cache_memory_bytes_per_rank": 25769803776,
+    "kv_capacity_tokens": 4321618,
+    "max_model_len": 1048576,
+    "max_num_seqs": 16,
+    "max_num_batched_tokens": 8192,
+    "prefill_schedule_interval": 8,
+    "speculative_method": "dflash",
+    "num_speculative_tokens": 7,
+    "sparkcache_enabled": true,
+    "sparkcache_publication_schema": "snapshot-v1"
+  },
+  "source_receipts": {
+    "matrix_sha256": "c725ee942ecd55fcfed85fe2abe8b7e62e613702c3f830e7a233d60fd40fbcb6",
+    "coding_sha256": "91d4e21323bcd6f8c1c323fae4be1a682a85d268fc7a2b41cd09e32a6eeaa122"
+  },
+  "prefill_c1": {
+    "8192": {"ttft_seconds": 3.516, "tokens_per_second": 2337.0, "samples": 1},
+    "16384": {"ttft_seconds": 6.531, "tokens_per_second": 2513.0, "samples": 1},
+    "32768": {"ttft_seconds": 12.796, "tokens_per_second": 2563.0, "samples": 1},
+    "65536": {"ttft_seconds": 25.469, "tokens_per_second": 2574.0, "samples": 1},
+    "131072": {"ttft_seconds": 51.109, "tokens_per_second": 2565.0, "samples": 1}
+  },
+  "aggregate_decode_tokens_per_second": {
+    "8192": {"1": 36.76, "2": 58.48, "4": 84.46, "8": 123.45, "16": 170.22},
+    "16384": {"1": 40.20, "2": 53.80, "4": 84.51, "8": 116.73, "16": 168.39},
+    "32768": {"1": 35.29, "2": 54.99, "4": 84.73, "8": 114.44},
+    "65536": {"1": 45.94},
+    "131072": {"1": 33.28}
+  },
+  "coding_peak": {
+    "runs": 3,
+    "median_tokens_per_second": 71.67,
+    "mean_tokens_per_second": 70.70,
+    "maximum_tokens_per_second": 78.95,
+    "minimum_tokens_per_second": 61.48,
+    "cjk_runs": 0
+  },
+  "limitations": [
+    "Prefill cells contain one observation each.",
+    "Decode cells use one 40-second measured window with unique prompt contexts.",
+    "The 32768-token C16 cell was omitted because the benchmark marked it capacity-limited.",
+    "The benchmark client did not record DCP size; DCP4 and the 24 GiB KV reservation were verified from the server launch and allocator logs.",
+    "Client hardware telemetry was not used as server hardware evidence."
+  ]
+}

--- a/performance/records/glm53-flash/dcp4-24g-default-20260901.md
+++ b/performance/records/glm53-flash/dcp4-24g-default-20260901.md
@@ -1,0 +1,36 @@
+# GLM-5.3 Flash DCP4 default-profile observation
+
+Status: **research-only**. This record describes one run of the published
+Linux/ARM64 image on four GB10 systems using TP4/DCP4, 24 GiB of FP8 KV per
+rank, BF16 DFlash2 at depth seven, an 8,192-token scheduler budget, scheduler
+interval eight, and SparkCache.
+
+The sanitized machine-readable summary is
+[`summary.json`](../../receipts/glm53-flash/dcp4-24g-default-20260901/summary.json).
+It binds the results to the source-receipt hashes without publishing private
+client or site identifiers.
+
+## Results
+
+| Context | C1 prefill | C1 decode | C2 decode | C4 decode | C8 decode | C16 decode |
+|---:|---:|---:|---:|---:|---:|---:|
+| 8K | 2,337 | 36.76 | 58.48 | 84.46 | 123.45 | 170.22 |
+| 16K | 2,513 | 40.20 | 53.80 | 84.51 | 116.73 | 168.39 |
+| 32K | 2,563 | 35.29 | 54.99 | 84.73 | 114.44 | — |
+| 64K | 2,574 | 45.94 | — | — | — | — |
+| 128K | 2,565 | 33.28 | — | — | — | — |
+
+All throughput values are tokens per second. Prefill cells contain one
+observation. Decode cells use one 40-second measured window with unique prompt
+contexts. The benchmark marked the 32K C16 cell as capacity-limited, so it is
+not displayed.
+
+The three-run coding prompt recorded 71.67 tok/s median, 70.70 tok/s mean, and
+78.95 tok/s maximum.
+
+## Conclusion
+
+The DCP4 profile sustained 2,337–2,574 tok/s C1 prefill from 8K through 128K
+and scaled aggregate decode through C16 at 8K and 16K. These observations do
+not establish long-duration behavior, output quality, repeated-sample
+variance, or performance at contexts beyond 128K.

--- a/performance/records/glm53-flash/test_dcp4_24g_default_benchmark.py
+++ b/performance/records/glm53-flash/test_dcp4_24g_default_benchmark.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[3]
+SUMMARY = (
+    ROOT
+    / "performance"
+    / "receipts"
+    / "glm53-flash"
+    / "dcp4-24g-default-20260901"
+    / "summary.json"
+)
+RECORD = Path(__file__).with_name("dcp4-24g-default-20260901.md")
+
+
+def test_dcp4_default_summary_binds_runtime_and_results() -> None:
+    summary = json.loads(SUMMARY.read_text(encoding="utf-8"))
+    conditions = summary["conditions"]
+
+    assert summary["status"] == "research-only"
+    assert conditions["decode_context_parallel_size"] == 4
+    assert conditions["kv_cache_memory_bytes_per_rank"] == 24 * 1024**3
+    assert conditions["kv_capacity_tokens"] == 4_321_618
+    assert conditions["max_num_batched_tokens"] == 8192
+    assert conditions["prefill_schedule_interval"] == 8
+    assert conditions["sparkcache_enabled"] is True
+    assert summary["prefill_c1"]["131072"]["tokens_per_second"] == 2565.0
+    assert summary["aggregate_decode_tokens_per_second"]["8192"]["16"] == 170.22
+    assert "16" not in summary["aggregate_decode_tokens_per_second"]["32768"]
+    assert summary["coding_peak"]["median_tokens_per_second"] == 71.67
+
+
+def test_dcp4_default_public_record_is_sanitized() -> None:
+    text = RECORD.read_text(encoding="utf-8") + SUMMARY.read_text(encoding="utf-8")
+
+    assert re.search(r"(?i)\b[A-Z]:\\", text) is None
+    assert re.search(r"\b(?:10\.|192\.168\.|172\.(?:1[6-9]|2[0-9]|3[01])\.)", text) is None
+    assert "DESKTOP-" not in text
+    assert "api_key" not in text.casefold()

--- a/scripts/test_glm53_flash_profile.py
+++ b/scripts/test_glm53_flash_profile.py
@@ -412,8 +412,15 @@ def test_public_glm53_benchmark_is_sanitized_and_front_page_uses_r8() -> None:
     assert "api_key" not in text.lower()
 
     readme = README_PATH.read_text(encoding="utf-8")
-    assert "GLM-5.3 Flash NVFP4 + BF16 DFlash2" in readme
-    assert "TP4/DCP4 by default; DCP1 and DCP2 available" in readme
+    assert "GLM-5.3 Flash NVFP4 target, BF16 DFlash2" in readme
+    assert "| DCP1 | 4 Sparks · TP4/DCP1 |" in readme
+    assert "| DCP2 | 4 Sparks · TP4/DCP2 |" in readme
+    assert "| **DCP4 — preferred default** | **4 Sparks · TP4/DCP4** |" in readme
+    assert "| 2,513 | 40.20 | 116.73 | C16: 168.39 | 71.67 |" in readme
+    quickstart = (
+        ROOT / "docs" / "GLM53_JJ_R8_GB10_SPARKCACHE_TP4_QUICKSTART.md"
+    ).read_text(encoding="utf-8")
+    assert "The preferred launch is TP4/DCP4 with 24 GiB of FP8 KV" in quickstart
     assert "942,898-token needle" in readme
     assert "GLM-5.3 Flash research observation" not in readme
     assert "IN PROGRESS" not in readme


### PR DESCRIPTION
## Result

The SparkRing front page presents GLM-5.3 Flash as three explicit DCP1, DCP2, and DCP4 profiles. DCP4 is visually marked as the preferred default and links to the primary four-system quickstart. The quickstart opens with the preferred TP4/DCP4, 24 GiB FP8 KV, 8,192-token batch, scheduler-interval-eight, DFlash2-depth-seven, SparkCache-enabled configuration.

A sanitized DCP4 performance record adds the observed 8K–128K prefill matrix, valid decode cells through C16, and the three-run coding result. The public summary binds the source receipts by SHA-256 and excludes private client and site identifiers.

At 16K, the preferred profile recorded 2,513 tok/s prefill, 40.20 tok/s C1 decode, 116.73 tok/s C8 aggregate decode, 168.39 tok/s C16 aggregate decode, and a 71.67 tok/s coding median. Prefill observations are N=1; the record states the measurement limits.

## Compatibility

Documentation and evidence only. Image bytes, launch defaults, model artifacts, SparkCache identity, stored schemas, and runtime behavior are unchanged.

## Validation

- 21 focused tests passed.
- Ruff passed.
- JSON parsing passed.
- `git diff --check` passed.