### PR TITLE
Persist DeepSeek compilation caches and NCCL diagnostics

### DIFF
--- a/docs/DEEPSEEK_V4_FLASH_QUICKSTART.md
+++ b/docs/DEEPSEEK_V4_FLASH_QUICKSTART.md
@@ -312,6 +312,21 @@ metrics. `Mean acceptance length` above one confirms speculative decoding is
 active, and `GPU KV cache size` reports the token capacity the reservation
 bought.
 
+## Preserve JIT and collective-hang evidence
+
+The environment templates keep TileLang, Triton, vLLM, and B12X CuTeDSL
+compilation data under the persistent `CACHE_HOST_PATH` mount. Recreating a
+container therefore does not discard those caches.
+
+PyTorch's NCCL flight recorder writes each rank's timeout dump beneath
+`CACHE_HOST_PATH/nccl-fr`. Archive every rank's `comm_lib_trace_rank_*` file
+together after a timeout; a later dump overwrites the static per-rank name.
+
+An on-demand pipe request is asynchronous. After writing to
+`/tmp/fr_dump_pipe_<rank>.pipe` inside a container, wait for the rank log to
+report that flight-recorder output finished, or wait until the dump file size
+stops changing, before stopping the container.
+
 ## Measured
 
 Both cache-disabled base setups were measured with the sampling settings in

--- a/scripts/config/deepseek-v4-flash-0731-pair.env.example
+++ b/scripts/config/deepseek-v4-flash-0731-pair.env.example
@@ -40,10 +40,13 @@ MODEL_HOST_PATH=<ABSOLUTE_MODEL_DIRECTORY>
 #   /cache/test/jit
 #   /cache/test/jit/triton
 #   /cache/test/jit/vllm
+#   /cache/test/jit/tilelang
+#   /cache/test/jit/b12x-cute
+#   /cache/test/nccl-fr
 #
-# Leave XDG_CACHE_HOME, TRITON_CACHE_DIR, and VLLM_CACHE_ROOT unchanged below.
-# Their /cache paths are container paths mapped beneath CACHE_HOST_PATH on the
-# host; they are not additional host directories to configure.
+# Leave the container-internal cache and recorder paths below unchanged. Their
+# /cache paths map beneath CACHE_HOST_PATH on the host; they are not additional
+# host directories to configure.
 CACHE_HOST_PATH=<ABSOLUTE_CACHE_DIRECTORY>
 
 # Operator-tunable serving values. These defaults reproduce
@@ -135,7 +138,7 @@ B12X_CUTE_COMPILE_CACHE_DIR=/cache/jit/b12x-cute
 
 # PyTorch ProcessGroupNCCL flight recorder. Dump files persist under the
 # existing CACHE_HOST_PATH mount and are overwritten by a later dump.
-TORCH_FR_BUFFER_SIZE=2000
+TORCH_NCCL_TRACE_BUFFER_SIZE=2000
 TORCH_NCCL_DUMP_ON_TIMEOUT=1
 TORCH_NCCL_ENABLE_MONITORING=1
 TORCH_FR_DUMP_TEMP_FILE=/cache/nccl-fr/comm_lib_trace_rank_

--- a/scripts/config/deepseek-v4-flash-0731-pair.env.example
+++ b/scripts/config/deepseek-v4-flash-0731-pair.env.example
@@ -130,4 +130,14 @@ HF_HUB_OFFLINE=1
 XDG_CACHE_HOME=/cache/jit
 TRITON_CACHE_DIR=/cache/jit/triton
 VLLM_CACHE_ROOT=/cache/jit/vllm
+TILELANG_CACHE_DIR=/cache/jit/tilelang
+B12X_CUTE_COMPILE_CACHE_DIR=/cache/jit/b12x-cute
+
+# PyTorch ProcessGroupNCCL flight recorder. Dump files persist under the
+# existing CACHE_HOST_PATH mount and are overwritten by a later dump.
+TORCH_FR_BUFFER_SIZE=2000
+TORCH_NCCL_DUMP_ON_TIMEOUT=1
+TORCH_NCCL_ENABLE_MONITORING=1
+TORCH_FR_DUMP_TEMP_FILE=/cache/nccl-fr/comm_lib_trace_rank_
+TORCH_NCCL_DEBUG_INFO_PIPE_FILE=/tmp/fr_dump_pipe_
 VLLM_NO_USAGE_STATS=1

