### PR TITLE
Show logical KV capacity for each GLM-5.3 profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,17 +52,20 @@ guides use immutable digests.
 All three profiles use the GLM-5.3 Flash NVFP4 target, BF16 DFlash2 at depth
 seven, FP8 KV, B12X GB10 kernels, and the same source-pinned ARM64 vLLM image.
 
-| Profile | Deployment | Context | Seqs | Batch | KV / cache | Start here |
-|---|---|---:|---:|---:|---|---|
-| DCP1 | 4 Sparks · TP4/DCP1 | 1M | 16 | 8,192 | 24 GiB/rank; SparkCache enabled | [Quickstart](docs/GLM53_JJ_R8_GB10_SPARKCACHE_TP4_QUICKSTART.md) |
-| DCP2 | 4 Sparks · TP4/DCP2 | 1M | 16 | 8,192 | 24 GiB/rank; SparkCache enabled | [Quickstart](docs/GLM53_JJ_R8_GB10_SPARKCACHE_TP4_QUICKSTART.md) |
-| **DCP4 preferred** | **4 Sparks · TP4/DCP4** | **1M** | **16** | **8,192** | **24 GiB/rank; SparkCache enabled** | **[Quickstart](docs/GLM53_JJ_R8_GB10_SPARKCACHE_TP4_QUICKSTART.md)** |
+| Profile | Deployment | Context | Seqs | Batch | KV / cache | Approx. logical KV capacity | Start here |
+|---|---|---:|---:|---:|---|---:|---|
+| DCP1 | 4 Sparks · TP4/DCP1 | 1M | 16 | 8,192 | 26 GiB/rank; SparkCache enabled | 1.30M tokens | [Quickstart](docs/GLM53_JJ_R8_GB10_SPARKCACHE_TP4_QUICKSTART.md) |
+| DCP2 | 4 Sparks · TP4/DCP2 | 1M | 16 | 8,192 | 30 GiB/rank; SparkCache enabled | 2.90M tokens | [Quickstart](docs/GLM53_JJ_R8_GB10_SPARKCACHE_TP4_QUICKSTART.md) |
+| **DCP4 preferred** | **4 Sparks · TP4/DCP4** | **1M** | **16** | **8,192** | **24 GiB/rank; SparkCache enabled** | **4.32M tokens** | **[Quickstart](docs/GLM53_JJ_R8_GB10_SPARKCACHE_TP4_QUICKSTART.md)** |
 
 DCP4 is preferred because it provides the largest KV capacity while retaining
 host-memory headroom with the 24 GiB reservation. The quickstart uses one
 Linux/ARM64 image for every row and both caching modes. Set
 `SPARKCACHE_ENABLED=0` to use vLLM prefix caching alone. The image is published at
 `ghcr.io/fujitsupolycom/sparkring-glm53-sparkcache@sha256:380283a506aeb8f9d486a3c64cd738e44268c3cc21590913ea9e4685869f256a`.
+
+KV capacity is the model-wide logical token capacity reported by vLLM. It is
+already sharded across the four ranks and must not be multiplied by four.
 
 ### Other model profiles
 

--- a/docs/GLM53_JJ_R8_GB10_SPARKCACHE_TP4_QUICKSTART.md
+++ b/docs/GLM53_JJ_R8_GB10_SPARKCACHE_TP4_QUICKSTART.md
@@ -143,11 +143,14 @@ DECODE_CONTEXT_PARALLEL_SIZE=4  # change to 1 or 2
 
 The launcher selects the matching GLM KV geometry automatically:
 
-| DCP | KV interleave | Full-CKV prefill gather | Default FP8 KV per rank |
-|---:|---:|---:|---:|
-| 1 | 1 token | disabled | 26 GiB |
-| 2 | 4 tokens | enabled | 30 GiB |
-| 4 | 4 tokens | enabled | 24 GiB |
+| DCP | KV interleave | Full-CKV prefill gather | Default FP8 KV per rank | Approx. logical KV capacity |
+|---:|---:|---:|---:|---:|
+| 1 | 1 token | disabled | 26 GiB | 1.30M tokens |
+| 2 | 4 tokens | enabled | 30 GiB | 2.90M tokens |
+| 4 | 4 tokens | enabled | 24 GiB | 4.32M tokens |
+
+The capacity column is the model-wide value reported by vLLM. Do not multiply
+it by the four physical ranks.
 
 The published image's DCP1 profile completed a 942,898-token needle retrieval
 under the 1M request limit. The DCP2 and DCP4 validation records used 30 GiB

--- a/scripts/test_glm53_flash_profile.py
+++ b/scripts/test_glm53_flash_profile.py
@@ -416,6 +416,9 @@ def test_public_glm53_benchmark_is_sanitized_and_front_page_uses_r8() -> None:
     assert "| DCP1 | 4 Sparks · TP4/DCP1 |" in readme
     assert "| DCP2 | 4 Sparks · TP4/DCP2 |" in readme
     assert "| **DCP4 preferred** | **4 Sparks · TP4/DCP4** |" in readme
+    assert "| 1.30M tokens |" in readme
+    assert "| 2.90M tokens |" in readme
+    assert "| **4.32M tokens** |" in readme
     assert "| 2,513 | 40.20 | 116.73 | C16: 168.39 | 71.67 |" in readme
     quickstart = (
         ROOT / "docs" / "GLM53_JJ_R8_GB10_SPARKCACHE_TP4_QUICKSTART.md"


### PR DESCRIPTION
## Result

The GLM-5.3 profile table and primary quickstart show the approximate model-wide KV capacity for every DCP configuration:

- DCP1 with 26 GiB per rank: approximately 1.30M tokens;
- DCP2 with 30 GiB per rank: approximately 2.90M tokens;
- preferred DCP4 with 24 GiB per rank: approximately 4.32M tokens.

The documentation states that these are already model-wide logical capacities reported by vLLM and must not be multiplied by the four physical ranks. The memory allocations are aligned with the topology-aware launcher policy.

## Compatibility

Documentation and regression coverage only. Runtime behavior, launch defaults, image bytes, SparkCache identity, and stored data are unchanged.

## Validation

- 19 focused tests passed.
- Ruff passed.
- `git diff --check` passed.