### PR TITLE
Record GLM B12X-KDA public-image performance

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -213,8 +213,9 @@ notices and license texts.
 
 ## 10. GLM-5.3 Flash profile artifacts (referenced; not included)
 
-The GLM-5.3 Flash TP4/DCP1 recipes reference model and runtime artifacts that
-are not distributed in this repository:
+The qualified GLM-5.3 Flash TP4/DCP4 operator image identified by
+`runtime/glm53-flash-jj-r8-gb10/pins.json` references model and runtime
+artifacts that are not distributed in this repository:
 
 - `local-inference-lab/GLM-5.3-Flash-NVFP4` revision
   `520de24eabf507659eaef7c70f14fd584527facc`, MIT, used as the ModelOpt
@@ -223,14 +224,34 @@ are not distributed in this repository:
   `dc77ff1c99eeb2df044ee3d4f0094eb033fee410`, CC BY-NC-ND 4.0, used as
   the BF16 speculative drafter; its model card limits use to research and
   evaluation and directs commercial licensing inquiries to Inco AI;
+- `FujitsuPolycom/vllm` commit
+  `e02b174693e13859de61811b5e8cd13d5308e259`, Apache-2.0, used as the
+  active Python serving runtime. That composition includes public B12X KDA
+  prefill commit `54371894ecaa77f2725a1c99e018f3fe93d358dd`, per-process KDA
+  workspace-isolation commit `57a6169a5c229a5ca8c24791762b1fc51c89e58d`,
+  sparse-MLA DSA commit `d662a1b0890271915c25439f22247ee22234739a`,
+  C4 indexer-binding commit `d6687475a3f2dbe7848663fd3e5174d90921a3da`,
+  and sparse-MLA cache-length commit
+  `83cb22a0e3f7ec4d2fb43f6ead34ba4d4a87a634`;
 - `local-inference-lab/vllm` commit
   `da4d7be6c97434f6942292ed8abbf4b32dc44355`, Apache-2.0, used as the
-  serving runtime; and
-- `local-inference-lab/b12x` commit
-  `2fcf23a0ce269be27b2e03fece73d46e90e6aeea`, used as the GB10 kernel
-  implementation under Apache-2.0 and its repository notices.
+  source parent for retained ARM64 native extensions built at
+  `3633d61c3c7b04bb4d598cadbdc342f3be40482d`; and
+- `voipmonitor/b12x` commit
+  `9ae41c5cb9935d740456479954b0089f80bd2ef2`, used as the GB10 attention,
+  KDA, linear, and MoE kernel implementation under Apache-2.0 and its
+  repository notices.
 
 SparkRing records these identities and validates compatible image content; it
 does not redistribute the model weights, vLLM source, or B12X source. Operators
-must obtain each artifact under its own terms. The complete profile provenance
-and known lineage limitations are in `runtime/glm53-flash/pins.json`.
+must obtain each artifact under its own terms. The exact operator-image
+composition is in `runtime/glm53-flash-jj-r8-gb10/pins.json` and
+`runtime/glm53-flash-jj-r8-gb10/glm53-dcp4-sircl-public-image-receipt.json`.
+
+The separate source-complete TP4/DCP1 builder under `runtime/glm53-flash/`
+remains bound to `local-inference-lab/vllm` commit
+`da4d7be6c97434f6942292ed8abbf4b32dc44355` and
+`local-inference-lab/b12x` commit
+`2fcf23a0ce269be27b2e03fece73d46e90e6aeea`. Its identities are recorded in
+`runtime/glm53-flash/pins.json`; they do not identify the qualified TP4/DCP4
+operator image above.

--- a/docs/RESULTS.md
+++ b/docs/RESULTS.md
@@ -7,7 +7,7 @@ all active streams.
 
 | Profile | Prefill | C1 decode | C8 decode | Highest tested concurrency | Coding Peak |
 |---|---:|---:|---:|---:|---:|
