### PR TITLE
Correct histogram publication ordering in the MTP3 mesh image

### DIFF
--- a/runtime/glm53-spark-mtp3-mesh/indexer-barrier/Dockerfile
+++ b/runtime/glm53-spark-mtp3-mesh/indexer-barrier/Dockerfile
@@ -1,0 +1,13 @@
+FROM ghcr.io/fujitsupolycom/sparkring-glm53-sparkcache@sha256:67dc0ae453baaae6831ccec1d259b4ef8b236a8b0dc9f747d901b95c66ec1987
+ARG SOURCE_RECEIPT_SHA256
+ARG COMPUTE_SOURCE_LOCK_SHA256
+ARG SPARKRING_REVISION
+COPY patch_indexer_barrier.py install.py /opt/sparkring/mesh-indexer-barrier/
+RUN python3 /opt/sparkring/mesh-indexer-barrier/install.py --expected-receipt ${SOURCE_RECEIPT_SHA256}
+LABEL org.opencontainers.image.revision="${SPARKRING_REVISION}" \
+      org.opencontainers.image.base.name="ghcr.io/fujitsupolycom/sparkring-glm53-sparkcache@sha256:67dc0ae453baaae6831ccec1d259b4ef8b236a8b0dc9f747d901b95c66ec1987" \
+      org.sparkring.mesh.parent-image="sha256:2e41b1e934a85ff7c21b780532db2f0a0e978df081e52f4ae2bf11f8992fb24f" \
+      org.sparkring.mesh.source-receipt-sha256="${SOURCE_RECEIPT_SHA256}" \
+      org.sparkring.compute.source-lock-sha256="${COMPUTE_SOURCE_LOCK_SHA256}" \
+      org.sparkring.vllm.compute-source="${COMPUTE_SOURCE_LOCK_SHA256}" \
+      org.sparkring.mesh.indexer-barrier="35a7564ec8bf18f1b7dc5562b21616437b65e7b0689c56341b6436c8d202637b"

