### PR TITLE
Gate public inference until readiness warmup completes

### DIFF
--- a/runtime/glm53-flash-jj-r8-gb10/Dockerfile
+++ b/runtime/glm53-flash-jj-r8-gb10/Dockerfile
@@ -12,6 +12,7 @@ COPY bundle/receipts/ /opt/sparkring/overlays/jj-r8-sparkcache-arm64/receipts/
 COPY bundle/sircl/ /opt/spark-sircl/
 COPY install_overlay.py /opt/sparkring/bin/install-jj-r8-sparkcache-overlay.py
 COPY verify_image.py /opt/sparkring/bin/verify-jj-r8-sparkcache-image.py
+COPY startup_admission.py /opt/sparkring/bin/startup_admission.py
 COPY warmup_dflash.py /opt/sparkring/bin/warmup_dflash.py
 COPY serve_with_warmup.py /opt/sparkring/bin/serve-with-warmup.py
 COPY scheduler_liveness.py /opt/sparkring/bin/scheduler_liveness.py

--- a/runtime/glm53-flash-jj-r8-gb10/build_image.py
+++ b/runtime/glm53-flash-jj-r8-gb10/build_image.py
@@ -393,6 +393,7 @@ def prepare_context(
         "verify_image.py",
         "warmup_dflash.py",
         "serve_with_warmup.py",
+        "startup_admission.py",
         "scheduler_liveness.py",
     ):
         shutil.copy2(HERE / name, context / name)
