### PR TITLE
Use exact DFlash graphs for every supported concurrency

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ guides use immutable digests.
 
 All three profiles use the GLM-5.3 Flash NVFP4 target, BF16 DFlash2 at depth
 seven, FP8 KV, B12X GB10 kernels, and the same source-pinned ARM64 vLLM image.
+The launcher captures one exact CUDA graph for every supported concurrency
+from C1 through C16.
 
 | Profile | Deployment | Context | Seqs | Batch | KV / cache | Approx. logical KV capacity | Start here |
 |---|---|---:|---:|---:|---|---:|---|
@@ -107,11 +109,13 @@ and evaluation; review its model card before use.
 ## Benchmark results
 
 All values are tokens per second. Prefill uses a cold prompt with caching
-disabled. Decode uses unique, cold prompt contexts at
-temperature 1.0; decode values are aggregate throughput across active streams.
+disabled. Decode reports sustained generation after the prompt context is
+available; each linked record states its context-sharing conditions. Decode
+values are aggregate throughput across active streams at temperature 1.0.
 
 | Profile | Prefill | C1 decode | C8 decode | Highest tested decode | Coding peak |
 |---|---:|---:|---:|---:|---:|
+| [GLM-5.3 Flash NVFP4-Spark exact request-batch graphs · 4 Sparks](performance/records/glm53-flash/dflash2-exact-concurrency-graphs-20260904.md) | 2,717 | 43.05 | 134.3 | C16: 187.0 | — |
 | [GLM-5.3 Flash B12X-KDA DCP4 public image · 4 Sparks](performance/records/glm53-flash/b12x-kda-dcp4-20260903.md) | 2,649 | 37.97 | — | C4: 90.36 | — |
 | [GLM-5.2 EXL3 3.5-bpw · 4 Sparks](performance/records/glm-3.5bpw/normalized-base-20260822.md) | 671 | 20.15 | 64.13 | C8: 64.13 | 25.39 |
 | [DeepSeek-V4-Flash DSpark · 2 Sparks](performance/records/deepseek-v4-flash/normalized-tp2-base-temp1-n5-20260823.md) | 1,926 | 58.36 | 162.69 | C32: 307.13 | 59.31 |

--- a/docs/GLM53_JJ_R8_GB10_SPARKCACHE_TP4_QUICKSTART.md
+++ b/docs/GLM53_JJ_R8_GB10_SPARKCACHE_TP4_QUICKSTART.md
@@ -356,9 +356,11 @@ capture have no matching live record; use complete snapshots or test those
 layouts separately.
 
 The environment template enables `DFLASH_WARMUP=1`. Rank 0 waits for the API,
-then exercises C1/C2/C4/C8/C16 and scheduled prompt spans covering DFlash's
-Triton block-size specializations. Treat completion of the rank-0 launch
-command—not an early `/health` response—as service readiness.
+then exercises every concurrency from C1 through C16 and scheduled prompt
+spans covering DFlash's Triton block-size specializations. DFlash depth seven
+verifies eight target rows per active request, so the launcher captures every
+eight-row request-batch shape from 8 through 128. Treat completion of the
+rank-0 launch command—not an early `/health` response—as service readiness.
 The engine-level failure and readiness replay are recorded in the
 [`DFlash readiness validation`](../runtime/glm53-flash-jj-r8-gb10/dflash-jit-readiness-validation.json).
 

--- a/docs/SIRCL.md
+++ b/docs/SIRCL.md
@@ -37,8 +37,9 @@ established. A developer can replace the embedded bundle with a read-only host
 mount. Its captured width-4096 path and eager fused-prefill path use separate
 signature checks. The fused path accepts contiguous TP4 BF16 `[Q, 4096]`
 tensors from Q128 through Q8192 and uses two operation slots. Unsupported
-signatures remain on NCCL. The GLM-5.3 profile captures Q8/Q16/Q32/Q64/Q128;
-those captured collectives use graph-native SIRCL with direct doorbells. The
+signatures remain on NCCL. The GLM-5.3 profile captures every eight-row DFlash
+request-batch shape from Q8 through Q128; those captured collectives use
+graph-native SIRCL with direct doorbells. The
 fused session uses four persistent QPs and two 67,109,888-byte operation
 arenas. See the
 [GLM-5.3 runtime guide](../runtime/glm53-flash-jj-r8-gb10/README.md) and the