--- a/runtime/glm53-spark-mtp3-mesh/indexer-barrier/README.md
+++ b/runtime/glm53-spark-mtp3-mesh/indexer-barrier/README.md
@@ -1,0 +1,106 @@
+# Mesh indexer publication-barrier image
+
+Status: research-only serving artifact with qualified bounded indexer GPU tests.
+The child image preserves the published native-MTP3 mesh parent's compute,
+CUDA 13.3, transport bundle, marker, and native libraries. Its only executable
+runtime change adds block-wide synchronization before histogram publication
+and increases the fused-indexer compile revision from 1 to 2.
+
+## Artifact identities
+
+Tag: `ghcr.io/fujitsupolycom/sparkring-glm53-sparkcache:20260906-mtp3-mesh-indexer-barrier`
+
+Immutable reference:
+`ghcr.io/fujitsupolycom/sparkring-glm53-sparkcache@sha256:7aa57ed1901b83c8581c53cb233db930bb1a133d74be01168d967b9dd56b3e49`
+
+Config image ID:
+`sha256:995a42b4b08f525813c5783f78f34571b6bd1c197fccee53617ff8060574a16d`
+
+Parent reference:
+`ghcr.io/fujitsupolycom/sparkring-glm53-sparkcache@sha256:67dc0ae453baaae6831ccec1d259b4ef8b236a8b0dc9f747d901b95c66ec1987`
+
+The image retains all 89 parent layers and adds two layers totaling 637,767
+uncompressed bytes. Its B12X selector retains the mesh parent's PR316 changes;
+it is not replaced with the SIRCL operator image's selector.
+
+The compute source lock is
+`57b6438ca014a493380fb874a84977d35b0983e9ee224a62ade3415fd9c7ce46`.
+The image source receipt is
+`030e9f3749672d186b66e41336980af1abb5c207f734feafa677ba82456c5d43`.
+The unchanged transport bundle is
+`69313e19e881ec93e9ed3bd150d2f24fc6b444488ac729a69f45d038e2243500`.
+
+## Conditions
+
+Validation used one NVIDIA GB10 SM121 on 2026-09-06, the image above, and
+PyTorch 2.13.0+cu130. Tests ran in isolated containers without model weights,
+serving traffic, or replacement of the running telemetry stack.
+
+## Measurement
+
+The delayed-publisher probe executes the mesh parent's barrier helper in a
+three-block kernel, then compares it with an entry-synchronized variant.
+Ten eager and ten graph-replay runs per variant check complete publication.
+The probe executes only one barrier and does not deliberately hang the GPU.
+
+The built child image runs fifteen fused-indexer correctness cases and 2,000
+graph replays, checking exact selected-index sets, top-k scores within 0.01
+absolute tolerance, and cleared merge state. Workloads use 32 heads, top-k 512,
+3/4/8/16 query rows, lengths alternating between 4,097 and 65,536 tokens
+(200,000 for the four-row case), and concurrent 64 MiB device copies.
+The harnesses and their dependency requirements are documented in SparkRing's
+`performance/harnesses/indexer_barrier/` directory on main.
+
+## Result
+
+- Parent helper: incomplete publication in 20/20 probes.
+- Entry synchronization: complete publication in 20/20 probes.
+- Built mesh image: fifteen GPU correctness tests and 2,000 graph replays passed.
+- Local mesh suite: 348 tests passed; three documented platform skips.
+- Unmodified mesh content verifier passed before and after installation.
+  It verifies 385 B12X files, the 24 vLLM overrides, CUDA components, and the
+  transport/marker/native-library contracts.
+- External verification passed the parent-layer, image-label, source-receipt,
+  and embedded-content checks.
+
+## Conclusion
+
+The barrier correction prevents the measured publication race in the mesh
+parent's selector. The built image preserves the tested numerical behavior
+and completes the bounded graph stress cases. These results support a model
+qualification run, not an assertion that every serving stall is eliminated.
+
+## Limitations and deployment boundary
+
+No four-rank model startup, collective execution, actual SparkCache restore,
+or serving soak was performed with this child image. The running telemetry
+image was not patched or replaced. Its additional SparkCache changes are not
+included in this artifact.
+
+The managed profile renderer still pins the parent image and compute lock.
+Do not bypass its receipt checks or pass this child's receipt as though it
+were the parent's. Managed deployment requires a profile update binding the
+child image, source lock, and coordinated startup inputs, followed by an
+authorized stop/start window. The artifact is available for that validation;
+this change does not silently promote it into the default managed profile.
+
+The embedded profile records cache namespace
+`glm53-spark-df116c4f-mtp3-nvfp4-a16-c57b6438c-mesh69313e19-tail-cow-v2`.
+Use a distinct JIT namespace for qualification. Do not rename existing cache
+entries into the source-bound namespace.
+
+## Rebuild and verify
+
+Place `Dockerfile`, `install.py`, and `patch_indexer_barrier.py` in an empty
+context. Run `install.py --output /probe/build-input.json` in an isolated
+container of the pinned parent with the context mounted at `/probe`. Build
+with that result's `source_receipt_sha256` and `source_lock_sha256` supplied
+as `SOURCE_RECEIPT_SHA256` and `COMPUTE_SOURCE_LOCK_SHA256`; set
+`SPARKRING_REVISION` to the source commit. The published build uses
+`8e54e22477907935c92c52a1c3d7a68e364bd776`.
+
+The installer preserves the parent source receipt, records the checked source
+transform, and updates compute package maps and the embedded profile. The
+existing mesh verifier runs before and after installation without modified
+verification logic. External verification uses the exact image ID, parent
+config ID, source-receipt hash, and bundle hash recorded above.