-| GLM-5.3 Flash DCP4 preferred default, four Sparks | 2,513 | 40.20 | 116.73 | C16: 168.39 | 71.67 |
+| GLM-5.3 Flash B12X-KDA DCP4 public image, four Sparks | 2,649 | 37.97 | — | C4: 90.36 | — |
 | GLM-5.2 EXL3 3.5-bpw, four Sparks | 671 | 20.15 | 64.13 | C8: 64.13 | 25.39 |
 | DeepSeek-V4-Flash DSpark, two Sparks | 1,926 | 58.36 | 162.69 | C32: 307.13 | 59.31 |
 | DeepSeek-V4-Flash-0731, four Sparks | 2,488 | 68.84 | 265.16 | C32: 508.11 | 95.77 |
@@ -18,7 +18,8 @@ all active streams.
 
 | Profile | Results | Green matrix | Receipts |
 |---|---|---|---|
-| GLM-5.3 Flash DCP4 preferred default, four Sparks | [Bounded record](../performance/records/glm53-flash/dcp4-24g-default-20260901.md) | — | [Sanitized summary](../performance/receipts/glm53-flash/dcp4-24g-default-20260901/summary.json) |
+| GLM-5.3 Flash B12X-KDA DCP4 public image, four Sparks | [Bounded record](../performance/records/glm53-flash/b12x-kda-dcp4-20260903.md) | — | [Sanitized summary](../performance/receipts/glm53-flash/b12x-kda-dcp4-20260903/summary.json) |
+| GLM-5.3 Flash DCP4 image `380283a5`, four Sparks | [Bounded record](../performance/records/glm53-flash/dcp4-24g-default-20260901.md) | — | [Sanitized summary](../performance/receipts/glm53-flash/dcp4-24g-default-20260901/summary.json) |
 | GLM-5.2 EXL3 3.5-bpw, four Sparks | [Full record](../performance/records/glm-3.5bpw/normalized-base-20260822.md) | [Matrix image](../performance/records/glm-3.5bpw/normalized-base-20260822.png) | [Receipts](../performance/receipts/glm-3.5bpw/temp1/) |
 | DeepSeek-V4-Flash DSpark, two Sparks | [Full record](../performance/records/deepseek-v4-flash/normalized-tp2-base-temp1-n5-20260823.md) | [Matrix image](../performance/records/deepseek-v4-flash/normalized-tp2-base-temp1-n5-20260823.png) | [Receipts](../performance/receipts/deepseek-v4-flash/temp1/) |
 | DeepSeek-V4-Flash-0731, four Sparks | [Full record](../performance/records/deepseek-v4-flash/normalized-tp4-base-temp1-n5-20260823.md) | [Matrix image](../performance/records/deepseek-v4-flash/normalized-tp4-base-temp1-n5-20260823.png) | [Receipts](../performance/receipts/deepseek-v4-flash/temp1/20260823-tp4/) |