--- a/scripts/config/deepseek-v4-flash-0731.env.example
+++ b/scripts/config/deepseek-v4-flash-0731.env.example
@@ -29,8 +29,12 @@ MODEL_HOST_PATH=<ABSOLUTE_MODEL_DIRECTORY>
 #   /cache/deepseek-cycle/jit
 #   /cache/deepseek-cycle/jit/triton
 #   /cache/deepseek-cycle/jit/vllm
+#   /cache/deepseek-cycle/jit/tilelang
+#   /cache/deepseek-cycle/jit/b12x-cute
+#   /cache/deepseek-cycle/nccl-fr
 #
-# Leave XDG_CACHE_HOME, TRITON_CACHE_DIR, and VLLM_CACHE_ROOT unchanged below.
+# Leave the container-internal cache and recorder paths below unchanged. Their
+# /cache paths map beneath CACHE_HOST_PATH on the host.
 CACHE_HOST_PATH=<ABSOLUTE_CACHE_DIRECTORY>
 
 # Operator-tunable serving values. These defaults reproduce
@@ -123,7 +127,7 @@ B12X_CUTE_COMPILE_CACHE_DIR=/cache/jit/b12x-cute
 
 # PyTorch ProcessGroupNCCL flight recorder. Dump files persist under the
 # existing CACHE_HOST_PATH mount and are overwritten by a later dump.
-TORCH_FR_BUFFER_SIZE=2000
+TORCH_NCCL_TRACE_BUFFER_SIZE=2000
 TORCH_NCCL_DUMP_ON_TIMEOUT=1
 TORCH_NCCL_ENABLE_MONITORING=1
 TORCH_FR_DUMP_TEMP_FILE=/cache/nccl-fr/comm_lib_trace_rank_

--- a/scripts/config/deepseek-v4-flash-0731.env.example
+++ b/scripts/config/deepseek-v4-flash-0731.env.example
@@ -118,4 +118,14 @@ HF_HUB_OFFLINE=1
 XDG_CACHE_HOME=/cache/jit
 TRITON_CACHE_DIR=/cache/jit/triton
 VLLM_CACHE_ROOT=/cache/jit/vllm
+TILELANG_CACHE_DIR=/cache/jit/tilelang
+B12X_CUTE_COMPILE_CACHE_DIR=/cache/jit/b12x-cute
+
+# PyTorch ProcessGroupNCCL flight recorder. Dump files persist under the
+# existing CACHE_HOST_PATH mount and are overwritten by a later dump.
+TORCH_FR_BUFFER_SIZE=2000
+TORCH_NCCL_DUMP_ON_TIMEOUT=1
+TORCH_NCCL_ENABLE_MONITORING=1
+TORCH_FR_DUMP_TEMP_FILE=/cache/nccl-fr/comm_lib_trace_rank_
+TORCH_NCCL_DEBUG_INFO_PIPE_FILE=/tmp/fr_dump_pipe_
 VLLM_NO_USAGE_STATS=1

--- a/scripts/deepseek_v4_cycle_serve.sh
+++ b/scripts/deepseek_v4_cycle_serve.sh
@@ -207,4 +207,12 @@ docker image inspect "$image" >/dev/null 2>&1 \
 if docker container inspect "$container_name" >/dev/null 2>&1; then
     die "container already exists; remove it intentionally before relaunch: $container_name"
 fi
+for cache_directory in \
+    "$CACHE_HOST_PATH/jit/tilelang" \
+    "$CACHE_HOST_PATH/jit/b12x-cute" \
+    "$CACHE_HOST_PATH/nccl-fr"; do
+    if ! mkdir -p "$cache_directory"; then
+        echo "deepseek cycle launcher: warning: could not create $cache_directory" >&2
+    fi
+done
 exec "${command[@]}"

--- a/scripts/deepseek_v4_pair_serve.sh
+++ b/scripts/deepseek_v4_pair_serve.sh
@@ -198,4 +198,12 @@ docker image inspect "$image" >/dev/null 2>&1 \
 if docker container inspect "$container_name" >/dev/null 2>&1; then
     die "container already exists; remove it intentionally before relaunch: $container_name"
 fi
+for cache_directory in \
+    "$CACHE_HOST_PATH/jit/tilelang" \
+    "$CACHE_HOST_PATH/jit/b12x-cute" \
+    "$CACHE_HOST_PATH/nccl-fr"; do
+    if ! mkdir -p "$cache_directory"; then
+        echo "deepseek pair launcher: warning: could not create $cache_directory" >&2
+    fi
+done
 exec "${command[@]}"

