### PR TITLE
Simplify README layout and organize profiles by node count

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,161 +1,75 @@
 # SparkRing
 
-> SparkRing is experimental. Use the immutable image digest and source
-> revisions in each quickstart when you need a repeatable deployment.
+SparkRing serves large language models across NVIDIA DGX Spark computers
+using vLLM, B12X kernels, and low-latency communication over direct links.
 
-SparkRing is a vLLM-based inference-serving stack with low-latency collective
-communication for switchless clusters of NVIDIA DGX Spark systems, powered
-by the GB10 Grace Blackwell Superchip.
-
-SparkRing supports GB10 pairs, four-node rings, and six-node rings
-(profiles pending).
-
-Models run across multiple systems using tensor parallelism. Depending on the
-profile, communication uses [SIRCL](docs/SIRCL.md),
-[RoCEnante](third_party/b12x_roce/README.md), and
-[patched NCCL](spark_transport/nccl/README.md). The four-node virtual-mesh
-profile adds hardware-forwarded paths between opposite nodes over the existing
-ring cables. The high-speed data fabric needs no external Ethernet or
-InfiniBand switch; administration uses a separate management network.
-
-The repository provides setup guides, launch tooling, model profiles,
-reproducible benchmarks, and [test results](performance/).
+> SparkRing is experimental. Use the image digest and source revisions in
+> your profile's quickstart. Qualification applies only to its documented tests.
 
 ## Setup
 
