### PR TITLE
Bind the GLM-5.3 recipe to public image source

### DIFF
--- a/recipes/glm53-flash-nvfp4-dflash2-bf16-tp4.json
+++ b/recipes/glm53-flash-nvfp4-dflash2-bf16-tp4.json
@@ -32,7 +32,7 @@
     "quickstart": "docs/GLM53_JJ_R8_GB10_SPARKCACHE_TP4_QUICKSTART.md",
     "image": "ghcr.io/fujitsupolycom/sparkring-glm53-sparkcache@sha256:3c377f1e4136285ebf66c32c36c3d01fd929f8aba0836cd0a16ed63cfd7e1762",
     "image_id": "sha256:d1a07147c9e25f3d3e0af6b1499c4988b1ae61138e327aa05c9ad9dc568e39a9",
-    "sparkring_source_commit": "d2f8911427d64bbb89c275814777fc3f8112fd21",
+    "sparkring_source_commit": "a150c98ccfdc4b655679860121f24712490dd9ee",
     "vllm_repository": "https://github.com/FujitsuPolycom/vllm.git",
     "vllm_commit": "22ffe1401ca9bd3e4503e62de7b414deca7661a1",
     "b12x_commit": "6255090a03b12c3f7d552102a02fac0b542fb8c9",

--- a/runtime/glm53-flash-jj-r8-gb10/ASYNC_CAPTURE_IMAGE_VALIDATION.md
+++ b/runtime/glm53-flash-jj-r8-gb10/ASYNC_CAPTURE_IMAGE_VALIDATION.md
@@ -5,6 +5,15 @@ of the recorded 124,928-token, 231.8 MiB-per-rank snapshot under the immutable
 Linux/ARM64 image and DCP4 conditions recorded in
 [`async-capture-image-receipt.json`](async-capture-image-receipt.json).
 
+> [!WARNING]
+> SparkRing commit `d2f8911427d64bbb89c275814777fc3f8112fd21`
+> is recorded by the image but is not reachable from the public repository
+> history. The measurements below remain evidence for the immutable image
+> digest, but the SparkRing source layer cannot be independently reconstructed.
+> Use the maintained operator image and public source contract in
+> [`multimodal-lease300-image-receipt.json`](multimodal-lease300-image-receipt.json)
+> for reproducible deployment.
+
 The image combines the Local Inference Lab GLM-5.3 runtime, BF16 DFlash2 at
 depth seven, B12X GB10 kernels, switchless NCCL, fastsafetensors, and
 SparkCache's bounded CUDA publication and restore paths.
@@ -16,7 +25,7 @@ SparkCache's bounded CUDA publication and restore paths.
 | Registry image | `ghcr.io/fujitsupolycom/sparkring-glm53-sparkcache@sha256:bc7d079f16ff4a418669c58c5250f2da52e989a0c5805569ba9429d41b765f65` |
 | Published tag | `ghcr.io/fujitsupolycom/sparkring-glm53-sparkcache:20260901-r10-async-telemetry` |
 | Image ID | `sha256:35f397668c01075d0bdd28bbdb3398afd3744df6086646c6f68bcf7ebe7f918f` |
-| SparkRing image source | commit `d2f8911427d64bbb89c275814777fc3f8112fd21` |
+| SparkRing image source | commit `d2f8911427d64bbb89c275814777fc3f8112fd21` (not available in public history) |
 | SparkCache source | commit `c5dda75ec46bf235f6ece6e0d0174c1e41bd805a` |
 | vLLM source | commit `22ffe1401ca9bd3e4503e62de7b414deca7661a1` |
 

--- a/scripts/test_glm53_flash_profile.py
+++ b/scripts/test_glm53_flash_profile.py
@@ -320,6 +320,12 @@ def test_site_and_runtime_profiles_have_one_identity_contract() -> None:
 def test_recipes_record_qualified_cached_and_cache_disabled_evidence() -> None:
     base = _json(BASE_RECIPE_PATH)
     cache = _json(CACHE_RECIPE_PATH)
+    image_receipt = _json(
+        ROOT
+        / "runtime"
+        / "glm53-flash-jj-r8-gb10"
+        / "multimodal-lease300-image-receipt.json"
+    )
 
     assert base["status"] == "implemented"
     assert base["serving_common"]["external_kv_cache"] is False
@@ -345,6 +351,22 @@ def test_recipes_record_qualified_cached_and_cache_disabled_evidence() -> None:
     assert cache["runtime"]["sparkcache"]["source_commit"] == (
         "b7d1c188a3f9e78595e6e7b649f3751131e269ea"
     )
+    assert base["runtime"]["sparkring_source_commit"] == (
+        image_receipt["sources"]["sparkring_image_revision"]
+    )
+
+
+def test_historical_async_capture_record_discloses_unavailable_source() -> None:
+    record = (
+        ROOT
+        / "runtime"
+        / "glm53-flash-jj-r8-gb10"
+        / "ASYNC_CAPTURE_IMAGE_VALIDATION.md"
+    ).read_text(encoding="utf-8")
+    assert "d2f8911427d64bbb89c275814777fc3f8112fd21" in record
+    assert "not reachable from the public repository" in record
+    assert "history." in record
+    assert "cannot be independently reconstructed" in record
 
 
 def test_public_glm53_benchmark_retains_only_valid_run1_cells() -> None:


### PR DESCRIPTION
## Result

The active GLM-5.3 recipe now names public image-build commit `a150c98…`, matching the published image label and machine receipt.

Closes #165.

The historical asynchronous-capture record still identifies the exact commit recorded by that older image, but now states directly that `d2f89114…` is unavailable from public history and its SparkRing source layer cannot be independently reconstructed. Its immutable-image measurements remain preserved rather than being reassigned to a different source revision.

## Compatibility

Documentation and provenance only. Runtime behavior, image contents, cache identity, DCP geometry, scheduler cadence, and launch defaults are unchanged.

## Validation

- 34 focused profile, image, and launcher checks passed.
- One filesystem-mode integration case is skipped on Windows/WSL and runs in Linux CI.
- `git diff --check` passed.