--- a/performance/receipts/glm53-flash/b12x-kda-dcp4-20260903/summary.json
+++ b/performance/receipts/glm53-flash/b12x-kda-dcp4-20260903/summary.json
@@ -1,0 +1,181 @@
+{
+  "schema": "sparkring-benchmark-summary/v1",
+  "status": "research-only",
+  "maturity_scope": "artifact-bound bounded performance observation; not repeated-sample performance qualification",
+  "benchmark_window": {
+    "started_at_local": "2026-09-03T23:45:01-05:00",
+    "ended_at_local": "2026-09-03T23:52:59-05:00",
+    "completed_at_local": "2026-09-03T23:53:01.920850-05:00",
+    "started_at_utc": "2026-09-04T04:45:01Z",
+    "ended_at_utc": "2026-09-04T04:52:59Z",
+    "completed_at_utc": "2026-09-04T04:53:01.920850Z"
+  },
+  "source_result": {
+    "filename": "glm-5.3-flash-long-matrix-022.json",
+    "bytes": 63601,
+    "sha256": "893a731ec34361f23d72f3cc2c0d43fb20b8771719c7b16568bcceffd9e6ffcf",
+    "publication": "omitted because the raw result contains a client hostname and private site address"
+  },
+  "harness": {
+    "repository": "https://github.com/local-inference-lab/llm-inference-bench.git",
+    "version": "0.4.32",
+    "commit": "a3a24a6631f011716be732bbf148f95e1d0cf716",
+    "public_origin_main_at_measurement": "d115feee75095081bda2520aa046986a8885f449",
+    "script": "llm_decode_bench.py",
+    "script_git_blob_sha1": "3bbb4eac59970b5c6393ef6cea8d96b3e97ea880",
+    "script_sha256": "53104c0cde0a67c1278279e933bc344eb7be7cd4cfef8364c6d93b82a9eab03c",
+    "public_reproduction_status": "The measured commit was one local commit ahead of public origin/main, so the exact harness source cannot yet be fetched from the public repository."
+  },
+  "artifact": {
+    "image": "ghcr.io/fujitsupolycom/sparkring-glm53-sparkcache@sha256:0d4029b3b7023cf32c37ac20279469c9a2ee16a057f25aae3bcfee9ee5fb660f",
+    "image_id": "sha256:5e32aaa1bbe3559e81db7706ed4286248f18d27cfdb186f6b851bf786eb43075",
+    "platform": "linux/arm64",
+    "sparkring_image_commit": "b358a818786d8506086aaaabb9afe464fa2ccb49",
+    "vllm_composition": "e02b174693e13859de61811b5e8cd13d5308e259",
+    "vllm_b12x_kda_prefill_upstream": "54371894ecaa77f2725a1c99e018f3fe93d358dd",
+    "vllm_b12x_kda_workspace_isolation_upstream": "57a6169a5c229a5ca8c24791762b1fc51c89e58d",
+    "b12x": "9ae41c5cb9935d740456479954b0089f80bd2ef2",
+    "sparkcache": "66057174301a4759ca3a45207ea41016689449cb",
+    "sircl_source_tree": "2aac02232a9115037723aa1dd40483a5693a3e1e",
+    "sircl_native_sha256": "61aa0ec56a1b438439bed8611dab0353d2c72c10af02bbd917fb77c87b33e5fc"
+  },
+  "conditions": {
+    "target": "local-inference-lab/GLM-5.3-Flash-NVFP4@520de24eabf507659eaef7c70f14fd584527facc",
+    "draft": "incoai/GLM-5.3-Flash-DFlash2@dc77ff1c99eeb2df044ee3d4f0094eb033fee410",
+    "ranks": 4,
+    "tensor_parallel_size": 4,
+    "decode_context_parallel_size": 4,
+    "cp_kv_cache_interleave_size": 4,
+    "attention_backend": "B12X",
+    "moe_backend": "b12x",
+    "linear_backend": "b12x",
+    "kda_prefill_backend": "b12x",
+    "full_ckv_gather": true,
+    "max_model_len": 1048576,
+    "max_num_seqs": 16,
+    "max_num_batched_tokens": 8192,
+    "prefill_schedule_interval": 2,
+    "kv_cache_dtype": "fp8",
+    "kv_cache_memory_bytes_per_rank": 25769803776,
+    "speculative_method": "dflash",
+    "num_speculative_tokens": 7,
+    "async_scheduling": true,
+    "sparkcache_access_mode": "read-write",
+    "sparkcache_publication_schema": "tail-cow-v2",
+    "sparkcache_shared_prefix_lease_seconds": 300,
+    "sparkcache_async_capture_slot_bytes": 3221225472,
+    "sparkcache_async_capture_slot_count": 2,
+    "cache_namespace": "glm53-issue55-followups-0c8ad7b-dcp4-page-tail-cow-v2",
+    "cache_namespace_matches_profile_default": false,
+    "transport": "dual-rail SIRCL for admitted TP collectives; patched NCCL 2.30.7 otherwise"
+  },
+  "runtime_correlation": {
+    "observed_at_utc": "2026-09-04T05:06:27.209Z",
+    "rank_count": 4,
+    "same_image_id_on_every_rank": true,
+    "container_started_at_utc": {
+      "0": "2026-09-04T04:39:47.591917193Z",
+      "1": "2026-09-04T04:39:40.779695891Z",
+      "2": "2026-09-04T04:39:40.960833751Z",
+      "3": "2026-09-04T04:39:40.620877287Z"
+    },
+    "status_on_every_rank": "running and healthy",
+    "restart_count_on_every_rank": 0,
+    "sircl_capability_vote_on_every_rank": true,
+    "b12x_kda_warmup_on_every_rank": true,
+    "b12x_full_ckv_gather_on_every_rank": true,
+    "runtime_log_window_utc": "2026-09-04T04:41:44Z/2026-09-04T04:43:22Z"
+  },
+  "benchmark": {
+    "engine": "vllm",
+    "reported_engine_version": "v0.1.dev1+gd377796e8",
+    "model": "glm-5.3-flash",
+    "decode_mode": "duration",
+    "duration_per_cell_seconds": 30.0,
+    "request_count": 0,
+    "run_burst": false,
+    "max_output_tokens": 2048,
+    "temperature": 1.0,
+    "ignore_eos": true,
+    "decode_warmup_seconds": 3.0,
+    "decode_concurrency": [1, 2, 4],
+    "decode_contexts": [8192, 16384, 32768],
+    "prefill_contexts": [8192, 16384, 32768, 65536, 131072],
+    "prefill_mode": "integrated_decode_scout",
+    "standalone_prefill": false,
+    "prefill_metric": "client",
+    "client_dcp_size_override": 0,
+    "client_kv_budget_override": 0,
+    "auto_detected_max_total_tokens": 1251328
+  },
+  "prefill": {
+    "8192": {
+      "prompt_tokens": 8197,
+      "method": "integrated_scout",
+      "client_ttft_seconds": 3.328,
+      "client_tokens_per_second": 2463.0,
+      "server_validation": {"method": "prometheus:kv_computed", "seconds": 3.303, "tokens_per_second": 2482.0, "cached_tokens": 0}
+    },
+    "16384": {
+      "prompt_tokens": 16227,
+      "method": "integrated_scout",
+      "client_ttft_seconds": 6.125,
+      "client_tokens_per_second": 2649.0,
+      "server_validation": {"method": "prometheus:kv_computed", "seconds": 6.096, "tokens_per_second": 2662.0, "cached_tokens": 0}
+    },
+    "32768": {
+      "prompt_tokens": 32318,
+      "method": "integrated_scout",
+      "client_ttft_seconds": 11.391,
+      "client_tokens_per_second": 2837.0,
+      "server_validation": {"method": "prometheus:kv_computed", "seconds": 11.327, "tokens_per_second": 2853.0, "cached_tokens": 0}
+    },
+    "65536": {
+      "prompt_tokens": 64508,
+      "method": "scout_only",
+      "client_ttft_seconds": 22.938,
+      "client_tokens_per_second": 2812.0,
+      "server_validation": null
+    },
+    "131072": {
+      "prompt_tokens": 128877,
+      "method": "scout_only",
+      "client_ttft_seconds": 45.453,
+      "client_tokens_per_second": 2835.0,
+      "server_validation": null
+    }
+  },
+  "aggregate_decode": {
+    "8192": {
+      "1": {"tokens_per_second": 37.439, "target_steps_per_second": 14.682, "effective_accept_length": 2.550, "output_tokens": 1122},
+      "2": {"tokens_per_second": 63.601, "target_steps_per_second": 22.290, "effective_accept_length": 2.853, "output_tokens": 1906},
+      "4": {"tokens_per_second": 85.901, "target_steps_per_second": 30.345, "effective_accept_length": 2.831, "output_tokens": 2593}
+    },
+    "16384": {
+      "1": {"tokens_per_second": 37.967, "target_steps_per_second": 14.600, "effective_accept_length": 2.600, "output_tokens": 1139},
+      "2": {"tokens_per_second": 61.500, "target_steps_per_second": 22.000, "effective_accept_length": 2.795, "output_tokens": 1845},
+      "4": {"tokens_per_second": 90.363, "target_steps_per_second": 32.034, "effective_accept_length": 2.821, "output_tokens": 2708}
+    },
+    "32768": {
+      "1": {"tokens_per_second": 35.851, "target_steps_per_second": 14.541, "effective_accept_length": 2.466, "output_tokens": 1075},
+      "2": {"tokens_per_second": 57.793, "target_steps_per_second": 21.556, "effective_accept_length": 2.681, "output_tokens": 1732},
+      "4": {"tokens_per_second": 87.441, "target_steps_per_second": 30.897, "effective_accept_length": 2.830, "output_tokens": 2615}
+    }
+  },
+  "result": {
+    "decode_cells": 9,
+    "request_errors": 0,
+    "readiness_timeouts": 0,
+    "capacity_limited_cells": 0
+  },
+  "limitations": [
+    "Each prefill cell contains one observation and each decode cell contains one 30-second measured window.",
+    "The 65536-token and 131072-token prefill cells have client TTFT timing but no server-side prefill or cached-token validation.",
+    "The run did not use standalone cold-prefill mode or finite-request burst mode.",
+    "Decode beyond 32768 tokens, concurrency above four, repeated-sample variance, output quality, and long-duration stability were not measured.",
+    "The measured benchmark-harness commit was not on the public remote at measurement time.",
+    "The raw result is omitted because it contains a client hostname and private site address.",
+    "The cache namespace differs from the source-bound profile default, so the observation must not be presented as a clean-cache measurement.",
+    "Client hardware telemetry describes the benchmark client, not the four GB10 serving ranks."
+  ]
+}

