### PR TITLE
Allow a site-level API keys file for the managed MTP3 mesh

### DIFF
--- a/docs/GLM53_SPARK_MTP3_MESH_QUICKSTART.md
+++ b/docs/GLM53_SPARK_MTP3_MESH_QUICKSTART.md
@@ -505,7 +505,20 @@ Edit those private copies. At minimum, review every field below:
 | `marker_binary_sha256` | `inside_image.marker_binary_sha256` from the verified image receipt, not the template's diagnostic binary hash |
 | `container_prefix` | An unused prefix reserved for this deployment |
 | `state_root` | Retain the schema's planned state path; the managed service separately uses `/run/sparkring-mesh` |
-| `api_keys_file` | Optional. Absolute host path to a mode-0600 file of newline-separated API keys. When present the renderer sets `API_KEYS_FILE` in every rank environment and the launcher serves `--api-key` for each non-empty line; when absent the API is unauthenticated. The keys become container arguments, so treat the rendered plan as sensitive and re-render after rotating the file |
+| `api_keys_file` | Optional. Absolute host path to a readable mode-0600 file of newline-separated API keys, present at the same path on every rank. The renderer sets `API_KEYS_FILE`; the launcher passes one `--api-key` option followed by all non-empty keys. Keys cannot contain whitespace. Omitting this field leaves the API unauthenticated. |
+
+API keys are separate from the managed mesh health key. Container creation
+copies API keys into the model arguments and the first key into the warmup
+environment. Treat Docker command plans and inspection output as sensitive.
+Rendering stores only the key-file path; it does not capture or rotate keys.
+
+To rotate API keys, coordinate a stop across all ranks, update the private key
+files, and recreate the serving containers. Update and revalidate the managed
+container identities before restarting through the
+[managed lifecycle](../runtime/glm53-spark-mtp3-mesh/MANAGED_MESH.md).
+Re-render if the key-file path changes. Re-rendering alone or restarting an
+existing container does not change its captured keys. The first-install helper
+is not an in-place deployment updater.
 
 Retain the topology's `bounded_runtime_seconds: 7200` compatibility field.
 It describes diagnostic-plan arguments and is validated by the renderer;

--- a/docs/GLM53_SPARK_MTP3_MESH_QUICKSTART.md
+++ b/docs/GLM53_SPARK_MTP3_MESH_QUICKSTART.md
@@ -505,6 +505,7 @@ Edit those private copies. At minimum, review every field below:
 | `marker_binary_sha256` | `inside_image.marker_binary_sha256` from the verified image receipt, not the template's diagnostic binary hash |
 | `container_prefix` | An unused prefix reserved for this deployment |
 | `state_root` | Retain the schema's planned state path; the managed service separately uses `/run/sparkring-mesh` |
+| `api_keys_file` | Optional. Absolute host path to a mode-0600 file of newline-separated API keys. When present the renderer sets `API_KEYS_FILE` in every rank environment and the launcher serves `--api-key` for each non-empty line; when absent the API is unauthenticated. The keys become container arguments, so treat the rendered plan as sensitive and re-render after rotating the file |
 
 Retain the topology's `bounded_runtime_seconds: 7200` compatibility field.
 It describes diagnostic-plan arguments and is validated by the renderer;

--- a/runtime/glm53-spark-mtp3-mesh/profile.py
+++ b/runtime/glm53-spark-mtp3-mesh/profile.py
@@ -65,9 +65,11 @@ def absolute(value: object, label: str) -> str:
 
 def load_site(path: Path):
     data = json.loads(path.read_text())
-    expected = {"schema", "topology_file", "management_addresses", "model_roots", "cache_roots",
+    required = {"schema", "topology_file", "management_addresses", "model_roots", "cache_roots",
                 "bundle_root", "container_prefix", "marker_binary", "marker_binary_sha256", "state_root"}
-    if set(data) != expected or data["schema"] != "sparkring-glm53-mtp3-mesh-site/v1":
+    optional = {"api_keys_file"}
+    if (not required <= set(data) <= required | optional
+            or data["schema"] != "sparkring-glm53-mtp3-mesh-site/v1"):
         raise ValueError("Site fields do not match sparkring-glm53-mtp3-mesh-site/v1")
     for name in ("management_addresses", "model_roots", "cache_roots"):
         if not isinstance(data[name], list) or len(data[name]) != 4:
@@ -84,6 +86,8 @@ def load_site(path: Path):
             absolute(value, key)
     for key in ("bundle_root", "marker_binary", "state_root"):
         absolute(data[key], key)
+    if "api_keys_file" in data:
+        absolute(data["api_keys_file"], "api_keys_file")
     topology_path = path.parent / data["topology_file"]
     topology = fabric.load_topology(topology_path)
     for node in topology.ranks:
@@ -197,6 +201,8 @@ def render(site_path: Path, bundle: Path, output: Path, image_receipt: Path | No
         "MASTER_ADDR": site["management_addresses"][0], "DFLASH_WARMUP": "1",
         "SPARKRING_WARMUP_TEMPERATURE": "0",
     })
+    if site.get("api_keys_file"):
+        values["API_KEYS_FILE"] = site["api_keys_file"]
     if image_record is not None:
         values["IMAGE_ID"] = image_record["image_id"]
         values["IMAGE_REF"] = image_record["image_reference"]