--- a/runtime/glm53-spark-mtp3-mesh/indexer-barrier/install.py
+++ b/runtime/glm53-spark-mtp3-mesh/indexer-barrier/install.py
@@ -1,0 +1,110 @@
+"""Install a checked mesh indexer patch while retaining compute/transport provenance."""
+import argparse
+import hashlib
+import json
+from pathlib import Path
+import subprocess
+import sys
+
+from patch_indexer_barrier import AFTER, BEFORE, RELATIVE, apply
+
+PARENT = 'ghcr.io/fujitsupolycom/sparkring-glm53-sparkcache@sha256:67dc0ae453baaae6831ccec1d259b4ef8b236a8b0dc9f747d901b95c66ec1987'
+PARENT_ID = 'sha256:2e41b1e934a85ff7c21b780532db2f0a0e978df081e52f4ae2bf11f8992fb24f'
+PARENT_LOCK = '139f36701e0e47f45bf99fba2cc2fa59b417f2ee801dad3a064455d5b464a459'
+RECEIPTS = Path('/opt/sparkring/receipts/glm53-spark-mtp3-mesh')
+COMPUTE = Path('/opt/sparkring-compute')
+INSTALLED = Path('/opt/sparkring/receipts/glm53-compute-installed.json')
+SITE = Path('/usr/local/lib/python3.12/dist-packages')
+VERIFY = '/opt/sparkring/bin/verify-mtp3-mesh-image.py'
+
+
+def sha(path):
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def load(path):
+    return json.loads(path.read_text(encoding='utf-8'))
+
+
+def write(path, value):
+    path.write_text(json.dumps(value, indent=2, sort_keys=True) + '\n', encoding='utf-8')
+
+
+def install():
+    subprocess.run([sys.executable, '-I', VERIFY, '--inside-image'], check=True)
+    lock_path = COMPUTE / 'source-lock.json'
+    if sha(lock_path) != PARENT_LOCK:
+        raise ValueError('Mesh compute source lock differs from the supported parent')
+    source_path = RECEIPTS / 'source-receipt.json'
+    source = load(source_path)
+    parent_source_sha = sha(source_path)
+    installed = load(INSTALLED)
+    if installed['b12x_files'][RELATIVE] != BEFORE:
+        raise ValueError('Installed mesh indexer receipt differs from its preimage')
+    for target in (SITE / RELATIVE, COMPUTE / 'b12x-source' / RELATIVE):
+        apply(target)
+    for cached in (SITE / RELATIVE).parent.glob('__pycache__/fused_indexer.*.pyc'):
+        cached.unlink()
+    installed['b12x_files'][RELATIVE] = AFTER
+    package_hash = hashlib.sha256(json.dumps(
+        installed['b12x_files'], sort_keys=True, separators=(',', ':')).encode()).hexdigest()
+    lock = load(lock_path)
+    lock['b12x']['package_files_sha256'] = package_hash
+    transform = {'path': RELATIVE, 'preimage_sha256': BEFORE, 'result_sha256': AFTER,
+                 'script_sha256': sha(Path(__file__).with_name('patch_indexer_barrier.py'))}
+    lock['b12x']['source_transforms'] = {'histogram_publication_barrier': transform}
+    write(lock_path, lock)
+    lock_hash = sha(lock_path)
+    installed['source_lock_sha256'] = lock_hash
+    installed['b12x_package_files_sha256'] = package_hash
+    write(INSTALLED, installed)
+    prepared_path = COMPUTE / 'prepared-manifest.json'
+    prepared = load(prepared_path)
+    prepared['source_lock_sha256'] = lock_hash
+    prepared['b12x_files'] = installed['b12x_files']
+    prepared['b12x_package_files_sha256'] = package_hash
+    write(prepared_path, prepared)
+    profile_path = RECEIPTS / 'profile-pins.json'
+    profile = load(profile_path)
+    profile['compute']['source_lock_sha256'] = lock_hash
+    profile['cache_identity']['namespace'] = profile['cache_identity']['namespace'].replace(
+        PARENT_LOCK[:8], lock_hash[:8])
+    profile['cache_identity']['compatibility'] = (
+        f"Cache entries require compute source lock {lock_hash} and transport bundle "
+        f"{profile['canonical_bundle_manifest_sha256']}. Do not relabel entries from another composition.")
+    write(profile_path, profile)
+    source_path.with_name('source-receipt.parent.json').write_bytes(source_path.read_bytes())
+    source['files']['compute/b12x-source/' + RELATIVE] = AFTER
+    for relative, path in (
+        ('compute/source-lock.json', lock_path),
+        ('compute/prepared-manifest.json', prepared_path),
+        ('receipts/profile-pins.json', profile_path),
+    ):
+        source['files'][relative] = sha(path)
+    source['derived_from_mesh_image'] = {
+        'reference': PARENT, 'image_id': PARENT_ID, 'source_receipt_sha256': parent_source_sha}
+    source['source_transforms'] = {'histogram_publication_barrier': transform}
+    write(source_path, source)
+    result = {'schema': 'sparkring-mesh-indexer-barrier/v1', 'status': 'research-only',
+              'parent_image': PARENT, 'parent_image_id': PARENT_ID,
+              'parent_source_lock_sha256': PARENT_LOCK,
+              'source_lock_sha256': lock_hash, 'source_receipt_sha256': sha(source_path),
+              'bundle_manifest_sha256': profile['canonical_bundle_manifest_sha256'],
+              'cache_namespace': profile['cache_identity']['namespace'],
+              'indexer': transform, 'installer_sha256': sha(Path(__file__))}
+    write(RECEIPTS / 'indexer-barrier.json', result)
+    subprocess.run([sys.executable, '-I', VERIFY, '--inside-image'], check=True)
+    return result
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--output', type=Path)
+    parser.add_argument('--expected-receipt')
+    args = parser.parse_args()
+    result = install()
+    if args.expected_receipt and result['source_receipt_sha256'] != args.expected_receipt:
+        raise ValueError('Mesh patch receipt differs from the prepared build input')
+    if args.output:
+        write(args.output, result)
+    print(json.dumps(result), flush=True)