--- a/performance/records/glm53-flash/b12x-kda-dcp4-20260903.md
+++ b/performance/records/glm53-flash/b12x-kda-dcp4-20260903.md
@@ -1,0 +1,147 @@
+# GLM-5.3 Flash B12X-KDA TP4/DCP4 observation
+
+Status: **research-only, artifact-bound performance observation**. The
+measurement used the qualified Linux/ARM64 operator image
+`ghcr.io/fujitsupolycom/sparkring-glm53-sparkcache@sha256:0d4029b3b7023cf32c37ac20279469c9a2ee16a057f25aae3bcfee9ee5fb660f`
+on four directly connected NVIDIA GB10 systems. It does not change the
+image's functional qualification scope.
+
+The sanitized machine-readable result is
+[`summary.json`](../../receipts/glm53-flash/b12x-kda-dcp4-20260903/summary.json).
+The source result was named `glm-5.3-flash-long-matrix-022.json`, contained
+63,601 bytes, and had SHA-256
+`893a731ec34361f23d72f3cc2c0d43fb20b8771719c7b16568bcceffd9e6ffcf`.
+The raw file is not published because it contains a client hostname and a
+private site address.
+
+## Conditions
+
+The four-rank service used TP4/DCP4, 24 GiB of FP8 KV per rank, an 8,192-token
+scheduler budget, scheduler interval two, B12X attention, MoE, linear, and KDA
+prefill backends, BF16 DFlash2 at depth seven, full and piecewise CUDA graphs,
+and asynchronous scheduling. SparkCache was read-write with the `tail-cow-v2`
+publication schema, two 3 GiB asynchronous capture slots, and a 300-second
+shared-prefix lease.
+
+The measurement used the source-compatible but non-default cache namespace
+`glm53-issue55-followups-0c8ad7b-dcp4-page-tail-cow-v2`. Cache namespace
+selection changes which persistent entries may be reused; it does not select
+the attention, KDA, or transport backend. A reproduction of this exact cache
+state must use an empty namespace or record its pre-existing contents.
+
+Read-only container inspection after the run found the same image ID,
+`sha256:5e32aaa1bbe3559e81db7706ed4286248f18d27cfdb186f6b851bf786eb43075`,
+on all four ranks. The containers started between
+`2026-09-04T04:39:40.620877287Z` and
+`2026-09-04T04:39:47.591917193Z`, before the benchmark began, and each still
+reported healthy with zero restarts at `2026-09-04T05:06:27.209Z`.
+
+Before measurement, every rank logged all three runtime markers:
+
+- `SIRCL capability vote accepted: physical_ranks=4`;
+- `Warmed up 1 b12x KDA prefill kernel signature(s).`; and
+- `Using full-CKV gather for GLM5Next B12X DCP prefill`.
+
+Those messages were emitted from `2026-09-04T04:41:44Z` through
+`2026-09-04T04:43:22Z`. The benchmark then ran from
+`2026-09-04T04:45:01Z` through `2026-09-04T04:52:59Z` and wrote its completion
+timestamp at `2026-09-04T04:53:01.920850Z`.
+
+The image labels bind the active Python source to vLLM
+`e02b174693e13859de61811b5e8cd13d5308e259`, including the public B12X-KDA
+prefill and workspace-isolation commits `54371894ecaa77f2725a1c99e018f3fe93d358dd`
+and `57a6169a5c229a5ca8c24791762b1fc51c89e58d`. They also bind B12X
+`9ae41c5cb9935d740456479954b0089f80bd2ef2`, SparkCache
+`66057174301a4759ca3a45207ea41016689449cb`, and the embedded SIRCL native
+library SHA-256
+`61aa0ec56a1b438439bed8611dab0353d2c72c10af02bbd917fb77c87b33e5fc`.
+The API reported version `v0.1.dev1+gd377796e8`; that version string is not
+the active Python source identity, which is defined by the image labels and
+[`pins.json`](../../../runtime/glm53-flash-jj-r8-gb10/pins.json).
+
+## Benchmark method
+
+The client used `local-inference-lab/llm-inference-bench` version `0.4.32` at
+commit `a3a24a6631f011716be732bbf148f95e1d0cf716`. The measured
+`llm_decode_bench.py` had SHA-256
+`53104c0cde0a67c1278279e933bc344eb7be7cd4cfef8364c6d93b82a9eab03c`.
+That commit was one local commit ahead of public `origin/main`
+`d115feee75095081bda2520aa046986a8885f449` at measurement time, so an exact
+public checkout of the benchmark harness is not yet available. The equivalent
+sanitized invocation is:
+
+```bash
+python llm_decode_bench.py \
+  --host 'http://<rank-0-address>' \
+  --port 8015 \
+  --model glm-5.3-flash \
+  --concurrency 1,2,4 \
+  --contexts 8k,16k,32k \
+  --duration 30 \
+  --request-count 0 \
+  --max-tokens 2048 \
+  --temperature 1 \
+  --decode-warmup-seconds 3 \
+  --prefill-contexts 8k,16k,32k,64k,128k \
+  --prefill-metric client \
+  --kv-budget 0 \
+  --dcp-size 0 \
+  --output glm-5.3-flash-long-matrix.json
+```
+
+The client auto-detected a 1,251,328-token request budget from 2,444 vLLM KV
+blocks of 512 tokens. It used integrated scout requests for 8K, 16K, and 32K
+prefill and additional scout-only requests for 64K and 128K. The run did not
+use standalone cold-prefill mode or the finite-request burst mode.
+
+## Results
+
+### Prefill scout observations
+
+| Requested context | Prompt tokens | Method | Client TTFT | Client tok/s | Server validation |
+|---:|---:|---|---:|---:|---:|
+| 8K | 8,197 | integrated scout | 3.328 s | 2,463 | 2,482 tok/s, 0 cached tokens |
+| 16K | 16,227 | integrated scout | 6.125 s | 2,649 | 2,662 tok/s, 0 cached tokens |
+| 32K | 32,318 | integrated scout | 11.391 s | 2,837 | 2,853 tok/s, 0 cached tokens |
+| 64K | 64,508 | scout only | 22.938 s | 2,812 | not recorded |
+| 128K | 128,877 | scout only | 45.453 s | 2,835 | not recorded |
+
+Client prefill throughput is prompt tokens divided by time to first token.
+Prometheus KV-computed timing independently validated the 8K, 16K, and 32K
+cells. The 64K and 128K values are client scout observations only; the result
+contains no server-side prefill sample or cached-token count for those cells.
+
+### Sustained decode observations
+
+Each cell used one 30-second measured window. Aggregate throughput is the sum
+of streamed completion tokens across active requests. Target steps per second
+removes the data-dependent DFlash acceptance length from the throughput.
+
+| Context | Concurrency | Aggregate tok/s | Target steps/s | Effective accept length |
+|---:|---:|---:|---:|---:|
+| 8K | 1 | 37.439 | 14.682 | 2.550 |
+| 8K | 2 | 63.601 | 22.290 | 2.853 |
+| 8K | 4 | 85.901 | 30.345 | 2.831 |
+| 16K | 1 | 37.967 | 14.600 | 2.600 |
+| 16K | 2 | 61.500 | 22.000 | 2.795 |
+| 16K | 4 | 90.363 | 32.034 | 2.821 |
+| 32K | 1 | 35.851 | 14.541 | 2.466 |
+| 32K | 2 | 57.793 | 21.556 | 2.681 |
+| 32K | 4 | 87.441 | 30.897 | 2.830 |
+
+All nine decode cells completed without a request error, readiness timeout, or
+capacity-limit marker.
+
+## Conclusion and limits
+
+This run establishes that the exact published image executed B12X KDA prefill
+on all four ranks and recorded 2,463–2,837 client prefill tok/s from 8K through
+128K plus 35.851–90.363 aggregate decode tok/s across the tested matrix. It is
+one bounded observation, not a repeated-sample performance qualification.
+
+The 64K and 128K prefill cells lack server-side validation, the raw result and
+exact benchmark-harness commit are not public, and the run did not test decode
+beyond 32K, concurrency above four, finite-request latency, output quality, or
+long-duration stability. Client GPU telemetry describes the benchmark client,
+not the four GB10 serving ranks, and is therefore excluded from the performance
+claim.