--- a/performance/records/glm53-flash/dflash2-exact-concurrency-graphs-20260904.md
+++ b/performance/records/glm53-flash/dflash2-exact-concurrency-graphs-20260904.md
@@ -1,0 +1,75 @@
+# GLM-5.3 Flash exact DFlash request-batch graphs
+
+Status: **implemented**. The performance comparison is **research-only**.
+
+DFlash2 at depth seven verifies eight target rows per active request. The
+GLM-5.3 launcher therefore captures every eight-row CUDA-graph shape from 8
+through 128 for a 16-sequence deployment. This gives C1 through C16 an exact
+request-batch graph. The launcher also warms every supported concurrency
+before reporting the service ready.
+
+The sparse five-shape configuration captured rows 8, 16, 32, 64, and 128.
+Intermediate concurrency levels used larger graph buckets. The exact-shape
+configuration removes that padding.
+
+## Conditions
+
+- Four directly connected NVIDIA GB10 systems, TP4/DCP4.
+- Target checkpoint:
+  `local-inference-lab/GLM-5.3-Flash-NVFP4-Spark@df116c4fb16b1d37ae43d2cfd624de26ffbc832e`.
+- BF16 DFlash2 depth seven, FP8 KV, 16 sequences, 8,192 batched tokens,
+  scheduler interval two, and asynchronous scheduling.
+- B12X attention, MoE, linear, and KDA-prefill backends.
+- Dual-rail SIRCL for admitted collectives with patched NCCL fallback.
+- SparkCache read-write mode with `tail-cow-v2` publication.
+- Operator image:
+  `ghcr.io/fujitsupolycom/sparkring-glm53-sparkcache@sha256:0d4029b3b7023cf32c37ac20279469c9a2ee16a057f25aae3bcfee9ee5fb660f`.
+- Benchmark harness: `local-inference-lab/llm-inference-bench` version 0.4.32,
+  commit `a3a24a6631f011716be732bbf148f95e1d0cf716`, using 20-second sustained
+  decode cells at temperature 1.0.
+- The harness computed each prompt once and measured sustained decode after
+  the prompt context was available. Concurrent streams shared that context.
+
+The image already accepts an explicit CUDA-graph capture list. The measured
+deployment used the launcher change documented here; no image bytes changed.
+
+## Result
+
+At a 16,384-token context, the exact-shape configuration produced the
+following changes against the same target checkpoint and serving topology:
+
+| Concurrency | Five-shape tok/s | Exact-shape tok/s | Change | Target-step change |
+|---:|---:|---:|---:|---:|
+| 6 | 91.0 | 113.6 | +24.8% | +26.9% |
+| 10 | 106.9 | 143.6 | +34.3% | +33.7% |
+| 12 | 126.6 | 157.3 | +24.2% | +23.5% |
+| 14 | 154.5 | 172.0 | +11.3% | +10.9% |
+| 16 | 184.4 | 187.0 | +1.4% | -2.0% |
+
+Target steps per second remove workload-dependent DFlash acceptance from the
+comparison. Their improvement at C6, C10, C12, and C14 shows that exact graph
+selection reduced execution work rather than merely observing higher draft
+acceptance. C1 through C16 had zero request errors, readiness timeouts,
+capacity-limit markers, or scheduler queueing.
+
+The source result files are not published because they contain a client
+hostname and private site address. Their identities are:
+
+| Configuration | Source file SHA-256 |
+|---|---|
+| Five graph shapes | `6b081de09d64f528457459cd248a518344983832a9395e003ca92fb2a3d652d0` |
+| Exact shapes, C1 through C10 | `eec5052232cea1a1c05a4f4c91d602ba7d7da05a6e6f871ed14a5612b95d8c18` |
+| Exact shapes, C11 through C16 | `e1e9bf733fc8229628910fcc22a20c46bd29a937ff7e2e7c4450aeaee89e783d` |
+
+## Limits
+
+The exact-shape measurements cover 8,192- and 16,384-token decode contexts.
+Longer-context spot checks remain useful but are not required to establish the
+request-batch padding mechanism. The target checkpoint is the smaller
+NVFP4-Spark quantization; graph row counts depend on speculative depth and
+active request count rather than checkpoint tensor values.
+
+`fused_recurrent_kda_fwd_kernel` compiled while the C5 8K stream was becoming
+ready and before its measured window. The recorded C5 value is not affected,
+but a longer C5 startup request is still needed to prevent that first-use
+compilation in ordinary serving.

