### PR TITLE
Accept either receipt image identity when scanning the canonical Docker envelope

### DIFF
--- a/runtime/glm53-spark-mtp3-mesh/managed_install.py
+++ b/runtime/glm53-spark-mtp3-mesh/managed_install.py
@@ -117,6 +117,17 @@ def expected_container_spec(argv, image):
     image_id = image.get('Id')
     if not isinstance(image_id, str) or not re.fullmatch('sha256:[0-9a-f]{64}', image_id):
         raise ValueError('Image inspection must provide an immutable identity')
+    # The launcher names the image with whichever identity the receipt supplied.
+    # sparkring-mtp3-mesh-image-receipt/v1 sets image_reference to the config
+    # image ID, but sparkring-mtp3-performance-public-image/v1 sets it to a
+    # registry reference carrying the manifest digest, so the envelope scan must
+    # accept either. The spec still reports the config ID, which is what Docker
+    # records as the container's Image.
+    repo_digests = image.get('RepoDigests') or []
+    if (not isinstance(repo_digests, list)
+            or any(not isinstance(digest, str) for digest in repo_digests)):
+        raise ValueError('Image inspection returned malformed repository digests')
+    image_names = {image_id, *repo_digests}
     config = image.get('Config', {})
     if config.get('Volumes'):
         raise ValueError('Managed profile does not support image-declared anonymous volumes')
@@ -127,7 +138,7 @@ def expected_container_spec(argv, image):
     value_options = {'--name', '--entrypoint', '--network', '--ipc', '--shm-size', '--gpus',
                      '--ulimit', '--cap-add', '--device', '--security-opt', '-v', '-e', '--label'}
     index = 2
-    while index < len(argv) and argv[index] != image_id:
+    while index < len(argv) and argv[index] not in image_names:
         flag = argv[index]
         if flag == '--init':
             if flag in options:

--- a/runtime/glm53-spark-mtp3-mesh/managed_install.py
+++ b/runtime/glm53-spark-mtp3-mesh/managed_install.py
@@ -123,9 +123,17 @@ def expected_container_spec(argv, image):
     # registry reference carrying the manifest digest, so the envelope scan must
     # accept either. The spec still reports the config ID, which is what Docker
     # records as the container's Image.
-    repo_digests = image.get('RepoDigests') or []
+    repo_digests = image.get('RepoDigests')
+    if repo_digests is None:
+        repo_digests = []
+    repository_digest = re.compile(
+        r'(?:[A-Za-z0-9][A-Za-z0-9.-]*(?::[0-9]+)?/)?'
+        r'[a-z0-9]+(?:(?:[._]|__|-+)[a-z0-9]+)*'
+        r'(?:/[a-z0-9]+(?:(?:[._]|__|-+)[a-z0-9]+)*)*@sha256:[0-9a-f]{64}'
+    )
     if (not isinstance(repo_digests, list)
-            or any(not isinstance(digest, str) for digest in repo_digests)):
+            or any(not isinstance(digest, str) or not repository_digest.fullmatch(digest)
+                   for digest in repo_digests)):
         raise ValueError('Image inspection returned malformed repository digests')
     image_names = {image_id, *repo_digests}
     config = image.get('Config', {})

--- a/runtime/glm53-spark-mtp3-mesh/test_managed_install.py
+++ b/runtime/glm53-spark-mtp3-mesh/test_managed_install.py
@@ -311,3 +311,39 @@ print('CPU-only installed imports passed')
                             cwd=tmp_path, capture_output=True, text=True, timeout=15)
     assert result.returncode == 0, result.stderr
     assert 'CPU-only installed imports passed' in result.stdout
+
+
+def _envelope_argv(image_name):
+    """A minimal canonical `docker create` naming the image with `image_name`."""
+    return ['docker', 'create', '--name', 'profile-r0', '--entrypoint', '/bin/bash',
+            image_name, '--model', '/models/target', '--served-model-name', 'glm']
+
+
+@pytest.mark.parametrize('by', ['config_id', 'repo_digest'])
+def test_envelope_scan_accepts_either_receipt_image_identity(by):
+    """sparkring-mtp3-mesh-image-receipt/v1 puts the config image ID in
+    image_reference, but sparkring-mtp3-performance-public-image/v1 puts a
+    registry reference there, and the launcher passes whichever it was given to
+    docker create. Both must terminate the envelope scan; without the registry
+    form the scan runs into the model arguments and dies on the first flag."""
+    image_id = 'sha256:' + 'a' * 64
+    repo_digest = 'ghcr.io/example/image@sha256:' + 'b' * 64
+    image = {'Id': image_id, 'RepoDigests': [repo_digest], 'Config': {}}
+    argv = _envelope_argv(image_id if by == 'config_id' else repo_digest)
+    spec = managed_install.expected_container_spec(argv, image)
+    assert spec['image'] == image_id, 'the spec always reports the config ID'
+    assert spec['name'] == 'profile-r0'
+    assert spec['cmd'] == ['--model', '/models/target', '--served-model-name', 'glm']
+
+
+def test_envelope_scan_still_rejects_an_unknown_image_identity():
+    image = {'Id': 'sha256:' + 'a' * 64, 'RepoDigests': ['ghcr.io/example/image@sha256:' + 'b' * 64],
+             'Config': {}}
+    with pytest.raises(ValueError):
+        managed_install.expected_container_spec(_envelope_argv('ghcr.io/other/image:latest'), image)
+
+
+def test_envelope_scan_rejects_malformed_repository_digests():
+    image = {'Id': 'sha256:' + 'a' * 64, 'RepoDigests': [123], 'Config': {}}
+    with pytest.raises(ValueError, match='repository digests'):
+        managed_install.expected_container_spec(_envelope_argv('sha256:' + 'a' * 64), image)