--- a/runtime/glm53-flash-jj-r8-gb10/glm53-dcp4-sircl-public-image-receipt.json
+++ b/runtime/glm53-flash-jj-r8-gb10/glm53-dcp4-sircl-public-image-receipt.json
@@ -46,7 +46,8 @@
     "speculative_method": "dflash",
     "speculative_tokens": 7,
     "sparkcache_access_mode": "read-write",
-    "sparkcache_publication_schema": "page-tail-cow-v2",
+    "sparkcache_publication_schema": "tail-cow-v2",
+    "sparkcache_cache_namespace_default": "glm53-flash-vllm-e02b1746-b12x-9ae41c5c-dcp4-page-tail-cow-v2",
     "sparkcache_shared_prefix_lease_seconds": 300,
     "async_capture_slot_bytes": 3221225472,
     "transport": "dual-rail SIRCL for admitted TP collectives; patched NCCL 2.30.7 otherwise"
@@ -81,6 +82,15 @@
       "record": "sircl-capability-health-live-validation.json",
       "details": "Separate test-only builds forced fused device poison and rank-2 proxy exit. No API became ready and the four worker groups stopped without a post-failure collective hang."
     }
+  },
+  "performance_observation": {
+    "status": "research-only",
+    "record": "performance/records/glm53-flash/b12x-kda-dcp4-20260903.md",
+    "summary": "performance/receipts/glm53-flash/b12x-kda-dcp4-20260903/summary.json",
+    "source_result_sha256": "893a731ec34361f23d72f3cc2c0d43fb20b8771719c7b16568bcceffd9e6ffcf",
+    "conditions": "The exact registry image ran at TP4/DCP4 with B12X KDA prefill, embedded dual-rail SIRCL, patched NCCL fallback, scheduler interval two, DFlash2 depth seven, and read-write SparkCache. The cache namespace differed from the source-bound profile default.",
+    "result": "One bounded matrix recorded 2,463-2,837 client prefill tok/s from 8K through 128K and 35.851-90.363 aggregate decode tok/s for C1, C2, and C4 at 8K, 16K, and 32K. All nine decode cells completed without an error, readiness timeout, or capacity-limit marker.",
+    "scope": "Artifact-bound observation only. The 64K and 128K prefill cells lack server validation, and the exact benchmark-harness commit was not public at measurement time."
   },
   "limitations": [
     "The recorded latency samples are functional evidence, not a broad performance benchmark.",

--- a/scripts/test_sparkcache_recipes.py
+++ b/scripts/test_sparkcache_recipes.py
@@ -214,7 +214,46 @@ def test_glm53_composition_matches_the_operator_contract() -> None:
         recipe["profiles"]["dcp4"]["capture_slot_bytes"]
         == receipt["configuration"]["async_capture_slot_bytes"]
     )