--- a/runtime/glm53-spark-mtp3-mesh/indexer-barrier/patch_indexer_barrier.py
+++ b/runtime/glm53-spark-mtp3-mesh/indexer-barrier/patch_indexer_barrier.py
@@ -1,0 +1,31 @@
+"""Apply histogram publication ordering to the pinned mesh indexer source."""
+import hashlib
+from pathlib import Path
+
+RELATIVE = 'b12x/attention/dsa_indexer/fused_indexer.py'
+BEFORE = '893fbcade135b7e1d146b8fb6530cde0650be515f69bf9a17ced0a9c61a141e2'
+AFTER = '35a7564ec8bf18f1b7dc5562b21616437b65e7b0689c56341b6436c8d202637b'
+
+
+def patch_bytes(source: bytes) -> bytes:
+    digest = hashlib.sha256(source).hexdigest()
+    if digest == AFTER:
+        return source
+    if digest != BEFORE:
+        raise ValueError(f'Unsupported mesh indexer source SHA-256: {digest}')
+    arrival = b'    arrival_ptr = _fused_state_ptr(state, group_id, Int32(_FUSED_STATE_ARRIVAL))'
+    barrier = (b'    # Publish only after every warp has finished its histogram writes.\r\n'
+               b'    cute.arch.sync_threads()\r\n' + arrival)
+    cache = b'"attention.indexer.fused_indexer", 1, cache_key, labels=labels'
+    if source.count(arrival) != 1 or source.count(cache) != 1:
+        raise ValueError('Mesh indexer barrier or compile-revision anchor differs')
+    result = source.replace(arrival, barrier, 1).replace(
+        cache, b'"attention.indexer.fused_indexer", 2, cache_key, labels=labels', 1)
+    if hashlib.sha256(result).hexdigest() != AFTER:
+        raise ValueError('Mesh indexer transform produced unexpected source bytes')
+    return result
+
+
+def apply(path: Path) -> None:
+    result = patch_bytes(path.read_bytes())
+    path.write_bytes(result)