-An [experimental GLM-5.3 Flash TP2 quickstart](docs/GLM53_FLASH_SPARK_TP2_EXPERIMENTAL_QUICKSTART.md)
-uses the [model-neutral runtime package](runtime/sparkring/README.md). It is
-still being tested and does not replace other profiles' qualified image pins.
-
-1. Choose a [model profile](#profiles) for your number of Sparks and review
-   the [hardware and software prerequisites](docs/PREREQUISITES.md).
-2. For a ring, follow the [bootstrap guide](docs/BOOTSTRAP.md) from an SSH
-   session on rank 0. It covers SSH enrollment, interface discovery, fabric
-   configuration, and Ring Doctor checks. Pair profiles use their own
-   quickstart's direct-link setup.
-3. Follow the selected quickstart to download its image and weights, launch
-   the model, and verify readiness. Use the
-   [validation runbook](docs/PROFILE_VALIDATION.md) to measure performance,
-   accuracy, and restart behavior.
-
-The [virtual-mesh prerequisites](docs/PREREQUISITES.md#four-spark-managed-hardware-forwarded-mesh)
-extend the shared setup with the additional ConnectX configuration required
-by that profile.
-
-## Resources
-
-- [Profile validation: performance, accuracy, and restart checks](docs/PROFILE_VALIDATION.md)
-- [Model profiles](#profiles)
-- [Container image roles](#container-images)
-- [Benchmark results](#benchmark-results)
-- [Deployment prerequisites](docs/PREREQUISITES.md) — then choose a profile quickstart below
-
-## Container images
-
-| Image family / profile | Purpose | Start here |
-|---|---|---|
-| [GLM-5.3 DFlash2/SIRCL](runtime/glm53-flash-jj-r8-gb10/README.md) | Linux/ARM64 vLLM image with B12X kernels, DFlash2, SIRCL, and optional SparkCache. | [DFlash2 quickstart](docs/GLM53_JJ_R8_GB10_SPARKCACHE_TP4_QUICKSTART.md) |
-| [GLM-5.3 native-MTP3 mesh](runtime/glm53-spark-mtp3-mesh/public-image.json) | Linux/ARM64 image for NVFP4-Spark, native MTP3, hybrid mesh transport, and SparkCache. | [Mesh quickstart](docs/GLM53_SPARK_MTP3_MESH_QUICKSTART.md) |
-| [`sparkring-glm53-runtime`](https://github.com/users/FujitsuPolycom/packages/container/package/sparkring-glm53-runtime) | Pinned GLM-5.3 bases used to build serving images. | Use the digest named by the source-build guide. |
-| [`gb10-vllm-serving`](https://github.com/users/FujitsuPolycom/packages/container/package/gb10-vllm-serving) | Profile-specific GB10 images, including DeepSeek. | Use the image named by the selected model quickstart. |
-
-Both GLM-5.3 serving images are published in the
-[`sparkring-glm53-sparkcache` package](https://github.com/users/FujitsuPolycom/packages/container/package/sparkring-glm53-sparkcache).
-They have different digests. Copy the immutable digest from the quickstart for
-your selected profile rather than substituting another image from the package.
+1. Choose a [profile](#profiles) and check the [prerequisites](docs/PREREQUISITES.md).
+2. For a four-node ring, follow the [bootstrap guide](docs/BOOTSTRAP.md).
+   Two-node profiles include their own direct-link setup.
+3. Follow the profile's quickstart, then run the
+   [validation checks](docs/PROFILE_VALIDATION.md).
 
 ## Profiles
 
-**Context** is the per-request token limit. **Seqs** is the maximum active
-sequence count. **Batch** is the scheduled-token budget per model step. These
-are separate limits; available KV memory also constrains which requests fit
-together. In the tables, 1M means 1,048,576 tokens.
+Context is the per-request token limit; sequences are active requests; batch
+is the scheduled-token budget per model step. KV memory also constrains which requests fit together.
+512K means 524,288 tokens; 1M means 1,048,576.
 
-### GLM-5.3 Flash
+### Two Sparks
 
-These three **DFlash2/SIRCL profiles** use the GLM-5.3 Flash NVFP4 target,
-an external BF16 DFlash2 predictor at depth seven, FP8 KV, B12X kernels, and
-the same ARM64 image. Target verification captures use rows 8 through 128 in
-eight-row increments, covering full request batches from C1 through C16.
+| Model / predictor | Layout | Context | Sequences | Batch | Guide |
+|---|---|---:|---:|---:|---|
+| GLM-5.3 Flash NVFP4-Spark · native MTP3 | TP2/DCP1 | 512K | 8 | 8,192 | [Quickstart](docs/GLM53_FLASH_SPARK_TP2_EXPERIMENTAL_QUICKSTART.md) |
+| DeepSeek-V4-Flash-0731 | TP2/DCP1 | 1M | 32 | 4,096 | [Quickstart](docs/DEEPSEEK_V4_FLASH_QUICKSTART.md) |
+| Qwen3.8-27B EXL3 K5/K6 | TP2/DCP1 | 1M | 32 | 8,192 | [Quickstart](docs/QWEN38_27B_EXL3_K5K6_PAIR_QUICKSTART.md) |
 
-| Profile | Deployment | Context | Seqs | Batch | KV / cache | Approx. recorded KV capacity | Start here |
-|---|---|---:|---:|---:|---|---:|---|
-| DCP1 | 4 Sparks · TP4/DCP1 | 1M | 16 | 8,192 | FP8 · 24 GiB/rank; SparkCache enabled | ~1.30M tokens | [Quickstart](docs/GLM53_JJ_R8_GB10_SPARKCACHE_TP4_QUICKSTART.md) |
-| DCP2 | 4 Sparks · TP4/DCP2 | 1M | 16 | 8,192 | FP8 · 24 GiB/rank; SparkCache enabled | ~2.90M tokens | [Quickstart](docs/GLM53_JJ_R8_GB10_SPARKCACHE_TP4_QUICKSTART.md) |
-| **DCP4 preferred** | **4 Sparks · TP4/DCP4** | **1M** | **16** | **8,192** | **FP8 · 24 GiB/rank; SparkCache enabled** | **~4.32M tokens** | **[Quickstart](docs/GLM53_JJ_R8_GB10_SPARKCACHE_TP4_QUICKSTART.md)** |
+The GLM pair is **research-only**, uses 5 GiB KV per rank, and has a
+[known video-color issue](https://github.com/FujitsuPolycom/sparkring/issues/229).
+Its configured context limit is not a full-context qualification.
 
-All three default to 24 GiB of KV memory per rank. The reference capacities
-were measured at 26/30/24 GiB for DCP1/2/4 respectively; vLLM reports the
-actual model-wide capacity at startup. That capacity is shared across requests.
-**DCP4 is the preferred DFlash2 profile** and the documented asynchronous
-SparkCache configuration.
+### Four Sparks
 
-Set `SPARKCACHE_ENABLED=0` for vLLM's in-memory prefix cache alone, or `1` to
-add persistent storage. DCP1/DCP2 use different publication settings from
-DCP4; follow the matching section of the quickstart when enabling SparkCache.
+| Model / predictor | Layout | Context | Sequences | Batch | Guide |
+|---|---|---:|---:|---:|---|
+| GLM-5.3 Flash NVFP4 · BF16 DFlash2 | TP4/DCP4 preferred; DCP1/2 available | 1M | 16 | 8,192 | [Quickstart](docs/GLM53_JJ_R8_GB10_SPARKCACHE_TP4_QUICKSTART.md) |
+| GLM-5.3 Flash NVFP4-Spark · native MTP3 mesh | TP4/DCP4 | 1M | 16 | 8,192 | [Quickstart](docs/GLM53_SPARK_MTP3_MESH_QUICKSTART.md) |
+| GLM-5.2 EXL3 3.5-bpw | TP4/DCP4 | 1M | 16 | 4,096 | [Quickstart](docs/GLM52_35BPW_QUICKSTART.md) |
+| DeepSeek-V4-Flash-0731 | TP4/DCP1 | 1M | 32 | 4,096 | [Quickstart](docs/DEEPSEEK_V4_FLASH_QUICKSTART.md) |
+| Qwen3.8-27B EXL3 K5/K6 | TP4/DCP1 | 1M | 64 | 8,192 | [Quickstart](docs/QWEN38_27B_EXL3_K5K6_QUICKSTART.md) |
 
-SIRCL accelerates eligible collectives, with patched NCCL handling the other
-paths. Startup checks require all four ranks to agree on the transport
-configuration, and runtime checks detect transport failures. The
-[public-image receipt](runtime/glm53-flash-jj-r8-gb10/glm53-dcp4-sircl-public-image-receipt.json)
-records **qualified** four-rank DCP4 startup, persistent restoration, and
-failure-containment checks.
+The native-MTP3 mesh profile is **research-only** and requires
+[managed-mesh setup](runtime/glm53-spark-mtp3-mesh/MANAGED_MESH.md).
+DFlash2 remains the preferred four-node GLM profile; its external draft
+weights have [separate CC BY-NC-ND 4.0 terms](https://huggingface.co/incoai/GLM-5.3-Flash-DFlash2#license).
 
-The operator image is published at
-`ghcr.io/fujitsupolycom/sparkring-glm53-sparkcache@sha256:0d4029b3b7023cf32c37ac20279469c9a2ee16a057f25aae3bcfee9ee5fb660f`
-and supports both caching methods. The quickstart includes installation,
-readiness, and recovery instructions.
+See the [profile index](docs/profiles/README.md) for evidence scopes and
+[SparkCache compositions](recipes/sparkcache/README.md) for persistent-cache
+support. Qwen with SparkCache is unsupported; six-node profiles are research-only.
 
-The external BF16 DFlash2 weights have a separate **CC BY-NC-ND 4.0** license
-for research and evaluation. See the
-[Inco AI model card](https://huggingface.co/incoai/GLM-5.3-Flash-DFlash2#license)
-for its terms. The native-MTP3 profile below does not require these weights.
+## Container images
 
-### GLM-5.3 Flash Spark with native MTP3 and mesh transport
+| Package / runtime | Profile | Details |
+|---|---|---|
+| `sparkring` | GLM-5.3 Flash native-MTP3 pair | [Model-neutral package](runtime/sparkring/README.md) |
+| `sparkring-glm53-sparkcache` | GLM-5.3 Flash DFlash2/SIRCL | [Operator image](runtime/glm53-flash-jj-r8-gb10/README.md) |
+| `sparkring-glm53-sparkcache` | GLM-5.3 Flash native-MTP3 mesh | [Mesh image](runtime/glm53-spark-mtp3-mesh/public-image.json) |
+| `sparkring-glm53-runtime` | GLM source-build bases | [Runtime builder](runtime/glm53-flash/README.md) |
+| `gb10-vllm-serving` | Profile-specific images, including DeepSeek | [Packages](https://github.com/users/FujitsuPolycom/packages/container/package/gb10-vllm-serving) |
 
-| Profile | Deployment | Context | Seqs | Batch | KV / cache | Start here |
-|---|---|---:|---:|---:|---|---|
-| NVFP4-Spark + native MTP3 + mesh · research-only | 4 Sparks · TP4/DCP4 | 1M | 16 | 8,192 | FP8 · 24 GiB/rank; SparkCache enabled | [Quickstart](docs/GLM53_SPARK_MTP3_MESH_QUICKSTART.md) |
-
-This profile uses the NVFP4-Spark checkpoint's built-in three-token predictor;
-no external draft checkpoint is required. It combines graph-native SIRCL for
-selected decode shapes, dual-rail SIRCL for large prefill collectives, and
-RoCEnante for selected small all-reduces. Target verification captures use
-four-row increments through 64 rows.
-
-The [profile package](runtime/glm53-spark-mtp3-mesh/README.md) provides the
-public image, transport files, and temperature-one warmup. The
-[mesh service](runtime/glm53-spark-mtp3-mesh/MANAGED_MESH.md) sets up and
-monitors the hardware-forwarded paths between opposite Sparks. It checks
-all-rank readiness before model startup and stops dependent serving when the
-fabric is unhealthy. The quickstart documents coordinated recovery.
-
-The [consolidated validation report](performance/records/glm53-flash/spark-mtp3-validation-summary-20260905.md)
-collects installation and restart checks, cache restoration, three-pass
-prefill measurements, decode matrices, Estonia accuracy, and long-context
-retrieval results. This is an opt-in profile; the DFlash2/SIRCL recommendation
-above is unchanged.
-
-### Other model profiles
-
-| Profile | Deployment | Context | Seqs | Batch | KV / cache | Start here |
-|---|---|---:|---:|---:|---|---|
-| GLM-5.2 EXL3 3.5-bpw | 4 Sparks · TP4/DCP4 | 1M | 16 | 4,096 | NVFP4 DS-MLA · 9.25 GB/rank | [Quickstart](docs/GLM52_35BPW_QUICKSTART.md) |
-| DeepSeek-V4-Flash-0731 | 2 Sparks · TP2/DCP1 | 1M | 32 | 4,096 | FP8 DS-MLA · 16 GiB/rank | [Quickstart](docs/DEEPSEEK_V4_FLASH_QUICKSTART.md) |
-| DeepSeek-V4-Flash-0731 | 4 Sparks · TP4/DCP1 | 1M | 32 | 4,096 | FP8 DS-MLA · 16 GiB/rank | [Quickstart](docs/DEEPSEEK_V4_FLASH_QUICKSTART.md) |
-| Qwen3.8-27B EXL3 K5/K6 | 2 Sparks · TP2/DCP1 | 1M | 32 | 8,192 | FP8 | [Quickstart](docs/QWEN38_27B_EXL3_K5K6_PAIR_QUICKSTART.md) |
-| Qwen3.8-27B EXL3 K5/K6 | 4 Sparks · TP4/DCP1 | 1M | 64 | 8,192 | FP8 | [Quickstart](docs/QWEN38_27B_EXL3_K5K6_QUICKSTART.md) |
-| GLM-5.2 EXL3 3.5-bpw + SparkCache | 4 Sparks · TP4/DCP4 | 1M | 16 | 4,096 | NVFP4 DS-MLA + SparkCache | [SparkCache compositions](recipes/sparkcache/README.md) |
-| DeepSeek-V4-Flash-0731 + SparkCache | 2 Sparks · TP2/DCP1 | 1M | 32 | 4,096 | FP8 DS-MLA + SparkCache | [SparkCache compositions](recipes/sparkcache/README.md) |
-| DeepSeek-V4-Flash-0731 + SparkCache | 4 Sparks · TP4/DCP1 | 1M | 32 | 4,096 | FP8 DS-MLA + SparkCache | [SparkCache compositions](recipes/sparkcache/README.md) |
+Use the exact digest in the selected quickstart. Images sharing a package
+name are not interchangeable; a model-neutral name does not qualify every profile.
 
 ## Benchmark results
 
-Throughput values below are tokens per second. Decode is sustained aggregate
-output across active requests at temperature 1.0; C denotes concurrency.
-The decode context is listed explicitly. Prefill entries identify their
-context and mark integrated scouts. Coding peak uses a separate coding
-prompt. Each linked record gives its sampling, cache settings, and repeat counts.
+Recorded tokens per second; C1/C8 mean one/eight concurrent requests.
+Decode is sustained aggregate output at temperature 1.0.
+Decode context is shown separately from prefill context. These results
+describe the linked workloads, not guaranteed performance.
 
 | Profile | Decode context | Prefill | C1 decode | C8 decode | Highest C at this context | Coding peak |
 |---|---:|---:|---:|---:|---:|---:|
@@ -168,54 +82,50 @@ prompt. Each linked record gives its sampling, cache settings, and repeat counts
 | [Qwen3.8-27B EXL3 K5/K6 · 2 Sparks](performance/records/qwen38-27b/normalized-tp2-1m-probmtp-temp1-20260823.md) | 16K | 1,367 (16K) | 29.50 | 142.20 | C16: 184.39 | 39.95 |
 | [Qwen3.8-27B EXL3 K5/K6 · 4 Sparks](performance/records/qwen38-27b/normalized-tp4-1m-probmtp-temp1-20260823.md) | 16K | 1,964 (16K) | 35.07 | 191.02 | C8: 191.02 | 48.46 |
 
-The native-MTP3 mesh row uses one observation per cell with caching enabled.
-Its [consolidated report](performance/records/glm53-flash/spark-mtp3-validation-summary-20260905.md)
-also includes three-pass cold-prefix prefill results, the 32K/64K decode
-matrices, Estonia **30/30** at C8, and **4/4** needle-hunt checks through
-507,367 prompt tokens.
-
-See [benchmark results and throughput tables](docs/RESULTS.md) for full
-matrices, sample counts, exact settings, and limitations.
+The native-MTP3 mesh row is a single observation per cell with caching enabled.
+Prefill scouts are integrated measurements, not isolated prefill benchmarks.
+See [full results](docs/RESULTS.md) and the
+[mesh validation report](performance/records/glm53-flash/spark-mtp3-validation-summary-20260905.md)
+for repeat counts, accuracy checks, settings, and limitations.
 
 ## Architecture
 
-Two-Spark profiles use one direct 200 Gb/s cable and patched NCCL. Four-Spark
-profiles use a `0-1-2-3-0` cable cycle. Their collective routing depends on
-the profile: SIRCL accelerates supported operations, the native-MTP3 mesh
-profile also uses RoCEnante, and patched NCCL supplies the remaining paths.
+Pairs use a direct 200 Gb/s link. Four-node deployments use a cable ring;
+the managed mesh adds hardware-forwarded paths without diagonal cables.
+Profiles select patched NCCL, SIRCL, or RoCEnante for eligible operations.
 
-The virtual mesh uses the same four ring cables. ConnectX-7 hardware forwards
-traffic between opposite nodes; no physical diagonal cables are added.
+[Architecture](docs/ARCHITECTURE.md) · [SIRCL](docs/SIRCL.md) ·
+[RoCEnante](third_party/b12x_roce/README.md) ·
+[Mesh prerequisites](docs/PREREQUISITES.md#four-spark-managed-hardware-forwarded-mesh)
 
-See [architecture](docs/ARCHITECTURE.md), [SIRCL](docs/SIRCL.md), and the
-[deployment prerequisites](docs/PREREQUISITES.md).
+## Resources
+
+[Validation](docs/PROFILE_VALIDATION.md) · [Deployment tooling](docs/DEPLOYMENT_SUITE.md) ·
+[Contributing](CONTRIBUTING.md) · [Discussions](https://github.com/FujitsuPolycom/sparkring/discussions)
 
 ## Repository map
 
 | Path | Purpose |
 |---|---|
-| `spark_transport/` | Native transport and vLLM adapters |
-| `runtime/` | Pinned runtime inputs and builders |
-| `scripts/` | Site validation, preflight, launch, and evidence tooling |
-| [`recipes/`](recipes/) | Machine-readable serving recipes and their operator-guide index |
-| `performance/` | Benchmark methods, records, and sanitized receipts |
-| `docs/` | Profile procedures, architecture, prerequisites, and evidence |
+| `spark_transport/` | Communication backends and vLLM adapters |
+| `runtime/` | Pinned images, builders, and serving profiles |
+| `scripts/` | Preflight, deployment, and validation tools |
+| [`recipes/`](recipes/) | Machine-readable serving recipes |
+| [`performance/`](performance/) | Measurement methods, evidence, and receipts |
+| `docs/` | Operator guides and architecture |
+| [`integrations/lil/`](integrations/lil/README.md) | Companion lifecycle and deployment integration |
 
 ## Acknowledgements
 
-SparkRing builds on vLLM, NVIDIA NCCL, B12X, SparkInfer, LMCache, ExLlamaV3,
-and the work of the [local inference community](https://github.com/local-inference-lab/).
-
+Built on vLLM, NVIDIA NCCL, B12X, SparkInfer, LMCache, ExLlamaV3, and the
+[local inference community](https://github.com/local-inference-lab/).
 Luke and Local Inference Lab's [RoCEnante implementation](https://github.com/local-inference-lab/b12x/pull/295)
 and [vLLM integration](https://github.com/local-inference-lab/vllm/pull/597)
-provided the communication implementation and inspiration for the virtual-mesh
-profile. SparkRing adapts that work to hardware-forwarded paths on the ring.
-
-Detailed third-party attribution is in
-[`THIRD_PARTY_NOTICES.md`](THIRD_PARTY_NOTICES.md).
+underpin the adapted mesh communication.
+See [third-party notices](THIRD_PARTY_NOTICES.md).
 
 ## License
 
-SparkRing code is licensed under Apache-2.0. See [`LICENSE`](LICENSE).
-Model weights and bundled third-party components retain their own licenses;
-review the selected model cards and third-party notices before deployment.
+SparkRing code is [Apache-2.0](LICENSE). Model weights and bundled components
+retain their own terms; review the selected model cards and
+[third-party notices](THIRD_PARTY_NOTICES.md) before deployment.

--- a/README.md
+++ b/README.md
@@ -1,24 +1,25 @@
 # SparkRing
 
-SparkRing is a vLLM-based inference-serving stack for running large language
-models across switchless clusters of NVIDIA DGX Spark systems, powered by
-the GB10 Grace Blackwell Superchip. It combines B12X kernels with low-latency
-collective communication so multiple Sparks can serve a model together
-using tensor parallelism.
+SparkRing is a vLLM-based inference-serving stack with low-latency collective
+communication for switchless clusters of NVIDIA DGX Spark systems, powered
+by the GB10 Grace Blackwell Superchip.
 
-Deployment profiles cover two-Spark pairs and four-Spark rings, with
-six-Spark configurations remaining research-only. Depending on the profile,
-communication uses [SIRCL](docs/SIRCL.md),
+SparkRing supports GB10 pairs and four-node rings; six-node configurations
+are research-only. Models run across multiple systems using tensor parallelism.
+
+Depending on the profile, communication uses [SIRCL](docs/SIRCL.md),
 [RoCEnante](third_party/b12x_roce/README.md), and
-[patched NCCL](spark_transport/nccl/README.md). The four-node virtual-mesh
-profile adds hardware-forwarded paths between opposite nodes over the
-existing ring cables. The high-speed data fabric needs no external Ethernet
-or InfiniBand switch; administration uses a separate management network.
+[patched NCCL](spark_transport/nccl/README.md). The high-speed data fabric
+needs no external Ethernet or InfiniBand switch; administration uses a
+separate management network.
+
+The four-node virtual-mesh profile adds hardware-forwarded paths between
+opposite nodes over the existing ring cables. This lets the communication
+topology extend beyond directly connected neighbors without adding a switch
+or changing the cabling.
 
 The repository provides setup guides, launch tooling, model profiles,
-container image definitions, reproducible benchmarks, and
-[test results](performance/). Profile-specific quickstarts tie the hardware,
-runtime, and serving settings together.
+reproducible benchmarks, and [test results](performance/).
 
 > SparkRing is experimental. Use the image digest and source revisions in
 > your profile's quickstart. Qualification applies only to its documented tests.

--- a/README.md
+++ b/README.md
@@ -1,28 +1,19 @@
 # SparkRing
 
 SparkRing is a vLLM-based inference-serving stack with low-latency collective
-communication for switchless clusters of NVIDIA DGX Spark systems, powered
-by the GB10 Grace Blackwell Superchip.
+communication for switchless clusters of NVIDIA GB10-based devices. 
 
-SparkRing supports GB10 pairs and four-node rings; six-node configurations
-are research-only. Models run across multiple systems using tensor parallelism.
+SparkRing supports pairs, four-node rings, and six-node rings (in dev).
 
-Depending on the profile, communication uses [SIRCL](docs/SIRCL.md),
-[RoCEnante](third_party/b12x_roce/README.md), and
-[patched NCCL](spark_transport/nccl/README.md). The high-speed data fabric
-needs no external Ethernet or InfiniBand switch; administration uses a
-separate management network.
+The collective communication stack combines [SIRCL](docs/SIRCL.md), [RoCEnante](third_party/b12x_roce/README.md), and [patched NCCL](spark_transport/nccl/README.md). The high-speed data fabric
+needs no external Ethernet or InfiniBand switch; administration and vLLM api serving occur over a node/s 10Gbe NIC.
 
-The four-node virtual-mesh profile adds hardware-forwarded paths between
-opposite nodes over the existing ring cables. This lets the communication
-topology extend beyond directly connected neighbors without adding a switch
-or changing the cabling.
+Four- and six-node rings use a virtual mesh built on custom RoCE RDMA routing and hardware forwarding in the ConnectX network ASICs. This creates paths between nodes that aren’t directly connected, carrying traffic over the existing ring cables without routing it through host CPUs. The result is mesh connectivity over a physical ring. 
 
 The repository provides setup guides, launch tooling, model profiles,
 reproducible benchmarks, and [test results](performance/).
 
-> SparkRing is experimental. Use the image digest and source revisions in
-> your profile's quickstart. Qualification applies only to its documented tests.
+> SparkRing is experimental. This repo is changing rapidly.
 
 ## Setup
 
@@ -31,40 +22,33 @@ reproducible benchmarks, and [test results](performance/).
    Two-node profiles include their own direct-link setup.
 3. Follow the profile's quickstart, then run the
    [validation checks](docs/PROFILE_VALIDATION.md).
+   
+   *more streamlined installation methods are pending validation; 'lil', sparkrun, etc*
 
 ## Profiles
-
-Context is the per-request token limit; sequences are active requests; batch
-is the scheduled-token budget per model step. KV memory also constrains which requests fit together.
-512K means 524,288 tokens; 1M means 1,048,576.
-
-### Two Sparks
-
-| Model / predictor | Layout | Context | Sequences | Batch | Guide |
-|---|---|---:|---:|---:|---|
-| GLM-5.3 Flash NVFP4-Spark · native MTP3 | TP2/DCP1 | 512K | 8 | 8,192 | [Quickstart](docs/GLM53_FLASH_SPARK_TP2_EXPERIMENTAL_QUICKSTART.md) |
-| DeepSeek-V4-Flash-0731 | TP2/DCP1 | 1M | 32 | 4,096 | [Quickstart](docs/DEEPSEEK_V4_FLASH_QUICKSTART.md) |
-| Qwen3.8-27B EXL3 K5/K6 | TP2/DCP1 | 1M | 32 | 8,192 | [Quickstart](docs/QWEN38_27B_EXL3_K5K6_PAIR_QUICKSTART.md) |
-
-The GLM pair is **research-only**, uses 5 GiB KV per rank, and has a
-[known video-color issue](https://github.com/FujitsuPolycom/sparkring/issues/229).
-Its configured context limit is not a full-context qualification.
 
 ### Four Sparks
 
 | Model / predictor | Layout | Context | Sequences | Batch | Guide |
 |---|---|---:|---:|---:|---|
-| GLM-5.3 Flash NVFP4 · BF16 DFlash2 | TP4/DCP4 preferred; DCP1/2 available | 1M | 16 | 8,192 | [Quickstart](docs/GLM53_JJ_R8_GB10_SPARKCACHE_TP4_QUICKSTART.md) |
-| GLM-5.3 Flash NVFP4-Spark · native MTP3 mesh | TP4/DCP4 | 1M | 16 | 8,192 | [Quickstart](docs/GLM53_SPARK_MTP3_MESH_QUICKSTART.md) |
+| **GLM-5.3 Flash NVFP4-Spark · MTP3 mesh** | TP4/DCP4 | 1M | 16 | 8,192 | [Quickstart](docs/GLM53_SPARK_MTP3_MESH_QUICKSTART.md) |
+| GLM-5.3 Flash NVFP4 · BF16 DFlash2 | TP4/DCP4; DCP1/2 | 1M | 16 | 8,192 | [Quickstart](docs/GLM53_JJ_R8_GB10_SPARKCACHE_TP4_QUICKSTART.md) |
 | GLM-5.2 EXL3 3.5-bpw | TP4/DCP4 | 1M | 16 | 4,096 | [Quickstart](docs/GLM52_35BPW_QUICKSTART.md) |
 | DeepSeek-V4-Flash-0731 | TP4/DCP1 | 1M | 32 | 4,096 | [Quickstart](docs/DEEPSEEK_V4_FLASH_QUICKSTART.md) |
 | Qwen3.8-27B EXL3 K5/K6 | TP4/DCP1 | 1M | 64 | 8,192 | [Quickstart](docs/QWEN38_27B_EXL3_K5K6_QUICKSTART.md) |
+* The GLM5.3 Flash MTP3 profile uses the new virtual meshing feature. *All profiles will be transitioned to said mesh.*
+* Requires:[managed-mesh setup](runtime/glm53-spark-mtp3-mesh/MANAGED_MESH.md). *Refined images in testing*
+* DFlash2 profiles will be replaced by more consistently performing, native-MTP. Also avoids: [separate CC BY-NC-ND 4.0 terms](https://huggingface.co/incoai/GLM-5.3-Flash-DFlash2#license).
 
-The native-MTP3 mesh profile is **research-only** and requires
-[managed-mesh setup](runtime/glm53-spark-mtp3-mesh/MANAGED_MESH.md).
-DFlash2 remains the preferred four-node GLM profile; its external draft
-weights have [separate CC BY-NC-ND 4.0 terms](https://huggingface.co/incoai/GLM-5.3-Flash-DFlash2#license).
+### Two Sparks
 
+| Model / predictor | Layout | Context | Sequences | Batch | Guide |
+|---|---|---:|---:|---:|---|
+| **GLM-5.3 Flash NVFP4-Spark · native MTP3** | TP2/DCP1 | 512K | 8 | 8,192 | [Quickstart](docs/GLM53_FLASH_SPARK_TP2_EXPERIMENTAL_QUICKSTART.md) |
+| DeepSeek-V4-Flash-0731 | TP2/DCP1 | 1M | 32 | 4,096 | [Quickstart](docs/DEEPSEEK_V4_FLASH_QUICKSTART.md) |
+| Qwen3.8-27B EXL3 K5/K6 | TP2/DCP1 | 1M | 32 | 8,192 | [Quickstart](docs/QWEN38_27B_EXL3_K5K6_PAIR_QUICKSTART.md) |
+* GLM5.3 pair is **research-only**, uses 5 GiB KV per rank, and has a
+[known video-color issue](https://github.com/FujitsuPolycom/sparkring/issues/229). In testing. 
 See the [profile index](docs/profiles/README.md) for evidence scopes and
 [SparkCache compositions](recipes/sparkcache/README.md) for persistent-cache
 support. Qwen with SparkCache is unsupported; six-node profiles are research-only.
@@ -80,14 +64,14 @@ support. Qwen with SparkCache is unsupported; six-node profiles are research-onl
 | `gb10-vllm-serving` | Profile-specific images, including DeepSeek | [Packages](https://github.com/users/FujitsuPolycom/packages/container/package/gb10-vllm-serving) |
 
 Use the exact digest in the selected quickstart. Images sharing a package
-name are not interchangeable; a model-neutral name does not qualify every profile.
+name are not interchangeable; a model-neutral name does not qualify every profile. Images will be condensed and homogenized in future releases. 
 
 ## Benchmark results
 
 Recorded tokens per second; C1/C8 mean one/eight concurrent requests.
 Decode is sustained aggregate output at temperature 1.0.
-Decode context is shown separately from prefill context. These results
-describe the linked workloads, not guaranteed performance.
+Decode context is shown separately from prefill context. Results attempt to reflect real world use-case numbers in ALL instances unless otherwise noted.
+*structured data sweeps*,*temperature 0 and/or other out-of-spec configurations are not provided or recommended*
 
 | Profile | Decode context | Prefill | C1 decode | C8 decode | Highest C at this context | Coding peak |
 |---|---:|---:|---:|---:|---:|---:|
@@ -100,17 +84,11 @@ describe the linked workloads, not guaranteed performance.
 | [Qwen3.8-27B EXL3 K5/K6 · 2 Sparks](performance/records/qwen38-27b/normalized-tp2-1m-probmtp-temp1-20260823.md) | 16K | 1,367 (16K) | 29.50 | 142.20 | C16: 184.39 | 39.95 |
 | [Qwen3.8-27B EXL3 K5/K6 · 4 Sparks](performance/records/qwen38-27b/normalized-tp4-1m-probmtp-temp1-20260823.md) | 16K | 1,964 (16K) | 35.07 | 191.02 | C8: 191.02 | 48.46 |
 
-The native-MTP3 mesh row is a single observation per cell with caching enabled.
-Prefill scouts are integrated measurements, not isolated prefill benchmarks.
 See [full results](docs/RESULTS.md) and the
 [mesh validation report](performance/records/glm53-flash/spark-mtp3-validation-summary-20260905.md)
 for repeat counts, accuracy checks, settings, and limitations.
 
 ## Architecture
-
-Pairs use a direct 200 Gb/s link. Four-node deployments use a cable ring;
-the managed mesh adds hardware-forwarded paths without diagonal cables.
-Profiles select patched NCCL, SIRCL, or RoCEnante for eligible operations.
 
 [Architecture](docs/ARCHITECTURE.md) · [SIRCL](docs/SIRCL.md) ·
 [RoCEnante](third_party/b12x_roce/README.md) ·
@@ -135,7 +113,7 @@ Profiles select patched NCCL, SIRCL, or RoCEnante for eligible operations.
 
 ## Acknowledgements
 
-Built on vLLM, NVIDIA NCCL, B12X, SparkInfer, LMCache, ExLlamaV3, and the
+Built on vLLM, NVIDIA NCCL, B12X, ExLlamaV3, and the
 [local inference community](https://github.com/local-inference-lab/).
 Luke and Local Inference Lab's [RoCEnante implementation](https://github.com/local-inference-lab/b12x/pull/295)
 and [vLLM integration](https://github.com/local-inference-lab/vllm/pull/597)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,24 @@
 # SparkRing
 
-SparkRing serves large language models across NVIDIA DGX Spark computers
-using vLLM, B12X kernels, and low-latency communication over direct links.
+SparkRing is a vLLM-based inference-serving stack for running large language
+models across switchless clusters of NVIDIA DGX Spark systems, powered by
+the GB10 Grace Blackwell Superchip. It combines B12X kernels with low-latency
+collective communication so multiple Sparks can serve a model together
+using tensor parallelism.
+
+Deployment profiles cover two-Spark pairs and four-Spark rings, with
+six-Spark configurations remaining research-only. Depending on the profile,
+communication uses [SIRCL](docs/SIRCL.md),
+[RoCEnante](third_party/b12x_roce/README.md), and
+[patched NCCL](spark_transport/nccl/README.md). The four-node virtual-mesh
+profile adds hardware-forwarded paths between opposite nodes over the
+existing ring cables. The high-speed data fabric needs no external Ethernet
+or InfiniBand switch; administration uses a separate management network.
+
+The repository provides setup guides, launch tooling, model profiles,
+container image definitions, reproducible benchmarks, and
+[test results](performance/). Profile-specific quickstarts tie the hardware,
+runtime, and serving settings together.
 
 > SparkRing is experimental. Use the image digest and source revisions in
 > your profile's quickstart. Qualification applies only to its documented tests.


### PR DESCRIPTION
## Summary

Reorganizes the main README as a concise entry point for operators. Profiles are grouped by two-node and four-node hardware, with consistent tables for topology, context, sequence limit, batch budget and quickstart. The GLM-5.3 Flash TP2 profile appears in the profile table rather than interrupting the general setup instructions.

Container roles, architecture, repository navigation and licensing each have compact sections. Detailed transport behavior, cache settings and validation history are linked from their dedicated guides. Research-only status and the video-color issue remain visible.

## Scope and compatibility

README only. No runtime, image, checkpoint, launch setting or cache identity changes. All eight benchmark rows and their values are preserved exactly, with measurement qualifiers retained. Existing quickstarts and the profile index remain the detailed sources of configuration and qualification information.

## Validation

- Repository Markdown-link checker: 518 relative links checked.
- Benchmark table compared byte-for-byte at the Markdown row level against the parent revision.
- git diff --check passed.

Draft for layout review; do not merge automatically.
