### PR TITLE
fix(doctor): preflight sudo before cluster repair

### DIFF
--- a/docs/BOOTSTRAP.md
+++ b/docs/BOOTSTRAP.md
@@ -145,7 +145,28 @@ sparkring doctor --verify --apply
 Ring Doctor can change only observed fabric routes, IPv4 forwarding, and
 fabric-to-fabric `DOCKER-USER` accepts. It checks the active management address
 and return route before and after every individual operation and stops at the
-first mismatch.
+first mismatch. Before any repair operation, it checks `sudo -n true` on every
+rank whose plan has commands. If any check fails, Ring Doctor identifies the
+rank and applies no repair command anywhere in the ring.
+
+## 8. Persist routing and firewall state across boots
+
+Routes, IPv4 forwarding, and `DOCKER-USER` rules applied by Ring Doctor are
+runtime state. Do not restore the firewall rules with a cron `@reboot` job.
+Cron can run before Docker creates its firewall chains, and Docker can replace
+rules installed that early.
+
+Use `sparkring doctor --emit-unit DIR` after reviewing the complete repair plan.
+The command writes one fail-closed repair program and systemd service per rank.
+Each program contains the complete idempotent route, forwarding, and
+fabric-to-fabric firewall plan. The service declares
+`After=network-online.target docker.service` and retries after ten seconds when
+the recorded management address or Docker firewall chain is not ready.
+
+The command writes files but does not install or enable them. The absolute
+program path recorded in `ExecStart` must exist on the corresponding rank
+before its service is installed. The installation requirements and management
+safety checks are described in [SparkRing prerequisites](PREREQUISITES.md#management-safety-during-repair).
 
 ## Worker-controller recovery
 

--- a/docs/PREREQUISITES.md
+++ b/docs/PREREQUISITES.md
@@ -122,7 +122,10 @@ records when worker recovery mode was used.
 Require zero `ERROR` findings, a passing canonical fabric preflight, and a
 reachability matrix in which every pair passes. `--apply` executes the printed
 plan only after both the discovered cycle and canonical fabric checks pass. It
-is idempotent and needs passwordless `sudo` on each node.
+is idempotent and needs non-interactive `sudo` on each node. Before any repair
+command runs, Ring Doctor executes `sudo -n true` on every node whose plan has
+commands. If any node fails that check, Ring Doctor reports each failing node
+and executes no route, forwarding, or firewall repair command on any node.
 
 ### Management safety during repair
 
@@ -144,12 +147,20 @@ recorded management addresses before and after every change. If a legacy
 `--node` invocation is used instead of `--site`, name the management interface
 for every node with `--socket-interface`; otherwise all mutation is withheld.
 
-The repairs are runtime state and do not survive a reboot. `--emit-unit DIR`
-writes a per-node program and systemd unit that revalidate the addresses and
-reapply the plan at boot. Install the program at a path that exists **on the
-node**, and set the unit's `ExecStart` to that path: the emitted unit names the
-directory the files were generated in, which is only correct when they are
-generated on the node itself.
+The repairs are runtime state and do not survive a reboot. Do not use a cron
+`@reboot` job to restore `DOCKER-USER` rules: cron can run before Docker creates
+its firewall chains, and Docker can replace rules installed that early.
+
+`--emit-unit DIR` writes a per-node program and systemd unit that revalidate the
+addresses and reapply the complete route, forwarding, and `DOCKER-USER` plan at
+boot. The unit orders itself after `network-online.target` and `docker.service`
+when those units are active. A missing management address or firewall chain
+fails closed, and systemd retries the program after ten seconds.
+
+The generated files are not installed automatically. Install the program at a
+path that exists **on the node**, and set the unit's `ExecStart` to that path:
+the emitted unit names the directory the files were generated in, which is only
+correct when they are generated on the node itself.
 
 ## Local configuration and preflight
 

--- a/scripts/ring_doctor.py
+++ b/scripts/ring_doctor.py
@@ -395,6 +395,14 @@ class Finding:
 
 
 @dataclasses.dataclass(frozen=True)
+class RepairApplication:
+    """Outcome of the all-rank repair preflight and mutation commands."""
+
+    executed: bool
+    findings: tuple[Finding, ...] = ()
+
+
+@dataclasses.dataclass(frozen=True)
 class ProposedRoute:
     """A route whose gateway is an address observed on an adjacent node."""
 
@@ -2130,9 +2138,10 @@ def apply_plans(
     plans: Mapping[str, NodePlan],
     guards: Mapping[str, ManagementGuard],
     runner: Runner,
-) -> list[Finding]:
-    """Apply one fabric change at a time while management stays invariant."""
+) -> RepairApplication:
+    """Validate every target, then apply fabric changes with management guards."""
     findings: list[Finding] = []
+    prepared: list[tuple[str, NodeObservation, list[str], str]] = []
     for name, plan in sorted(plans.items()):
         commands = plan.commands()
         if not commands:
@@ -2163,7 +2172,32 @@ def apply_plans(
                 )
             )
             continue