--- a/runtime/glm53-spark-mtp3-mesh/indexer-barrier/test_patch.py
+++ b/runtime/glm53-spark-mtp3-mesh/indexer-barrier/test_patch.py
@@ -1,0 +1,30 @@
+import hashlib
+import importlib.util
+from pathlib import Path
+import tarfile
+
+import pytest
+
+HERE = Path(__file__).resolve().parent
+spec = importlib.util.spec_from_file_location('mesh_indexer_patch', HERE / 'patch_indexer_barrier.py')
+patch = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(patch)
+
+
+def test_pinned_selector_archive_produces_the_checked_barrier_source():
+    with tarfile.open(HERE.parent / 'compute/b12x-selector-files.tar.gz') as archive:
+        source = archive.extractfile(patch.RELATIVE).read()
+    assert hashlib.sha256(source).hexdigest() == patch.BEFORE
+    result = patch.patch_bytes(source)
+    assert hashlib.sha256(result).hexdigest() == patch.AFTER
+    assert result.count(b'\r\n') == source.count(b'\r\n') + 2
+    compile(result.decode('utf-8'), patch.RELATIVE, 'exec')
+    assert patch.patch_bytes(result) == result
+
+
+def test_unknown_source_is_rejected_without_mutation(tmp_path):
+    target = tmp_path / 'indexer.py'
+    target.write_bytes(b'unsupported source\n')
+    with pytest.raises(ValueError, match='Unsupported mesh indexer'):
+        patch.apply(target)
+    assert target.read_bytes() == b'unsupported source\n'