--- a/runtime/glm53-flash-jj-r8-gb10/README.md
+++ b/runtime/glm53-flash-jj-r8-gb10/README.md
@@ -59,7 +59,7 @@ The recommended profile uses:
 | sequences | 16 |
 | scheduler | asynchronous with chunked prefill and prefix caching |
 | graph mode | `FULL_AND_PIECEWISE` |
-| CUDA graph capture sizes | 8, 16, 32, 64, and 128 |
+| CUDA graph capture sizes | every eight-row DFlash request-batch shape from 8 through 128 |
 | model kernels | B12X attention, KDA prefill, MoE, and linear |
 | collective/RMSNorm fusion | disabled |
 | FlashInfer autotuning | disabled |
@@ -275,13 +275,19 @@ arena wait that would justify more unified-memory pressure.
 
 The image entrypoint runs `warmup_dflash.py` before Docker reports rank 0 as
 healthy.
-The default environment template enables C1/C2/C4/C8/C16 warmup and prompt
-spans covering the DFlash Triton `BLOCK_SIZE` specializations through 256.
+The default environment template warms every concurrency from C1 through C16
+and prompt spans covering the DFlash Triton `BLOCK_SIZE` specializations
+through 256. DFlash depth seven verifies eight target rows per active request,
+so the launcher captures every eight-row request-batch shape from 8 through
+128. Each supported concurrency therefore has an exact CUDA graph instead of
+padding intermediate request counts to a larger graph.
 Do not admit normal traffic until the rank-0 launcher returns. A failed or
 timed-out warmup makes launch fail instead of leaving an apparently healthy
 API in front of a wedged engine.
 The failure-shaped replay and remaining causal limitation are recorded in
 [`dflash-jit-readiness-validation.json`](dflash-jit-readiness-validation.json).
+The measured effect of exact request-batch graphs is recorded in
+[`dflash2-exact-concurrency-graphs-20260904.md`](../../performance/records/glm53-flash/dflash2-exact-concurrency-graphs-20260904.md).
 
 The page-tail registry image contains `tail-cow-v2`. The complete-snapshot
 image remains available in the rollback section below.

--- a/runtime/glm53-flash-jj-r8-gb10/launch-rank.sh
+++ b/runtime/glm53-flash-jj-r8-gb10/launch-rank.sh
@@ -63,7 +63,7 @@ fi
 : "${JIT_CACHE_NAMESPACE:=glm53-flash-sm121-vllm-e02b1746-b12x-9ae41c5c}"
 : "${JIT_MONITOR_VERBOSE:=0}"
 : "${DFLASH_WARMUP:=0}"
-: "${DFLASH_WARMUP_CONCURRENCIES:=1,2,4,8,16}"
+: "${DFLASH_WARMUP_CONCURRENCIES:=1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16}"
 : "${DFLASH_WARMUP_SHAPE_WORDS:=8,24,56,120,248}"
 : "${DFLASH_WARMUP_MAX_TOKENS:=16}"
 : "${DFLASH_WARMUP_TIMEOUT_SECONDS:=600}"
