### PR TITLE
fix(doctor): retry emitted ring-doctor unit when it races NM startup

### DIFF
--- a/scripts/ring_doctor.py
+++ b/scripts/ring_doctor.py
@@ -2325,6 +2325,8 @@ After=network-online.target docker.service
 
 [Service]
 Type=oneshot
+Restart=on-failure
+RestartSec=10
 ExecStart=/usr/bin/python3 {program_path}
 RemainAfterExit=yes
 

--- a/scripts/test_ring_doctor.py
+++ b/scripts/test_ring_doctor.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import ipaddress
+import tempfile
 import unittest
 from pathlib import Path
 
@@ -30,6 +31,7 @@ from scripts.ring_doctor import (
     discover_nodes,
     discovery_sufficient,
     docker_user_accepts,
+    emit_units,
     infer_adjacency,
     infer_topology,
     enforce_controller_location,
@@ -390,6 +392,31 @@ class ManagementRepairSafetyTests(unittest.TestCase):
 
         self.assertIn("EXPECTED_MANAGEMENT = {'eth0': ['192.0.2.10/24']}", program)
         self.assertGreaterEqual(program.count("require_management()"), 5)
+
+    def test_emitted_unit_restarts_after_program_failure(self) -> None:
+        guarded = self.guarded_observation()
+        guard = ManagementGuard("r0", (guarded.host_interfaces["eth0"],))
+        plan = NodePlan("r0")
+
+        with tempfile.TemporaryDirectory() as directory:
+            emit_units(
+                Path(directory),
+                {"r0": guarded},
+                {"r0": plan},
+                {"r0": guard},
+            )
+            unit = Path(directory, "ring-doctor-r0.service").read_text(
+                encoding="utf-8"
+            )
+
+        self.assertIn(
+            "[Service]\n"
+            "Type=oneshot\n"
+            "Restart=on-failure\n"
+            "RestartSec=10\n"
+            "ExecStart=",
+            unit,
+        )
 
 
 class AddressAndTopologyTests(unittest.TestCase):


### PR DESCRIPTION
Fixes #170

## Resulting behavior

Systemd services generated by `sparkring doctor --emit-unit` restart ten seconds after the generated repair program exits with a failure. The repair program continues to validate the recorded fabric and management addresses before applying routes or firewall rules, so a missing or changed management address remains a fail-closed condition.

Existing generated services are unchanged until an operator regenerates and reinstalls their unit files.

## Technical reason

`network-online.target` can become active before NetworkManager assigns the management IPv4 address on a netplan-managed host. A `Type=oneshot` service without a restart policy remains failed after that startup race, leaving the recorded fabric routes and `DOCKER-USER` rules unapplied for the rest of the boot.

The generated service declares `Restart=on-failure` and `RestartSec=10`. A transient address-readiness failure is retried without weakening the program's address checks.

## Compatibility

The command-line interface, cluster configuration schema, repair-plan construction, management-address invariant, route commands, and firewall commands are unchanged. The generated systemd unit contract gains an on-failure restart policy. No model-serving, image, or cache-identity contract changes.

## Validation

- `python -m pytest scripts/test_ring_doctor.py -q` — 45 passed.
- Full CPU-only repository suite — 1,937 passed and 9 skipped.
- `python -m ruff check --select E,F,W --ignore E501 scripts/ring_doctor.py scripts/test_ring_doctor.py` — passed.
- `git diff --check` — passed.
- Hardware evidence supplied by the pull-request author: on one Ubuntu 24.04 DGX Spark rank with a netplan-managed management interface, the first service invocation failed before address assignment; the retry approximately ten seconds later restored the routes and firewall rules, and the service entered the active state.

The offline tests validate generated service text and repair-program invariants. They do not execute systemd, NetworkManager, or a live fabric.

## Scope

Issues #168 and #169 describe separate configuration and immediate-repair paths and are not changed by this pull request.