+    assert (
+        receipt["configuration"]["sparkcache_publication_schema"]
+        == recipe["sparkcache"]["publication_schema"]
+        == "tail-cow-v2"
+    )
+    assert (
+        receipt["configuration"]["sparkcache_cache_namespace_default"]
+        == recipe["sparkcache"]["cache_namespace_default"]
+        == "glm53-flash-vllm-e02b1746-b12x-9ae41c5c-dcp4-page-tail-cow-v2"
+    )
     assert recipe["evidence"]["machine_receipt"] == (
         "runtime/glm53-flash-jj-r8-gb10/"
         "glm53-dcp4-sircl-public-image-receipt.json"
     )
+
+
+def test_glm53_b12x_performance_observation_is_artifact_bound() -> None:
+    pins = _load(ROOT / "runtime" / "glm53-flash-jj-r8-gb10" / "pins.json")
+    receipt = _load(
+        ROOT
+        / "runtime"
+        / "glm53-flash-jj-r8-gb10"
+        / "glm53-dcp4-sircl-public-image-receipt.json"
+    )
+    observation = receipt["performance_observation"]
+    summary_path = ROOT / observation["summary"]
+    summary = _load(summary_path)
+
+    assert summary["status"] == observation["status"] == "research-only"
+    assert summary["source_result"]["sha256"] == observation[
+        "source_result_sha256"
+    ]
+    assert summary["artifact"]["image"] == receipt["artifact"][
+        "registry_reference"
+    ]
+    assert summary["artifact"]["image_id"] == receipt["artifact"]["image_id"]
+    assert summary["artifact"]["vllm_composition"] == pins["vllm"]["commit"]
+    assert summary["artifact"]["b12x"] == pins["b12x"]["commit"]
+    assert summary["artifact"]["sparkcache"] == pins["sparkcache"]["commit"]
+    assert summary["conditions"]["kda_prefill_backend"] == "b12x"
+    assert summary["runtime_correlation"]["b12x_kda_warmup_on_every_rank"] is True
+    assert summary["runtime_correlation"]["b12x_full_ckv_gather_on_every_rank"] is True
+    assert (ROOT / observation["record"]).is_file()