@@ -451,6 +452,7 @@ def prepare_context(
                 "verify_image.py",
                 "warmup_dflash.py",
                 "serve_with_warmup.py",
+                "startup_admission.py",
                 "scheduler_liveness.py",
                 "bundle/receipts/pins.json",
                 "bundle/receipts/vllm-source-manifest.json",

--- a/runtime/glm53-flash-jj-r8-gb10/hotfix/README.md
+++ b/runtime/glm53-flash-jj-r8-gb10/hotfix/README.md
@@ -64,7 +64,10 @@ serving qualification.
 
 Assemble an empty context with this `Dockerfile` and `install_hotfix.py`, plus
 `patch_indexer_barrier.py`, `serve_with_warmup.py`, and `scheduler_liveness.py`
-from the parent runtime directory. Use LF line endings. Run the installer in
+from the parent runtime directory at source commit
+`ef3c381bd41eef07abcb5daebfc9c81d5928ff88`. This recipe reproduces that
+artifact; wrappers from another revision can require additional installed
+modules and must not be substituted. Use LF line endings. Run the installer in
 an isolated container of the pinned parent with that context mounted at
 `/hotfix`, passing `--output /hotfix/build-input.json`.
 

--- a/runtime/glm53-flash-jj-r8-gb10/serve_with_warmup.py
+++ b/runtime/glm53-flash-jj-r8-gb10/serve_with_warmup.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import json
 import os
 import signal
+import secrets
 import subprocess
 import sys
 import time
@@ -38,6 +39,9 @@ def warmup_sampling(
         "chat_template_kwargs": {"enable_thinking": True},
     }
     headers = {"Content-Type": "application/json"}
+    token = os.environ.get("SPARKRING_STARTUP_TOKEN")
+    if token:
+        headers["X-Sparkring-Startup-Token"] = token
     if credential:
         headers["Authorization"] = f"Bearer {credential}"
     request = urllib.request.Request(
@@ -139,7 +143,17 @@ os.environ.get("SPARKRING_LIVENESS_SAMPLE_SECONDS", "10")
 
 def main() -> int:
     READY_PATH.unlink(missing_ok=True)
-    child = subprocess.Popen(["vllm", "serve", *sys.argv[1:]])
+    # Rotate the bypass on every process start, before the public listener exists.
+    os.environ["SPARKRING_STARTUP_TOKEN"] = secrets.token_urlsafe(32)
+    os.environ["SPARKRING_READY_PATH"] = str(READY_PATH)
+    child_env = os.environ.copy()
+    child_env["PYTHONPATH"] = os.pathsep.join(filter(None, (
+        str(Path(__file__).resolve().parent), child_env.get("PYTHONPATH")
+    )))
+    child = subprocess.Popen([
+        "vllm", "serve", *sys.argv[1:],
+        "--middleware", "startup_admission.StartupAdmission",
+    ], env=child_env)
     liveness_service = None
 
     def forward(signum, _frame):
@@ -188,6 +202,7 @@ def main() -> int:
             child.wait(timeout=30)
         raise
     finally:
+        READY_PATH.unlink(missing_ok=True)
         if liveness_service is not None:
             liveness_service.close()
 

--- a/runtime/glm53-flash-jj-r8-gb10/startup_admission.py
+++ b/runtime/glm53-flash-jj-r8-gb10/startup_admission.py
@@ -1,0 +1,45 @@
+"""Keep public inference outside the scheduler until startup warmup completes."""
+
+import hmac
+import os
+from pathlib import Path
+
+HEADER = b"x-sparkring-startup-token"
+
+
+class StartupAdmission:
+    def __init__(self, app):
+        self.app = app
+        self.token = os.environ.get("SPARKRING_STARTUP_TOKEN", "").encode()
+        if not self.token:
+            raise RuntimeError("The serving wrapper must provide a startup token")
+        self.ready = Path(os.environ.get(
+            "SPARKRING_READY_PATH", "/tmp/sparkring-engine-ready"
+        ))
+
+    async def __call__(self, scope, receive, send):
+        if scope["type"] not in ("http", "websocket"):
+            await self.app(scope, receive, send)
+            return
+        headers = scope.get("headers", ())
+        tokens = [value for name, value in headers if name.lower() == HEADER]
+        internal = len(tokens) == 1 and hmac.compare_digest(tokens[0], self.token)
+        # Do not leak the bypass credential into downstream request logging.
+        scope = dict(scope, headers=[(name, value) for name, value in headers
+                                     if name.lower() != HEADER])
+        probe = scope.get("method") in ("GET", "HEAD") and scope["path"] in (
+            "/health", "/v1/models", "/metrics"
+        )
+        if not (internal or probe or self.ready.is_file()):
+            if scope["type"] == "websocket":
+                await send({"type": "websocket.close", "code": 1013})
+                return
+            body = b'{"error":{"message":"Model warmup is in progress","type":"service_unavailable"}}'
+            await send({"type": "http.response.start", "status": 503, "headers": [
+                (b"content-type", b"application/json"),
+                (b"content-length", str(len(body)).encode()),
+                (b"retry-after", b"5"),
+            ]})
+            await send({"type": "http.response.body", "body": body})
+            return
+        await self.app(scope, receive, send)

--- a/runtime/glm53-flash-jj-r8-gb10/test_image_contract.py
+++ b/runtime/glm53-flash-jj-r8-gb10/test_image_contract.py
@@ -93,6 +93,8 @@ def test_image_packages_dflash_warmup_and_rank_zero_waits_for_it() -> None:
     assert '"warmup_dflash.py"' in builder
     assert '"serve_with_warmup.py"' in builder
     assert '"scheduler_liveness.py"' in builder
+    assert '"startup_admission.py"' in builder
+    assert "COPY startup_admission.py /opt/sparkring/bin/startup_admission.py" in recipe
     assert '0) container_action=(run -d)' in launcher
     assert '1) container_action=(create)' in launcher
     assert 'container_command=(docker "${container_action[@]}"' in launcher
@@ -103,7 +105,7 @@ def test_image_packages_dflash_warmup_and_rank_zero_waits_for_it() -> None:
     wrapper = (HERE / "serve_with_warmup.py").read_text(encoding="utf-8")
     main_source = wrapper.split("def main() -> int:", 1)[1]
     assert main_source.index("READY_PATH.unlink(missing_ok=True)") < main_source.index(
-        'subprocess.Popen(["vllm", "serve"'
+        'subprocess.Popen('
     )
 
 

--- a/runtime/glm53-flash-jj-r8-gb10/test_serve_with_warmup.py
+++ b/runtime/glm53-flash-jj-r8-gb10/test_serve_with_warmup.py
@@ -217,3 +217,58 @@ def test_headless_rank_does_not_start_scheduler_liveness(monkeypatch) -> None:
         )
         is None
     )
