### PR TITLE
Add opt-in multi-key authentication to the GLM-5.3 launcher

### DIFF
--- a/docs/GLM53_JJ_R8_GB10_SPARKCACHE_TP4_QUICKSTART.md
+++ b/docs/GLM53_JJ_R8_GB10_SPARKCACHE_TP4_QUICKSTART.md
@@ -142,6 +142,16 @@ modality. SparkCache binds media identity and placeholder geometry into the
 persistent context digest, so different media cannot share an entry merely
 because their placeholder tokens have the same shape.
 
+The server binds `0.0.0.0` and serves without authentication by default. To
+require an OpenAI-compatible bearer token, point `API_KEYS_FILE` at a mode-0600
+rank-local file holding one accepted key per line; the launcher refuses to
+start if the file is missing, empty, world- or group-readable, or contains
+whitespace in a key.
+
+This is host-level access control, not secret management. vLLM receives the
+keys in its process arguments, which remain visible to an administrator who
+can inspect the container or host process.
+
 Choose the DCP degree with one line:
 
 ```bash

--- a/runtime/glm53-flash-jj-r8-gb10/launch-rank.sh
+++ b/runtime/glm53-flash-jj-r8-gb10/launch-rank.sh
@@ -87,6 +87,7 @@ fi
 : "${TORCHINDUCTOR_COMPILE_THREADS:=1}"
 : "${FASTSAFETENSORS_QUEUE_SIZE:=1}"
 : "${ENABLE_PROMPT_TOKENS_DETAILS:=1}"
+: "${API_KEYS_FILE:=}"
 
 die() {
   printf '%s\n' "$*" >&2
@@ -240,6 +241,24 @@ do
   [[ "${!name}" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]] || \
     die "${name} must contain only letters, digits, dot, underscore, or hyphen"
 done
+api_key_args=()
+if [[ -n "${API_KEYS_FILE}" ]]; then
+  [[ -f "${API_KEYS_FILE}" && -r "${API_KEYS_FILE}" ]] || \
+    die "API_KEYS_FILE is not a readable regular file: ${API_KEYS_FILE}"
+  api_keys_file_mode="$(stat -c %a -- "${API_KEYS_FILE}" 2>/dev/null \
+    || stat -f %Lp -- "${API_KEYS_FILE}" 2>/dev/null || true)"
+  [[ "${api_keys_file_mode}" == 600 ]] || \
+    die "API_KEYS_FILE must be mode 0600, got 0${api_keys_file_mode:-???}"
+  mapfile -t api_keys < <(awk 'NF {print}' "${API_KEYS_FILE}")
+  (( ${#api_keys[@]} > 0 )) || die 'API_KEYS_FILE contains no non-empty keys'
+  for api_key in "${api_keys[@]}"; do
+    [[ "${api_key}" != *[[:space:]]* ]] || \
+      die 'API_KEYS_FILE contains whitespace in a key'
+  done
+  # vLLM parses --api-key with nargs="+"; keep every key in one occurrence so a
+  # later option cannot truncate the accepted set.
+  api_key_args=(--api-key "${api_keys[@]}")
+fi
 for name in TARGET_MODEL_HOST_PATH DFLASH_MODEL_HOST_PATH CACHE_HOST_ROOT; do
   value="${!name}"
   [[ "${value}" == /* ]] || die "${name} must be an absolute host path"
@@ -478,7 +497,8 @@ exec docker run -d \
   --label org.sparkring.multimodal-inputs="${MULTIMODAL_INPUTS}" \
   "${IMAGE_REF}" \
   /models/target \
-  --served-model-name "${SERVED_MODEL_NAME}" --host 0.0.0.0 --port "${PORT}" \
+  --served-model-name "${SERVED_MODEL_NAME}" "${api_key_args[@]}" \
+  --host 0.0.0.0 --port "${PORT}" \
   --tensor-parallel-size "${TENSOR_PARALLEL_SIZE}" \
   --pipeline-parallel-size "${PIPELINE_PARALLEL_SIZE}" \
   --decode-context-parallel-size "${DECODE_CONTEXT_PARALLEL_SIZE}" \

--- a/runtime/glm53-flash-jj-r8-gb10/runtime.env.example
+++ b/runtime/glm53-flash-jj-r8-gb10/runtime.env.example
@@ -109,3 +109,9 @@ FASTSAFETENSORS_QUEUE_SIZE=1
 # usage. Streaming clients must request usage with stream_options.include_usage.
 # Set to 0 to omit prompt_tokens_details from API responses.
 ENABLE_PROMPT_TOKENS_DETAILS=1
+
+# Optional OpenAI-compatible bearer authentication. Unset (the default) serves
+# keyless, exactly as before. When set, the path must be a readable regular
+# file with mode 0600 holding one key per line; every non-empty line is passed
+# to vLLM in a single --api-key option.
+#API_KEYS_FILE='/REPLACE/RANK_LOCAL_API_KEYS_FILE'

--- a/runtime/glm53-flash-jj-r8-gb10/test_launcher_contract.py
+++ b/runtime/glm53-flash-jj-r8-gb10/test_launcher_contract.py
@@ -6,6 +6,8 @@ import re
 import subprocess
 from pathlib import Path
 
+import pytest
+
 
 HERE = Path(__file__).resolve().parent
 ROOT = HERE.parents[1]
@@ -259,6 +261,127 @@ def test_launcher_rejects_shared_prefix_retention_above_five_minutes(
 
     assert result.returncode == 78
     assert "must be between 1 and 300" in result.stderr
+
+
+@pytest.mark.skipif(
+    os.name == "nt",
+    reason="WSL DrvFS reports Windows temporary files as mode 0777",
+)
+def test_launcher_renders_optional_multi_key_authentication(tmp_path: Path) -> None:
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    capture = tmp_path / "docker-arguments.txt"
+    docker = fake_bin / "docker"
+    docker.write_text(
+        """#!/bin/sh
+if [ "$1" = image ] && [ "$2" = inspect ]; then
+  printf '%s\n' "$EXPECTED_IMAGE_ID"
+elif [ "$1" = container ] && [ "$2" = inspect ]; then
+  exit 1
+elif [ "$1" = run ]; then
+  printf '%s\n' "$@" > "$CAPTURE_PATH"
+else
+  exit 97
+fi
+        """,
+        encoding="utf-8",
+        newline="\n",
+    )
+    os.chmod(docker, 0o755)
+    sha256sum = fake_bin / "sha256sum"
+    sha256sum.write_text(
+        """#!/bin/sh
+case "$2" in
+  */target/config.json) hash=676382abd1e90a6c85f0c8f33d45441ecd45fd514fd7b63ce5610e732d8e4996 ;;
+  */target/model.safetensors.index.json) hash=0d1d9e6b226e76520e182de10d4e7194cc885c5cb1bf885bb90de1916ce312cb ;;
+  */draft/config.json) hash=c4aeac0101196a6e26705b34c45230bcd0c7c68ee2d2d1efdb242087f3712573 ;;
+  */draft/model.safetensors) hash=b33c03475ba7322cf398828f2d8d1be376df30dc05c6b40c28c8ea8da23e410b ;;
+  *) exit 95 ;;
+esac
+printf '%s  %s\n' "$hash" "$2"
+        """,
+        encoding="utf-8",
+        newline="\n",
+    )
+    os.chmod(sha256sum, 0o755)
+
+    directories = {name: tmp_path / name for name in ("target", "draft", "cache")}
+    for directory in directories.values():
+        directory.mkdir()
+    for path in (
+        directories["target"] / "config.json",
+        directories["target"] / "model.safetensors.index.json",
+        directories["draft"] / "config.json",
+        directories["draft"] / "model.safetensors",
+    ):
+        path.write_text("fixture", encoding="utf-8")
+
+    def launch(name: str, *overrides: str) -> subprocess.CompletedProcess[str]:
+        config = tmp_path / f"{name}.env"
+        config.write_text(
+            "\n".join(
+                (
+                    "HOST_IP=rank0.example.net",
+                    "MASTER_ADDR=rank0.example.net",
+                    f"TARGET_MODEL_HOST_PATH={_bash_path(directories['target'])}",
+                    f"DFLASH_MODEL_HOST_PATH={_bash_path(directories['draft'])}",
+                    f"CACHE_HOST_ROOT={_bash_path(directories['cache'])}",
+                    f"PATH={_bash_path(fake_bin)}:$PATH",
+                    f"export CAPTURE_PATH={_bash_path(capture)}",
+                    f"export EXPECTED_IMAGE_ID={IMAGE_ID}",
+                    "IMAGE_REF=test-image:r8",
+                    f"IMAGE_ID={IMAGE_ID}",
+                )
+                + overrides
+            ),
+            encoding="utf-8",
+            newline="\n",
+        )
+        return subprocess.run(
+            ["bash", _bash_path(LAUNCHER), "0", _bash_path(config)],
+            cwd=ROOT,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+    # Unset is the default and must render exactly the keyless command.
+    result = launch("auth-unset")
+    assert result.returncode == 0, result.stderr
+    keyless = capture.read_text(encoding="utf-8").splitlines()
+    assert "--api-key" not in keyless
+
+    # A two-key file renders one --api-key option carrying both keys.
+    keys = tmp_path / "api-keys"
+    keys.write_text("k1\n\nk2\n", encoding="utf-8", newline="\n")
+    os.chmod(keys, 0o600)
+    result = launch("auth-set", f"API_KEYS_FILE={_bash_path(keys)}")
+    assert result.returncode == 0, result.stderr
+    keyed = capture.read_text(encoding="utf-8").splitlines()
+    assert keyed.count("--api-key") == 1
+    index = keyed.index("--api-key")
+    assert keyed[index + 1 : index + 3] == ["k1", "k2"]
+    assert keyed[index + 3] == "--host"
+    assert [
+        argument for argument in keyed if argument not in ("--api-key", "k1", "k2")
+    ] == keyless
+
+    # A file readable beyond its owner is refused before the container starts.
+    loose = tmp_path / "api-keys-loose"
+    loose.write_text("k1\n", encoding="utf-8", newline="\n")
+    os.chmod(loose, 0o644)
+    result = launch("auth-loose", f"API_KEYS_FILE={_bash_path(loose)}")
+    assert result.returncode == 78, result.stdout + result.stderr
+    assert "API_KEYS_FILE must be mode 0600" in result.stderr
+
+
+def test_launcher_fails_closed_on_unusable_api_key_files() -> None:
+    launcher = LAUNCHER.read_text(encoding="utf-8")
+    assert ': "${API_KEYS_FILE:=}"' in launcher
+    assert "API_KEYS_FILE is not a readable regular file" in launcher
+    assert "API_KEYS_FILE contains no non-empty keys" in launcher
+    assert "API_KEYS_FILE contains whitespace in a key" in launcher
+    assert "API_KEYS_FILE must be mode 0600" in launcher
 
 
 def test_launcher_can_use_vllm_prefix_cache_without_sparkcache() -> None:


### PR DESCRIPTION
## Result

The GLM-5.3 launcher can require one or more OpenAI-compatible bearer tokens through an optional rank-local key file. Keyless serving remains the default.

Adapted from and preserves the authorship of #166.

## Behavior

- `API_KEYS_FILE` points to a readable regular file with one key per non-empty line.
- The launcher requires mode 0600, at least one key, and no whitespace within a key.
- Every key is passed through one `--api-key` occurrence because vLLM parses the option with `nargs="+"`.
- Invalid configuration stops before Docker creates a container.
- Unset `API_KEYS_FILE` preserves the keyless command.

## Security boundary

This provides host/LAN access control, not secret management. vLLM receives keys in process arguments, so host or Docker administrators can inspect them.

## Compatibility

No image rebuild is required. Multimodal defaults, text-only mode, interval-two scheduler cadence, SparkCache, DCP geometry, KV allocation, and speculation remain unchanged.

## Validation

- 24 GLM runtime tests passed locally; the mode-sensitive test is skipped only on Windows because WSL DrvFS reports mounted files as mode 0777.
- 23 profile, recipe, and scheduler-record tests passed.
- GitHub Linux CI executes the full mode-0600 integration case.
- `git diff --check` passed.