-        guard_command = guard.shell_command()
+        prepared.append((name, observation, commands, guard.shell_command()))
+
+    if findings:
+        return RepairApplication(False, tuple(findings))
+
+    for name, observation, _commands, _guard_command in prepared:
+        result = runner.run(observation.spec.target, "sudo -n true", None)
+        if result.ok:
+            continue
+        findings.append(
+            Finding(
+                "error",
+                "apply-failed",
+                name,
+                "No repair was applied because non-interactive sudo is unavailable "
+                "on this node.",
+                result.detail
+                or result.stderr.strip()
+                or "sudo -n true failed without diagnostic output",
+            )
+        )
+
+    if findings:
+        return RepairApplication(False, tuple(findings))
+
+    for name, observation, commands, guard_command in prepared:
         for index, command in enumerate(commands, start=1):
             result = runner.run(
                 observation.spec.target,
@@ -2184,7 +2218,7 @@ def apply_plans(
                 )
             )
             break
-    return findings
+    return RepairApplication(True, tuple(findings))
 
 
 def _unit_program(
@@ -2875,15 +2909,19 @@ def main(argv: Sequence[str] | None = None) -> int:
     repair_safe = enough and fabric_preflight_ok and management_repair_safe
     if args.apply:
         if repair_safe:
-            apply_executed = True
-            apply_findings.extend(
-                apply_plans(observations, plans, management_guards, runner)
+            application = apply_plans(
+                observations, plans, management_guards, runner
             )
-            observations, topology, plans, findings = _probe_by_name(
-                specs, runner, interfaces, rendezvous_address
-            )
-            enough = discovery_sufficient(specs, observations, topology)
-            repair_safe = enough and fabric_preflight_ok and management_repair_safe
+            apply_executed = application.executed
+            apply_findings.extend(application.findings)
+            if application.executed:
+                observations, topology, plans, findings = _probe_by_name(
+                    specs, runner, interfaces, rendezvous_address
+                )
+                enough = discovery_sufficient(specs, observations, topology)
+                repair_safe = (
+                    enough and fabric_preflight_ok and management_repair_safe
+                )
         else:
             if not enough:
                 reason = topology.reason

--- a/scripts/test_ring_doctor.py
+++ b/scripts/test_ring_doctor.py
@@ -290,15 +290,17 @@ class DiagnosticReceiptAdapterTests(unittest.TestCase):
 
 
 class ManagementRepairSafetyTests(unittest.TestCase):
-    def guarded_observation(self) -> NodeObservation:
+    def guarded_observation(
+        self, name: str = "r0", management_address: str = "192.0.2.10"
+    ) -> NodeObservation:
         return observation(
-            "r0",
+            name,
             f"{IF0} UP 10.0.1.10/24\n{IF1} UP 10.0.4.10/24",
             socket_interfaces=("eth0",),
             host_addresses=(
                 f"{IF0} UP 10.0.1.10/24\n"
                 f"{IF1} UP 10.0.4.10/24\n"
-                "eth0 UP 192.0.2.10/24"
+                f"eth0 UP {management_address}/24"
             ),
         )
 
@@ -363,14 +365,70 @@ class ManagementRepairSafetyTests(unittest.TestCase):
                 return CommandResult(True)
 
         runner = ApplyRunner()
-        findings = apply_plans(
+        application = apply_plans(
             {"r0": guarded}, {"r0": plan}, {"r0": guard}, runner
         )
 
-        self.assertEqual(findings, [])
-        self.assertEqual(len(runner.commands), 1)
-        self.assertGreaterEqual(runner.commands[0].count("192.0.2.10/24"), 2)
-        self.assertIn("ip route replace 10.0.2.0/24", runner.commands[0])
+        self.assertTrue(application.executed)
+        self.assertEqual(application.findings, ())
+        self.assertEqual(len(runner.commands), 2)
+        self.assertEqual(runner.commands[0], "sudo -n true")
+        self.assertGreaterEqual(runner.commands[1].count("192.0.2.10/24"), 2)
+        self.assertIn("ip route replace 10.0.2.0/24", runner.commands[1])
+
+    def test_apply_withholds_every_plan_when_any_node_lacks_noninteractive_sudo(
+        self,
+    ) -> None:
+        rank0 = self.guarded_observation()
+        rank1 = self.guarded_observation("r1", "192.0.2.11")
+        observations = {"r0": rank0, "r1": rank1}
+        plans = {
+            name: NodePlan(
+                name,
+                routes=[
+                    ProposedRoute(
+                        ipaddress.ip_network("10.0.2.0/24"),
+                        ipaddress.ip_address("10.0.1.11"),
+                        IF0,
+                        (name, "peer"),
+                    )
+                ],
+            )
+            for name in observations
+        }
+        guards = {
+            name: ManagementGuard(name, (item.host_interfaces["eth0"],))
+            for name, item in observations.items()
+        }
+
+        class PrivilegeRunner:
+            def __init__(self) -> None:
+                self.calls: list[tuple[str, str]] = []
+
+            def run(self, target, command, proxy_jump=None):
+                self.calls.append((target, command))
+                if command != "sudo -n true":
+                    raise AssertionError(f"repair command executed on {target}")
+                if target == "operator@r0":
+                    return CommandResult(False, stderr="sudo: a password is required")
+                return CommandResult(True)
+
+        runner = PrivilegeRunner()
+        application = apply_plans(observations, plans, guards, runner)
+
+        self.assertFalse(application.executed)
+        self.assertEqual(
+            [(finding.node, finding.code) for finding in application.findings],
+            [("r0", "apply-failed")],
+        )
+        self.assertIn("non-interactive sudo", application.findings[0].message)
+        self.assertEqual(
+            runner.calls,
+            [
+                ("operator@r0", "sudo -n true"),
+                ("operator@r1", "sudo -n true"),
+            ],
+        )
 
     def test_boot_program_checks_management_after_every_change(self) -> None:
         guarded = self.guarded_observation()
@@ -417,6 +475,30 @@ class ManagementRepairSafetyTests(unittest.TestCase):
             "ExecStart=",
             unit,
         )
+
+    def test_emitted_unit_restores_firewall_plan_after_docker_startup(self) -> None:
+        guarded = self.guarded_observation()
+        guard = ManagementGuard("r0", (guarded.host_interfaces["eth0"],))
+        plan = NodePlan("r0", relay_directions={(IF0, IF1)})
+
+        with tempfile.TemporaryDirectory() as directory:
+            emit_units(
+                Path(directory),
+                {"r0": guarded},
+                {"r0": plan},
+                {"r0": guard},
+            )
+            root = Path(directory)
+            unit = root.joinpath("ring-doctor-r0.service").read_text(
+                encoding="utf-8"
+            )
+            program = root.joinpath("ring-doctor-r0.py").read_text(
+                encoding="utf-8"
+            )
+
+        self.assertIn("After=network-online.target docker.service", unit)
+        self.assertIn(f"RELAY_DIRECTIONS = [['{IF0}', '{IF1}']]", program)
+        self.assertIn('["iptables", "-I", "DOCKER-USER", "1", *rule]', program)
 
 
 class AddressAndTopologyTests(unittest.TestCase):


### PR DESCRIPTION
Fixes #169
Fixes #174

## Resulting behavior

`ring-doctor --apply` verifies `sudo -n true` on every node whose repair plan contains commands before executing any route, forwarding, or firewall mutation. If any node cannot run sudo non-interactively, Ring Doctor:

- checks the remaining repair targets so every privilege failure can be reported;
- executes no repair command on any node;
- records an `apply-failed` finding for each affected rank; and
- reports `apply.executed` as false, which renders as `Repair application: withheld`.

When every privilege check passes, the existing per-operation management guards and repair commands run unchanged.

Status: **implemented** and covered by GPU-free regression tests.

## Technical reason

A repair command can fail on rank 0 because `sudo -n` requires non-interactive authorization while the same command succeeds when an operator supplies a password manually. Processing repair plans independently permits ranks 1–3 to mutate after the rank-0 failure, leaving a partially repaired ring.

The all-rank privilege preflight makes non-interactive sudo an atomic prerequisite for the repair plan. It does not weaken the management-address or fabric-only mutation invariants.

## Reboot persistence

The generated Ring Doctor systemd service is the supported persistence mechanism for routes, IPv4 forwarding, and fabric-to-fabric `DOCKER-USER` rules. Operator documentation states that cron `@reboot` jobs are unsupported because they can run before Docker creates its firewall chains. The generated service declares `After=network-online.target docker.service`, fails closed when required state is unavailable, and retries after ten seconds.

No second firewall-specific service is introduced.

## Compatibility

The command-line interface, JSON report schema, repair-plan commands, management guards, and generated systemd program format are unchanged. The `apply.executed` field remains false when privilege preflight prevents every repair command, accurately distinguishing a withheld plan from an attempted mutation.

No model-serving, image, or cache-identity contract changes.

## Validation

A deterministic four-rank harness modeled rank 0 returning `sudo: a password is required` while ranks 1–3 accepted non-interactive sudo:

- before the change, rank 0 attempted one command and ranks 1–3 each executed five repair commands in all three runs;
- with the all-rank preflight, all four privilege checks ran, zero repair commands ran, and rank 0 produced one explicit finding in all three runs.

Additional validation:

- `python -m pytest scripts/test_ring_doctor.py -q` — 47 passed.
- Full CPU-only repository suite — 1,941 passed and 9 skipped.
- `python -m ruff check --select E,F,W --ignore E501 spark_transport runtime scripts performance` — passed.
- `git diff --check` — passed.

The CPU-only validation does not contact SSH targets, execute sudo, mutate network state, start Docker, or exercise a live fabric. A successful privilege preflight cannot prevent an unrelated command or management-path failure after mutation begins; the existing per-operation fail-closed checks remain responsible for those failures.

Reported by @Saolence in #169 and @sethforprivacy in #174.