### PR TITLE
runtime/glm53-flash-jj-r8-gb10: CHAT_TEMPLATE_HOST_PATH override; quickstart revision 46aaae8a (2026-09-04 GLM-5.3 chat-template update, weights unchanged)

### DIFF
--- a/docs/GLM53_JJ_R8_GB10_SPARKCACHE_TP4_QUICKSTART.md
+++ b/docs/GLM53_JJ_R8_GB10_SPARKCACHE_TP4_QUICKSTART.md
@@ -83,12 +83,23 @@ target_model=/srv/models/glm53-target
 draft_model=/srv/models/glm53-dflash2-bf16
 
 hf download local-inference-lab/GLM-5.3-Flash-NVFP4 \
-  --revision 520de24eabf507659eaef7c70f14fd584527facc \
+  --revision 46aaae8a82032f77100f2f03e9cc11b391df3b4d \
   --local-dir "${target_model}"
 hf download incoai/GLM-5.3-Flash-DFlash2 \
   --revision dc77ff1c99eeb2df044ee3d4f0094eb033fee410 \
   --local-dir "${draft_model}"
 ```
+
+Revision `46aaae8a` differs from the previously documented `520de24e` only in
+`README.md` and `chat_template.jinja`: it carries zai-org's 2026-09-04 GLM-5.3
+chat-template update (tool-result reordering exits early; a `content is not
+none` guard on assistant text). The weights, `config.json`, and
+`model.safetensors.index.json` are byte-identical, so the launcher's identity
+checks accept either revision. A site that already holds `520de24e` can adopt
+the template alone by pointing `CHAT_TEMPLATE_HOST_PATH` at the new
+`chat_template.jinja` (SHA-256
+`0c4099f3382d6c92700dfb99725025360966fd73032f0ecf32377c0d9e6309c5`) instead of
+re-downloading the checkpoint.
 
 Copy each immutable directory to the same absolute path on the three follower
 ranks. Use direct-link addresses where the site permits SSH over the 200 Gb/s
@@ -230,6 +241,12 @@ whitespace in a key.
 This is host-level access control, not secret management. vLLM receives the
 keys in its process arguments, which remain visible to an administrator who
 can inspect the container or host process.
+
+`CHAT_TEMPLATE_HOST_PATH` (empty by default) bind-mounts one host file
+read-only and passes it as `--chat-template`, replacing the template shipped
+inside the target checkpoint directory. Use it to adopt a template-only
+checkpoint update without re-staging weights; leave it empty to serve the
+checkpoint's own `chat_template.jinja`.
 
 Choose the DCP degree with one line. DCP4 uses the environment template as
 written:

--- a/runtime/glm53-flash-jj-r8-gb10/README.md
+++ b/runtime/glm53-flash-jj-r8-gb10/README.md
@@ -43,7 +43,10 @@ Follow the
 to obtain or build the image, distribute it once through the direct fabric,
 and start four ranks. [`runtime.env.example`](runtime.env.example) exposes the
 model paths, image identity, DCP degree, context limit, scheduler budget, KV
-allocation, speculation, cache limits, network interfaces, and ports.
+allocation, speculation, cache limits, network interfaces, ports, and an
+optional chat-template override (`CHAT_TEMPLATE_HOST_PATH`, bind-mounted
+read-only and passed as `--chat-template`; empty serves the checkpoint's own
+template).
 
 The recommended profile uses:
 

--- a/runtime/glm53-flash-jj-r8-gb10/launch-rank.sh
+++ b/runtime/glm53-flash-jj-r8-gb10/launch-rank.sh
@@ -135,6 +135,7 @@ fi
 : "${FASTSAFETENSORS_QUEUE_SIZE:=1}"
 : "${ENABLE_PROMPT_TOKENS_DETAILS:=1}"
 : "${API_KEYS_FILE:=}"
+: "${CHAT_TEMPLATE_HOST_PATH:=}"
 
 die() {
   printf '%s\n' "$*" >&2
@@ -282,6 +283,16 @@ if [[ "${SPARKCACHE_ASYNC_PAGE_CAPTURE}" == 1 ]]; then
     read-write|store-only) ;;
     *) die 'asynchronous page capture requires a publication-capable access mode' ;;
   esac
+fi
+if [[ -n "${CHAT_TEMPLATE_HOST_PATH}" ]]; then
+  [[ "${CHAT_TEMPLATE_HOST_PATH}" == /* ]] || \
+    die 'CHAT_TEMPLATE_HOST_PATH must be an absolute host path when set'
+  [[ "${CHAT_TEMPLATE_HOST_PATH}" != *:* && "${CHAT_TEMPLATE_HOST_PATH}" != *$'\n'* ]] || \
+    die 'CHAT_TEMPLATE_HOST_PATH cannot be represented safely as a Docker bind mount'
+  [[ -f "${CHAT_TEMPLATE_HOST_PATH}" && -r "${CHAT_TEMPLATE_HOST_PATH}" ]] || \
+    die 'CHAT_TEMPLATE_HOST_PATH is not a readable regular file'
+  [[ -s "${CHAT_TEMPLATE_HOST_PATH}" ]] || \
+    die 'CHAT_TEMPLATE_HOST_PATH is empty'
 fi
 case "${MULTIMODAL_INPUTS}" in
   0|1) ;;
@@ -766,6 +777,12 @@ fi
 
 # Text-only mode avoids loading the vision tower. Multimodal mode uses the
 # independently configurable image and video request limits.
+chat_template_mount=()
+chat_template_args=()
+if [[ -n "${CHAT_TEMPLATE_HOST_PATH}" ]]; then
+  chat_template_mount=(-v "${CHAT_TEMPLATE_HOST_PATH}:/opt/sparkring/chat_template.jinja:ro")
+  chat_template_args=(--chat-template /opt/sparkring/chat_template.jinja)
+fi
 multimodal_args=(--language-model-only)
 if [[ "${MULTIMODAL_INPUTS}" == 1 ]]; then
   multimodal_args=(
@@ -795,6 +812,7 @@ container_id="$(docker run -d \
   -v "${TARGET_MODEL_HOST_PATH}:/models/target:ro" \
   -v "${DFLASH_MODEL_HOST_PATH}:/dflash-draft:ro" \
   -v "${CACHE_HOST_ROOT}:/cache/jit" \
+  "${chat_template_mount[@]}" \
   "${sparkcache_source_args[@]}" \
   "${vllm_metrics_args[@]}" \
   "${sircl_args[@]}" \
@@ -867,6 +885,7 @@ container_id="$(docker run -d \
   --distributed-executor-backend mp --nnodes "${NODE_COUNT}" --node-rank "${rank}" \
   --master-addr "${MASTER_ADDR}" --master-port "${MASTER_PORT}" \
   --disable-custom-all-reduce --mamba-cache-mode align "${multimodal_args[@]}" \
+  "${chat_template_args[@]}" \
   --enable-chunked-prefill --dtype bfloat16 --kv-cache-dtype "${KV_CACHE_DTYPE}" \
   --quantization modelopt_mixed --attention-backend "${ATTENTION_BACKEND}" \
   --block-size 256 --moe-backend "${MOE_BACKEND}" --linear-backend "${LINEAR_BACKEND}" \

--- a/runtime/glm53-flash-jj-r8-gb10/runtime.env.example
+++ b/runtime/glm53-flash-jj-r8-gb10/runtime.env.example
@@ -7,6 +7,12 @@
 HOST_IP='REPLACE_WITH_THIS_RANK_ADDRESS'
 MASTER_ADDR='REPLACE_WITH_RANK0_ADDRESS'
 TARGET_MODEL_HOST_PATH='/REPLACE/TARGET_MODEL_HOST_PATH'
+# Optional: serve a chat template other than the checkpoint's own chat_template.jinja.
+# The file is bind-mounted read-only and passed as --chat-template. Use it to adopt a
+# template-only checkpoint update (for example zai-org's 2026-09-04 tool-result reordering
+# fix, published as local-inference-lab/GLM-5.3-Flash-NVFP4@46aaae8a) without re-staging
+# weights. Empty (default) keeps the template shipped in TARGET_MODEL_HOST_PATH.
+CHAT_TEMPLATE_HOST_PATH=''
 DFLASH_MODEL_HOST_PATH='/REPLACE/DFLASH_MODEL_HOST_PATH'
 CACHE_HOST_ROOT='/REPLACE/DEDICATED_RANK_LOCAL_CACHE_ROOT'
 

--- a/runtime/glm53-flash-jj-r8-gb10/test_launcher_contract.py
+++ b/runtime/glm53-flash-jj-r8-gb10/test_launcher_contract.py
@@ -420,6 +420,20 @@ printf '%s  %s\n' "$hash" "$2"
     assert "API_KEYS_FILE must be mode 0600" in result.stderr
 
 
+def test_launcher_exposes_optional_chat_template_override() -> None:
+    launcher = LAUNCHER.read_text(encoding="utf-8")
+    assert ': "${CHAT_TEMPLATE_HOST_PATH:=}"' in launcher
+    assert "CHAT_TEMPLATE_HOST_PATH must be an absolute host path when set" in launcher
+    assert "CHAT_TEMPLATE_HOST_PATH is not a readable regular file" in launcher
+    assert "CHAT_TEMPLATE_HOST_PATH is empty" in launcher
+    assert (
+        '-v "${CHAT_TEMPLATE_HOST_PATH}:/opt/sparkring/chat_template.jinja:ro"'
+        in launcher
+    )
+    assert "--chat-template /opt/sparkring/chat_template.jinja" in launcher
+    assert "CHAT_TEMPLATE_HOST_PATH=''" in ENVIRONMENT.read_text(encoding="utf-8")
+
+
 def test_launcher_fails_closed_on_unusable_api_key_files() -> None:
     launcher = LAUNCHER.read_text(encoding="utf-8")
     assert ': "${API_KEYS_FILE:=}"' in launcher


### PR DESCRIPTION
## Why

zai-org updated the GLM-5.3 / GLM-5.3-Flash chat templates on 2026-09-04 (tool-result reordering now exits early; `content is not none` guard on assistant text; `~` concatenation) and asked deployments to pull the new template. The quant provider synced it the same morning as `local-inference-lab/GLM-5.3-Flash-NVFP4@46aaae8a82032f77100f2f03e9cc11b391df3b4d` ("Sync GLM-5.3 tool-result chat template (#3)"). The HF compare `520de24e..46aaae8a` touches only `README.md` and `chat_template.jinja`; `config.json` and `model.safetensors.index.json` are byte-identical, so the launcher's checkpoint identity checks accept either revision and no weights need to move. The new template's SHA-256 is `0c4099f3382d6c92700dfb99725025360966fd73032f0ecf32377c0d9e6309c5` (identical to `zai-org/GLM-5.3-Flash@main`).

## What

- `launch-rank.sh`: optional `CHAT_TEMPLATE_HOST_PATH` (default empty = checkpoint's own template). When set it is validated (absolute, readable, non-empty, bind-mount-safe), bind-mounted read-only at `/opt/sparkring/chat_template.jinja`, and passed as `--chat-template`. Unset renders byte-identically to today.
- `runtime.env.example`: the knob, documented.
- `README.md`: one sentence in the knob list.
- Quickstart: download revision `46aaae8a`, plus a paragraph stating exactly what differs from `520de24e` and how a site that already holds `520de24e` adopts the template alone.
- `test_launcher_contract.py`: contract test for the knob (27/27 pass on Linux; the pre-existing 9 failures under macOS bash 3.2 are environmental and unchanged).

## Evidence

Deployed on our four-GB10 TP4/DCP4 ring (image `0d4029b3…`, launcher at `efe404d` + this change) at 2026-09-04 22:42Z with the `46aaae8a` template as the override: readiness, auth matrix, semantic canary, modality gate (9/9), QP check and the 8-run corruption probe (Hangul / tool-call JSON / repetition) all green. A dedicated tool-turn probe (two tool calls followed by their results in reversed order, in order, and with a `null` tool result) is running now; I will post its output here.

Out of scope: the other runtimes' `pins.json` still name `520de24e` as the quantization source revision; that statement stays true (the weights are the same bytes), so I left them alone.
