### PR TITLE
Make GLM release identities and evidence self-contained

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ launches Ring Doctor before any model profile is selected.
 | Package | Purpose | When to use it |
 |---|---|---|
 | [`sparkring-glm53-sparkcache`](https://github.com/users/FujitsuPolycom/packages/container/package/sparkring-glm53-sparkcache) | Published Linux/ARM64 GLM-5.3 operator image with source-pinned vLLM, B12X GB10 kernels, DFlash2, and optional SparkCache. | Use the immutable digest from the [GLM-5.3 quickstart](docs/GLM53_JJ_R8_GB10_SPARKCACHE_TP4_QUICKSTART.md). |
-| [`sparkring-glm53-runtime`](https://github.com/users/FujitsuPolycom/packages/container/package/sparkring-glm53-runtime) | Source-pinned GLM-5.3 runtime bases used to construct later operator images. | Use only when a source-build procedure names an exact digest. |
+| [`sparkring-glm53-runtime`](https://github.com/users/FujitsuPolycom/packages/container/package/sparkring-glm53-runtime) | Source-pinned GLM-5.3 runtime bases used as operator-image construction inputs. | Use only when a source-build procedure names an exact digest. |
 | [`gb10-vllm-serving`](https://github.com/users/FujitsuPolycom/packages/container/package/gb10-vllm-serving) | Profile-specific GB10 serving images, including published DeepSeek inputs. | Use only when a model profile names an exact digest. |
 
 Package tags are convenient labels, not reproducible identities. Deployment
@@ -85,8 +85,8 @@ The [public-image receipt](runtime/glm53-flash-jj-r8-gb10/glm53-dcp4-sircl-publi
 records the image ID, source identities, registry-pull verification, and exact
 functional scope.
 
-The previous complete-snapshot image remains available as the rollback named
-in the quickstart.
+The quickstart also identifies a complete-snapshot recovery image by immutable
+digest and names the source revision required by its launcher.
 
 ### Other model profiles
 
@@ -112,7 +112,7 @@ temperature 1.0; decode values are aggregate throughput across active streams.
 
 | Profile | Prefill | C1 decode | C8 decode | Highest tested decode | Coding peak |
 |---|---:|---:|---:|---:|---:|
-| [GLM-5.3 Flash DCP4 preferred default · 4 Sparks](performance/records/glm53-flash/dcp4-24g-default-20260901.md) | 2,513 | 40.20 | 116.73 | C16: 168.39 | 71.67 |
+| [GLM-5.3 Flash B12X-KDA DCP4 public image · 4 Sparks](performance/records/glm53-flash/b12x-kda-dcp4-20260903.md) | 2,649 | 37.97 | — | C4: 90.36 | — |
 | [GLM-5.2 EXL3 3.5-bpw · 4 Sparks](performance/records/glm-3.5bpw/normalized-base-20260822.md) | 671 | 20.15 | 64.13 | C8: 64.13 | 25.39 |
 | [DeepSeek-V4-Flash DSpark · 2 Sparks](performance/records/deepseek-v4-flash/normalized-tp2-base-temp1-n5-20260823.md) | 1,926 | 58.36 | 162.69 | C32: 307.13 | 59.31 |
 | [DeepSeek-V4-Flash-0731 · 4 Sparks](performance/records/deepseek-v4-flash/normalized-tp4-base-temp1-n5-20260823.md) | 2,488 | 68.84 | 265.16 | C32: 508.11 | 95.77 |

--- a/docs/GLM53_JJ_R8_GB10_SPARKCACHE_TP4_QUICKSTART.md
+++ b/docs/GLM53_JJ_R8_GB10_SPARKCACHE_TP4_QUICKSTART.md
@@ -9,9 +9,9 @@ alone without changing the image.
 The preferred launch is TP4/DCP4 with 24 GiB of FP8 KV per rank, SIRCL with
 capability and health checks, scheduler interval two, BF16 DFlash2 at depth
 seven, and SparkCache's flat copy-on-write page tails. Patched NCCL is the
-fallback transport and handles collective signatures outside SIRCL's admission
-rules. Growing conversations write changed pages instead of another complete
-cached context. An earlier complete-snapshot image remains available as a
+fallback transport and handles collective signatures that SIRCL does not
+support. Growing conversations write changed pages instead of another complete
+cached context. A complete-snapshot image remains available as a
 recovery artifact.
 
 The image does not contain model checkpoints. It mounts the exact
@@ -22,7 +22,14 @@ BF16 draft. Local Inference Lab's
 [`vLLM GLM development`](https://github.com/local-inference-lab/vllm/tree/dev/jovian-judgement)
 and [`B12X`](https://github.com/local-inference-lab/b12x) GB10 kernels provide
 the model-specific runtime and performance foundation. The pinned vLLM source
-line is named `Jovian Judgement Community R10` in the image contract.
+line is named `Jovian Judgement Community R10` in the image contract. For an
+exact public checkout, the
+[`sparkring-glm53-flash-gb10-e02b1746`](https://github.com/FujitsuPolycom/vllm/tree/sparkring-glm53-flash-gb10-e02b1746)
+tag resolves to commit `e02b174693e13859de61811b5e8cd13d5308e259`.
+The image installs B12X commit `9ae41c5c` from the `voipmonitor/b12x` fork
+recorded in
+[`pins.json`](../runtime/glm53-flash-jj-r8-gb10/pins.json); Local Inference Lab
+remains the upstream B12X project.
 
 ## Choose the image
 
@@ -60,8 +67,8 @@ local image ID: sha256:d1a07147c9e25f3d3e0af6b1499c4988b1ae61138e327aa05c9ad9dc5
 platform: linux/arm64
 ```
 
-The recovery image predates the readiness entrypoint used by this guide and is
-not compatible with the launcher in this checkout. Its matching SparkRing
+The recovery image does not contain the readiness entrypoint required by this
+guide and is not compatible with the launcher in this checkout. Its matching SparkRing
 source revision is `a150c98ccfdc4b655679860121f24712490dd9ee`; the
 [`recovery image receipt`](../runtime/glm53-flash-jj-r8-gb10/multimodal-lease300-image-receipt.json)
 records its exact launch contract. The remaining commands in this guide use
@@ -287,10 +294,10 @@ set of discoverable entries.
 
 The three documented defaults name vLLM `e02b1746` and B12X `9ae41c5c`
 because those sources determine the manager-page state being persisted. This
-keeps state written by the current runtime out of the generic directories used
-by earlier source compositions. Existing entries are not migrated or deleted.
-Do not rename or copy an old directory into a source-bound root; allow a cache
-miss to recompute and publish current state.
+keeps state written by that exact composition separate from entries written by
+other source compositions. Existing entries are not migrated or deleted. Do
+not rename or copy an incompatible directory into a source-bound root; allow a
+cache miss to recompute and publish state with the named sources.
 
 `JIT_CACHE_NAMESPACE` independently selects persistent Triton,
 TorchInductor, B12X, and vLLM compilation data. Keep its source-bound default
@@ -304,6 +311,10 @@ The image supports three persistent publication formats:
 | `snapshot-v1` | A complete immutable context for every publication | DCP1/DCP2 persistent-cache profile and simple storage inspection |
 | `tail-cow-v1` | An immutable base with changed page objects | Compatibility testing for the first page-tail format |
 | `tail-cow-v2` | An authenticated base with a flat chain of changed-page descriptors | Recommended DCP4 profile for growing conversations |
+
+SparkCache translates the operator setting `tail-cow-v2` to the cache-identity
+wire value `page-tail-cow-v2`. The DCP4 storage directory includes that wire
+value, which explains why the setting and directory use different strings.
 
 The publication format is part of cache identity. An incompatible entry is a
 miss, and vLLM computes the prompt normally. Keep each format in a separately
@@ -399,8 +410,9 @@ stale, or when SparkCache cannot prove capture-page ownership. Nonzero idle KV
 is warning-only until it remains unchanged beyond the configured 330-second
 interval.
 
-Before directing normal traffic to the service, run a concurrent prompt gate.
-The requests disable model thinking, put a unique nonce at the front of every
+Before directing normal traffic to the service, run the concurrent scheduler
+and cache-ownership check implemented by `scripts/glm53_liveness_gate.py`.
+Its requests disable model thinking, put a unique nonce at the front of every
 prompt, and require request, capture, and KV usage to return to their measured
 idle baseline:
 
@@ -411,7 +423,7 @@ python scripts/glm53_liveness_gate.py \
   --concurrency 4 \
   --prompt-words 100000 \
   --cycles 3 \
-  --output ./glm53-liveness-gate.json
+  --output ./glm53-scheduler-liveness.json
 ```
 
 Add `--api-key-file /secure/api-keys` when the API requires authentication.
@@ -477,8 +489,9 @@ pressure. See the
 and
 [`DFlash readiness validation`](../runtime/glm53-flash-jj-r8-gb10/dflash-jit-readiness-validation.json).
 
-The retained vLLM, B12X, NCCL, and CUDA components also have DCP4 evidence
-from an earlier SparkCache source composition. That deployment captured a
+The retained vLLM, B12X, NCCL, and CUDA components also have DCP4 evidence in
+`ASYNC_CAPTURE_IMAGE_VALIDATION.md`, which records a different SparkCache
+source composition. That deployment captured a
 124,928-token boundary and restored 899,072-token and 999,424-token entries.
 Those measurements support the unchanged runtime components; they are not
 performance qualification of the registry artifact above. See the

--- a/docs/SIRCL.md
+++ b/docs/SIRCL.md
@@ -27,11 +27,15 @@ qualification. A four-rank matched comparison established native replay,
 API health, and zero overflow for the target and DSpark capture path; see the
 [DeepSeek SIRCL evidence record](../performance/records/deepseek-v4-flash/sircl-width4096-nccl-ab-20260822.md).
 
-The current GLM-5.3 Flash GB10 image composition embeds a source-bound SIRCL
-bundle for its implemented performance-testing lane. A developer can replace
-that bundle with a read-only host mount. Its captured width-4096 path and eager
-fused-prefill path have separate
-admission gates. The fused path accepts contiguous TP4 BF16 `[Q, 4096]`
+The GLM-5.3 Flash GB10 operator image embeds a source-bound SIRCL bundle. The
+exact public image is **qualified** for the recorded four-rank TP4/DCP4
+functional checks: capability agreement, startup, semantic inference,
+persistent SparkCache restore, concurrent store-ownership drain, and injected
+failure containment. Its artifact-bound throughput matrix is
+**research-only**; no broad SIRCL-versus-NCCL performance comparison has been
+established. A developer can replace the embedded bundle with a read-only host
+mount. Its captured width-4096 path and eager fused-prefill path use separate
+signature checks. The fused path accepts contiguous TP4 BF16 `[Q, 4096]`
 tensors from Q128 through Q8192 and uses two operation slots. Unsupported
 signatures remain on NCCL. The GLM-5.3 profile captures Q8/Q16/Q32/Q64/Q128;
 those captured collectives use graph-native SIRCL with direct doorbells. The
@@ -41,7 +45,9 @@ arenas. See the
 [vLLM adapter contract](../spark_transport/integrations/vllm/README.md). The
 [public SIRCL build receipt](../runtime/glm53-flash-jj-r8-gb10/sircl-public-build-receipt.json)
 binds the native build and single-node test identity; it does not establish a
-four-rank serving result.
+four-rank serving result. The
+[operator-image receipt](../runtime/glm53-flash-jj-r8-gb10/glm53-dcp4-sircl-public-image-receipt.json)
+records the four-rank functional result and its limits.
 
 Before native construction, the GLM-5.3 adapter exchanges a capability record
 over the CPU process group. Shared protocol and artifact identities must match,

--- a/performance/records/glm53-flash/b12x-kda-dcp4-20260903.md
+++ b/performance/records/glm53-flash/b12x-kda-dcp4-20260903.md
@@ -55,6 +55,9 @@ and `57a6169a5c229a5ca8c24791762b1fc51c89e58d`. They also bind B12X
 `66057174301a4759ca3a45207ea41016689449cb`, and the embedded SIRCL native
 library SHA-256
 `61aa0ec56a1b438439bed8611dab0353d2c72c10af02bbd917fb77c87b33e5fc`.
+The public vLLM tag
+[`sparkring-glm53-flash-gb10-e02b1746`](https://github.com/FujitsuPolycom/vllm/tree/sparkring-glm53-flash-gb10-e02b1746)
+resolves to the recorded vLLM commit.
 The API reported version `v0.1.dev1+gd377796e8`; that version string is not
 the active Python source identity, which is defined by the image labels and
 [`pins.json`](../../../runtime/glm53-flash-jj-r8-gb10/pins.json).

--- a/recipes/glm53-flash-nvfp4-dflash2-bf16-tp4.json
+++ b/recipes/glm53-flash-nvfp4-dflash2-bf16-tp4.json
@@ -102,7 +102,7 @@
   "transport": {
     "backend": "dual-rail-sircl-with-patched-nccl-fallback",
     "capability_vote": true,
-    "output_health_gate": true,
+    "output_health_check": true,
     "embedded_bundle": true,
     "nccl_version": "2.30.7",
     "topology": "four-rank switchless direct-cable cycle",

--- a/recipes/sparkcache/glm53-flash-nvfp4-dflash2-bf16-tp4.json
+++ b/recipes/sparkcache/glm53-flash-nvfp4-dflash2-bf16-tp4.json
@@ -76,7 +76,7 @@
   "transport": {
     "backend": "dual-rail-sircl-with-patched-nccl-fallback",
     "capability_vote": true,
-    "output_health_gate": true,
+    "output_health_check": true,
     "embedded_bundle": true,
     "nccl_version": "2.30.7"
   },
@@ -152,7 +152,7 @@
     "conditions": "The immutable Linux/ARM64 image ran on four directly connected NVIDIA GB10 systems at TP4/DCP4 with the embedded dual-rail SIRCL bundle, rank-wide capability and output-health checks, patched NCCL fallback, FP8 KV, 24 GiB per rank, a 1,048,576-token request limit, 8,192 scheduler tokens, interval two, BF16 DFlash2 depth seven, SparkCache tail-cow-v2 publication, and a 300-second shared-prefix lease.",
     "measurement": "All four ranks pulled the immutable digest and resolved the recorded image ID. The exact registry image started with SIRCL, restored a 32,768-token entry after restart, completed one 129K-class request followed by eight concurrent 4K-class requests, and underwent separate test-only fused-device-poison and rank-2 proxy-exit injections.",
     "result": "Every rank accepted the capability vote; startup, persistent restore, and concurrent stores completed; running requests, waiting requests, delayed ownership, retained pages, and uncertain ranks returned to zero. During both injected SIRCL failures, no API became ready and all four worker groups stopped without a post-failure collective hang.",
-    "conclusion": "The registry artifact functionally qualifies the preferred DCP4 profile with embedded SIRCL, patched NCCL fallback, persistent restart restore, and fail-stop transport health handling.",
+    "conclusion": "The registry artifact functionally qualifies the preferred DCP4 profile with embedded SIRCL, patched NCCL fallback, persistent restart restore, and worker termination after a transport error.",
     "limitations": [
       "The receipt records functional checks, not a broad transport-performance benchmark.",
       "DCP1 and DCP2 are implemented profiles, but asynchronous capture is disabled because those slot sizes lack matching live evidence.",

--- a/runtime/README.md
+++ b/runtime/README.md
@@ -22,6 +22,13 @@ runtime they describe.
 | [`public-overlay-files.json`](public-overlay-files.json) | Explicit source-file allowlist for the public overlay |
 | [`test_public_overlay.py`](test_public_overlay.py) | Offline contract coverage for allowlisting and manifest generation |
 
+The path `runtime/glm53-flash-jj-r8-gb10/` and JSON schema names beginning
+with `sparkring-glm53-jj-r8-gb10` are stable filesystem and interface
+locators. Their `r8` component does not identify the embedded vLLM sources.
+The directory's [`pins.json`](glm53-flash-jj-r8-gb10/pins.json) records the
+GLM source composition, including the vLLM commit associated with the Local
+Inference Lab community release named `Jovian Judgement Community R10`.
+
 ## GLM-5.3 Flash operator image
 
 The [`GLM-5.3 GB10 runtime`](glm53-flash-jj-r8-gb10/README.md) is the operator

--- a/runtime/glm53-flash-jj-r8-gb10/README.md
+++ b/runtime/glm53-flash-jj-r8-gb10/README.md
@@ -3,11 +3,18 @@
 This directory builds and runs one Linux/ARM64 image for GLM-5.3 Flash on four
 NVIDIA GB10 systems. The runtime combines Local Inference Lab's GLM-specific
 vLLM work, BF16 DFlash2 speculation, B12X kernels, patched NCCL,
-fastsafetensors, and SparkCache. The current composition also embeds the
-source-bound SIRCL Python overlay and ARM64 native library. The pinned Local
-Inference Lab source line is named
+fastsafetensors, and SparkCache. The operator image also embeds the source-bound
+SIRCL Python overlay and ARM64 native library. The pinned Local Inference Lab
+source line is named
 `Jovian Judgement Community R10` in [`pins.json`](pins.json). One image supports
 TP4 with DCP1, DCP2, or DCP4.
+
+The path `runtime/glm53-flash-jj-r8-gb10/` and JSON schema names beginning
+with `sparkring-glm53-jj-r8-gb10` are stable compatibility locators. Their
+`r8` component identifies the filesystem and JSON interface family; it does
+not identify the embedded vLLM source composition. The exact vLLM commit and
+the `community_release` field in [`pins.json`](pins.json) define that source
+composition.
 
 Local Inference Lab supplies the model quantization and the primary runtime
 work that makes this profile practical:
@@ -15,9 +22,15 @@ work that makes this profile practical:
 - [`local-inference-lab/GLM-5.3-Flash-NVFP4`](https://huggingface.co/local-inference-lab/GLM-5.3-Flash-NVFP4)
   is the target checkpoint;
 - [`local-inference-lab/vllm`](https://github.com/local-inference-lab/vllm/tree/dev/jovian-judgement)
-  supplies the GLM runtime and scheduler work;
-- [`voipmonitor/b12x`](https://github.com/voipmonitor/b12x)
-  supplies the source-pinned GB10 kernel package installed by this builder.
+  supplies the upstream GLM runtime and scheduler work. The builder consumes
+  the public
+  [`sparkring-glm53-flash-gb10-e02b1746`](https://github.com/FujitsuPolycom/vllm/tree/sparkring-glm53-flash-gb10-e02b1746)
+  tag in the FujitsuPolycom vLLM fork; that tag resolves to commit
+  `e02b174693e13859de61811b5e8cd13d5308e259` in `pins.json`;
+- [`local-inference-lab/b12x`](https://github.com/local-inference-lab/b12x)
+  is the upstream B12X project. The builder installs commit `9ae41c5c` from the
+  exact source fork recorded as
+  [`voipmonitor/b12x`](https://github.com/voipmonitor/b12x) in `pins.json`.
 
 The external BF16 draft is
 [`incoai/GLM-5.3-Flash-DFlash2`](https://huggingface.co/incoai/GLM-5.3-Flash-DFlash2).
@@ -154,14 +167,14 @@ ports for each admitted capacity Q1024/Q2048/Q4096/Q8192.
 SIRCL's two transport slots are independent from SparkCache's two 3-GiB
 asynchronous page-capture slots and two 256-MiB restore arenas.
 
-#### Current evidence
+#### Recorded functional evidence
 
 The exact public image passed four-rank DCP4 startup with the embedded bundle.
 Every rank accepted the capability vote; a 32,768-token SparkCache entry
 restored after restart; a 129K-class request followed by eight concurrent
 4K-class requests returned scheduler and cache ownership to idle. Test-only
 builds also forced fused-device poison and a rank-2 proxy exit: no API became
-ready and all four worker groups stopped without a later collective hang. The
+ready and all four worker groups stopped without a collective hang. The
 [`public-image receipt`](glm53-dcp4-sircl-public-image-receipt.json) records
 these checks and their limits. They establish functional qualification, not a
 broad transport-performance comparison.
@@ -174,15 +187,16 @@ is created.
 
 After vLLM's existing output synchronization, a host-only native health check
 prevents synchronous or asynchronous model output from leaving an unhealthy
-worker. The check does not synchronize CUDA. Worker failure is fail-stop:
-vLLM's multiprocess monitor terminates the peer workers. Four-rank fault
-injection must verify that teardown completes without a collective hang before
-the transport is marked qualified.
+worker. The check does not synchronize CUDA. When one worker reports a SIRCL
+error, vLLM's multiprocess monitor terminates every peer worker. Four-rank
+fault injection must show that every worker terminates without a collective
+hang before that image and profile receive functional qualification.
 
 ### NCCL fallback
 
-Patched NCCL 2.30.7 handles every collective outside the SIRCL admission
-table. The launcher selects the ring algorithm over RoCE/IB, the
+Patched NCCL 2.30.7 handles every collective outside the SIRCL
+supported-signature table. The launcher selects the ring algorithm over
+RoCE/IB, the
 `LL,LL128,Simple` protocol set, four minimum and maximum channels, cross-NIC
 routing, and subnet-aware routing. `NCCL_SWITCHLESS_RING_ONLY=1` rejects a
 topology that cannot use the direct cycle. cuMem is disabled, and the P2P level
@@ -215,6 +229,10 @@ format cannot be mistaken for entries from another.
 | `tail-cow-v2` | One authenticated base plus a flat descriptor chain of changed page objects | Recommended source-built TP4/DCP4 profile for growing conversations |
 
 `tail-cow-v2` captures only the changed physical pages after a reusable base.
+SparkCache translates the operator setting `tail-cow-v2` to the cache-identity
+wire value `page-tail-cow-v2`; the longer name appears in the DCP4
+storage-directory name so an operator can see which stored identity it
+contains.
 The publication worker encodes those sparse pages directly instead of
 reconstructing and comparing another complete snapshot. Restore resolves the
 flat descriptors onto the authenticated base, which keeps lookup depth
@@ -233,10 +251,10 @@ meaning. Use these complete values:
 | DCP4 page tails | `glm53-flash-vllm-e02b1746-b12x-9ae41c5c-dcp4-page-tail-cow-v2` |
 
 These names prevent vLLM `e02b1746` with B12X `9ae41c5c` from discovering
-entries through an older runtime's default directory. Existing directories
-remain on disk, but operators must not rename or copy them into a new
-source-bound root. Recompute the prompt with the current runtime to populate
-the new root. The published complete-snapshot rollback retains its historical
+entries written by a different source composition. Other directories remain
+on disk, but operators must not rename or copy them into this source-bound
+root. Recompute the prompt with vLLM `e02b1746` and B12X `9ae41c5c` to populate
+the matching root. The complete-snapshot recovery image retains its assigned
 `glm53-flash-dcp4-snapshot-v1` directory and must use the launcher named by its
 receipt.
 
@@ -356,10 +374,11 @@ docker image inspect sparkring-glm53-sparkcache:page-tail-v2-local \
   --format '{{.Id}}'
 ```
 
-The older image recorded by
+The image recorded by
 [`async-store-completion-public-image-receipt.json`](async-store-completion-public-image-receipt.json)
-predates the embedded SIRCL bundle. That immutable receipt remains historical
-evidence for its own artifact and is not the canonical operator-image record.
+does not contain the embedded SIRCL bundle. That immutable receipt describes
+only its named artifact; `glm53-dcp4-sircl-public-image-receipt.json` describes
+the DCP4 operator image documented here.
 
 ## Page-tail operator image
 

--- a/runtime/glm53-flash-jj-r8-gb10/build_image.py
+++ b/runtime/glm53-flash-jj-r8-gb10/build_image.py
@@ -395,6 +395,9 @@ def prepare_context(
         "sources": {
             "vllm": {
                 "repository": pins["vllm"]["repository"],
+                "public_tag": pins["vllm"]["public_tag"],
+                "public_tag_object": pins["vllm"]["public_tag_object"],
+                "public_tag_commit": pins["vllm"]["public_tag_commit"],
                 "commit": pins["vllm"]["commit"],
                 "tree": pins["vllm"]["tree"],
                 "package_tree": pins["vllm"]["package_tree"],
@@ -417,6 +420,7 @@ def prepare_context(
             },
             "b12x": {
                 "repository": pins["b12x"]["repository"],
+                "upstream_repository": pins["b12x"]["upstream_repository"],
                 "commit": pins["b12x"]["commit"],
                 "tree": pins["b12x"]["tree"],
                 "package_tree": pins["b12x"]["package_tree"],

--- a/runtime/glm53-flash-jj-r8-gb10/glm53-dcp4-sircl-public-image-receipt.json
+++ b/runtime/glm53-flash-jj-r8-gb10/glm53-dcp4-sircl-public-image-receipt.json
@@ -2,6 +2,11 @@
   "schema": "sparkring-glm53-dcp4-sircl-public-image/v1",
   "status": "qualified",
   "date": "2026-09-03",
+  "compatibility_locator": {
+    "directory": "runtime/glm53-flash-jj-r8-gb10",
+    "schema_prefix": "sparkring-glm53-jj-r8-gb10",
+    "meaning": "Stable filesystem and JSON interface locator. The r8 text does not identify the embedded vLLM source composition."
+  },
   "artifact": {
     "registry_reference": "ghcr.io/fujitsupolycom/sparkring-glm53-sparkcache@sha256:0d4029b3b7023cf32c37ac20279469c9a2ee16a057f25aae3bcfee9ee5fb660f",
     "image_id": "sha256:5e32aaa1bbe3559e81db7706ed4286248f18d27cfdb186f6b851bf786eb43075",
@@ -10,6 +15,10 @@
   },
   "sources": {
     "sparkring_image_commit": "b358a818786d8506086aaaabb9afe464fa2ccb49",
+    "vllm_repository": "https://github.com/FujitsuPolycom/vllm.git",
+    "vllm_public_tag": "sparkring-glm53-flash-gb10-e02b1746",
+    "vllm_public_tag_object": "2ac6883ac5156db713493fe9683bea99ecf928a4",
+    "vllm_public_tag_commit": "e02b174693e13859de61811b5e8cd13d5308e259",
     "vllm_composition": "e02b174693e13859de61811b5e8cd13d5308e259",
     "vllm_base": "22ffe1401ca9bd3e4503e62de7b414deca7661a1",
     "vllm_upstream_commits": [
@@ -19,6 +28,8 @@
       "d6687475a3f2dbe7848663fd3e5174d90921a3da",
       "83cb22a0e3f7ec4d2fb43f6ead34ba4d4a87a634"
     ],
+    "b12x_upstream_repository": "https://github.com/local-inference-lab/b12x.git",
+    "b12x_source_repository": "https://github.com/voipmonitor/b12x.git",
     "b12x": "9ae41c5cb9935d740456479954b0089f80bd2ef2",
     "sparkcache": "66057174301a4759ca3a45207ea41016689449cb",
     "sircl_source_tree": "2aac02232a9115037723aa1dd40483a5693a3e1e",
@@ -81,6 +92,11 @@
       "result": "passed",
       "record": "sircl-capability-health-live-validation.json",
       "details": "Separate test-only builds forced fused device poison and rank-2 proxy exit. No API became ready and the four worker groups stopped without a post-failure collective hang."
+    },
+    "sircl_scope": {
+      "functional_status": "qualified",
+      "performance_status": "research-only",
+      "details": "The exact image passed the recorded embedded dual-rail SIRCL TP4/DCP4 functional checks. The receipt does not establish a broad SIRCL-versus-NCCL performance result."
     }
   },
   "performance_observation": {

--- a/runtime/glm53-flash-jj-r8-gb10/pins.json
+++ b/runtime/glm53-flash-jj-r8-gb10/pins.json
@@ -1,5 +1,10 @@
 {
   "schema": "sparkring-glm53-jj-r8-gb10-image/v1",
+  "compatibility_locator": {
+    "directory": "runtime/glm53-flash-jj-r8-gb10",
+    "schema_prefix": "sparkring-glm53-jj-r8-gb10",
+    "meaning": "Stable filesystem and JSON interface locator. The r8 text identifies the interface family, not the embedded vLLM source composition."
+  },
   "parent": {
     "reference": "ghcr.io/fujitsupolycom/sparkring-glm53-sparkcache@sha256:f012dd915c0fff0be384820c2d72cd015b83b9b33c3f980445dd718a807cd0c5",
     "image_id": "sha256:6af83baabb239db6b05e379401daf93c8f51694f81483c2781f6014c30e31db4",
@@ -18,12 +23,16 @@
     "reference": "ghcr.io/fujitsupolycom/sparkring-glm53-sparkcache@sha256:0d4029b3b7023cf32c37ac20279469c9a2ee16a057f25aae3bcfee9ee5fb660f",
     "image_id": "sha256:5e32aaa1bbe3559e81db7706ed4286248f18d27cfdb186f6b851bf786eb43075",
     "platform": "linux/arm64",
-    "status": "implemented",
+    "status": "qualified",
+    "performance_status": "research-only",
     "qualification_scope": "registry-pull verified on four ranks; GLM-5.3 Flash TP4/DCP4 passed embedded dual-rail SIRCL startup, concurrent SparkCache ownership drain, and persistent restart restore",
     "receipt": "glm53-dcp4-sircl-public-image-receipt.json"
   },
   "vllm": {
     "repository": "https://github.com/FujitsuPolycom/vllm.git",
+    "public_tag": "sparkring-glm53-flash-gb10-e02b1746",
+    "public_tag_object": "2ac6883ac5156db713493fe9683bea99ecf928a4",
+    "public_tag_commit": "e02b174693e13859de61811b5e8cd13d5308e259",
     "commit": "e02b174693e13859de61811b5e8cd13d5308e259",
     "tree": "6caadd392ddea2dc90441d0a078da67f38d2fd3a",
     "package_tree": "c91299c2303dc05abc85aa2133224a749657a583",
@@ -51,6 +60,7 @@
   },
   "b12x": {
     "repository": "https://github.com/voipmonitor/b12x.git",
+    "upstream_repository": "https://github.com/local-inference-lab/b12x.git",
     "commit": "9ae41c5cb9935d740456479954b0089f80bd2ef2",
     "tree": "6e77441fe99f6ead7ff2cc2b6a8a37fa4e93e30b",
     "package_tree": "12029e19da6543c5d225395f6da199d946b0972e"

--- a/runtime/glm53-flash-jj-r8-gb10/runtime.env.example
+++ b/runtime/glm53-flash-jj-r8-gb10/runtime.env.example
@@ -75,9 +75,10 @@ SPARKCACHE_ACCESS_MODE='read-write'
 SPARKCACHE_SHARED_PREFIX_LEASE_TTL_SECONDS=300
 # The DCP4 source profile uses `tail-cow-v2`. Its namespace names the vLLM and
 # B12X source revisions because the directory selector is outside SparkCache's
-# content identity. Do not rename an older cache root to this value; recompute
-# state with this runtime. DCP1 and DCP2 use the same source prefix followed by
-# `dcp1-snapshot-v1` and `dcp2-snapshot-v1`, respectively.
+# content identity. Do not rename an incompatible cache root to this value;
+# recompute state with the named vLLM and B12X sources. DCP1 and DCP2 use the
+# same source prefix followed by `dcp1-snapshot-v1` and `dcp2-snapshot-v1`,
+# respectively.
 SPARKCACHE_CACHE_NAMESPACE='glm53-flash-vllm-e02b1746-b12x-9ae41c5c-dcp4-page-tail-cow-v2'
 JIT_CACHE_NAMESPACE='glm53-flash-sm121-vllm-e02b1746-b12x-9ae41c5c'
 JIT_MONITOR_VERBOSE=0
@@ -97,11 +98,13 @@ SPARKRING_IDLE_KV_WARN_SECONDS=330
 SPARKRING_LIVENESS_STALE_SECONDS=15
 SPARKRING_LIVENESS_SAMPLE_SECONDS=10
 
-# Research-only SIRCL tensor-parallel all-reduce. Images built by this
-# checkout contain the source-bound Python and native bundle. Developers may
-# set SIRCL_BUNDLE_HOST_ROOT to replace it with a complete read-only host
-# bundle. Each peer address must be reachable through the device in the same
-# numbered slot.
+# SIRCL is qualified for the four-rank TP4/DCP4 functional checks recorded for
+# the exact public image. Broader transport-performance claims remain
+# research-only. The base file leaves SIRCL disabled because peer addresses and
+# RDMA devices are rank-specific; append sircl-fused.env.example to configure
+# them. The image contains the source-bound Python and native bundle. Developers
+# may replace it with a complete read-only host bundle. Each peer address must
+# be reachable through the device in the same numbered slot.
 SIRCL_ENABLED=0
 SIRCL_BUNDLE_HOST_ROOT=''
 SPARK_TP4_PEER0=''

--- a/runtime/glm53-flash-jj-r8-gb10/sircl-capability-health-live-validation.json
+++ b/runtime/glm53-flash-jj-r8-gb10/sircl-capability-health-live-validation.json
@@ -2,7 +2,7 @@
   "schema": "sparkring-glm53-sircl-capability-health-live/v1",
   "status": "passed",
   "date": "2026-09-03",
-  "purpose": "Record the normal TP4/DCP4 serving result and two deliberate SIRCL fail-stop runs for issue 198 without relying on conversation history.",
+  "purpose": "Record the TP4/DCP4 serving result and two deliberate SIRCL failure-injection runs for issue 198 without relying on conversation history.",
   "system": {
     "model": "GLM-5.3-Flash NVFP4 with DFlash2 BF16 draft",
     "hosts": [
@@ -30,7 +30,7 @@
     "sircl": {
       "mode": "custom",
       "capability_vote": true,
-      "post_output_health_gate": true,
+      "post_output_health_check": true,
       "graph_width4096": true,
       "graph_direct_doorbell": true,
       "fused_prefill": true,
@@ -168,7 +168,7 @@
         "all_containers_finished": true,
         "last_container_finished_seconds_after_first_fatal": 40.726
       },
-      "conclusion": "The deliberately poisoned sequence did not reach API readiness or expose model output. All four native proxies fail-stopped and every worker monitor initiated shutdown without an unbounded collective wait. Because the fault fired during startup, this run establishes containment and convergence, not direct observation of the Python post-output gate."
+      "conclusion": "The deliberately poisoned sequence did not reach API readiness or expose model output. All four native proxies reported fatal errors, and every worker monitor initiated shutdown without an unbounded collective wait. Because the fault occurred during startup, this result establishes containment and convergence, not direct observation of the Python post-output health check."
     },
     {
       "name": "rank-2-fused-proxy-exit",
@@ -213,7 +213,7 @@
         "all_containers_finished": true,
         "last_container_finished_seconds_after_rank2_fatal": 64.970
       },
-      "conclusion": "Rank 2 entered the intended real proxy-fatal path first. The other three ranks starved, reached their configured five-second proxy timeout, and fail-stopped locally; all worker monitors initiated shutdown. No model output or fallback escaped, and no post-output Gloo collective was used."
+      "conclusion": "Rank 2 entered the intended proxy-fatal path first. The other three ranks received no peer progress, reached their configured five-second proxy timeout, reported errors, and stopped locally; every worker monitor initiated shutdown. No model output or fallback escaped, and no post-output Gloo collective was used."
     }
   ],
   "publication_boundary": {
@@ -224,7 +224,7 @@
   },
   "limitations": [
     "The normal observation records functional serving and transport progress, not a throughput comparison.",
-    "Both injected faults occurred during determine_available_memory before API readiness, so they validate fail-stop convergence but do not directly exercise an already-running request's post-output Python gate.",
+    "Both injected faults occurred during determine_available_memory before API readiness, so they validate bounded worker termination but do not directly exercise an already-running request's post-output Python health check.",
     "Container exit codes are launcher-level outcomes: rank 0 ended with 137 and OOMKilled=false in both injected runs, while follower containers ended with 0. Native fatal logs and worker-monitor logs are the failure evidence.",
     "Normal HTTP counts are cumulative at the stated observation timestamp and include 39 loopback warmup requests plus 27 external chat requests."
   ]

--- a/runtime/glm53-flash-jj-r8-gb10/sircl-fused.env.example
+++ b/runtime/glm53-flash-jj-r8-gb10/sircl-fused.env.example
@@ -1,4 +1,5 @@
-# Implemented fused SIRCL performance-testing overlay for GLM-5.3 TP4/DCP4.
+# Functionally qualified fused SIRCL overlay for the recorded GLM-5.3 TP4/DCP4
+# public image. Broader transport-performance claims remain research-only.
 # Append this file to a rank-local copy of runtime.env.example, then replace
 # every value marked REPLACE. The base runtime settings remain unchanged.
 

--- a/runtime/glm53-flash-jj-r8-gb10/test_image_contract.py
+++ b/runtime/glm53-flash-jj-r8-gb10/test_image_contract.py
@@ -72,6 +72,14 @@ def test_image_packages_dflash_warmup_and_rank_zero_waits_for_it() -> None:
 
 def test_pins_bind_effective_sources_and_operator_defaults() -> None:
     pins = json.loads((HERE / "pins.json").read_text(encoding="utf-8"))
+    assert pins["compatibility_locator"] == {
+        "directory": "runtime/glm53-flash-jj-r8-gb10",
+        "schema_prefix": "sparkring-glm53-jj-r8-gb10",
+        "meaning": (
+            "Stable filesystem and JSON interface locator. The r8 text identifies "
+            "the interface family, not the embedded vLLM source composition."
+        ),
+    }
     assert pins["operator_image"] == {
         "reference": (
             "ghcr.io/fujitsupolycom/sparkring-glm53-sparkcache@"
@@ -81,7 +89,8 @@ def test_pins_bind_effective_sources_and_operator_defaults() -> None:
             "sha256:5e32aaa1bbe3559e81db7706ed4286248f18d27cfdb186f6b851bf786eb43075"
         ),
         "platform": "linux/arm64",
-        "status": "implemented",
+        "status": "qualified",
+        "performance_status": "research-only",
         "qualification_scope": (
             "registry-pull verified on four ranks; GLM-5.3 Flash TP4/DCP4 "
             "passed embedded dual-rail SIRCL startup, concurrent SparkCache "
@@ -92,6 +101,11 @@ def test_pins_bind_effective_sources_and_operator_defaults() -> None:
     assert pins["vllm"]["commit"] == (
         "e02b174693e13859de61811b5e8cd13d5308e259"
     )
+    assert pins["vllm"]["public_tag"] == "sparkring-glm53-flash-gb10-e02b1746"
+    assert pins["vllm"]["public_tag_object"] == (
+        "2ac6883ac5156db713493fe9683bea99ecf928a4"
+    )
+    assert pins["vllm"]["public_tag_commit"] == pins["vllm"]["commit"]
     assert pins["vllm"]["tree"] == "6caadd392ddea2dc90441d0a078da67f38d2fd3a"
     assert pins["vllm"]["package_tree"] == (
         "c91299c2303dc05abc85aa2133224a749657a583"
@@ -135,6 +149,7 @@ def test_pins_bind_effective_sources_and_operator_defaults() -> None:
     )
     assert pins["b12x"] == {
         "repository": "https://github.com/voipmonitor/b12x.git",
+        "upstream_repository": "https://github.com/local-inference-lab/b12x.git",
         "commit": "9ae41c5cb9935d740456479954b0089f80bd2ef2",
         "tree": "6e77441fe99f6ead7ff2cc2b6a8a37fa4e93e30b",
         "package_tree": "12029e19da6543c5d225395f6da199d946b0972e",
@@ -305,11 +320,14 @@ def test_runtime_hashes_are_enforced_inside_image() -> None:
     assert "verify_public_overlay(SIRCL_ROOT, sircl_manifest)" in verifier
 
 
-def test_builder_requires_source_pinned_b12x_checkout() -> None:
+def test_builder_requires_source_pinned_b12x_and_records_public_sources() -> None:
     builder = (HERE / "build_image.py").read_text(encoding="utf-8")
     assert '"--b12x-source"' in builder
     assert 'pins["b12x"], "b12x"' in builder
     assert '"b12x-source-manifest.json"' in builder
+    assert '"public_tag": pins["vllm"]["public_tag"]' in builder
+    assert '"public_tag_object": pins["vllm"]["public_tag_object"]' in builder
+    assert '"upstream_repository": pins["b12x"]["upstream_repository"]' in builder
 
 
 def test_builder_requires_the_receipt_bound_prebuilt_sircl_library() -> None:
@@ -453,6 +471,47 @@ def test_operator_docs_distinguish_page_tails_from_published_rollback() -> None:
     assert rollback_digest in quickstart
     assert rollback_digest in runtime_index
     assert "380283a506aeb8f9" not in runtime_index
+
+
+def test_operator_docs_name_public_sources_and_explain_stable_locators() -> None:
+    runtime_readme = (HERE / "README.md").read_text(encoding="utf-8")
+    quickstart = (
+        ROOT / "docs/GLM53_JJ_R8_GB10_SPARKCACHE_TP4_QUICKSTART.md"
+    ).read_text(encoding="utf-8")
+    sircl_readme = (ROOT / "docs/SIRCL.md").read_text(encoding="utf-8")
+    runtime_index = (ROOT / "runtime/README.md").read_text(encoding="utf-8")
+    root_readme = (ROOT / "README.md").read_text(encoding="utf-8")
+
+    for document in (runtime_readme, quickstart):
+        assert "sparkring-glm53-flash-gb10-e02b1746" in document
+        assert "e02b174693e13859de61811b5e8cd13d5308e259" in document
+        assert "local-inference-lab/b12x" in document
+        assert "voipmonitor/b12x" in document
+        assert "`tail-cow-v2` to the cache-identity\nwire value `page-tail-cow-v2`" in document
+
+    for document in (runtime_readme, runtime_index):
+        assert "stable compatibility locator" in document or (
+            "stable filesystem and interface\nlocators" in document
+        )
+        assert "does not identify the embedded vLLM source" in " ".join(
+            document.split()
+        )
+
+    assert "four-rank TP4/DCP4\nfunctional checks" in sircl_readme
+    assert "**research-only**" in sircl_readme
+    assert "b12x-kda-dcp4-20260903.md" in root_readme
+    assert "C4: 90.36" in root_readme
+
+    active_docs = "\n".join((runtime_readme, quickstart, sircl_readme))
+    for ambiguous in (
+        "Current evidence",
+        "current composition",
+        "fail-stop",
+        "concurrent prompt gate",
+        "earlier SparkCache source composition",
+        "older runtime's default directory",
+    ):
+        assert ambiguous not in active_docs
 
 
 def test_multimodal_lease_image_receipt_binds_public_artifact_and_smoke() -> None:
@@ -612,9 +671,40 @@ def test_dcp4_public_image_receipt_records_b12x_kda() -> None:
     )
     assert receipt["status"] == "qualified"
     assert receipt["configuration"]["kda_prefill_backend"] == "b12x"
+    assert receipt["sources"]["vllm_public_tag"] == (
+        "sparkring-glm53-flash-gb10-e02b1746"
+    )
+    assert receipt["sources"]["vllm_composition"] == (
+        "e02b174693e13859de61811b5e8cd13d5308e259"
+    )
+    assert receipt["sources"]["vllm_public_tag_commit"] == receipt["sources"][
+        "vllm_composition"
+    ]
+    assert receipt["sources"]["b12x_upstream_repository"] == (
+        "https://github.com/local-inference-lab/b12x.git"
+    )
+    assert receipt["sources"]["b12x_source_repository"] == (
+        "https://github.com/voipmonitor/b12x.git"
+    )
     assert receipt["sources"]["b12x"] == (
         "9ae41c5cb9935d740456479954b0089f80bd2ef2"
     )
+    health_receipt = json.loads(
+        (HERE / "sircl-capability-health-live-validation.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert health_receipt["system"]["sircl"]["post_output_health_check"] is True
+    assert "post_output_health_gate" not in health_receipt["system"]["sircl"]
+    assert receipt["validation"]["sircl_scope"] == {
+        "functional_status": "qualified",
+        "performance_status": "research-only",
+        "details": (
+            "The exact image passed the recorded embedded dual-rail SIRCL "
+            "TP4/DCP4 functional checks. The receipt does not establish a broad "
+            "SIRCL-versus-NCCL performance result."
+        ),
+    }
 
 
 def test_sircl_public_build_receipt_binds_overlay_and_native_test(

--- a/scripts/test_glm53_flash_profile.py
+++ b/scripts/test_glm53_flash_profile.py
@@ -340,6 +340,10 @@ def test_recipes_record_qualified_cached_and_cache_disabled_evidence() -> None:
     assert cache["serving_common"]["chunked_prefill"] is True
     assert base["serving_common"]["kda_prefill_backend"] == "b12x"
     assert cache["serving_common"]["kda_prefill_backend"] == "b12x"
+    assert base["transport"]["output_health_check"] is True
+    assert cache["transport"]["output_health_check"] is True
+    assert "output_health_gate" not in base["transport"]
+    assert "output_health_gate" not in cache["transport"]
     assert cache["profiles"]["dcp4"]["status"] == "qualified"
     assert cache["profiles"]["dcp4"]["preferred"] is True
     assert cache["profiles"]["dcp1"]["async_page_capture"] is False
@@ -443,7 +447,8 @@ def test_public_glm53_benchmark_is_sanitized_and_front_page_lists_dcp_profiles()
     assert "| 1.30M tokens |" in readme
     assert "| 2.90M tokens |" in readme
     assert "| **4.32M tokens** |" in readme
-    assert "| 2,513 | 40.20 | 116.73 | C16: 168.39 | 71.67 |" in readme
+    assert "b12x-kda-dcp4-20260903.md" in readme
+    assert "| 2,649 | 37.97 | — | C4: 90.36 | — |" in readme
     quickstart = (
         ROOT / "docs" / "GLM53_JJ_R8_GB10_SPARKCACHE_TP4_QUICKSTART.md"
     ).read_text(encoding="utf-8")


### PR DESCRIPTION
## What and why

The GLM-5.3 operator documentation and machine contracts now identify every source and tested behavior without relying on release shorthand:

- vLLM composition `e02b174693e13859de61811b5e8cd13d5308e259` is publicly fetchable through annotated tag `sparkring-glm53-flash-gb10-e02b1746` in `FujitsuPolycom/vllm`.
- B12X is credited to Local Inference Lab, while the exact installed source is identified as `voipmonitor/b12x` commit `9ae41c5cb9935d740456479954b0089f80bd2ef2`.
- The `r8` text retained in directory and schema names is defined as a compatibility locator; `pins.json` identifies the embedded Jovian Judgement Community R10 source composition.
- Embedded dual-rail SIRCL is qualified for the recorded TP4/DCP4 functional checks. Its bounded throughput observation remains research-only and is not presented as a SIRCL-versus-NCCL comparison.
- The front-page GLM result points to the immutable public-image B12X-KDA observation.
- SparkCache's `tail-cow-v2` operator setting is distinguished from the `page-tail-cow-v2` cache-identity wire value.

## Validation

- Focused GLM profile and image-contract suite: 68 passed, 1 skipped
- Complete CPU contract suite: 2,182 passed, 20 documented skips
- `ruff check --select E,F,W --ignore E501 spark_transport runtime scripts performance`: passed
- `git diff --check`: passed
- GitHub tag object `2ac6883ac5156db713493fe9683bea99ecf928a4` dereferences to vLLM commit `e02b174693e13859de61811b5e8cd13d5308e259`; its public Git tree is `6caadd392ddea2dc90441d0a078da67f38d2fd3a`.

## Additional context

Recipe field `output_health_gate` becomes `output_health_check`. Evidence field `post_output_health_gate` becomes `post_output_health_check`. Consumers of those JSON fields must use the descriptive names. The image digest, image contents, model artifacts, runtime behavior, SparkCache identity, publication schema, and cache namespaces are unchanged.

No host, container, model, cache, or network state was changed.

- [x] I removed credentials and private site identifiers from the change.
- [x] I identified copied or adapted work and updated third-party notices when required.