@@ -677,18 +677,19 @@ print(json.dumps({
 PY
 )"
 
-export CUDAGRAPH_MODE MAX_CUDAGRAPH_CAPTURE_SIZE
+export CUDAGRAPH_MODE MAX_CUDAGRAPH_CAPTURE_SIZE NUM_SPECULATIVE_TOKENS
 compilation_config="$(python3 - <<'PY'
 import json
 import os
 
 maximum = int(os.environ["MAX_CUDAGRAPH_CAPTURE_SIZE"])
-capture_sizes = []
-size = 8
-while size < maximum:
-    capture_sizes.append(size)
-    size *= 2
-capture_sizes.append(maximum)
+rows_per_request = int(os.environ["NUM_SPECULATIVE_TOKENS"]) + 1
+if maximum % rows_per_request:
+    raise SystemExit(
+        "MAX_CUDAGRAPH_CAPTURE_SIZE must be divisible by "
+        "NUM_SPECULATIVE_TOKENS + 1"
+    )
+capture_sizes = list(range(rows_per_request, maximum + 1, rows_per_request))
 print(json.dumps({
     "cudagraph_mode": os.environ["CUDAGRAPH_MODE"],
     "cudagraph_capture_sizes": capture_sizes,

--- a/runtime/glm53-flash-jj-r8-gb10/runtime.env.example
+++ b/runtime/glm53-flash-jj-r8-gb10/runtime.env.example
@@ -63,6 +63,9 @@ LINEAR_BACKEND='b12x'
 KDA_PREFILL_BACKEND='b12x'
 LOAD_FORMAT='fastsafetensors'
 CUDAGRAPH_MODE='FULL_AND_PIECEWISE'
+# DFlash verifies seven draft tokens plus one target token for each active
+# request. The launcher captures every eight-row request-batch shape through
+# this limit so each supported concurrency has an exact CUDA graph.
 MAX_CUDAGRAPH_CAPTURE_SIZE=128
 
 # The manager-page geometry is part of the persistent-cache identity.
@@ -83,7 +86,7 @@ SPARKCACHE_CACHE_NAMESPACE='glm53-flash-vllm-e02b1746-b12x-9ae41c5c-dcp4-page-ta
 JIT_CACHE_NAMESPACE='glm53-flash-sm121-vllm-e02b1746-b12x-9ae41c5c'
 JIT_MONITOR_VERBOSE=0
 DFLASH_WARMUP=1
-DFLASH_WARMUP_CONCURRENCIES='1,2,4,8,16'
+DFLASH_WARMUP_CONCURRENCIES='1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16'
 DFLASH_WARMUP_SHAPE_WORDS='8,24,56,120,248'
 DFLASH_WARMUP_MAX_TOKENS=16
 DFLASH_WARMUP_TIMEOUT_SECONDS=600

--- a/runtime/glm53-flash-jj-r8-gb10/serve_with_warmup.py
+++ b/runtime/glm53-flash-jj-r8-gb10/serve_with_warmup.py
@@ -113,7 +113,10 @@ def main() -> int:
             model=os.environ.get("SERVED_MODEL_NAME", "glm-5.3-flash"),
             warmup_enabled=os.environ.get("DFLASH_WARMUP", "0") == "1",
             concurrencies=_positive_csv(
-                os.environ.get("DFLASH_WARMUP_CONCURRENCIES", "1,2,4,8,16"),
+                os.environ.get(
+                    "DFLASH_WARMUP_CONCURRENCIES",
+                    "1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16",
+                ),
                 "DFLASH_WARMUP_CONCURRENCIES",
             ),
             shape_words=_positive_csv(

--- a/runtime/glm53-flash-jj-r8-gb10/test_launcher_contract.py
+++ b/runtime/glm53-flash-jj-r8-gb10/test_launcher_contract.py
@@ -48,6 +48,9 @@ def test_environment_exposes_reproducible_operator_defaults() -> None:
     assert values["DECODE_CONTEXT_PARALLEL_SIZE"] == "4"
     assert values["MAX_NUM_BATCHED_TOKENS"] == "8192"
     assert values["KDA_PREFILL_BACKEND"] == "b12x"
+    assert values["DFLASH_WARMUP_CONCURRENCIES"] == (
+        "1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16"
+    )
     assert values["PREFILL_SCHEDULE_INTERVAL"] == "2"
     assert values["MAX_IMAGES_PER_PROMPT"] == "4"
     assert values["MAX_VIDEOS_PER_PROMPT"] == "1"
@@ -172,6 +175,15 @@ printf '%s  %s\n' "$hash" "$2"
         mm_index = arguments.index("--limit-mm-per-prompt")
         assert json.loads(arguments[mm_index + 1]) == {"image": 4, "video": 1}
         assert "--kv-transfer-config" in arguments
+        compilation = json.loads(
+            arguments[arguments.index("--compilation-config") + 1]
+        )
+        assert compilation["cudagraph_capture_sizes"] == list(
+            range(8, 129, 8)
+        )
+        assert "DFLASH_WARMUP_CONCURRENCIES=" + ",".join(
+            str(value) for value in range(1, 17)
+        ) in arguments
         jit_namespace = "glm53-flash-sm121-vllm-e02b1746-b12x-9ae41c5c"
         assert f"VLLM_CACHE_ROOT=/cache/jit/vllm/{jit_namespace}" in arguments
         assert (
@@ -476,7 +488,9 @@ def test_public_operator_documents_use_portable_examples_and_resolving_links() -
     assert "fanout_image_archive.py" in quickstart
     assert "sircl-fused.env.example" in quickstart
     assert "SIRCL_ENABLED=1" in quickstart
-    assert "Q=8/16/32/64/128" in runtime_readme
+    assert "every eight-row DFlash request-batch shape from 8 through 128" in (
+        runtime_readme
+    )
     assert "Q128 through Q8192" in runtime_readme
     assert re.search(r"primary\s+ports 19006/19007", runtime_readme)
     assert "67,109,888-byte mapped arena" in runtime_readme

--- a/runtime/glm53-flash-jj-r8-gb10/warmup_dflash.py
+++ b/runtime/glm53-flash-jj-r8-gb10/warmup_dflash.py
@@ -129,7 +129,10 @@ def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--endpoint", required=True)
     parser.add_argument("--model", default="glm-5.3-flash")
-    parser.add_argument("--concurrencies", default="1,2,4,8,16")
+    parser.add_argument(
+        "--concurrencies",
+        default="1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16",
+    )
     parser.add_argument("--max-tokens", type=int, default=16)
     parser.add_argument("--shape-words", default="8,24,56,120,248")
     parser.add_argument("--timeout-seconds", type=float, default=600.0)


### PR DESCRIPTION
## Resulting behavior

The GLM-5.3 DFlash2 depth-seven profile captures one CUDA graph for every supported request concurrency. Eight target verification rows are emitted per active request, so the default C16 deployment captures rows 8 through 128 in increments of eight and warms C1 through C16 before reporting readiness.

## Technical reason

The five-shape list covered only C1, C2, C4, C8, and C16. Intermediate request counts were padded into larger graph buckets, producing repeatable throughput troughs. Exact request-batch graphs remove that excess execution work.

## Compatibility

- No model, image, persistent-cache identity, or cache namespace changes.
- The published image already accepts the explicit graph list and warmup concurrency environment value.
- The launcher stops before container creation when the configured maximum graph size is not divisible by the DFlash rows-per-request value.

## Evidence

On four directly connected NVIDIA GB10 systems at TP4/DCP4 with DFlash2 depth seven, 16K sustained decode improved by 24.8% at C6, 34.3% at C10, 24.2% at C12, and 11.3% at C14. Acceptance-normalized target-step improvements were 26.9%, 33.7%, 23.5%, and 10.9%, respectively. C1 through C16 completed without request errors, readiness timeouts, capacity-limit markers, or scheduler queueing. The artifact identities, conditions, and limitations are recorded in `performance/records/glm53-flash/dflash2-exact-concurrency-graphs-20260904.md`.

## Validation

- `python -m pytest spark_transport runtime/exl3-r7 runtime/glm53-flash runtime/glm53-flash-jj-r8-gb10 runtime/deepseek0731-gb10 runtime/qwen38 runtime/test_public_overlay.py performance/harnesses scripts -q -rs`: 2,220 passed, 20 skipped
- Focused GLM-5.3 launcher and warmup tests: 33 passed, 1 skipped
- `python -m ruff check --select E,F,W --ignore E501 .`
- `bash -n runtime/glm53-flash-jj-r8-gb10/launch-rank.sh`
- `git diff --check`