--- a/scripts/test_deepseek_v4_pair_launcher.py
+++ b/scripts/test_deepseek_v4_pair_launcher.py
@@ -139,6 +139,34 @@ def test_pair_env_explains_host_cache_mapping() -> None:
     assert "configure the host location only through" in source
 
 
+@pytest.mark.parametrize("template", [TEMPLATE, CYCLE_TEMPLATE])
+def test_deepseek_templates_persist_native_jit_and_flight_recorder_data(
+    template: Path,
+) -> None:
+    values = _env_values(template)
+
+    assert values["TILELANG_CACHE_DIR"] == "/cache/jit/tilelang"
+    assert values["B12X_CUTE_COMPILE_CACHE_DIR"] == "/cache/jit/b12x-cute"
+    assert values["TORCH_FR_BUFFER_SIZE"] == "2000"
+    assert values["TORCH_NCCL_DUMP_ON_TIMEOUT"] == "1"
+    assert values["TORCH_NCCL_ENABLE_MONITORING"] == "1"
+    assert values["TORCH_FR_DUMP_TEMP_FILE"] == (
+        "/cache/nccl-fr/comm_lib_trace_rank_"
+    )
+    assert values["TORCH_NCCL_DEBUG_INFO_PIPE_FILE"] == "/tmp/fr_dump_pipe_"
+
+
+@pytest.mark.parametrize("launcher", [LAUNCHER, CYCLE_LAUNCHER])
+def test_deepseek_launchers_prepare_persistent_cache_directories(
+    launcher: Path,
+) -> None:
+    source = launcher.read_text(encoding="utf-8")
+
+    assert '"$CACHE_HOST_PATH/jit/tilelang"' in source
+    assert '"$CACHE_HOST_PATH/jit/b12x-cute"' in source
+    assert '"$CACHE_HOST_PATH/nccl-fr"' in source
+
+
 def test_cycle_env_defaults_match_recipe() -> None:
     values = _env_values(CYCLE_TEMPLATE)
     recipe = json.loads(CYCLE_RECIPE.read_text(encoding="utf-8"))

--- a/scripts/test_deepseek_v4_pair_launcher.py
+++ b/scripts/test_deepseek_v4_pair_launcher.py
@@ -35,10 +35,14 @@ def _run_launcher(
     env_file: Path,
     mode: str | None = "--check",
     launcher: Path = LAUNCHER,
+    path_prefix: Path | None = None,
 ) -> subprocess.CompletedProcess[str]:
     arguments = [str(env_file)] if mode is None else [mode, str(env_file)]
     if os.name != "nt":
         command = ["bash", str(launcher), *arguments]
+        environment = os.environ.copy()
+        if path_prefix is not None:
+            environment["PATH"] = f"{path_prefix}{os.pathsep}{environment['PATH']}"
     else:
         rendered = " ".join(
             shlex.quote(value)
@@ -48,8 +52,20 @@ def _run_launcher(
                 *([_bash_path(env_file)] if mode is None else [mode, _bash_path(env_file)]),
             )
         )
