### PR TITLE
Gate managed GLM startup on available and contiguous memory

### DIFF
--- a/docs/GLM53_SPARK_MTP3_MESH_QUICKSTART.md
+++ b/docs/GLM53_SPARK_MTP3_MESH_QUICKSTART.md
@@ -603,6 +603,13 @@ mesh service.
 
 ### Model output and persistent-cache restoration
 
+The managed startup command checks available and contiguous memory on all four
+hosts. With serving stopped, it automatically reclaims clean page cache and
+compacts memory only where required. If a rank still fails, startup stops and
+identifies the host requiring a reboot; it never reboots automatically. Stop
+unrelated containers and GPU workloads first. See
+[startup memory preparation](../runtime/glm53-spark-mtp3-mesh/MANAGED_MESH.md#automatic-startup-memory-preparation).
+
 Start the four-rank model through `managed_cluster.py start-model` and wait
 for completed speculation warmup. Set the endpoint to the rank-zero
 management address:

--- a/performance/records/glm53-flash/spark-mtp3-startup-memory-gate-20260905.json
+++ b/performance/records/glm53-flash/spark-mtp3-startup-memory-gate-20260905.json
@@ -1,0 +1,358 @@
+{
+  "schema": "sparkring-managed-startup-memory-validation/v1",
+  "status": "qualified",
+  "scope": "Four stopped DGX Spark hosts: guarded repair refusal, explicitly authorized reboot, memory-gated startup, and model readiness.",
+  "hardware": "Four NVIDIA DGX Spark GB10 hosts, 4096-byte kernel pages",
+  "serving_image": "sha256:3b4768e5ba31cadcc882dffa06d7b667af44abdf157d5c11b7ac7fe962e80c43",
+  "model": "GLM-5.3-Flash-NVFP4-Spark, TP4/DCP4, native MTP3, SparkCache and hardware-forwarded mesh",
+  "source_hashes": {
+    "runtime/glm53-spark-mtp3-mesh/managed_memory.py": "a338586470ebcae67df13bb30d4f6707d2b10da0f67eecaf6c3b5c1fcc22a367",
+    "runtime/glm53-spark-mtp3-mesh/managed_service.py": "e75dcd5394951a5801f6c5f742d1aef69f91d9fbfbd324be012667b893c4ed08",
+    "runtime/glm53-spark-mtp3-mesh/managed_network.py": "f2c9538e356537f6e9c63fcbd6ee086d4641491b034b07b8b86860be7c678877",
+    "runtime/glm53-spark-mtp3-mesh/managed_units.py": "4a8f47de02e2acba28a4a6a0847f95ed9877ee8cf9ad15e040bd82ef7540e786",
+    "runtime/glm53-spark-mtp3-mesh/managed_cluster.py": "c772836f208f24e8bedb5c6b57c8818146dade2a46b88bc18f974fd1f16b023f",
+    "runtime/glm53-spark-mtp3-mesh/managed_install.py": "99c080788a8810a06a0aa96f3ddeac7647ff9cc8228ddca86903171d8d8f7080",
+    "runtime/glm53-spark-mtp3-mesh/profile.py": "5860e8a986f404965f77713b528ea69ea31d16161e653c63e6f01f531e180f12",
+    "runtime/glm53-spark-mtp3-mesh/inspect_fabric.py": "def378fea0534c4302c14b0b22be5d40f7bfe456880748e3ee6c7b7237203cc6",
+    "runtime/glm53-spark-mtp3-mesh/pins.json": "400b190cc66b32a6c3d0707d763c55d9814f1d5dc8be9adabf2e437168258a6c",
+    "runtime/glm53-flash-jj-r8-gb10/pins.json": "dc49370d911ecc32f1c7ea7656f41837334a8e5ed800db263174781bee2b2313",
+    "runtime/glm53-flash-jj-r8-gb10/warmup_dflash.py": "f41c38eef41d15d63dcfc49cd6643357ca1a3ae18200ddbe4f8692d0b767ee79",
+    "runtime/glm53-flash-jj-r8-gb10/launch-rank.sh": "8a4511eb80e3d12d9daccfc9c1d2e6305c67926e24017f4e90528cc3be6c3ba7",
+    "runtime/glm53-flash-jj-r8-gb10/runtime.env.example": "707e0568d0410e8911efbb15f2d4e97e779ef1ac81712de70265f4e7769cc911",
+    "runtime/glm53-flash-jj-r8-gb10/sircl-fused.env.example": "f47619ad2aaece7425e1958ddf19fa9b6508fbe0964fb66fe88aee0f864c3038",
+    "spark_transport/experiments/cx7_hairpin_diagonal/__init__.py": "67fd1b48093286b47f2cf32c7fcd69d3e6d29bf6484abc7216a82da0e10e7b41",
+    "spark_transport/experiments/cx7_hairpin_diagonal/fabric.py": "cbf2f596e744ab50caac66db41e91c1cd3a5625f3cc6ba77ffbd1d667147d544",
+    "spark_transport/experiments/glm53_rocenante_overlay/build_bundle.py": "ca5f5502b55fbe095bdcdf1283b1f5df85b0f9727873970df727475d5f305a3b"
+  },
+  "repair": [
+    {
+      "rank": 0,
+      "status": "reboot-required",
+      "reclaimed": true,
+      "before": {
+        "available_bytes": 125128163328,
+        "equivalent_32mib_blocks": 21,
+        "minimum_available_bytes": 103079215104,
+        "minimum_blocks": 200,
+        "passed": false
+      },
+      "after": {
+        "available_bytes": 125560930304,
+        "equivalent_32mib_blocks": 80,
+        "minimum_available_bytes": 103079215104,
+        "minimum_blocks": 200,
+        "passed": false
+      },
+      "passed": false
+    },
+    {
+      "rank": 1,
+      "status": "reboot-required",
+      "reclaimed": true,
+      "before": {
+        "available_bytes": 125293953024,
+        "equivalent_32mib_blocks": 97,
+        "minimum_available_bytes": 103079215104,
+        "minimum_blocks": 200,
+        "passed": false
+      },
+      "after": {
+        "available_bytes": 125651247104,
+        "equivalent_32mib_blocks": 175,
+        "minimum_available_bytes": 103079215104,
+        "minimum_blocks": 200,
+        "passed": false
+      },
+      "passed": false
+    },
+    {
+      "rank": 2,
+      "status": "reboot-required",
+      "reclaimed": true,
+      "before": {
+        "available_bytes": 125426774016,
+        "equivalent_32mib_blocks": 119,
+        "minimum_available_bytes": 103079215104,
+        "minimum_blocks": 200,
+        "passed": false
+      },
+      "after": {
+        "available_bytes": 125619617792,
+        "equivalent_32mib_blocks": 185,
+        "minimum_available_bytes": 103079215104,
+        "minimum_blocks": 200,
+        "passed": false
+      },
+      "passed": false
+    },
+    {
+      "rank": 3,
+      "status": "reboot-required",
+      "reclaimed": true,
+      "before": {
+        "available_bytes": 125443579904,
+        "equivalent_32mib_blocks": 25,
+        "minimum_available_bytes": 103079215104,
+        "minimum_blocks": 200,
+        "passed": false
+      },
+      "after": {
+        "available_bytes": 125687177216,
+        "equivalent_32mib_blocks": 57,
+        "minimum_available_bytes": 103079215104,
+        "minimum_blocks": 200,
+        "passed": false
+      },
+      "passed": false
+    }
+  ],
+  "automatic_reboots": 0,
+  "operator_authorized_reboots": 4,
+  "post_reboot_blocks": [
+    3671,
+    3685,
+    3687,
+    3683
+  ],
+  "startup_phases": [
+    {
+      "name": "model-stop-barrier",
+      "ranks": [
+        {
+          "rank": 0,
+          "returncode": 0
+        },
+        {
+          "rank": 1,
+          "returncode": 0
+        },
+        {
+          "rank": 2,
+          "returncode": 0
+        },
+        {
+          "rank": 3,
+          "returncode": 0
+        }
+      ]
+    },
+    {
+      "name": "memory-idle-barrier",
+      "ranks": [
+        {
+          "rank": 0,
+          "returncode": 0
+        },
+        {
+          "rank": 1,
+          "returncode": 0
+        },
+        {
+          "rank": 2,
+          "returncode": 0
+        },
+        {
+          "rank": 3,
+          "returncode": 0
+        }
+      ]
+    },
+    {
+      "name": "prepare-launch-memory",
+      "ranks": [
+        {
+          "rank": 0,
+          "returncode": 0,
+          "measurement": {
+            "status": "ready",
+            "reclaimed": false,
+            "before": {
+              "available_bytes": 125142220800,
+              "equivalent_32mib_blocks": 3601,
+              "minimum_available_bytes": 103079215104,
+              "minimum_blocks": 200,
+              "passed": true
+            },
+            "after": {
+              "available_bytes": 125142220800,
+              "equivalent_32mib_blocks": 3601,
+              "minimum_available_bytes": 103079215104,
+              "minimum_blocks": 200,
+              "passed": true
+            },
+            "passed": true
+          }
+        },
+        {
+          "rank": 1,
+          "returncode": 0,
+          "measurement": {
+            "status": "ready",
+            "reclaimed": false,
+            "before": {
+              "available_bytes": 125358505984,
+              "equivalent_32mib_blocks": 3617,
+              "minimum_available_bytes": 103079215104,
+              "minimum_blocks": 200,
+              "passed": true
+            },
+            "after": {
+              "available_bytes": 125358505984,
+              "equivalent_32mib_blocks": 3617,
+              "minimum_available_bytes": 103079215104,
+              "minimum_blocks": 200,
+              "passed": true
+            },
+            "passed": true
+          }
+        },
+        {
+          "rank": 2,
+          "returncode": 0,
+          "measurement": {
+            "status": "ready",
+            "reclaimed": false,
+            "before": {
+              "available_bytes": 125268967424,
+              "equivalent_32mib_blocks": 3620,
+              "minimum_available_bytes": 103079215104,
+              "minimum_blocks": 200,
+              "passed": true
+            },
+            "after": {
+              "available_bytes": 125268967424,
+              "equivalent_32mib_blocks": 3620,
+              "minimum_available_bytes": 103079215104,
+              "minimum_blocks": 200,
+              "passed": true
+            },
+            "passed": true
+          }
+        },
+        {
+          "rank": 3,
+          "returncode": 0,
+          "measurement": {
+            "status": "ready",
+            "reclaimed": false,
+            "before": {
+              "available_bytes": 125365452800,
+              "equivalent_32mib_blocks": 3605,
+              "minimum_available_bytes": 103079215104,
+              "minimum_blocks": 200,
+              "passed": true
+            },
+            "after": {
+              "available_bytes": 125365452800,
+              "equivalent_32mib_blocks": 3605,
+              "minimum_available_bytes": 103079215104,
+              "minimum_blocks": 200,
+              "passed": true
+            },
+            "passed": true
+          }
+        }
+      ]
+    },
+    {
+      "name": "memory-ready-barrier",
+      "ranks": [
+        {
+          "rank": 0,
+          "returncode": 0,
+          "measurement": {
+            "available_bytes": 125124636672,
+            "equivalent_32mib_blocks": 3601,
+            "minimum_available_bytes": 103079215104,
+            "minimum_blocks": 200,
+            "passed": true
+          }
+        },
+        {
+          "rank": 1,
+          "returncode": 0,
+          "measurement": {
+            "available_bytes": 125357621248,
+            "equivalent_32mib_blocks": 3617,
+            "minimum_available_bytes": 103079215104,
+            "minimum_blocks": 200,
+            "passed": true
+          }
+        },
+        {
+          "rank": 2,
+          "returncode": 0,
+          "measurement": {
+            "available_bytes": 125272875008,
+            "equivalent_32mib_blocks": 3620,
+            "minimum_available_bytes": 103079215104,
+            "minimum_blocks": 200,
+            "passed": true
+          }
+        },
+        {
+          "rank": 3,
+          "returncode": 0,
+          "measurement": {
+            "available_bytes": 125357641728,
+            "equivalent_32mib_blocks": 3605,
+            "minimum_available_bytes": 103079215104,
+            "minimum_blocks": 200,
+            "passed": true
+          }
+        }
+      ]
+    },
+    {
+      "name": "four-rank-ready",
+      "ranks": [
+        {
+          "rank": 0,
+          "returncode": 0
+        },
+        {
+          "rank": 1,
+          "returncode": 0
+        },
+        {
+          "rank": 2,
+          "returncode": 0
+        },
+        {
+          "rank": 3,
+          "returncode": 0
+        }
+      ]
+    },
+    {
+      "name": "start-model-units",
+      "ranks": [
+        {
+          "rank": 0,
+          "returncode": 0
+        },
+        {
+          "rank": 1,
+          "returncode": 0
+        },
+        {
+          "rank": 2,
+          "returncode": 0
+        },
+        {
+          "rank": 3,
+          "returncode": 0
+        }
+      ]
+    }
+  ],
+  "readiness_elapsed_seconds": 439.7970000000205,
+  "raw_receipt_sha256": {
+    "preparation.jsonl": "d3e4ae42ff26c3c34c83a7a403b13e18a20b3bb1000ed3a3060256f263ddc5c3",
+    "model-start.json": "84456b195141dfb1f58d11b95373ea93bddf8c72942e2b4f69a5a9b73d7b48b7",
+    "source-manifest.json": "ac0fe7cbf732d30ffca7009b4f9ef1ceceabf63f1ba315cbe9eda0c8c51d0395"
+  },
+  "readiness_receipt_sha256": "d47e8eea7010ad82a8593946aeb8a10824be121dafab9bbd94380ebbfea7118c",
+  "validation": "324 CPU tests passed, three platform-dependent tests skipped. Four-rank native Q4/Q20/Q28/Q64 checks passed after reboot.",
+  "limits": "This validates refusal and healthy startup, not automatic reboot, recovery beneath live model work, or a serving speedup."
+}

--- a/performance/records/glm53-flash/spark-mtp3-startup-memory-gate.md
+++ b/performance/records/glm53-flash/spark-mtp3-startup-memory-gate.md
@@ -1,0 +1,63 @@
+# Managed model startup memory-gate evidence
+
+Status: qualified for the bounded refusal and startup cases described here.
+The [machine-readable record](spark-mtp3-startup-memory-gate-20260905.json),
+schema `sparkring-managed-startup-memory-validation/v1`, preserves the
+measurements and source hashes collected on 2026-09-05.
+
+## Conditions
+
+Four NVIDIA DGX Spark GB10 hosts used 4,096-byte kernel pages. The served model
+was GLM-5.3-Flash-NVFP4-Spark with TP4/DCP4, native MTP3, SparkCache, and the
+hardware-forwarded mesh. Its image ID was
+`sha256:3b4768e5ba31cadcc882dffa06d7b667af44abdf157d5c11b7ac7fe962e80c43`.
+The JSON record's `source_hashes` identifies the tested coordinator, host
+memory controls, launcher, and profile inputs.
+
+The startup gate requires at least 96 GiB of available RAM and 200 equivalent
+free 32 MiB blocks in the kernel's Normal memory zones on every rank. Model
+processes were stopped before the guarded memory-preparation measurements.
+
+## Measurement
+
+Available memory comes from `/proc/meminfo`'s `MemAvailable` field. Contiguous
+capacity is calculated from `/proc/buddyinfo`: each block of at least 32 MiB
+contributes its size divided by 32 MiB. The record retains per-rank snapshots,
+repair outcomes, and each coordinated startup command's exit status.
+
+`readiness_elapsed_seconds` is retained as a reported observation. The record
+does not identify its clock or exact timing boundaries, so that field does
+not support a startup-speed comparison. The qualification claim depends on
+gate outcomes, readiness completion, and native collective checks.
+
+## Result
+
+After one guarded reclamation/compaction pass, ranks 0–3 had 80, 175, 185, and
+57 equivalent 32 MiB blocks. Every rank remained below the 200-block threshold
+and returned `reboot-required`. No automatic reboot occurred.
+
+Four operator-authorized reboots were recorded. Subsequent block counts were
+3,671, 3,685, 3,687, and 3,683. During coordinated startup, all ranks passed
+the stopped-model, idle-host, memory-preparation, memory-check, and peer-readiness
+checks. Memory preparation reported `reclaimed: false` because the measured
+memory already met both thresholds. All model units started successfully;
+four-rank model readiness and native collective checks at 4, 20, 28, and 64
+token rows passed.
+
+Local CPU validation reports 324 tests passed and three platform-dependent
+skips. These tests use mocked host interfaces and do not access cluster hosts.
+
+## Conclusion
+
+The tested managed controls refused model startup when contiguous-memory
+capacity remained insufficient and allowed startup when every rank met the
+thresholds. The adequate-memory path skipped reclamation. These results
+qualify those bounded startup behaviors for the recorded source and image.
+
+## Limitations
+
+The record does not qualify automatic reboot, compaction beneath active model
+work, unattended recovery, or a serving-speed improvement. Direct Docker
+startup bypasses the managed authorization lock. The raw JSON remains an
+immutable record of the hardware run; this description adds interpretation
+without changing its measurements.

--- a/runtime/glm53-spark-mtp3-mesh/MANAGED_MESH.md
+++ b/runtime/glm53-spark-mtp3-mesh/MANAGED_MESH.md
@@ -42,8 +42,8 @@ does not delete model weights or persistent SparkCache data. Stop unrelated
 containers and GPU workloads before invoking this host-wide operation.
 
 Direct systemd model startup checks the memory thresholds but does not compact
-memory. Model arming and compaction share a host-local lock, so the managed
-model cannot start while compaction is in progress. Use one cluster coordinator
+memory. A host-local lock prevents compaction from overlapping the step that
+authorizes managed model startup. Use one cluster coordinator
 at a time; direct `docker start` bypasses the managed startup contract.
 
 ## Prerequisites and identities

--- a/runtime/glm53-spark-mtp3-mesh/MANAGED_MESH.md
+++ b/runtime/glm53-spark-mtp3-mesh/MANAGED_MESH.md
@@ -19,6 +19,33 @@ intermediate packets traverse the ConnectX-7 ASIC. Endpoint
 posting still uses CPU-side transport machinery and GPU-mapped host memory;
 this does not add GPUDirect RDMA to DGX Spark.
 
+## Automatic startup memory preparation
+
+Status: implemented, with CPU contract tests and
+[four-host startup evidence](../../performance/records/glm53-flash/spark-mtp3-startup-memory-gate-20260905.json).
+
+`managed_cluster.py start-model` checks memory before starting any model rank.
+Each host must have at least 96 GiB available and 200 equivalent free blocks
+of 32 MiB or larger. Plenty of available RAM does not guarantee that the large
+contiguous allocations needed by the loader can succeed.
+
+The coordinator first verifies that all model ranks are stopped, no containers
+or GPU workloads are running, and the configured serving and rendezvous ports
+are free. Hosts that pass the memory thresholds skip repair. Hosts that fail
+flush pending writes, release clean page-cache pages, and request kernel memory
+compaction. Every rank must pass the subsequent memory check before model
+startup proceeds. Before/after measurements are saved in the coordinator receipt.
+
+If repair is insufficient, startup stops with `reboot-required`; reboot the
+affected hosts and rerun startup. No host is rebooted automatically. Preparation
+does not delete model weights or persistent SparkCache data. Stop unrelated
+containers and GPU workloads before invoking this host-wide operation.
+
+Direct systemd model startup checks the memory thresholds but does not compact
+memory. Model arming and compaction share a host-local lock, so the managed
+model cannot start while compaction is in progress. Use one cluster coordinator
+at a time; direct `docker start` bypasses the managed startup contract.
+
 ## Prerequisites and identities
 
 Prepare the target, verified transport bundle, image receipt, and rendered

--- a/runtime/glm53-spark-mtp3-mesh/managed_cluster.py
+++ b/runtime/glm53-spark-mtp3-mesh/managed_cluster.py
@@ -28,7 +28,11 @@ def phases(action, code_root, config_root):
         'up': [('model-stop-barrier', command('model-stopped')),
                ('start-mesh-units', [*systemctl, 'start', 'sparkring-mesh.service']),
                ('four-rank-ready', [*command('gate'), '--timeout', '60'])],
-        'start-model': [('four-rank-ready', [*command('gate'), '--timeout', '60']),
+        'start-model': [('model-stop-barrier', command('model-stopped')),
+                        ('memory-idle-barrier', command('memory-idle')),
+                        ('prepare-launch-memory', command('memory-prepare')),
+                        ('memory-ready-barrier', command('memory-check')),
+                        ('four-rank-ready', [*command('gate'), '--timeout', '60']),
                         ('start-model-units', [*systemctl, 'start', 'sparkring-mesh-model.service'])],
         'stop-model': stop,
         'down': down,
@@ -44,7 +48,7 @@ def execute(host, argv):
     started = time.monotonic()
     try:
         result = subprocess.run(['ssh', '-o', 'BatchMode=yes', '-o', 'ConnectTimeout=10', host, shlex.join(argv)],
-                                capture_output=True, text=True, timeout=120)
+                                capture_output=True, text=True, timeout=240)
         return {'host': host, 'argv': argv, 'returncode': result.returncode,
                 'stdout': result.stdout, 'stderr': result.stderr, 'seconds': time.monotonic() - started}
     except subprocess.TimeoutExpired:

--- a/runtime/glm53-spark-mtp3-mesh/managed_install.py
+++ b/runtime/glm53-spark-mtp3-mesh/managed_install.py
@@ -21,6 +21,7 @@ CODE_DIR = Path('/opt/sparkring/managed-mesh')
 CONFIG_DIR = Path('/etc/sparkring/managed-mesh')
 UNIT_DIR = Path('/etc/systemd/system')
 SOURCE_FILES = (
+    'runtime/glm53-spark-mtp3-mesh/managed_memory.py',
     'runtime/glm53-spark-mtp3-mesh/managed_service.py',
     'runtime/glm53-spark-mtp3-mesh/managed_network.py',
     'runtime/glm53-spark-mtp3-mesh/managed_units.py',

--- a/runtime/glm53-spark-mtp3-mesh/managed_memory.py
+++ b/runtime/glm53-spark-mtp3-mesh/managed_memory.py
@@ -1,0 +1,109 @@
+"""Guard GLM startup with available-memory and contiguous-allocation checks."""
+from contextlib import contextmanager
+import json
+import os
+from pathlib import Path
+import subprocess
+import time
+
+MIN_AVAILABLE = 96 << 30
+BLOCK_BYTES = 32 << 20
+MIN_BLOCKS = 200
+
+
+def evaluate(meminfo, buddyinfo, page_size):
+    """Count Normal-zone blocks using the shared GLM preflight thresholds."""
+    fields = dict(line.split(':', 1) for line in meminfo.splitlines() if ':' in line)
+    available = int(fields['MemAvailable'].split()[0]) * 1024
+    if page_size <= 0 or BLOCK_BYTES % page_size:
+        raise ValueError('Unsupported host page size for the 32 MiB allocation check')
+    pages = BLOCK_BYTES // page_size
+    if pages < 1 or pages & (pages - 1):
+        raise ValueError('Unsupported host page size for the 32 MiB allocation check')
+    order = pages.bit_length() - 1
+    blocks = 0
+    found = False
+    for line in buddyinfo.splitlines():
+        words = line.split()
+        if len(words) >= 5 and words[3] == 'Normal':
+            found = True
+            counts = [int(value) for value in words[4:]]
+            if any(value < 0 for value in counts):
+                raise ValueError('Invalid buddy allocator counters')
+            blocks += sum(count << (index - order) for index, count in enumerate(counts) if index >= order)
+    if not found:
+        raise ValueError('Normal-zone buddy allocator counters are unavailable')
+    return {'available_bytes': available, 'equivalent_32mib_blocks': blocks,
+            'minimum_available_bytes': MIN_AVAILABLE, 'minimum_blocks': MIN_BLOCKS,
+            'passed': available >= MIN_AVAILABLE and blocks >= MIN_BLOCKS}
+
+
+def snapshot():
+    return evaluate(Path('/proc/meminfo').read_text(), Path('/proc/buddyinfo').read_text(),
+                    os.sysconf('SC_PAGE_SIZE'))
+
+
+def require_ready(value):
+    if not value['passed']:
+        raise RuntimeError('Host memory is not ready for GLM startup: ' + json.dumps(value)
+                           + '. Run the coordinated start-model command to prepare memory.')
+
+
+@contextmanager
+def start_lock(config):
+    """Serialize compaction with managed model arming on this host."""
+    import fcntl
+    path = Path(config['state_dir']) / 'memory-start.lock'
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open('a') as lock:
+        fcntl.flock(lock, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        yield
+
+
+def run(argv, timeout=10):
+    return subprocess.run(argv, capture_output=True, text=True, check=True, timeout=timeout).stdout
+
+
+def assert_idle(config):
+    """Refuse host mutation while a container, GPU workload, or serving port is active."""
+    intent = Path(config['state_dir']) / 'model-intent.json'
+    if intent.exists() and json.loads(intent.read_text()).get('active') is True:
+        raise RuntimeError('Model startup is armed; quiesce it before memory preparation')
+    if run(['docker', 'ps', '--quiet']).strip():
+        raise RuntimeError('Stop all running containers before host memory preparation')
+    pids = run(['nvidia-smi', '--query-compute-apps=pid', '--format=csv,noheader,nounits']).strip()
+    if pids:
+        raise RuntimeError('GPU workloads are present or cannot be excluded: ' + pids)
+    container = json.loads(run(['docker', 'inspect', config['container_id']]))[0]
+    if container['Image'] != config['container_image'] or container['State']['Running']:
+        raise RuntimeError('Expected stopped, source-pinned model container')
+    env = dict(value.split('=', 1) for value in container['Config']['Env'] if '=' in value)
+    argv = container['Config']['Cmd']
+    if argv.count('--master-port') != 1:
+        raise ValueError('Expected exactly one rendezvous port in model arguments')
+    ports = [env['PORT'], env['SPARKRING_LIVENESS_PORT'], argv[argv.index('--master-port') + 1]]
+    for value in ports:
+        port = int(value)
+        if not 1 <= port <= 65535:
+            raise ValueError('Invalid serving port in model container')
+        if run(['ss', '-ltnH', f'sport = :{port}']).strip():
+            raise RuntimeError(f'Refusing memory preparation while TCP port {port} is listening')
+
+
+def reclaim():
+    """Flush writes, release clean page cache, and request bounded kernel compaction."""
+    run(['sync'], timeout=60)
+    run(['sh', '-c', 'echo 3 > /proc/sys/vm/drop_caches; echo 1 > /proc/sys/vm/compact_memory'], timeout=90)
+    time.sleep(2)
+
+
+def prepare(config):
+    with start_lock(config):
+        before = snapshot()
+        if before['passed']:
+            return {'status': 'ready', 'reclaimed': False, 'before': before, 'after': before, 'passed': True}
+        assert_idle(config)
+        reclaim()
+        after = snapshot()
+        return {'status': 'recovered' if after['passed'] else 'reboot-required',
+                'reclaimed': True, 'before': before, 'after': after, 'passed': after['passed']}

--- a/runtime/glm53-spark-mtp3-mesh/managed_service.py
+++ b/runtime/glm53-spark-mtp3-mesh/managed_service.py
@@ -77,7 +77,7 @@ def load_config(path):
         mesh_profile.absolute(document[name], name)
     site, topology, plan = mesh_profile.load_site(Path(document['site_path']))
     sources = {name: mesh_profile.sha(Path(__file__).with_name(name))
-               for name in ('managed_service.py', 'managed_network.py', 'profile.py', 'inspect_fabric.py')}
+               for name in ('managed_service.py', 'managed_network.py', 'managed_memory.py', 'profile.py', 'inspect_fabric.py')}
     identity = digest({'protocol': PROTOCOL, 'site': site, 'topology': topology.sha256,
                        'epoch': document['epoch'], 'port': document['health_port'], 'sources': sources,
                        'image': document['container_image']})
@@ -558,7 +558,8 @@ def reset_units():
 def main():
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument('action', choices=('run', 'gate', 'stop-model', 'cleanup', 'model-arm',
-                                         'model-quiesce', 'model-stopped', 'reset-units'))
+                                         'model-quiesce', 'model-stopped', 'reset-units',
+                                         'memory-idle', 'memory-prepare', 'memory-check'))
     parser.add_argument('--config', type=Path, required=True)
     parser.add_argument('--timeout', type=float, default=60)
     args = parser.parse_args()