--- a/runtime/glm53-spark-mtp3-mesh/test_managed_install.py
+++ b/runtime/glm53-spark-mtp3-mesh/test_managed_install.py
@@ -343,7 +343,25 @@ def test_envelope_scan_still_rejects_an_unknown_image_identity():
         managed_install.expected_container_spec(_envelope_argv('ghcr.io/other/image:latest'), image)
 
 
-def test_envelope_scan_rejects_malformed_repository_digests():
-    image = {'Id': 'sha256:' + 'a' * 64, 'RepoDigests': [123], 'Config': {}}
+@pytest.mark.parametrize('value', ['', {}, 0, False, [123], ['mutable:tag'],
+                                  [''], ['repo@sha256:' + 'b' * 63],
+                                  ['repo@sha256:' + 'G' * 64],
+                                  ['bad repo@sha256:' + 'b' * 64]])
+def test_envelope_scan_rejects_malformed_repository_digests(value):
+    image = {'Id': 'sha256:' + 'a' * 64, 'RepoDigests': value, 'Config': {}}
     with pytest.raises(ValueError, match='repository digests'):
         managed_install.expected_container_spec(_envelope_argv('sha256:' + 'a' * 64), image)
+
+
+@pytest.mark.parametrize('value', [None, []])
+def test_envelope_scan_accepts_absent_repository_digests(value):
+    image_id = 'sha256:' + 'a' * 64
+    image = {'Id': image_id, 'RepoDigests': value, 'Config': {}}
+    assert managed_install.expected_container_spec(_envelope_argv(image_id), image)['image'] == image_id
+
+
+def test_envelope_scan_accepts_registry_port_in_repository_digest():
+    image_id = 'sha256:' + 'a' * 64
+    reference = 'registry.example:5000/team/image@sha256:' + 'b' * 64
+    image = {'Id': image_id, 'RepoDigests': [reference], 'Config': {}}
+    assert managed_install.expected_container_spec(_envelope_argv(reference), image)['image'] == image_id


### PR DESCRIPTION
## Problem

The cache+checkpoints composition documented in
`docs/GLM53_MTP3_CACHE_CHECKPOINTS_QUICKSTART.md` cannot be installed through
`managed_install.py`.

The two receipt schemas mean different things by `image_reference`:

| Schema | `image_id` | `image_reference` |
|---|---|---|
| `sparkring-mtp3-mesh-image-receipt/v1` | config image ID | **the same config image ID** |
| `sparkring-mtp3-performance-public-image/v1` | config image ID | **`ghcr.io/...@sha256:<manifest digest>`** |

`render` copies `image_reference` into `IMAGE_REF`, and the launcher passes it
to `docker create`, so the token naming the image in argv is whichever form the
receipt supplied.

`managed_install.expected_container_spec` walked the argv until it matched
`docker image inspect`'s `.Id`, which is only ever the config image ID. With a
registry reference the scan never terminates at the image, runs on into the
model arguments, and fails on the first flag outside the Docker envelope
allowlist:

```
ValueError: Unsupported Docker envelope option in canonical launcher
```

## Change

Accept the config ID **or any of the image's `RepoDigests`** as the envelope
terminator.

The returned spec still reports the config ID, which is what Docker records as
the container's `Image` and what `validate_container_spec` compares against, so
identity checking is unchanged. Malformed `RepoDigests` are rejected rather
than skipped, and an image name matching neither form still fails closed.

This deliberately keeps the registry reference in the create command, since
`performance/test_performance_profile.py::test_renderer_uses_matched_image_native_and_namespace`
asserts the renderer emits exactly that. An earlier draft of this fix instead
rendered `IMAGE_REF` as the config ID; that contradicted your existing renderer
contract and broke that test, so the fix belongs on the installer side. Happy
to switch if you would rather normalise in the renderer.

## Tests

Four cases added to `test_managed_install.py`:

- `test_envelope_scan_accepts_either_receipt_image_identity` (parametrized over
  config ID and repository digest) — asserts the scan terminates and the spec
  still reports the config ID
- `test_envelope_scan_still_rejects_an_unknown_image_identity` — fails closed
- `test_envelope_scan_rejects_malformed_repository_digests`

`python -m pytest runtime/glm53-spark-mtp3-mesh -q` on Linux/bash 5.2:
**440 passed, 2 skipped**, with no previously passing test affected.

## Verified on hardware

Four DGX Sparks, hardware-forwarded mesh. The failure reproduces on all four
ranks with the published cache+checkpoints receipt. On the deployed image,
`docker image inspect` reports

```
ghcr.io/fujitsupolycom/sparkring-glm53-sparkcache@sha256:11a556a5...
```

in `RepoDigests`, exactly matching the receipt's `image_reference`, so this is
the token the scan now terminates on. With the equivalent identity accepted,
`managed_install --apply` succeeded on every rank and the model reached
`READY`, then passed 1M NIAH at 0.1/0.5/0.9, an 8-run corruption probe, and the
exact semantic canary.

## Unrelated observation

On macOS, 12 tests in `test_mtp_launcher.py` and `test_managed_service.py` fail
on an unpatched checkout with `draft_mount_args[@]: unbound variable`, because
bash 3.2 treats an empty array as unset under `set -u`. Not addressed here, but
`${arr[@]+"${arr[@]}"}` in the launcher would fix it if macOS is a supported
authoring platform.