-        command = ["bash", "-lc", f"exec {rendered}"]
-    return subprocess.run(command, text=True, capture_output=True, check=False)
+        path_assignment = (
+            f"export PATH={shlex.quote(_bash_path(path_prefix))}:$PATH; "
+            if path_prefix is not None
+            else ""
+        )
+        command = ["bash", "-lc", f"{path_assignment}exec {rendered}"]
+        environment = os.environ.copy()
+    return subprocess.run(
+        command,
+        env=environment,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
 
 
 def _env_values(path: Path) -> dict[str, str]:
@@ -135,7 +151,10 @@ def test_pair_env_explains_host_cache_mapping() -> None:
     source = TEMPLATE.read_text(encoding="utf-8")
     assert "CACHE_HOST_PATH=/cache/test" in source
     assert "/cache/test/jit/triton" in source
-    assert "Leave XDG_CACHE_HOME, TRITON_CACHE_DIR, and VLLM_CACHE_ROOT unchanged" in source
+    assert "/cache/test/jit/tilelang" in source
+    assert "/cache/test/jit/b12x-cute" in source
+    assert "/cache/test/nccl-fr" in source
+    assert "Leave the container-internal cache and recorder paths" in source
     assert "configure the host location only through" in source
 
 
@@ -147,7 +166,7 @@ def test_deepseek_templates_persist_native_jit_and_flight_recorder_data(
 
     assert values["TILELANG_CACHE_DIR"] == "/cache/jit/tilelang"
     assert values["B12X_CUTE_COMPILE_CACHE_DIR"] == "/cache/jit/b12x-cute"
-    assert values["TORCH_FR_BUFFER_SIZE"] == "2000"
+    assert values["TORCH_NCCL_TRACE_BUFFER_SIZE"] == "2000"
     assert values["TORCH_NCCL_DUMP_ON_TIMEOUT"] == "1"
     assert values["TORCH_NCCL_ENABLE_MONITORING"] == "1"
     assert values["TORCH_FR_DUMP_TEMP_FILE"] == (
@@ -165,6 +184,56 @@ def test_deepseek_launchers_prepare_persistent_cache_directories(
     assert '"$CACHE_HOST_PATH/jit/tilelang"' in source
     assert '"$CACHE_HOST_PATH/jit/b12x-cute"' in source
     assert '"$CACHE_HOST_PATH/nccl-fr"' in source
+
+
+@pytest.mark.parametrize(
+    ("launcher", "environment_fixture"),
+    [(LAUNCHER, "pair_env"), (CYCLE_LAUNCHER, "cycle_env")],
+)
+def test_deepseek_launchers_create_persistent_cache_directories_before_run(
+    launcher: Path,
+    environment_fixture: str,
+    request: pytest.FixtureRequest,
+    tmp_path: Path,
+) -> None:
+    env_file = request.getfixturevalue(environment_fixture)
+    cache = tmp_path / "cache"
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    docker = fake_bin / "docker"
+    cache_for_bash = shlex.quote(_bash_path(cache))
+    docker.write_text(
+        f"""#!/bin/sh
+case "$1 $2" in
+  "image inspect") exit 0 ;;
+  "container inspect") exit 1 ;;
+  "run -d")
+    cache={cache_for_bash}
+    test -d "$cache/jit/tilelang" || exit 91
+    test -d "$cache/jit/b12x-cute" || exit 92
+    test -d "$cache/nccl-fr" || exit 93
+    printf '%s\n' fake-container-id
+    ;;
+  *) exit 94 ;;
+esac
+""",
+        encoding="utf-8",
+        newline="\n",
+    )
+    docker.chmod(0o755)
+
+    result = _run_launcher(
+        env_file,
+        mode="--run",
+        launcher=launcher,
+        path_prefix=fake_bin,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "fake-container-id" in result.stdout
+    assert (cache / "jit" / "tilelang").is_dir()
+    assert (cache / "jit" / "b12x-cute").is_dir()
+    assert (cache / "nccl-fr").is_dir()
 
 
 def test_cycle_env_defaults_match_recipe() -> None:


### PR DESCRIPTION
## What and why

The DeepSeek pair and cycle profiles now keep TileLang and B12X CuTeDSL compilation data beneath the existing persistent cache mount. Recreating a container can reuse those caches instead of compiling the same kernels again.

The same profiles enable PyTorch's ProcessGroupNCCL flight recorder. Timeout dumps persist beneath `CACHE_HOST_PATH/nccl-fr`, and the launchers create the cache and dump directories before starting Docker. Documentation explains the static per-rank filenames and the asynchronous on-demand dump behavior.

The boot-time shape warmup proposed in #188 is not included because its exact compile-key coverage has not been measured on the DeepSeek runtime.

Closes #185.
Closes #190.

## Validation

- Full CPU contract suite: 2,186 passed, 20 skipped
- `ruff check --select E,F,W --ignore E501 spark_transport runtime scripts performance`: passed
- `bash -n scripts/deepseek_v4_pair_serve.sh`: passed
- `bash -n scripts/deepseek_v4_cycle_serve.sh`: passed
- Fake-Docker launcher tests prove both launchers create the persistent directories before invoking `docker run`

A DeepSeek container was not launched. The pull request remains a draft until a DeepSeek pair or cycle confirms cache reuse and produces a readable flight-recorder dump.

## Additional context

The cache-directory and flight-recorder configuration was informed by `MiaAI-Lab/DeepSeek-v4-Flash-DSpark-2x-DGX-Spark` commit `bc2ef473a1cc37a572f413443f14054eea9bb37d` (MIT). No source code from that repository is included.

The environment variable in PyTorch is `TORCH_NCCL_TRACE_BUFFER_SIZE`; the issue text's `TORCH_FR_BUFFER_SIZE` spelling is not used.

- [x] I removed credentials and private site identifiers from the change.
- [x] I identified copied or adapted work and updated third-party notices when required.