### PR TITLE
Document exact-image MTP3 smoke validation and deployment limits

### DIFF
--- a/docs/GLM53_MTP3_CACHE_CHECKPOINTS_QUICKSTART.md
+++ b/docs/GLM53_MTP3_CACHE_CHECKPOINTS_QUICKSTART.md
@@ -1,9 +1,17 @@
 # GLM-5.3 native MTP3 with verified caching and recurrent checkpoints
 
-Status: **research-only**. The image build and source checks are implemented.
-The published image's vLLM, B12X, transport, and warmup files match the deployed
-composition in 5,308 byte comparisons. It incorporates SparkCache main at the
-revision below. Source equivalence is not a serving soak of this rebuilt image.
+Status: **research-only**. The exact published image passed
+[eight bounded serving checks](../performance/records/glm53-flash/mtp3-cache-checkpoints-serving-smoke-20260906.md):
+text, growing conversation, streaming, reasoning rejection, and image responses.
+Its 5,308 runtime-file comparisons and 5,472-file image verification also passed.
+The smoke test configured 40 GiB of persistent cache per rank but did not fill
+it; no explicit persistent restore was observed. It is not a long-duration soak.
+
+The startup-admission fix in merged
+[SparkRing #237](https://github.com/FujitsuPolycom/sparkring/pull/237) is absent
+from this image. Public traffic can compete with warmup before Docker readiness.
+Keep client traffic off the API until readiness completes. The HTTP 503 startup
+gate requires a rebuilt image and separate startup verification.
 
 ## Prerequisites
 

--- a/performance/records/glm53-flash/mtp3-cache-checkpoints-serving-smoke-20260906.json
+++ b/performance/records/glm53-flash/mtp3-cache-checkpoints-serving-smoke-20260906.json
@@ -1,0 +1,300 @@
+{
+  "schema": "sparkring-mtp3-bounded-serving-smoke/v1",
+  "status": "qualified",
+  "runtime_status": "research-only",
+  "conditions": {
+    "model_repository": "local-inference-lab/GLM-5.3-Flash-NVFP4-Spark",
+    "model_revision": "df116c4fb16b1d37ae43d2cfd624de26ffbc832e",
+    "image_reference": "ghcr.io/fujitsupolycom/sparkring-glm53-sparkcache@sha256:11a556a54041fd823d152a7f051ac4f7c617dc539030df26e93008392fee0746",
+    "image_id": "sha256:6921a6c163ea40b603e19a0332330efe3dbccbf4dce9f6cbbf6b756c9231835a",
+    "sparkcache_commit": "48bbd2be4a7b972e56632a2d7b934bac5460f272",
+    "hardware": "four NVIDIA GB10 Sparks",
+    "transport": "managed hardware-forwarded mesh",
+    "tensor_parallel_size": 4,
+    "decode_context_parallel_size": 4,
+    "mtp_depth": 3,
+    "prefill_checkpoints": 2,
+    "kv_gib_per_rank": 24,
+    "max_num_seqs": 16,
+    "max_num_batched_tokens": 8192,
+    "cache_max_gib_per_rank": 40,
+    "cache_low_watermark_gib_per_rank": 32,
+    "periodic_full_capture_interval_tokens": 0,
+    "cache_state": "Warm cache, not filled to configured capacity; one aggregate log sample reported 6.0 GiB used across 160.0 GiB capacity.",
+    "request_concurrency": 1,
+    "repetitions": "one sequence of eight cases; red image repeated once",
+    "temperature": 0,
+    "reasoning_effort": "low, except the deliberate unsupported none request",
+    "max_tokens": 512,
+    "harness_role": "one-off Python urllib chat-completion smoke client",
+    "harness_sha256": "bbebdebe1c2fed61ea04eddb43ee759bace22cfb4ed7b8998b32e91335d4c083",
+    "warmup": "Required request-shape and sampling warmup completed before smoke traffic."
+  },
+  "measurement": {
+    "clock": "Python time.perf_counter for elapsed and streaming latency; time.time for request start timestamps",
+    "elapsed_scope": "request serialization, HTTP response reading and local result checks; no connection-pool reuse",
+    "aggregation": "Individual observations, no repeated-run variance or throughput comparison",
+    "raw_api_observations": "checks",
+    "rank_log_observations": "rank_commits",
+    "request_start_utc": "2026-09-06T22:04:39.212026+00:00",
+    "file_verifier_count_per_rank": 5472
+  },
+  "result": {
+    "passed": 8,
+    "total": 8,
+    "sum_case_elapsed_seconds": 8.012548800019431,
+    "explicit_persistent_restores_observed": 0,
+    "all_four_ranks_running_healthy": true
+  },
+  "conclusion": "The immutable published image passed the eight bounded text, continuation, streaming, reasoning-rejection and image checks and committed a 4096-token context on all four ranks.",
+  "limitations": [
+    "Not a matched reproduction of SparkCache issues 60 or 61.",
+    "Configured 40 GiB per rank was not filled; no near-capacity eviction or sustained-publication qualification.",
+    "API cached-token accounting does not distinguish local retention from persistent restoration.",
+    "Image requests were below the persistent minimum span and did not qualify multimodal persistent restoration.",
+    "Public traffic could compete with startup warmup in this image; the source fix in SparkRing PR 237 requires an image rebuild and separate startup verification.",
+    "No isolated throughput benchmark, repeatability estimate, long-duration soak or unattended-availability qualification.",
+    "The one-off harness source is identified by SHA-256; it is not packaged as a reusable public harness."
+  ],
+  "checks": [
+    {
+      "name": "text",
+      "request_id": "integrated-smoke-a383a7e030014a20b689b2356d6f323d",
+      "started_unix": 1788732279.2120261,
+      "expected": "5",
+      "image_sha256": null,
+      "status": 200,
+      "response_id": "chatcmpl-integrated-smoke-a383a7e030014a20b689b2356d6f323d",
+      "usage": {
+        "prompt_tokens": 26,
+        "total_tokens": 29,
+        "completion_tokens": 3,
+        "prompt_tokens_details": {
+          "cached_tokens": 0,
+          "created_cache_tokens": 0,
+          "multimodal_tokens": null
+        },
+        "completion_tokens_details": {
+          "reasoning_tokens": 0
+        }
+      },
+      "answer": "5",
+      "finish_reason": "stop",
+      "passed": true,
+      "elapsed_seconds": 0.2550358000007691
+    },
+    {
+      "name": "growing-chat-start",
+      "request_id": "integrated-smoke-b9284f450eb848d99be2f76707ed4837",
+      "started_unix": 1788732279.4675455,
+      "expected": "orchid",
+      "image_sha256": null,
+      "status": 200,
+      "response_id": "chatcmpl-integrated-smoke-b9284f450eb848d99be2f76707ed4837",
+      "usage": {
+        "prompt_tokens": 5628,
+        "total_tokens": 5633,
+        "completion_tokens": 5,
+        "prompt_tokens_details": {
+          "cached_tokens": 0,
+          "created_cache_tokens": 4608,
+          "multimodal_tokens": null
+        },
+        "completion_tokens_details": {
+          "reasoning_tokens": 0
+        }
+      },
+      "answer": "ORCHID",
+      "finish_reason": "stop",
+      "passed": true,
+      "elapsed_seconds": 3.0998375000053784
+    },
+    {
+      "name": "growing-chat-continuation",
+      "request_id": "integrated-smoke-3cb519e9573d478693d51d4668d19b52",
+      "started_unix": 1788732282.567156,
+      "expected": "orchid",
+      "image_sha256": null,
+      "status": 200,
+      "response_id": "chatcmpl-integrated-smoke-3cb519e9573d478693d51d4668d19b52",
+      "usage": {
+        "prompt_tokens": 5650,
+        "total_tokens": 5663,
+        "completion_tokens": 13,
+        "prompt_tokens_details": {
+          "cached_tokens": 4608,
+          "created_cache_tokens": 512,
+          "multimodal_tokens": null
+        },
+        "completion_tokens_details": {
+          "reasoning_tokens": 8
+        }
+      },
+      "answer": "ORCHID",
+      "finish_reason": "stop",
+      "passed": true,
+      "elapsed_seconds": 1.6567629000055604
+    },
+    {
+      "name": "streamed-text",
+      "request_id": "integrated-smoke-7697428224ff4a22a5ff8e36c3dd897f",
+      "started_unix": 1788732284.223929,
+      "expected": "7",
+      "image_sha256": null,
+      "status": 200,
+      "first_event_seconds": 0.2015294000011636,
+      "first_content_seconds": 0.24906609999015927,
+      "answer": "7",
+      "usage": {
+        "prompt_tokens": 26,
+        "total_tokens": 29,
+        "completion_tokens": 3,
+        "prompt_tokens_details": {
+          "cached_tokens": 0,
+          "created_cache_tokens": 0
+        },
+        "completion_tokens_details": {
+          "reasoning_tokens": 0
+        }
+      },
+      "finish_reason": "stop",
+      "sse_done": true,
+      "events": 3,
+      "passed": true,
+      "elapsed_seconds": 0.24915009998949245
+    },
+    {
+      "name": "reject-disabled-reasoning",
+      "request_id": "integrated-smoke-934ba5e6a888445a8ba472eb4a436e5d",
+      "started_unix": 1788732284.4732332,
+      "expected": null,
+      "image_sha256": null,
+      "status": 400,
+      "error": "{\"error\":{\"message\":\"GLM-5.3-Flash does not support disabling thinking with its chat template. Use reasoning_effort='low', 'high', or 'max'.\",\"type\":\"BadRequestError\",\"param\":null,\"code\":400}}",
+      "passed": true,
+      "elapsed_seconds": 0.017933800001628697
+    },
+    {
+      "name": "image-1-red",
+      "request_id": "integrated-smoke-1694404792ef432883a018abd2487ee1",
+      "started_unix": 1788732284.491566,
+      "expected": "red",
+      "image_sha256": "f2279b67d1a030bc3c0cc285cc70129b8f8bdf1d51423a031c7feccd4d5a2daf",
+      "status": 200,
+      "response_id": "chatcmpl-integrated-smoke-1694404792ef432883a018abd2487ee1",
+      "usage": {
+        "prompt_tokens": 223,
+        "total_tokens": 226,
+        "completion_tokens": 3,
+        "prompt_tokens_details": {
+          "cached_tokens": 0,
+          "created_cache_tokens": 0,
+          "multimodal_tokens": {
+            "image": 196
+          }
+        },
+        "completion_tokens_details": {
+          "reasoning_tokens": 0
+        }
+      },
+      "answer": "red",
+      "finish_reason": "stop",
+      "passed": true,
+      "elapsed_seconds": 0.9791747999988729
+    },
+    {
+      "name": "image-2-blue",
+      "request_id": "integrated-smoke-82f3a27ade9b4294871d45f65a5c668f",
+      "started_unix": 1788732285.4705372,
+      "expected": "blue",
+      "image_sha256": "f65916066f15023a2651638b0755637a1af304200757a6ab78b58c38b6fc5e3c",
+      "status": 200,
+      "response_id": "chatcmpl-integrated-smoke-82f3a27ade9b4294871d45f65a5c668f",
+      "usage": {
+        "prompt_tokens": 223,
+        "total_tokens": 226,
+        "completion_tokens": 3,
+        "prompt_tokens_details": {
+          "cached_tokens": 0,
+          "created_cache_tokens": 0,
+          "multimodal_tokens": {
+            "image": 196
+          }
+        },
+        "completion_tokens_details": {
+          "reasoning_tokens": 0
+        }
+      },
+      "answer": "Blue",
+      "finish_reason": "stop",
+      "passed": true,
+      "elapsed_seconds": 0.8685438000102295
+    },
+    {
+      "name": "image-3-red",
+      "request_id": "integrated-smoke-d3e83f694a424fbdbc9d9951e94ad410",
+      "started_unix": 1788732286.3393188,
+      "expected": "red",
+      "image_sha256": "f2279b67d1a030bc3c0cc285cc70129b8f8bdf1d51423a031c7feccd4d5a2daf",
+      "status": 200,
+      "response_id": "chatcmpl-integrated-smoke-d3e83f694a424fbdbc9d9951e94ad410",
+      "usage": {
+        "prompt_tokens": 223,
+        "total_tokens": 226,
+        "completion_tokens": 3,
+        "prompt_tokens_details": {
+          "cached_tokens": 0,
+          "created_cache_tokens": 0,
+          "multimodal_tokens": {
+            "image": 196
+          }
+        },
+        "completion_tokens_details": {
+          "reasoning_tokens": 0
+        }
+      },
+      "answer": "red",
+      "finish_reason": "stop",
+      "passed": true,
+      "elapsed_seconds": 0.8861101000074996
+    }
+  ],
+  "rank_commits": [
+    {
+      "rank": 0,
+      "tokens": 4096,
+      "context_digest_prefix": "5a8faef36b84",
+      "manifest_digest_prefix": "68a43cbd0671",
+      "commit_ms": 164.0,
+      "container_state": "running",
+      "container_health": "healthy"
+    },
+    {
+      "rank": 1,
+      "tokens": 4096,
+      "context_digest_prefix": "5a8faef36b84",
+      "manifest_digest_prefix": "a61e41e9ac88",
+      "commit_ms": 178.0,
+      "container_state": "running",
+      "container_health": "healthy"
+    },
+    {
+      "rank": 2,
+      "tokens": 4096,
+      "context_digest_prefix": "5a8faef36b84",
+      "manifest_digest_prefix": "f973781b91af",
+      "commit_ms": 184.9,
+      "container_state": "running",
+      "container_health": "healthy"
+    },
+    {
+      "rank": 3,
+      "tokens": 4096,
+      "context_digest_prefix": "5a8faef36b84",
+      "manifest_digest_prefix": "74d5b6fe880c",
+      "commit_ms": 182.9,
+      "container_state": "running",
+      "container_health": "healthy"
+    }
+  ]
+}

--- a/performance/records/glm53-flash/mtp3-cache-checkpoints-serving-smoke-20260906.md
+++ b/performance/records/glm53-flash/mtp3-cache-checkpoints-serving-smoke-20260906.md
@@ -1,0 +1,97 @@
+# Native-MTP3 cache/checkpoint image: bounded serving smoke
+
+Status: **qualified** for the eight correctness checks below. The deployment
+profile remains **research-only**.
+
+## Conditions
+
+The test used four NVIDIA GB10 Sparks in the managed hardware-forwarded mesh,
+TP4/DCP4, native MTP depth three, and two recurrent prefill checkpoints. The
+model was `local-inference-lab/GLM-5.3-Flash-NVFP4-Spark` at revision
+`df116c4fb16b1d37ae43d2cfd624de26ffbc832e`.
+
+The exact serving image was
+`ghcr.io/fujitsupolycom/sparkring-glm53-sparkcache@sha256:11a556a54041fd823d152a7f051ac4f7c617dc539030df26e93008392fee0746`,
+config ID
+`sha256:6921a6c163ea40b603e19a0332330efe3dbccbf4dce9f6cbbf6b756c9231835a`.
+It includes SparkCache revision
+`48bbd2be4a7b972e56632a2d7b934bac5460f272`.
+
+Each rank had 24 GiB KV capacity, 16 sequence slots, and an 8,192-token batch
+limit. Persistent-cache limits were **40 GiB maximum and 32 GiB low watermark
+per rank**, with periodic full captures disabled. The cache was warm and not
+filled to capacity; one aggregate log sample reported 6.0 GiB used across
+160.0 GiB configured capacity.
+
+The client sent one sequence of eight requests at concurrency one, beginning
+September 6, 2026 at 22:04:39 UTC. Requests used temperature zero, a 512-token
+output limit, and low reasoning effort, except the deliberate unsupported
+reasoning request. The conversation contained a repeated garden passage and
+an access word, followed by a request to repeat that word. Image requests
+asked for the color of a red or blue square, in red/blue/red order.
+
+## Measurement
+
+The one-off Python HTTP client's source SHA-256 and complete API observations
+are retained in the [machine-readable record](mtp3-cache-checkpoints-serving-smoke-20260906.json).
+Elapsed times use `time.perf_counter` around request construction, response
+reading, and result checks. Start timestamps use `time.time`. Each duration
+is a single observation; no variance estimate or matched throughput comparison
+is available.
+
+All four ranks passed the 5,472-file image verifier before launch. The host
+memory and mesh startup gates passed, and request-shape and sampling warmup
+completed before the smoke requests. Rank logs supplied commit times and
+container health observations. The JSON retains those extracted measurements
+without host addresses or unrelated client log entries.
+
+## Result
+
+All eight checks passed; their elapsed times sum to 8.013 seconds.
+
+| Case | Result | Elapsed time |
+|---|---|---:|
+| Arithmetic text | Correct answer, normal stop | 0.255 s |
+| 5,628-token conversation start | Correct access word | 3.100 s |
+| 5,650-token continuation | Correct retained word; API reported 4,608 cached tokens | 1.657 s |
+| Streamed arithmetic | Correct answer, normal stop, SSE completion marker | 0.249 s |
+| Unsupported reasoning suppression | Expected HTTP 400 | 0.018 s |
+| Red image | Correct color | 0.979 s |
+| Blue image | Correct color | 0.869 s |
+| Repeated red image | Correct color | 0.886 s |
+
+All ranks committed the same 4,096-token context, whose digest prefix was
+`5a8faef36b84`. Commit times were 164.0, 178.0, 184.9, and 182.9 ms for ranks
+zero through three. No explicit persistent-restore event was observed during
+the eight checks. All four containers were running and healthy afterward.
+
+## Conclusion
+
+The immutable image passed bounded text, growing-conversation, streaming,
+reasoning-rejection, and image-response correctness checks. It also published
+a persistent context on all four ranks. These observations establish serving
+behavior for the exact image, beyond its separate
+[source-equivalence checks](mtp3-integrated-image-source-equivalence.md).
+
+## Limitations
+
+The cache was configured for 40 GiB per rank but was not filled. This is not
+a near-capacity eviction test, sustained-publication test, isolated benchmark,
+long-duration soak, or unattended-availability qualification. It is not a
+matched reproduction of [SparkCache #60](https://github.com/FujitsuPolycom/sparkcache/issues/60)
+or [#61](https://github.com/FujitsuPolycom/sparkcache/issues/61).
+
+API cached-token accounting does not distinguish local prefix retention from
+persistent restoration. The image prompts contained 223 tokens, including
+196 image tokens, below the persistent cache's minimum span. They establish
+image-response correctness, not multimodal persistent-restore qualification.
+The one-off harness is identified by hash but is not packaged as a reusable
+public harness.
+
+Public requests could occupy scheduler slots before readiness warmup finished
+in this image. External traffic contended with warmup; after its queue drained,
+warmup completed without a model restart. The startup-admission fix in merged
+[SparkRing #237](https://github.com/FujitsuPolycom/sparkring/pull/237) is
+**implemented in repository source but absent from this published image**.
+Its HTTP 503 admission gate requires a rebuilt image and separate startup
+verification. Merging source does not change the running image.

--- a/performance/records/glm53-flash/mtp3-integrated-image-source-equivalence.md
+++ b/performance/records/glm53-flash/mtp3-integrated-image-source-equivalence.md
@@ -43,8 +43,10 @@ the composition without private workspace paths.
 
 ## Limitations
 
-No serving soak was run on this exact rebuilt image. Source equivalence does not
-transfer every measurement from the comparison image. Earlier cache-pressure
+This file-comparison record does not measure serving behavior. The exact image
+also passed a separate [bounded serving smoke](mtp3-cache-checkpoints-serving-smoke-20260906.md);
+no long-duration serving soak of this exact image is claimed. Source equivalence
+does not transfer every measurement from the comparison image. Earlier cache-pressure
 tests used a 2 GiB/rank namespace; 40 GiB multimodal stress behavior remains
 unqualified. Native binary rebuilds can differ with toolchains and require
 separate verification. This record does not establish unattended availability.


### PR DESCRIPTION
Record eight successful serving checks and four-rank cache publication for the published native-MTP3 image. The quickstart distinguishes configured 40 GiB capacity from near-capacity qualification and states that the merged startup-admission gate is absent from this image. No runtime settings or immutable receipts change. Validation: evidence totals, image identities, privacy scan, documentation links, and whitespace checks passed.