@@ -570,8 +571,27 @@ def main():
         gate(args.config, args.timeout)
     elif args.action == 'cleanup':
         cleanup_orphans(args.config)
-    elif args.action in ('model-arm', 'model-quiesce'):
-        model_intent(args.config, args.action == 'model-arm')
+    elif args.action in ('memory-idle', 'memory-prepare', 'memory-check', 'model-arm'):
+        import managed_memory
+        config, *_ = load_config(args.config)
+        if args.action == 'memory-idle':
+            managed_memory.assert_idle(config)
+            print(json.dumps({'idle': True}))
+        elif args.action == 'memory-prepare':
+            receipt = managed_memory.prepare(config)
+            print(json.dumps(receipt), flush=True)
+            if not receipt['passed']:
+                raise SystemExit('Memory remains below startup thresholds; reboot this rank and rerun startup.')
+        elif args.action == 'memory-check':
+            receipt = managed_memory.snapshot()
+            print(json.dumps(receipt), flush=True)
+            managed_memory.require_ready(receipt)
+        else:
+            with managed_memory.start_lock(config):
+                managed_memory.require_ready(managed_memory.snapshot())
+                model_intent(args.config, True)
+    elif args.action == 'model-quiesce':
+        model_intent(args.config, False)
     elif args.action == 'model-stopped':
         config, *_ = load_config(args.config)
         if docker_running(config['container_id']):