--- a/runtime/glm53-spark-mtp3-mesh/test_profile.py
+++ b/runtime/glm53-spark-mtp3-mesh/test_profile.py
@@ -401,3 +401,39 @@ def test_invalid_image_receipt_creates_no_rendered_output(tmp_path, manifest_bun
     with pytest.raises(ValueError, match="Image receipt"):
         mesh_profile.render(_site(tmp_path), manifest_bundle, output, path)
     assert not output.exists()
+
+
+def _site_with_api_keys(tmp_path, value="/srv/sparkring/private/api-keys"):
+    path = _site(tmp_path)
+    data = json.loads(path.read_text())
+    data["api_keys_file"] = value
+    path.write_text(json.dumps(data))
+    return path
+
+
+def test_site_accepts_absolute_api_keys_file(tmp_path):
+    site, _, _ = mesh_profile.load_site(_site_with_api_keys(tmp_path))
+    assert site["api_keys_file"] == "/srv/sparkring/private/api-keys"
+
+
+@pytest.mark.parametrize("value", ["relative/keys", "/srv/../etc/keys", "/srv/a:b", "/srv/a\nexec", "/"])
+def test_site_rejects_unsafe_api_keys_file(tmp_path, value):
+    with pytest.raises(ValueError):
+        mesh_profile.load_site(_site_with_api_keys(tmp_path, value))
+
+
+def test_render_omits_api_keys_file_when_site_is_silent(tmp_path, manifest_bundle):
+    output = tmp_path / "rendered-default"
+    mesh_profile.render(_site(tmp_path), manifest_bundle, output)
+    for rank in range(4):
+        assert "API_KEYS_FILE" not in mesh_profile.defaults(output / f"rank{rank}.env")
+
+
+def test_render_propagates_api_keys_file_to_every_rank(tmp_path, manifest_bundle):
+    path = _site_with_api_keys(tmp_path)
+    output = tmp_path / "rendered-keys"
+    mesh_profile.render(path, manifest_bundle, output)
+    for rank in range(4):
+        values = mesh_profile.defaults(output / f"rank{rank}.env")
+        assert values["API_KEYS_FILE"] == "/srv/sparkring/private/api-keys"
+    mesh_profile.load_site(output / "site.json")


### PR DESCRIPTION
## Problem

The managed MTP3 mesh has no way to serve authenticated traffic, even though
the profile's own rendered launcher implements multi-key auth in full.

`runtime/glm53-spark-mtp3-mesh/launch-rank.sh` reads `API_KEYS_FILE` host-side,
requires the file be a readable regular file of mode `0600`, rejects whitespace
inside a key, refuses an empty list, and emits one `--api-key` per non-empty
line (added in #180). Nothing can reach it:

- `profile.py::load_site` validates with `set(data) != expected`, so adding
  `api_keys_file` to a private site is rejected outright.
- The managed installer regenerates the rank environments from the site and
  runs the launcher under a sanitized environment, so an ambient
  `API_KEYS_FILE` is not inherited either — asserted by
  `test_managed_install.py::test_canonical_spec_runs_only_regenerated_inputs_in_sanitized_environment`.
- `canonical_container_spec` rejects post-render edits to `rank*.env`
  (`test_canonical_spec_rejects_changed_launch_before_execution`), so an
  operator cannot add the variable afterwards.

A managed mesh deployment therefore serves `:8015` with no key. That is fine
for an isolated bench, but it blocks the profile for anyone whose clients
authenticate — including replacing an existing lane that does.

## Change

Accept an **optional** `api_keys_file` in `sparkring-glm53-mtp3-mesh-site/v1`:

- `load_site` now requires the existing fields and permits exactly this one
  extra key. Unknown fields are still rejected, and the existing
  `test_site_schema_is_exact` "extra field" case passes unchanged.
- The value goes through the existing `absolute()` guard, so `/`, relative
  paths, parent traversal, `:` and newline injection are all refused.
- When present, `render` sets `API_KEYS_FILE` in all four rank environments.
  When absent the rendered environments are byte-identical to today, so
  existing private sites are unaffected.

The launcher and installer are untouched; this only unblocks a code path the
profile already ships.

## Tests

Four tests added to `test_profile.py`:

- `test_site_accepts_absolute_api_keys_file`
- `test_site_rejects_unsafe_api_keys_file` (5 parametrized unsafe values)
- `test_render_omits_api_keys_file_when_site_is_silent` — proves the default
  render is unchanged
- `test_render_propagates_api_keys_file_to_every_rank` — all four ranks, and
  the copied `site.json` still round-trips through `load_site`

`python -m pytest runtime/glm53-spark-mtp3-mesh -q` on Linux/bash 5.2:
**456 passed, 2 skipped**, against a 448-passed baseline on the same commit.

## Verified on hardware

Four DGX Sparks, hardware-forwarded mesh, cache+checkpoints composition. With
this change the rendered `rank*.env` carry `API_KEYS_FILE`, and the served
endpoint returns **401** without a key and **200** with one. The lane then
passed 1M NIAH at depths 0.1/0.5/0.9 (exact retrieval, ~1.006M prompt tokens
each), an 8-run corruption probe, and the exact semantic canary.

## Note on key handling

Keys become container arguments, so the rendered plan and `docker inspect`
output are sensitive, and rotating the key file needs a re-render rather than
a restart. Happy to follow up with a mount-based alternative that keeps keys
out of argv and makes rotation a restart, if you would prefer that shape.
