### PR TITLE
fix(cluster): wait for management address after netplan apply

### DIFF
--- a/scripts/sparkring_bootstrap.py
+++ b/scripts/sparkring_bootstrap.py
@@ -493,6 +493,10 @@ def _network_apply_script(cluster: ClusterConfig, rank_id: int) -> str:
     timestamp = time.strftime("%Y%m%dT%H%M%SZ", time.gmtime())
     backup = f"{target}.before-sparkring-{timestamp}"
     management_cidr_fragment = f" {rank.management.address}/"
+    management_check = (
+        f"ip -4 -o addr show dev {rank.management.interface} | "
+        f"grep -F -q -- '{management_cidr_fragment}'"
+    )
     return "\n".join(
         [
             "set -eu",
@@ -514,8 +518,19 @@ def _network_apply_script(cluster: ClusterConfig, rank_id: int) -> str:
             "  echo 'netplan apply failed; prior fabric netplan restored' >&2",
             "  exit 1",
             "fi",
-            f"if ! ip -4 -o addr show dev {rank.management.interface} | "
-            f"grep -F -q -- '{management_cidr_fragment}'; then",
+            "# Netplan may reload the management connection. Accept only the recorded "
+            "IPv4 address and fail after five seconds.",
+            "management_ready=0",
+            "management_attempt=0",
+            'while test "$management_attempt" -lt 50; do',
+            f"  if {management_check}; then",
+            "    management_ready=1",
+            "    break",
+            "  fi",
+            '  management_attempt=$((management_attempt + 1))',
+            "  sleep 0.1",
+            "done",
+            'if test "$management_ready" -ne 1; then',
             "  rollback",
             "  netplan generate",
             "  netplan apply",

--- a/scripts/test_sparkring_bootstrap.py
+++ b/scripts/test_sparkring_bootstrap.py
@@ -138,6 +138,52 @@ def test_generated_netplan_contains_only_fabric_interfaces():
     assert "ip -4 -o addr show dev enP7s7" in apply_script
 
 
+def test_network_apply_waits_for_the_recorded_management_address():
+    cluster = validate_cluster(
+        build_cluster_document(
+            facts(4), name="management-wait", fabric_supernet="198.18.0.0/21"
+        )
+    )
+
+    apply_script = _network_apply_script(cluster, 0)
+
+    assert (
+        "# Netplan may reload the management connection. Accept only the recorded "
+        "IPv4 address and fail after five seconds.\n"
+        "management_ready=0\n"
+        "management_attempt=0\n"
+        'while test "$management_attempt" -lt 50; do\n'
+        "  if ip -4 -o addr show dev enP7s7 | "
+        "grep -F -q -- ' 192.0.2.10/'; then\n"
+        "    management_ready=1\n"
+        "    break\n"
+        "  fi\n"
+        '  management_attempt=$((management_attempt + 1))\n'
+        "  sleep 0.1\n"
+        "done"
+    ) in apply_script
+
+
+def test_network_apply_rolls_back_when_management_wait_expires():
+    cluster = validate_cluster(
+        build_cluster_document(
+            facts(4), name="management-timeout", fabric_supernet="198.18.0.0/21"
+        )
+    )
+
+    apply_script = _network_apply_script(cluster, 0)
+
+    assert (
+        'if test "$management_ready" -ne 1; then\n'
+        "  rollback\n"
+        "  netplan generate\n"
+        "  netplan apply\n"
+        "  echo 'management invariant failed; fabric netplan rolled back' >&2\n"
+        "  exit 91\n"
+        "fi"
+    ) in apply_script
+
+
 def test_head_self_authorization_is_idempotent_and_preserves_existing_keys(tmp_path):
     public = tmp_path / "bootstrap.pub"
     key = "ssh-ed25519 QkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkI= bootstrap@spark"


### PR DESCRIPTION
Fixes #168

## Resulting behavior

`sparkring cluster configure --apply` allows a netplan-managed management IPv4 address up to five seconds to return after `netplan apply`. The generated fabric-configuration script checks immediately and then every 100 milliseconds. Configuration continues as soon as the exact recorded address is present on the configured management interface.

If the recorded address does not return within five seconds, the script restores the prior fabric netplan, applies the restored configuration, reports `management invariant failed; fabric netplan rolled back`, and exits with status 91. A different address does not satisfy the invariant.

Status: **implemented** and covered by GPU-free generated-script contract tests.

## Technical reason

Netplan can reload a NetworkManager-managed connection while applying a fabric-only configuration. The management address may be temporarily absent even though the generated fabric netplan does not define or modify the management interface. A single immediate check treats that transient reload as persistent management loss.

Bounded polling preserves rollback for persistent failures while allowing the recorded address to recover from a short connection reload.

## Compatibility

The command-line interface, cluster configuration schema, generated fabric netplan, route behavior, management-address identity, and rollback status are unchanged. No model-serving, image, or cache-identity contract changes.

## Validation

- `python -m pytest scripts/test_sparkring_bootstrap.py -q` — 10 passed.
- Full CPU-only repository suite — 1,939 passed and 9 skipped.
- `python -m ruff check --select E,F,W --ignore E501 spark_transport runtime scripts performance` — passed.
- `git diff --check` — passed.

The generated-script tests require the bounded exact-address poll and the rollback branch after timeout. The CPU-only validation does not execute netplan, NetworkManager, SSH, or a live fabric.

Issue #168 reports three reproductions on four Ubuntu 24.04 DGX Spark systems where the management address was absent immediately after `netplan apply` and returned after approximately one second. That hardware observation was supplied by the issue reporter and was not repeated by this validation.