### PR TITLE
Describe the GLM-5.3 runtime before its identifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ launches Ring Doctor before any model profile is selected.
 
 | Package | Purpose | When to use it |
 |---|---|---|
-| [`sparkring-glm53-sparkcache`](https://github.com/users/FujitsuPolycom/packages/container/package/sparkring-glm53-sparkcache) | Published GLM-5.3 R8 operator image. One image supports SparkCache-enabled and vLLM-only launches. | Use the immutable digest from the [GLM-5.3 quickstart](docs/GLM53_JJ_R8_GB10_SPARKCACHE_TP4_QUICKSTART.md). |
+| [`sparkring-glm53-sparkcache`](https://github.com/users/FujitsuPolycom/packages/container/package/sparkring-glm53-sparkcache) | Published Linux/ARM64 GLM-5.3 operator image with source-pinned vLLM, B12X GB10 kernels, DFlash2, and optional SparkCache. | Use the immutable digest from the [GLM-5.3 quickstart](docs/GLM53_JJ_R8_GB10_SPARKCACHE_TP4_QUICKSTART.md). |
 | [`sparkring-glm53-runtime`](https://github.com/users/FujitsuPolycom/packages/container/package/sparkring-glm53-runtime) | Source-pinned GLM-5.3 runtime bases used to construct later operator images. | Use only when a source-build procedure names an exact digest. |
 | [`gb10-vllm-serving`](https://github.com/users/FujitsuPolycom/packages/container/package/gb10-vllm-serving) | Profile-specific GB10 serving images, including published DeepSeek inputs. | Use only when a model profile names an exact digest. |
 
@@ -50,7 +50,7 @@ guides use immutable digests.
 ### GLM-5.3 Flash
 
 All three profiles use the GLM-5.3 Flash NVFP4 target, BF16 DFlash2 at depth
-seven, FP8 KV, and the Jovian Judgement R8 runtime.
+seven, FP8 KV, B12X GB10 kernels, and the same source-pinned ARM64 vLLM image.
 
 | Profile | Deployment | Context | Seqs | Batch | KV / cache | Start here |
 |---|---|---:|---:|---:|---|---|

--- a/docs/RESULTS.md
+++ b/docs/RESULTS.md
@@ -28,7 +28,7 @@ all active streams.
 The normalized DeepSeek two-Spark profile also completed a
 [three-hour llama-benchy prefix-cache benchmark](../performance/records/deepseek-v4-flash/llama-benchy-normalized-tp2-20260822.md).
 
-The published GLM-5.3 R8 TP4/DCP1 image completed a
+The published Linux/ARM64 GLM-5.3 operator image completed a TP4/DCP1
 [942,898-token needle retrieval](../runtime/glm53-flash-jj-r8-gb10/PUBLIC_IMAGE_VALIDATION.md)
 with a 1,048,576-token request limit and 26 GiB of FP8 KV per rank.
 

--- a/scripts/test_glm53_flash_profile.py
+++ b/scripts/test_glm53_flash_profile.py
@@ -415,7 +415,7 @@ def test_public_glm53_benchmark_is_sanitized_and_front_page_uses_r8() -> None:
     assert "GLM-5.3 Flash NVFP4 target, BF16 DFlash2" in readme
     assert "| DCP1 | 4 Sparks · TP4/DCP1 |" in readme
     assert "| DCP2 | 4 Sparks · TP4/DCP2 |" in readme
-    assert "| **DCP4 — preferred default** | **4 Sparks · TP4/DCP4** |" in readme
+    assert "| **DCP4 preferred** | **4 Sparks · TP4/DCP4** |" in readme
     assert "| 2,513 | 40.20 | 116.73 | C16: 168.39 | 71.67 |" in readme
     quickstart = (
         ROOT / "docs" / "GLM53_JJ_R8_GB10_SPARKCACHE_TP4_QUICKSTART.md"


### PR DESCRIPTION
## Result

The SparkRing front page describes the GLM-5.3 execution stack before exposing internal source identifiers. It now identifies a published Linux/ARM64 operator image containing source-pinned vLLM, B12X GB10 kernels, BF16 DFlash2 speculative decoding, FP8 KV, and optional SparkCache.

The unexplained phrase `Jovian Judgement R8 runtime` is removed from the front page. Exact upstream revisions and durable paths remain available from the linked quickstart and image record where operators need them.

## Compatibility

Documentation only. Profiles, measurements, image bytes, launch defaults, package identities, and runtime behavior are unchanged.

## Validation

- 21 focused tests passed.
- Ruff passed.
- `git diff --check` passed.