--- a/runtime/glm53-spark-mtp3-mesh/indexer-barrier/validation.json
+++ b/runtime/glm53-spark-mtp3-mesh/indexer-barrier/validation.json
@@ -1,0 +1,408 @@
+{
+  "bundle_manifest_sha256": "69313e19e881ec93e9ed3bd150d2f24fc6b444488ac729a69f45d038e2243500",
+  "cache_namespace": "glm53-spark-df116c4f-mtp3-nvfp4-a16-c57b6438c-mesh69313e19-tail-cow-v2",
+  "indexer": {
+    "path": "b12x/attention/dsa_indexer/fused_indexer.py",
+    "preimage_sha256": "893fbcade135b7e1d146b8fb6530cde0650be515f69bf9a17ced0a9c61a141e2",
+    "result_sha256": "35a7564ec8bf18f1b7dc5562b21616437b65e7b0689c56341b6436c8d202637b",
+    "script_sha256": "70ac64c8e58c448eb2b4184395c55821d371d5654298a4fb7c5f55a76ab884ff"
+  },
+  "installer_sha256": "af89efb28e34b2035f608ca1a2edf20a34d3f397f52a0e5e65d24f9b2b37667f",
+  "parent_image": "ghcr.io/fujitsupolycom/sparkring-glm53-sparkcache@sha256:67dc0ae453baaae6831ccec1d259b4ef8b236a8b0dc9f747d901b95c66ec1987",
+  "parent_image_id": "sha256:2e41b1e934a85ff7c21b780532db2f0a0e978df081e52f4ae2bf11f8992fb24f",
+  "parent_source_lock_sha256": "139f36701e0e47f45bf99fba2cc2fa59b417f2ee801dad3a064455d5b464a459",
+  "schema": "sparkring-mesh-indexer-barrier/v1",
+  "source_lock_sha256": "57b6438ca014a493380fb874a84977d35b0983e9ee224a62ade3415fd9c7ce46",
+  "source_receipt_sha256": "030e9f3749672d186b66e41336980af1abb5c207f734feafa677ba82456c5d43",
+  "status": "research-only",
+  "artifact": {
+    "reference": "ghcr.io/fujitsupolycom/sparkring-glm53-sparkcache@sha256:7aa57ed1901b83c8581c53cb233db930bb1a133d74be01168d967b9dd56b3e49",
+    "image_id": "sha256:995a42b4b08f525813c5783f78f34571b6bd1c197fccee53617ff8060574a16d"
+  },
+  "verification": {
+    "added_layers": 2,
+    "bundle_manifest_sha256": "69313e19e881ec93e9ed3bd150d2f24fc6b444488ac729a69f45d038e2243500",
+    "checks_passed": true,
+    "image": "sha256:995a42b4b08f525813c5783f78f34571b6bd1c197fccee53617ff8060574a16d",
+    "image_id": "sha256:995a42b4b08f525813c5783f78f34571b6bd1c197fccee53617ff8060574a16d",
+    "image_reference": "sha256:995a42b4b08f525813c5783f78f34571b6bd1c197fccee53617ff8060574a16d",
+    "image_size_bytes": 22108643353,
+    "inside_image": {
+      "b12x_commit": "ef308bac0f3b3eb8fea63e4013afc0c2ea1c6301",
+      "bundle_files": 28,
+      "bundle_manifest_sha256": "69313e19e881ec93e9ed3bd150d2f24fc6b444488ac729a69f45d038e2243500",
+      "checks_passed": true,
+      "compute": {
+        "b12x_files": 385,
+        "b12x_revision": "ef308bac0f3b3eb8fea63e4013afc0c2ea1c6301",
+        "b12x_tree": "dcf039e5e754136275835ea997e6b9abbb6b15ae",
+        "cuda_version": "13.3",
+        "environment": {
+          "CUDA_HOME": "/opt/cuda-13.3",
+          "TRITON_PTXAS_PATH": "/opt/cuda-13.3/bin/ptxas",
+          "VLLM_B12X_DENSE_ACTIVATION_MODE": "auto",
+          "VLLM_GDN_SPEC_DECODE_METADATA_FASTPATH": "1",
+          "VLLM_LM_HEAD_A16": "1",
+          "VLLM_MTP_NVFP4_LM_HEAD": "1",
+          "VLLM_MXFP8_LM_HEAD": "0"
+        },
+        "proposal_head_nvfp4": true,
+        "source_lock_sha256": "57b6438ca014a493380fb874a84977d35b0983e9ee224a62ade3415fd9c7ce46",
+        "target_head_quantization": false,
+        "vllm_overrides": 24,
+        "vllm_parent_files": 2905
+      },
+      "cuda_initialized": false,
+      "device_access": false,
+      "limitation": "Content and CPU checks do not qualify CUDA graphs, RDMA forwarding, native MTP, cache restoration, or model performance.",
+      "marker_binary_sha256": "2828c07e4255c4962c77425be2c88969e7eb7dd4b1bf9e36485bc705bb5d6d64",
+      "marker_source_sha256": "8684a6961b8e86aa474fa2310ff71e4cdf219a63a72ceb5593b2f95e54812792",
+      "model_loaded": false,
+      "parent_package_files": {
+        "b12x": 385,
+        "sparkcache": 150,
+        "vllm": 2905
+      },
+      "python_syntax_files": 25,
+      "readiness_warmup": {
+        "environment": "SPARKRING_WARMUP_TEMPERATURE",
+        "helper_sha256": "f41c38eef41d15d63dcfc49cd6643357ca1a3ae18200ddbe4f8692d0b767ee79",
+        "temperature": 1.0
+      },
+      "rocenante_lazy_import": "/opt/spark-sircl/b12x_overlay/b12x/comm/roce/__init__.py",
+      "sircl_native_sha256": "61aa0ec56a1b438439bed8611dab0353d2c72c10af02bbd917fb77c87b33e5fc",
+      "source_receipt_sha256": "030e9f3749672d186b66e41336980af1abb5c207f734feafa677ba82456c5d43",
+      "sparkcache_commit": "66057174301a4759ca3a45207ea41016689449cb",
+      "status": "research-only",
+      "vllm_commit": "e02b174693e13859de61811b5e8cd13d5308e259",
+      "vllm_native_extensions": 15
+    },
+    "limitation": "Content-verifier scope excludes GPU and model execution; separate GPU evidence follows.",
+    "parent_image_id": "sha256:2e41b1e934a85ff7c21b780532db2f0a0e978df081e52f4ae2bf11f8992fb24f",
+    "parent_layers_retained": 89,
+    "platform": "linux/arm64",
+    "schema": "sparkring-mtp3-mesh-image-receipt/v1",
+    "source_receipt_sha256": "030e9f3749672d186b66e41336980af1abb5c207f734feafa677ba82456c5d43",
+    "status": "research-only",
+    "verification_command": [
+      "docker",
+      "run",
+      "--rm",
+      "--network",
+      "none",
+      "--read-only",
+      "--cap-drop",
+      "ALL",
+      "--security-opt",
+      "no-new-privileges",
+      "--cpus",
+      "2",
+      "--memory",
+      "2g",
+      "--pids-limit",
+      "128",
+      "--tmpfs",
+      "/tmp:rw,nosuid,nodev,size=128m",
+      "--env",
+      "PYTHONDONTWRITEBYTECODE=1",
+      "--entrypoint",
+      "python3",
+      "sha256:995a42b4b08f525813c5783f78f34571b6bd1c197fccee53617ff8060574a16d",
+      "-I",
+      "/opt/sparkring/bin/verify-mtp3-mesh-image.py",
+      "--inside-image"
+    ]
+  },
+  "gpu_probe": [
+    {
+      "gpu": "NVIDIA GB10",
+      "sm": [
+        12,
+        1
+      ],
+      "source": "/usr/local/lib/python3.12/dist-packages/b12x/attention/dsa_indexer/fused_indexer.py",
+      "source_sha256": "893fbcade135b7e1d146b8fb6530cde0650be515f69bf9a17ced0a9c61a141e2",
+      "torch": "2.13.0+cu130"
+    },
+    {
+      "entry_sync": false,
+      "eager": [
+        [
+          512,
+          513,
+          512
+        ],
+        [
+          512,
+          513,
+          512
+        ],
+        [
+          512,
+          513,
+          512
+        ],
+        [
+          512,
+          513,
+          512
+        ],
+        [
+          512,
+          513,
+          512
+        ],
+        [
+          512,
+          513,
+          512
+        ],
+        [
+          512,
+          513,
+          512
+        ],
+        [
+          512,
+          513,
+          512
+        ],
+        [
+          512,
+          513,
+          512
+        ],
+        [
+          512,
+          513,
+          512
+        ]
+      ],
+      "graph": [
+        [
+          512,
+          513,
+          512
+        ],
+        [
+          512,
+          513,
+          512
+        ],
+        [
+          512,
+          513,
+          512
+        ],
+        [
+          512,
+          513,
+          512
+        ],
+        [
+          512,
+          513,
+          512
+        ],
+        [
+          512,
+          513,
+          512
+        ],
+        [
+          512,
+          513,
+          512
+        ],
+        [
+          512,
+          513,
+          512
+        ],
+        [
+          512,
+          513,
+          512
+        ],
+        [
+          512,
+          513,
+          512
+        ]
+      ],
+      "incomplete_reads": 20
+    },
+    {
+      "entry_sync": true,
+      "eager": [
+        [
+          513,
+          513,
+          513
+        ],
+        [
+          513,
+          513,
+          513
+        ],
+        [
+          513,
+          513,
+          513
+        ],
+        [
+          513,
+          513,
+          513
+        ],
+        [
+          513,
+          513,
+          513
+        ],
+        [
+          513,
+          513,
+          513
+        ],
+        [
+          513,
+          513,
+          513
+        ],
+        [
+          513,
+          513,
+          513
+        ],
+        [
+          513,
+          513,
+          513
+        ],
+        [
+          513,
+          513,
+          513
+        ]
+      ],
+      "graph": [
+        [
+          513,
+          513,
+          513
+        ],
+        [
+          513,
+          513,
+          513
+        ],
+        [
+          513,
+          513,
+          513
+        ],
+        [
+          513,
+          513,
+          513
+        ],
+        [
+          513,
+          513,
+          513
+        ],
+        [
+          513,
+          513,
+          513
+        ],
+        [
+          513,
+          513,
+          513
+        ],
+        [
+          513,
+          513,
+          513
+        ],
+        [
+          513,
+          513,
+          513
+        ],
+        [
+          513,
+          513,
+          513
+        ]
+      ],
+      "incomplete_reads": 0
+    }
+  ],
+  "stress": [
+    {
+      "source_sha256": "35a7564ec8bf18f1b7dc5562b21616437b65e7b0689c56341b6436c8d202637b",
+      "gpu": "NVIDIA GB10",
+      "torch": "2.13.0+cu130"
+    },
+    {
+      "rows": 3,
+      "heads": 32,
+      "topk": 512,
+      "lengths": [
+        4097,
+        65536
+      ],
+      "graph_replays": 500,
+      "concurrent_copy_bytes": 67108864,
+      "wall_seconds": 0.42007936000300106,
+      "result": "passed"
+    },
+    {
+      "rows": 4,
+      "heads": 32,
+      "topk": 512,
+      "lengths": [
+        4097,
+        200000
+      ],
+      "graph_replays": 500,
+      "concurrent_copy_bytes": 67108864,
+      "wall_seconds": 0.5173187279942795,
+      "result": "passed"
+    },
+    {
+      "rows": 8,
+      "heads": 32,
+      "topk": 512,
+      "lengths": [
+        4097,
+        65536
+      ],
+      "graph_replays": 500,
+      "concurrent_copy_bytes": 67108864,
+      "wall_seconds": 0.5455467720021261,
+      "result": "passed"
+    },
+    {
+      "rows": 16,
+      "heads": 32,
+      "topk": 512,
+      "lengths": [
+        4097,
+        65536
+      ],
+      "graph_replays": 500,
+      "concurrent_copy_bytes": 67108864,
+      "wall_seconds": 0.7676780149995466,
+      "result": "passed"
+    }
+  ],
+  "gpu_tests_passed": 15,
+  "local_tests": {
+    "passed": 348,
+    "skipped": 3
+  }
+}


