### PR TITLE
runtime/glm53-flash-jj-r8-gb10: add --enable-prompt-tokens-details so usage reports cached_tokens

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
             --index-url https://download.pytorch.org/whl/cpu \
             "torch==${TORCH_VERSION}"
       - name: Test maintained Python trees
-        run: python -m pytest spark_transport runtime/exl3-r7 runtime/glm53-flash runtime/deepseek0731-gb10 runtime/qwen38 runtime/test_public_overlay.py performance/harnesses scripts -q -rs
+        run: python -m pytest spark_transport runtime/exl3-r7 runtime/glm53-flash runtime/glm53-flash-jj-r8-gb10 runtime/deepseek0731-gb10 runtime/qwen38 runtime/test_public_overlay.py performance/harnesses scripts -q -rs
 
   docs-links:
     name: docs links

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,7 +106,7 @@ test imports torch:
 python -m pip install -r requirements-dev.txt
 python -m pip install --index-url https://download.pytorch.org/whl/cpu "torch==2.11.0"
 ruff check --select E,F,W --ignore E501 spark_transport runtime scripts performance
-python -m pytest spark_transport runtime/exl3-r7 runtime/glm53-flash runtime/deepseek0731-gb10 runtime/qwen38 runtime/test_public_overlay.py performance/harnesses scripts -q -rs
+python -m pytest spark_transport runtime/exl3-r7 runtime/glm53-flash runtime/glm53-flash-jj-r8-gb10 runtime/deepseek0731-gb10 runtime/qwen38 runtime/test_public_overlay.py performance/harnesses scripts -q -rs
 ```
 
 The test suite is CPU-only contract coverage. It does not validate CUDA,

--- a/runtime/glm53-flash-jj-r8-gb10/launch-rank.sh
+++ b/runtime/glm53-flash-jj-r8-gb10/launch-rank.sh
@@ -82,6 +82,7 @@ fi
 : "${OMP_NUM_THREADS:=16}"
 : "${TORCHINDUCTOR_COMPILE_THREADS:=1}"
 : "${FASTSAFETENSORS_QUEUE_SIZE:=1}"
+: "${ENABLE_PROMPT_TOKENS_DETAILS:=1}"
 
 die() {
   printf '%s\n' "$*" >&2
@@ -198,6 +199,10 @@ esac
 case "${SPARKCACHE_ENABLED}" in
   0|1) ;;
   *) die 'SPARKCACHE_ENABLED must be 0 or 1' ;;
+esac
+case "${ENABLE_PROMPT_TOKENS_DETAILS}" in
+  0|1) ;;
+  *) die 'ENABLE_PROMPT_TOKENS_DETAILS must be 0 or 1' ;;
 esac
 case "${SPARKCACHE_ASYNC_PAGE_CAPTURE}" in
   0|1) ;;
@@ -394,6 +399,11 @@ fi
 headless=()
 [[ "${rank}" == 0 ]] || headless=(--headless)
 
+prompt_tokens_details=()
+if [[ "${ENABLE_PROMPT_TOKENS_DETAILS}" == 1 ]]; then
+  prompt_tokens_details=(--enable-prompt-tokens-details)
+fi
+
 exec docker run -d \
   --name "${container}" \
   --network host --ipc host --shm-size "${SHM_SIZE}" --gpus all \
@@ -462,4 +472,5 @@ exec docker run -d \
   --compilation-config "${compilation_config}" \
   --max-cudagraph-capture-size "${MAX_CUDAGRAPH_CAPTURE_SIZE}" \
   --async-scheduling --enable-prefix-caching --cudagraph-metrics \
+  "${prompt_tokens_details[@]}" \
   "${kv_transfer_args[@]}" "${headless[@]}"

--- a/runtime/glm53-flash-jj-r8-gb10/runtime.env.example
+++ b/runtime/glm53-flash-jj-r8-gb10/runtime.env.example
@@ -97,7 +97,7 @@ OMP_NUM_THREADS=16
 TORCHINDUCTOR_COMPILE_THREADS=1
 FASTSAFETENSORS_QUEUE_SIZE=1
 
-# Report usage.prompt_tokens_details.cached_tokens on every response. This is
-# the only per-request prefix-cache signal an API client can see. Set to 0 to
-# restore the previous responses, which omit the field.
+# Include usage.prompt_tokens_details.cached_tokens whenever a response carries
+# usage. Streaming clients must request usage with stream_options.include_usage.
+# Set to 0 to omit prompt_tokens_details from API responses.
 ENABLE_PROMPT_TOKENS_DETAILS=1

--- a/runtime/glm53-flash-jj-r8-gb10/runtime.env.example
+++ b/runtime/glm53-flash-jj-r8-gb10/runtime.env.example
@@ -96,3 +96,8 @@ NCCL_MAX_NCHANNELS=4
 OMP_NUM_THREADS=16
 TORCHINDUCTOR_COMPILE_THREADS=1
 FASTSAFETENSORS_QUEUE_SIZE=1
+
+# Report usage.prompt_tokens_details.cached_tokens on every response. This is
+# the only per-request prefix-cache signal an API client can see. Set to 0 to
+# restore the previous responses, which omit the field.
+ENABLE_PROMPT_TOKENS_DETAILS=1

--- a/runtime/glm53-flash-jj-r8-gb10/test_launcher_contract.py
+++ b/runtime/glm53-flash-jj-r8-gb10/test_launcher_contract.py
@@ -47,6 +47,7 @@ def test_environment_exposes_reproducible_operator_defaults() -> None:
     assert values["PREFILL_SCHEDULE_INTERVAL"] == "8"
     assert values["KV_CACHE_MEMORY_BYTES"] == "auto"
     assert values["SPARKCACHE_ENABLED"] == "1"
+    assert values["ENABLE_PROMPT_TOKENS_DETAILS"] == "1"
     assert values["SPARKCACHE_ACCESS_MODE"] == "read-write"
     assert values["SPARKCACHE_MAX_SPAN_TOKENS"] == "1048576"
     assert values["CP_KV_CACHE_INTERLEAVE_SIZE"] == "auto"
@@ -145,6 +146,7 @@ printf '%s  %s\n' "$hash" "$2"
         assert f"VLLM_B12X_MLA_CKV_GATHER={gather}" in arguments
         kv_index = arguments.index("--kv-cache-memory-bytes")
         assert arguments[kv_index + 1] == kv_bytes
+        assert "--enable-prompt-tokens-details" in arguments
         assert "--kv-transfer-config" in arguments
         connector = json.loads(arguments[arguments.index("--kv-transfer-config") + 1])
         extra = connector["kv_connector_extra_config"]
@@ -187,6 +189,13 @@ printf '%s  %s\n' "$hash" "$2"
     assert "--enable-prefix-caching" in arguments
     assert "--kv-transfer-config" not in arguments
     assert "org.sparkring.sparkcache.enabled=0" in arguments
+
+
+def test_launcher_gates_prompt_tokens_details_on_a_validated_flag() -> None:
+    launcher = LAUNCHER.read_text(encoding="utf-8")
+    assert ': "${ENABLE_PROMPT_TOKENS_DETAILS:=1}"' in launcher
+    assert "ENABLE_PROMPT_TOKENS_DETAILS must be 0 or 1" in launcher
+    assert "prompt_tokens_details=(--enable-prompt-tokens-details)" in launcher
 
 
 def test_launcher_can_use_vllm_prefix_cache_without_sparkcache() -> None:

--- a/runtime/glm53-flash-jj-r8-gb10/test_launcher_contract.py
+++ b/runtime/glm53-flash-jj-r8-gb10/test_launcher_contract.py
@@ -54,7 +54,9 @@ def test_environment_exposes_reproducible_operator_defaults() -> None:
     assert values["B12X_MLA_CKV_GATHER"] == "auto"
 
 
-def test_launcher_resolves_dcp1_dcp2_and_dcp4(tmp_path: Path) -> None:
+def test_launcher_resolves_dcp_profiles_and_prompt_token_details(
+    tmp_path: Path,
+) -> None:
     subprocess.run(["bash", "-n", _bash_path(LAUNCHER)], check=True, cwd=ROOT)
     fake_bin = tmp_path / "bin"
     fake_bin.mkdir()
@@ -190,12 +192,43 @@ printf '%s  %s\n' "$hash" "$2"
     assert "--kv-transfer-config" not in arguments
     assert "org.sparkring.sparkcache.enabled=0" in arguments
 
+    disabled = tmp_path / "prompt-token-details-disabled.env"
+    disabled.write_text(
+        config.read_text(encoding="utf-8")
+        + "\nENABLE_PROMPT_TOKENS_DETAILS=0\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+    result = subprocess.run(
+        ["bash", _bash_path(LAUNCHER), "0", _bash_path(disabled)],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    arguments = capture.read_text(encoding="utf-8").splitlines()
+    assert "--enable-prompt-tokens-details" not in arguments
 
-def test_launcher_gates_prompt_tokens_details_on_a_validated_flag() -> None:
-    launcher = LAUNCHER.read_text(encoding="utf-8")
-    assert ': "${ENABLE_PROMPT_TOKENS_DETAILS:=1}"' in launcher
-    assert "ENABLE_PROMPT_TOKENS_DETAILS must be 0 or 1" in launcher
-    assert "prompt_tokens_details=(--enable-prompt-tokens-details)" in launcher
+
+def test_launcher_rejects_invalid_prompt_tokens_details_setting(tmp_path: Path) -> None:
+    config = tmp_path / "prompt-token-details-invalid.env"
+    config.write_text(
+        f"source '{_bash_path(ENVIRONMENT)}'\nENABLE_PROMPT_TOKENS_DETAILS=invalid\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+
+    result = subprocess.run(
+        ["bash", _bash_path(LAUNCHER), "0", _bash_path(config)],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 78
+    assert "ENABLE_PROMPT_TOKENS_DETAILS must be 0 or 1" in result.stderr
 
 
 def test_launcher_can_use_vllm_prefix_cache_without_sparkcache() -> None:

--- a/scripts/test_glm53_flash_profile.py
+++ b/scripts/test_glm53_flash_profile.py
@@ -511,4 +511,10 @@ def test_operator_docs_state_status_invariants_and_full_provenance() -> None:
 
 def test_ci_runs_glm53_runtime_contracts() -> None:
     workflow = (ROOT / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
-    assert "runtime/exl3-r7 runtime/glm53-flash runtime/deepseek0731-gb10" in workflow
+    pytest_command = next(
+        line for line in workflow.splitlines() if "python -m pytest spark_transport" in line
+    )
+    assert "runtime/exl3-r7" in pytest_command
+    assert "runtime/glm53-flash" in pytest_command
+    assert "runtime/glm53-flash-jj-r8-gb10" in pytest_command
+    assert "runtime/deepseek0731-gb10" in pytest_command


### PR DESCRIPTION
## Resulting behavior

The GLM-5.3 GB10 operator launcher passes vLLM's `--enable-prompt-tokens-details` option by default. API responses that carry usage include `usage.prompt_tokens_details.cached_tokens`, giving clients a per-request count of prompt tokens supplied from cache. Streaming clients must set `stream_options.include_usage` to receive usage.

`ENABLE_PROMPT_TOKENS_DETAILS=0` omits the option and leaves `prompt_tokens_details` absent. Values other than `0` or `1` stop the launcher with status 78 before Docker runs.

Status: **implemented** and covered by GPU-free launcher tests.

## Technical reason

The pinned vLLM runtime at commit `22ffe1401ca9bd3e4503e62de7b414deca7661a1` computes cached-token counts but returns `prompt_tokens_details` only when the server option is enabled. Fleet metrics expose aggregate cache behavior; the response field exposes the cached-token count for one request.

## Compatibility

The default API usage object gains `prompt_tokens_details` when usage is present. Operators that require omission can set `ENABLE_PROMPT_TOKENS_DETAILS=0`. Model execution, scheduling, persistent-cache identity, stored cache data, image identity, and connector configuration are unchanged.

The reported count is vLLM's request-level cached-token total. It does not identify whether native GPU prefix caching or the external SparkCache connector supplied each cached token.

## Evidence

The pull-request author supplied a four-GB10 TP4/DCP4 observation using image digest `bc7d079f16ff4a418669c58c5250f2da52e989a0c5805569ba9429d41b765f65`. Two requests with the same 6,778-token prompt reported 0 cached tokens and then 6,144 cached tokens. This review did not repeat that hardware observation.

## Validation

- `python -m pytest runtime/glm53-flash-jj-r8-gb10 -q -rs` — 18 passed.
- Focused GLM-5.3 operator and profile tests — 32 passed.
- Maintained CPU-only repository suite, including the GLM-5.3 GB10 operator-image directory — 1,959 passed and 9 skipped.
- Repository-wide maintained-tree Ruff checks — passed.
- Launcher `bash -n` validation runs through the operator-image test suite — passed.
- GitHub Actions workflow YAML parse — passed.
- `git diff --check` — passed.

The CPU-only validation proves launcher arguments, opt-out behavior, invalid-value rejection, and test collection. It does not start vLLM, issue an API request, or exercise a live GPU cache.

## CI coverage

The maintained pytest command in `.github/workflows/ci.yml` and `AGENTS.md` includes `runtime/glm53-flash-jj-r8-gb10`. A repository contract independently requires the source-built and GB10 operator-image GLM-5.3 suites in that command.