+
+
+def test_wrapper_launches_gate_before_readiness_and_removes_marker(tmp_path, monkeypatch):
+    wrapper, _ = _load_module(monkeypatch)
+    ready = tmp_path / "ready"
+    ready.touch()
+    monkeypatch.setattr(wrapper, "READY_PATH", ready)
+    monkeypatch.setenv("SPARKRING_STARTUP_TOKEN", "stale-token")
+    monkeypatch.setenv("SPARKRING_LIVENESS_ENABLED", "0")
+    monkeypatch.setattr(wrapper.sys, "argv", ["serve-with-warmup.py", "model"])
+    monkeypatch.setattr(wrapper.signal, "signal", lambda *_: None)
+    started = []
+
+    class Child:
+        def wait(self):
+            assert ready.exists()
+            return 0
+
+    def popen(argv, env):
+        assert not ready.exists()
+        assert argv[-2:] == ["--middleware", "startup_admission.StartupAdmission"]
+        assert env["SPARKRING_STARTUP_TOKEN"] != "stale-token"
+        assert len(env["SPARKRING_STARTUP_TOKEN"]) >= 40
+        assert env["SPARKRING_STARTUP_TOKEN"] not in argv
+        assert str(HERE) in env["PYTHONPATH"].split(wrapper.os.pathsep)
+        assert env["SPARKRING_READY_PATH"] == str(ready)
+        started.append(env["SPARKRING_STARTUP_TOKEN"])
+        return Child()
+
+    def complete(**kwargs):
+        assert started == [wrapper.os.environ["SPARKRING_STARTUP_TOKEN"]]
+        ready.touch()
+
+    monkeypatch.setattr(wrapper.subprocess, "Popen", popen)
+    monkeypatch.setattr(wrapper, "complete_readiness", complete)
+    assert wrapper.main() == 0
+    assert not ready.exists()
+
+
+def test_both_warmup_requests_carry_internal_token_and_api_auth(monkeypatch):
+    wrapper, warmup = _load_module(monkeypatch)
+    monkeypatch.setenv("SPARKRING_STARTUP_TOKEN", "internal-secret")
+    observed = []
+
+    def urlopen(request, **kwargs):
+        observed.append(request)
+        return io.BytesIO(b'{"choices":[{"message":{"content":"ok"}}]}')
+
+    monkeypatch.setattr(wrapper.urllib.request, "urlopen", urlopen)
+    wrapper.warmup_sampling("http://localhost", "model", 16, 10, "api-secret")
+    warmup.send_warmup_request("http://localhost", "model", "nonce", 16, 10, 8, "api-secret")
+    assert len(observed) == 2
+    for request in observed:
+        assert request.get_header("X-sparkring-startup-token") == "internal-secret"
+        assert request.get_header("Authorization") == "Bearer api-secret"