### PR DESCRIPTION
Status: research-only serving image with bounded GPU validation. Related to #224; extends the compute/transport composition in #219.

The derived image adds block-wide synchronization before B12X histogram publication and increments the compiled-kernel revision. The installer checks the exact mesh selector preimage and updates the compute package map, source lock, embedded profile, and source receipt. It preserves the parent transport bundle, CUDA components, vLLM overrides, marker, and native libraries. The unmodified mesh verifier passes before and after installation.

Published image:
`ghcr.io/fujitsupolycom/sparkring-glm53-sparkcache@sha256:7aa57ed1901b83c8581c53cb233db930bb1a133d74be01168d967b9dd56b3e49`

Validation: 348 local tests passed with three platform skips. On GB10, the mesh parent helper exposed incomplete publication in 20/20 probes; the entry-synchronized helper passed 20/20. The built child passed fifteen GPU correctness cases and 2,000 graph replays with exact selected-index parity, contexts up to 200K tokens, and concurrent copies. External image verification and anonymous pull passed.

No serving containers were replaced. No full-model startup, TP4 collective test, actual SparkCache restore, or soak was run with this child. The managed renderer retains its parent-image pins; deployment requires an explicit source-bound profile update and coordinated validation. The running SparkCache telemetry composition is outside this artifact. The README and validation receipt identify image, parent, source lock, cache namespace, test conditions, and limitations.