### PR DESCRIPTION
## What and why

Record the bounded GLM-5.3 Flash TP4/DCP4 benchmark that ran against the immutable public image. The record binds its values to the image digest, exact vLLM, B12X, SparkCache, and SIRCL identities, and the all-rank B12X KDA and SIRCL startup markers.

The machine receipt now distinguishes the operator setting `tail-cow-v2` from the resulting source-bound `page-tail-cow-v2` cache namespace. Third-party notices identify the active Python serving composition, retained native source, and B12X implementation instead of the separate DCP1 builder revisions.

## Validation

- Raw-result SHA-256, every prefill result, and every rounded decode result were compared programmatically with the 63,601-byte source JSON
- `python -m pytest scripts/test_sparkcache_recipes.py runtime/glm53-flash-jj-r8-gb10/test_image_contract.py runtime/glm53-flash-jj-r8-gb10/test_launcher_contract.py -q`: 52 passed, 1 skipped
- `ruff check --select E,F,W --ignore E501 scripts/test_sparkcache_recipes.py runtime/glm53-flash-jj-r8-gb10`: passed
- Modified Markdown links, JSON parsing, private-identifier scanning, and `git diff --check`: passed

## Additional context

The result is explicitly research-only and artifact-bound. The 64K and 128K prefill values have client TTFT timing but no server-side prefill/cached-token sample. The raw JSON is omitted because it contains a client hostname and private site address. The measured benchmark-harness commit was local-only at measurement time, so the record includes its script hash and a sanitized equivalent command without claiming exact public harness reproducibility.

- [x] I removed credentials and private site identifiers from the change.
- [x] I identified copied or adapted work and updated third-party notices when required.