--- a/runtime/glm53-spark-mtp3-mesh/test_managed_memory.py
+++ b/runtime/glm53-spark-mtp3-mesh/test_managed_memory.py
@@ -1,0 +1,94 @@
+"""Exercise startup memory thresholds, mutation guards, and cluster ordering."""
+from contextlib import nullcontext
+import json
+from pathlib import Path
+import sys
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import managed_cluster
+import managed_memory as memory
+
+
+def value(blocks=200, gib=96, page=4096):
+    order = ((32 << 20) // page).bit_length() - 1
+    counts = [0] * (order + 2)
+    counts[order] = blocks
+    return memory.evaluate(f'MemAvailable: {gib * (1 << 20)} kB',
+                           'Node 0, zone Normal ' + ' '.join(map(str, counts)), page)
+
+
+@pytest.mark.parametrize('page', [4096, 65536])
+def test_thresholds(page):
+    assert value(page=page)['passed']
+    assert not value(blocks=199, page=page)['passed']
+    assert not value(gib=95, page=page)['passed']
+
+
+def test_larger_blocks_are_counted_proportionally():
+    counts = [0] * 15
+    counts[14] = 100
+    actual = memory.evaluate('MemAvailable: 125829120 kB',
+                             'Node 0, zone Normal ' + ' '.join(map(str, counts)), 4096)
+    assert actual['equivalent_32mib_blocks'] == 200
+
+
+@pytest.mark.parametrize('page', [0, -1, 12288])
+def test_invalid_page_size_fails_closed(page):
+    with pytest.raises(ValueError):
+        memory.evaluate('MemAvailable: 125829120 kB', 'Node 0, zone Normal 0', page)
+
+
+def test_missing_buddy_data_fails_closed():
+    with pytest.raises(ValueError):
+        memory.evaluate('MemAvailable: 125829120 kB', '', 4096)
+
+
+@pytest.mark.parametrize('after_passes', [True, False])
+def test_preparation_rechecks_and_never_reboots(monkeypatch, after_passes):
+    snapshots = iter([value(blocks=20), value(blocks=200 if after_passes else 30)])
+    actions = []
+    monkeypatch.setattr(memory, 'start_lock', lambda config: nullcontext())
+    monkeypatch.setattr(memory, 'snapshot', lambda: next(snapshots))
+    monkeypatch.setattr(memory, 'assert_idle', lambda config: actions.append('idle'))
+    monkeypatch.setattr(memory, 'reclaim', lambda: actions.append('reclaim'))
+    result = memory.prepare({})
+    assert actions == ['idle', 'reclaim']
+    assert result['passed'] is after_passes
+    assert result['status'] == ('recovered' if after_passes else 'reboot-required')
+
+
+def test_healthy_memory_does_not_reclaim(monkeypatch):
+    monkeypatch.setattr(memory, 'start_lock', lambda config: nullcontext())
+    monkeypatch.setattr(memory, 'snapshot', value)
+    monkeypatch.setattr(memory, 'reclaim', lambda: pytest.fail('Unexpected mutation'))
+    assert not memory.prepare({})['reclaimed']
+
+
+@pytest.mark.parametrize('obstacle', ['intent', 'container', 'gpu', 'port', 'identity'])
+def test_idle_guard_rejects_active_or_unknown_state(monkeypatch, tmp_path, obstacle):
+    config = {'state_dir': str(tmp_path), 'container_id': 'a'*64, 'container_image': 'sha256:'+'b'*64}
+    if obstacle == 'intent':
+        (tmp_path/'model-intent.json').write_text('{"active":true}')
+    def run(argv, **kwargs):
+        if argv[:2] == ['docker', 'ps']:
+            return 'container' if obstacle == 'container' else ''
+        if argv[0] == 'nvidia-smi':
+            return '1234' if obstacle == 'gpu' else ''
+        if argv[:2] == ['docker', 'inspect']:
+            return json.dumps([{'Image': 'wrong' if obstacle == 'identity' else config['container_image'],
+                'State': {'Running': False}, 'Config': {'Env': ['PORT=8015','SPARKRING_LIVENESS_PORT=8016'],
+                'Cmd': ['--master-port','29775']}}])
+        if argv[0] == 'ss':
+            return 'LISTEN' if obstacle == 'port' else ''
+        pytest.fail(str(argv))
+    monkeypatch.setattr(memory, 'run', run)
+    with pytest.raises(RuntimeError):
+        memory.assert_idle(config)
+
+
+def test_all_memory_barriers_precede_model_start():
+    names = [name for name, _ in managed_cluster.phases('start-model', '/code', '/config')]
+    assert names == ['model-stop-barrier','memory-idle-barrier','prepare-launch-memory',
+                     'memory-ready-barrier','four-rank-ready','start-model-units']


### PR DESCRIPTION
## Behavior

Status: **implemented** startup control, with **qualified** bounded four-host memory checks and model startup recorded in the linked evidence.

Managed GLM model startup requires at least 96 GiB of available RAM and 200 equivalent free blocks of 32 MiB or larger on every rank. The coordinator verifies stopped models and idle hosts before repair. Hosts meeting both thresholds skip repair. Other hosts flush pending writes, release clean page cache, request kernel compaction, and recheck. No model unit starts unless every rank passes. Insufficient recovery returns `reboot-required`; no automatic reboot is performed.

Direct systemd model startup checks the memory thresholds without compacting memory. A host-local lock serializes model startup authorization with memory preparation. Repair refuses active containers, GPU workloads, or configured serving-port listeners. Direct Docker starts bypass the managed startup contract.

## Compatibility

This changes host startup tooling, not model kernels, transport algorithms, sampling, or serving defaults. Reinstall the managed controls on all four stopped ranks because authenticated peer identities include the memory-gate source. No inference-image rebuild is required. The quickstart and managed-service guide describe the checks and failure handling.

## Validation

- Mesh CPU suite: 324 passed, three platform-dependent skips.
- Focused memory-gate and shared memory-preparation tests: 23 passed.
- Four stopped Sparks remained below the 200-block threshold after one guarded compaction pass: ranks 0–3 had 80 / 175 / 185 / 57 blocks. Startup was refused.
- An explicitly authorized reboot restored 3,671 / 3,685 / 3,687 / 3,683 blocks. The installed coordinator passed all startup gates and skipped compaction because both memory thresholds were satisfied.
- Four-rank model readiness and native collective checks with 4, 20, 28, and 64 token rows passed. Watchdog and memory-protection thresholds were not relaxed.

The [validation record](https://github.com/FujitsuPolycom/sparkring/blob/codex/managed-launch-memory-gate/performance/records/glm53-flash/spark-mtp3-startup-memory-gate-20260905.json) identifies the serving image, deployed source hashes, thresholds, per-rank measurements, and startup checks. These results do not establish unattended availability or a serving-speed improvement.