--- a/runtime/glm53-flash-jj-r8-gb10/test_startup_admission.py
+++ b/runtime/glm53-flash-jj-r8-gb10/test_startup_admission.py
@@ -1,0 +1,97 @@
+"""Requests cannot enter the inference scheduler before warmup completes."""
+
+import asyncio
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+
+def load_gate():
+    spec = importlib.util.spec_from_file_location(
+        "startup_admission", Path(__file__).with_name("startup_admission.py")
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def request(gate, path, headers=(), client="192.0.2.10", method="POST"):
+    messages = []
+
+    async def receive():
+        raise AssertionError("Rejected requests must not consume the request body")
+
+    async def send(message):
+        messages.append(message)
+
+    asyncio.run(gate({"type": "http", "path": path, "method": method,
+                      "headers": list(headers), "client": (client, 1234)}, receive, send))
+    return messages
+
+
+@pytest.mark.parametrize("path", ["/v1/chat/completions", "/v1/completions",
+                                     "/v1/responses", "/v1/embeddings", "/generate"])
+def test_public_requests_never_reach_scheduler_before_ready(tmp_path, monkeypatch, path):
+    module = load_gate()
+    monkeypatch.setenv("SPARKRING_STARTUP_TOKEN", "internal-secret")
+    monkeypatch.setenv("SPARKRING_READY_PATH", str(tmp_path / "ready"))
+
+    async def scheduler(*args):
+        raise AssertionError("Request entered inference before warmup")
+
+    gate = module.StartupAdmission(scheduler)
+    for headers, client in [((), "192.0.2.10"), ((), "127.0.0.1"),
+                            (((b"x-sparkring-startup-token", b"wrong"),), "127.0.0.1")]:
+        messages = request(gate, path, headers, client)
+        assert messages[0]["status"] == 503
+        assert (b"retry-after", b"5") in messages[0]["headers"]
+
+
+def test_internal_warmup_then_public_admission_and_marker_removal(tmp_path, monkeypatch):
+    module = load_gate()
+    ready = tmp_path / "ready"
+    monkeypatch.setenv("SPARKRING_STARTUP_TOKEN", "internal-secret")
+    monkeypatch.setenv("SPARKRING_READY_PATH", str(ready))
+    calls = []
+
+    async def scheduler(scope, receive, send):
+        calls.append(scope)
+        await send({"type": "http.response.start", "status": 200, "headers": []})
+
+    gate = module.StartupAdmission(scheduler)
+    assert request(gate, "/v1/chat/completions",
+                   [(b"x-sparkring-startup-token", b"internal-secret")])[0]["status"] == 200
+    assert calls[0]["headers"] == []
+    for path in ("/health", "/v1/models", "/metrics"):
+        assert request(gate, path, method="GET")[0]["status"] == 200
+    ready.touch()
+    assert request(gate, "/v1/chat/completions")[0]["status"] == 200
+    ready.unlink()
+    assert request(gate, "/v1/chat/completions")[0]["status"] == 503
+
+
+def test_missing_internal_token_fails_closed(tmp_path, monkeypatch):
+    module = load_gate()
+    monkeypatch.delenv("SPARKRING_STARTUP_TOKEN", raising=False)
+    monkeypatch.setenv("SPARKRING_READY_PATH", str(tmp_path / "ready"))
+    with pytest.raises(RuntimeError, match="startup token"):
+        module.StartupAdmission(None)
+
+
+def test_websocket_cannot_bypass_admission(tmp_path, monkeypatch):
+    module = load_gate()
+    monkeypatch.setenv("SPARKRING_STARTUP_TOKEN", "internal-secret")
+    monkeypatch.setenv("SPARKRING_READY_PATH", str(tmp_path / "ready"))
+    messages = []
+
+    async def scheduler(*args):
+        raise AssertionError("Websocket reached scheduler during warmup")
+
+    async def send(message):
+        messages.append(message)
+
+    asyncio.run(module.StartupAdmission(scheduler)(
+        {"type": "websocket", "path": "/v1/realtime", "headers": []}, None, send
+    ))
+    assert messages == [{"type": "websocket.close", "code": 1013}]

--- a/runtime/glm53-flash-jj-r8-gb10/warmup_dflash.py
+++ b/runtime/glm53-flash-jj-r8-gb10/warmup_dflash.py
@@ -81,6 +81,9 @@ def send_warmup_request(
         "chat_template_kwargs": {"enable_thinking": False},
     }
     headers = {"Content-Type": "application/json"}
+    token = os.environ.get("SPARKRING_STARTUP_TOKEN")
+    if token:
+        headers["X-Sparkring-Startup-Token"] = token
     if credential:
         headers["Authorization"] = f"Bearer {credential}"
     request = urllib.request.Request(

--- a/runtime/glm53-spark-mtp3-mesh/performance/README.md
+++ b/runtime/glm53-spark-mtp3-mesh/performance/README.md
@@ -62,3 +62,25 @@ source or ownership dependency fails the build rather than weakening checks.
 The image verifier establishes file identity, not a throughput result.
 Source equivalence with a serving image and bounded test evidence must be
 recorded separately from any claim that this image completed a serving soak.
+
+## Startup admission
+
+Status: implemented; CPU request-boundary tests cover admission. A rebuilt
+serving image must be validated before hardware qualification is claimed.
+
+The serving wrapper installs vLLM middleware that returns HTTP 503 with
+`Retry-After: 5` until its readiness marker exists. Public requests cannot
+consume scheduler slots during request-shape and sampling warmup. Read-only
+`/health`, `/v1/models`, and `/metrics` probes remain available; `/health` is
+liveness, not completion of warmup. Docker readiness uses the marker.
+
+The wrapper generates a random startup token before launching vLLM and passes
+it to its warmup requests in an internal header. The middleware removes the
+header before forwarding a request. A loopback address alone does not bypass
+the gate. The token changes at every startup, and stopping the wrapper removes
+the marker. Failed warmup keeps public inference blocked.
+
+The build context includes the wrapper, warmup client, and admission module;
+the image receipt verifies all three files. Published image receipts describe
+immutable artifacts and do not claim this behavior until an image containing
+these sources has been built and recorded.

--- a/runtime/glm53-spark-mtp3-mesh/performance/install.py
+++ b/runtime/glm53-spark-mtp3-mesh/performance/install.py
@@ -45,6 +45,12 @@ subprocess.run(
 sys.path.insert(0, str(SOURCE / "reasoning"))
 from patch_contract import apply
 
+for name, target in (
+    ("serve_with_warmup.py", "serve-with-warmup.py"),
+    ("warmup_dflash.py", "warmup_dflash.py"),
+    ("startup_admission.py", "startup_admission.py"),
+):
+    shutil.copyfile(SOURCE / "startup" / name, Path("/opt/sparkring/bin") / target)
 apply(SITE, Path("/opt/sparkring/bin/warmup_dflash.py"))
 shutil.copytree(SOURCE / "sparkcache", SITE / "sparkcache", dirs_exist_ok=True)
 contract = (
@@ -83,6 +89,8 @@ for root in (
             files[str(path)] = hashlib.sha256(path.read_bytes()).hexdigest()
 for path in (
     Path("/opt/sparkring/bin/warmup_dflash.py"),
+    Path("/opt/sparkring/bin/serve-with-warmup.py"),
+    Path("/opt/sparkring/bin/startup_admission.py"),
     Path(
         "/opt/sparkcache-src/sparkcache/native/build-cuda/libspark_cache_placement.so"
     ),

--- a/runtime/glm53-spark-mtp3-mesh/performance/prepare.py
+++ b/runtime/glm53-spark-mtp3-mesh/performance/prepare.py
@@ -78,6 +78,11 @@ def prepare(cache, placement, transport, output):
     shutil.copyfile(placement, output / "libspark_cache_placement.so")
     for name in ("install.py", "verify.py", "start.py", "Dockerfile"):
         shutil.copyfile(HERE / name, output / name)
+    startup = output / "startup"
+    startup.mkdir()
+    for name in ("serve_with_warmup.py", "warmup_dflash.py", "startup_admission.py"):
+        shutil.copyfile(HERE.parent.parent / "glm53-flash-jj-r8-gb10" / name,
+                        startup / name)
     files = {
         p.relative_to(output).as_posix(): hashlib.sha256(p.read_bytes()).hexdigest()
         for p in output.rglob("*")

--- a/runtime/glm53-spark-mtp3-mesh/profile.py
+++ b/runtime/glm53-spark-mtp3-mesh/profile.py
@@ -127,10 +127,19 @@ def load_image_receipt(path: Path) -> dict:
             or inside.get("cuda_initialized") is not False or inside.get("model_loaded") is not False):
         raise ValueError("Image receipt does not verify the pinned parent and mesh bundle")
     warmup = inside.get("readiness_warmup")
-    if warmup is not None and warmup != {
+    expected_warmup = {
         "environment": "SPARKRING_WARMUP_TEMPERATURE",
         "helper_sha256": sha(BASE / "warmup_dflash.py"), "temperature": 1.0,
-    }:
+    }
+    public = json.loads((HERE / "public-image.json").read_text())
+    if image_id == public["config_image_id"]:
+        # Immutable images retain their packaged helper when checkout sources change.
+        # The public identity only authorizes its complete canonical content receipt.
+        canonical = json.loads((HERE / "image-receipt.json").read_text())
+        if canonical["image_id"] != public["config_image_id"] or document != canonical:
+            raise ValueError("Published image receipt differs from the repository pin")
+        expected_warmup = canonical["inside_image"].get("readiness_warmup")
+    if warmup is not None and warmup != expected_warmup:
         raise ValueError("Image receipt does not verify the sampling warmup helper")
     compute = inside.get("compute")
     required = PINS.get("compute", {})

--- a/runtime/glm53-spark-mtp3-mesh/test_public_recipe.py
+++ b/runtime/glm53-spark-mtp3-mesh/test_public_recipe.py
@@ -4,6 +4,8 @@ import json
 from pathlib import Path
 import sys
 
+import pytest
+
 HERE = Path(__file__).resolve().parent
 ROOT = HERE.parents[1]
 
@@ -35,3 +37,27 @@ def test_public_content_receipt_is_accepted_by_renderer():
     assert receipt['image_id'] == public['config_image_id']
     assert public['checks_passed'] and public['anonymous_pull']
     assert public['all_layer_diff_ids_match_tested_image']
+
+
+def test_published_warmup_receipt_does_not_follow_checkout_source(monkeypatch):
+    spec = importlib.util.spec_from_file_location('public_warmup_profile', HERE / 'profile.py')
+    profile = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(profile)
+    monkeypatch.setattr(profile, "sha", lambda path: "f" * 64)
+    receipt = profile.load_image_receipt(HERE / 'image-receipt.json')
+    assert receipt['inside_image']['readiness_warmup']['helper_sha256'] != "f" * 64
+
+
+@pytest.mark.parametrize("use_published_identity", [True, False])
+def test_published_identity_cannot_authorize_forged_warmup(tmp_path, use_published_identity):
+    spec = importlib.util.spec_from_file_location('forged_warmup_profile', HERE / 'profile.py')
+    profile = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(profile)
+    document = json.loads((HERE / 'image-receipt.json').read_text())
+    document['inside_image']['readiness_warmup']['helper_sha256'] = "f" * 64
+    if not use_published_identity:
+        document['image_id'] = document['image_reference'] = "sha256:" + "a" * 64
+    path = tmp_path / 'receipt.json'
+    path.write_text(json.dumps(document))
+    with pytest.raises(ValueError, match="Published image receipt|sampling warmup helper"):
+        profile.load_image_receipt(path)


### PR DESCRIPTION
Public inference can enter the scheduler after vLLM opens its listener but before the serving wrapper completes readiness warmup. A busy client can occupy every sequence slot, queue warmup requests, and cause the container readiness deadline to expire even while inference continues.

Status: **implemented**; rebuilt-image startup qualification is pending.

The serving wrapper installs a vLLM ASGI middleware that rejects public requests with HTTP 503 and `Retry-After: 5` until the readiness marker exists. Health, model discovery, and metrics probes remain available. Internal warmup requests carry a fresh per-start token; localhost alone is not trusted, duplicate token headers are rejected, and the token is stripped before downstream request handling. WebSocket admission follows the same gate. The wrapper removes readiness on exit or warmup failure.

The base image builder ships the middleware, and the MTP3 performance builder packages and attests the wrapper, warmup helper, and middleware. Existing published image receipts remain unchanged. The immutable hotfix recipe selects its matching wrapper revision explicitly.

Compatibility: requests during startup receive a retryable response instead of entering the scheduler. Serving after readiness, model authentication, SparkCache identities, and cache namespaces are unchanged. Deploying this behavior requires a rebuilt image.

Validation: request-boundary regression cases reproduced admission before the fix. The focused suite passed 147 tests with one optional skip; Ruff and whitespace checks passed. Independent review found no blocking issues. Live observation established the trigger: 16 running requests and 18 queued requests while the readiness marker was absent. The published image subsequently became healthy after the client stopped and warmup completed; that observation does not qualify the middleware fix.

Repository-wide offline validation: 3,034 passed, 85 documented platform/optional-artifact skips. Ruff passed and 552 repository-relative documentation links checked. Published-receipt compatibility tests verify that source edits preserve the canonical published image and reject forged helper hashes.
