### PR TITLE
List shared GLM profiles and retire superseded TP4 guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ reproducible benchmarks, and [test results](performance/).
 ## Setup
 
 1. Choose a [profile](#profiles) and check the [prerequisites](docs/PREREQUISITES.md).
-2. For a four-node ring, follow the [bootstrap guide](docs/BOOTSTRAP.md).
+2. For a four-node ring, follow the [mesh host setup guide](docs/GLM53_SPARK_MESH_HOST_SETUP.md).
    Two-node profiles include their own direct-link setup.
 3. Follow the profile's quickstart, then run the
    [validation checks](docs/PROFILE_VALIDATION.md).
@@ -29,8 +29,9 @@ reproducible benchmarks, and [test results](performance/).
 
 | Model / predictor | Serving stack | Transport | Layout | Context | Sequences | Batch | Guide |
 |---|---|---|---|---:|---:|---:|---|
-| **GLM-5.3 Flash NVFP4-Spark · MTP3 cache/checkpoint mesh** | [SparkRing vLLM/B12X image](runtime/glm53-spark-mtp3-mesh/performance/README.md) | [SIRCL + RoCEnante + NCCL](runtime/glm53-spark-mtp3-mesh/README.md) | TP4/DCP4 | 1M | 16 | 8,192 | [Quickstart](docs/GLM53_MTP3_CACHE_CHECKPOINTS_QUICKSTART.md) |
-| GLM-5.3 Flash NVFP4 · BF16 DFlash2 | [SparkRing vLLM/B12X image](runtime/glm53-flash-jj-r8-gb10/README.md) | [SIRCL + NCCL](spark_transport/integrations/vllm/README.md) | TP4/DCP4; DCP1/2 | 1M | 16 | 8,192 | [Quickstart](docs/GLM53_JJ_R8_GB10_SPARKCACHE_TP4_QUICKSTART.md) |
+| **GLM-5.3 Flash NVFP4-Spark · native MTP3** | [Shared SparkRing image](runtime/sparkring/source_image/README.md) | [Mesh + dual-domain NCCL](runtime/glm53-spark-mtp3-mesh/README.md) | TP4/DCP1; DCP4 option | 1M | 16 | 8,192 | [Quickstart](docs/GLM53_TP4_PREFILL_QUICKSTART.md) |
+| GLM-5.3 Flash NVFP4-Spark · MTP3 + SparkCache | [Shared SparkRing image](runtime/sparkring/source_image/README.md) | [Mesh + dual-domain NCCL](runtime/glm53-spark-mtp3-mesh/README.md) | TP4/DCP1 | 1M | 16 | 8,192 | [Cache profile selection](docs/GLM53_TP4_PREFILL_QUICKSTART.md#verify-the-image-and-select-a-profile) |
+| GLM-5.3 Flash NVFP4-Spark · MTP3, switched | [Shared SparkRing image](runtime/sparkring/source_image/README.md) | Operator-selected NCCL links | TP4/DCP1 | 1M | 16 | 8,192 | [Switched quickstart](docs/GLM53_SWITCHED_TP4_QUICKSTART.md) |
 | GLM-5.2 EXL3 3.5-bpw | [SparkRing vLLM/ExLlamaV3 build](runtime/exl3-r7/README.md) | [SIRCL + NCCL](docs/SIRCL.md) | TP4/DCP4 | 1M | 16 | 4,096 | [Quickstart](docs/GLM52_35BPW_QUICKSTART.md) |
 | DeepSeek-V4-Flash-0731 | [SparkRing vLLM/B12X image](runtime/deepseek0731-gb10/README.md) | [Patched NCCL](spark_transport/nccl/README.md) | TP4/DCP1 | 1M | 32 | 4,096 | [Quickstart](docs/DEEPSEEK_V4_FLASH_QUICKSTART.md) |
 | Qwen3.8-27B EXL3 K5/K6 | [SparkRing vLLM/ExLlamaV3 build](runtime/qwen38/README.md) | [Patched NCCL](spark_transport/nccl/README.md) | TP4/DCP1 | 1M | 64 | 8,192 | [Quickstart](docs/QWEN38_27B_EXL3_K5K6_QUICKSTART.md) |
@@ -41,41 +42,60 @@ identifies the Anemll image, MiaAI-Lab recipe, and SparkRing transport separatel
 Contributor-reported results are linked from the guide; independent reproduction
 of the selected artifacts is not claimed.
 
-The four-Spark GLM-5.3 native-MTP3 profile uses hardware-forwarded mesh paths and requires
-[managed-mesh setup](runtime/glm53-spark-mtp3-mesh/MANAGED_MESH.md).
-DFlash2 profiles use a separate draft checkpoint with
-[CC BY-NC-ND 4.0 terms](https://huggingface.co/incoai/GLM-5.3-Flash-DFlash2#license).
+The shared-image GLM profiles enable continuation coalescing and token-sharded
+mHC. Ring profiles use hardware-forwarded mesh paths and NCCL across both host
+PCIe domains. Their source integration is **implemented**; full shared-image
+serving qualification remains **research-only**. Switched deployments are
+provided as-is and have not been validated on switched hardware.
 
 ### Two Sparks
 
 | Model / predictor | Serving stack | Transport | Layout | Context | Sequences | Batch | Guide |
 |---|---|---|---|---:|---:|---:|---|
-| **GLM-5.3 Flash NVFP4-Spark · native MTP3** | [SparkRing runtime image](runtime/sparkring/README.md) | [Patched NCCL](runtime/profiles/glm53-flash-spark-tp2/runtime.env.example) | TP2/DCP1 | 512K | 8 | 8,192 | [Quickstart](docs/GLM53_FLASH_SPARK_TP2_EXPERIMENTAL_QUICKSTART.md) |
+| **GLM-5.3 Flash original NVFP4 · native MTP3** | [Shared SparkRing image](runtime/sparkring/source_image/README.md) | [Adaptive RoCEnante + dual-domain NCCL](runtime/profiles/glm53-flash-nvfp4-tp2/README.md) | TP2/DCP1 | 256K | 8 | 8,192 | [Quickstart](runtime/profiles/glm53-flash-nvfp4-tp2/README.md) |
+| GLM-5.3 Flash NVFP4-Spark · MTP3, 5 GiB KV | [Three-asset SparkRing package](runtime/sparkring/README.md) | [Patched NCCL](runtime/profiles/glm53-flash-spark-tp2/runtime.env.example) | TP2/DCP1 | 512K | 8 | 8,192 | [Alternative profile](docs/GLM53_FLASH_SPARK_TP2_EXPERIMENTAL_QUICKSTART.md) |
 | DeepSeek-V4-Flash-0731 | [SparkRing vLLM/B12X image](runtime/deepseek0731-gb10/README.md) | [Patched NCCL](spark_transport/nccl/README.md) | TP2/DCP1 | 1M | 32 | 4,096 | [Quickstart](docs/DEEPSEEK_V4_FLASH_QUICKSTART.md) |
 | Qwen3.8-27B EXL3 K5/K6 | [SparkRing vLLM/ExLlamaV3 build](runtime/qwen38/README.md) | [Patched NCCL](spark_transport/nccl/README.md) | TP2/DCP1 | 1M | 32 | 8,192 | [Quickstart](docs/QWEN38_27B_EXL3_K5K6_PAIR_QUICKSTART.md) |
 
-The GLM-5.3 pair is **research-only**, uses 5 GiB KV per rank, and has a
+The original-NVFP4 shared-image pair uses 6.75 GiB KV per rank, one DAC and
+both host PCIe domains. Coalescing and mHC are enabled; SparkCache is
+unsupported for this TP2 composition. Shared-image GPU qualification remains
+**research-only**. The separate NVFP4-Spark pair uses 5 GiB KV per rank and has a
 [known video-color issue](https://github.com/FujitsuPolycom/sparkring/issues/229).
 
 See the [profile index](docs/profiles/README.md) for evidence scopes and
 [SparkCache compositions](recipes/sparkcache/README.md) for persistent-cache
 support. Qwen with SparkCache is unsupported; six-node profiles are research-only.
 
+### Retired TP4 GLM-5.3 profiles
+
+These guides retain their pinned configurations and evidence for reproduction.
+For deployment with the shared image, use the four-Spark entries above.
+
+| Profile | Layout | Retained guide | Replacement |
+|---|---|---|---|
+| NVFP4-Spark MTP3 cache/checkpoint mesh | TP4/DCP4 | [Pinned cache/checkpoint setup](docs/GLM53_MTP3_CACHE_CHECKPOINTS_QUICKSTART.md) | [Shared-image MTP3 profiles](docs/GLM53_TP4_PREFILL_QUICKSTART.md) |
+| NVFP4 with BF16 DFlash2 | TP4/DCP1, DCP2 or DCP4 | [Pinned DFlash2 setup](docs/GLM53_JJ_R8_GB10_SPARKCACHE_TP4_QUICKSTART.md) | [Shared-image native MTP3](docs/GLM53_TP4_PREFILL_QUICKSTART.md) |
+
+DFlash2 uses a separate draft checkpoint with
+[CC BY-NC-ND 4.0 terms](https://huggingface.co/incoai/GLM-5.3-Flash-DFlash2#license).
+
 ## Container images
 
 | Package / runtime | Profile | Details |
 |---|---|---|
-| `sparkring` | GLM-5.3 Flash native-MTP3 pair | [Model-neutral package](runtime/sparkring/README.md) |
-| `sparkring-glm53-sparkcache` | GLM-5.3 Flash DFlash2/SIRCL | [Operator image](runtime/glm53-flash-jj-r8-gb10/README.md) |
-| `sparkring-glm53-sparkcache` | GLM-5.3 Flash native-MTP3 mesh | [Mesh image](runtime/glm53-spark-mtp3-mesh/performance/public-image.json) |
-| `sparkring-glm53-runtime` | GLM source-build bases | [Runtime builder](runtime/glm53-flash/README.md) |
+| `ghcr.io/fujitsupolycom/sparkring` | Shared GLM TP2/TP4 image; profile selects topology and optional cache | [Source build and profile verification](runtime/sparkring/source_image/README.md) |
 | `gb10-vllm-serving` | Profile-specific images, including DeepSeek | [Packages](https://github.com/users/FujitsuPolycom/packages/container/package/gb10-vllm-serving) |
 | Anemll `dspark-vllm-gx10` | DeepSeek-V4-Flash-Vision-Exp with the MiaAI-Lab recipe | [Image, recipe, and transport provenance](runtime/deepseek-vision-exp/profile.json) |
 
 Use the exact digest in the selected quickstart. Images sharing a package
-name are not interchangeable; a model-neutral name does not qualify every profile. Images will be condensed and homogenized in future releases. 
+name are not interchangeable; a model-neutral name does not qualify every profile.
+Retired profiles retain their image references in their linked guides.
 
 ## Benchmark results
+
+Each row links the exact measured configuration. These records include retired
+profiles and are not benchmark results for the shared-image build.
 
 Decode is sustained aggregate output at temperature 1.0.
 Results attempt to reflect real world use-case numbers in all instances unless otherwise noted.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ reproducible benchmarks, and [test results](performance/).
 ## Setup
 
 1. Choose a [profile](#profiles) and check the [prerequisites](docs/PREREQUISITES.md).
-2. For a four-node ring, follow the [mesh host setup guide](docs/GLM53_SPARK_MESH_HOST_SETUP.md).
+2. For a shared-image GLM four-node ring, follow the [mesh host setup guide](docs/GLM53_SPARK_MESH_HOST_SETUP.md).
+   Other four-node profiles use the [bootstrap guide](docs/BOOTSTRAP.md).
    Two-node profiles include their own direct-link setup.
 3. Follow the profile's quickstart, then run the
    [validation checks](docs/PROFILE_VALIDATION.md).
@@ -47,7 +48,7 @@ mHC. Ring profiles use hardware-forwarded mesh paths and NCCL across both host
 PCIe domains. Their source integration is **implemented**; full shared-image
 serving qualification remains **research-only**. Switched deployments are
 provided as-is and have not been validated on switched hardware.
-Ring deployment requires the [managed-mesh setup](runtime/glm53-spark-mtp3-mesh/MANAGED_MESH.md).
+Shared-image GLM ring deployment requires the [managed-mesh setup](runtime/glm53-spark-mtp3-mesh/MANAGED_MESH.md).
 
 ### Two Sparks
 

--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ DFlash2 uses a separate draft checkpoint with
 Use the exact digest in the selected quickstart. Images sharing a package
 name are not interchangeable; a model-neutral name does not qualify every profile.
 Retired profiles retain their image references in their linked guides.
+The [shared-image publication record](runtime/sparkring/source_image/publication.json)
+contains the download digest and profile verification scope.
 
 ## Benchmark results
 

--- a/docs/GLM53_TP4_PREFILL_QUICKSTART.md
+++ b/docs/GLM53_TP4_PREFILL_QUICKSTART.md
@@ -84,6 +84,7 @@ requires separate native-output qualification.
 
 Keep the prepared context: verification uses it to check the image's verifier,
 source lock and manifest before executing the CPU verification program.
+Select the cache-disabled DCP1 profile:
 
 ```bash
 python runtime/sparkring/source_image/verify_image.py \
@@ -91,6 +92,7 @@ python runtime/sparkring/source_image/verify_image.py \
   --context "$PWD/.private/glm-tp4-context" \
   --profile tp4-dcp1-mtp3-prefill \
   --output "$PWD/.private/glm-tp4-dcp1-image-receipt.json"
+SPARKRING_RECEIPT="$PWD/.private/glm-tp4-dcp1-image-receipt.json"
 ```
 
 This receipt identifies a local Docker config ID, not a published registry
@@ -101,6 +103,21 @@ To select DCP4, generate a separate receipt with
 `--profile tp4-dcp4-mtp3-prefill`. That profile enables the DCP4 owner exchange
 and fused endpoints. SparkCache and compact index cache remain disabled.
 Do not change individual flags inside a verified receipt.
+
+To enable bounded SparkCache capture and restore, use this profile instead:
+
+```bash
+python runtime/sparkring/source_image/verify_image.py \
+  --image "$SPARKRING_IMAGE" \
+  --context "$PWD/.private/glm-tp4-context" \
+  --profile tp4-dcp1-mtp3-sparkcache \
+  --output "$PWD/.private/glm-tp4-dcp1-sparkcache-receipt.json"
+SPARKRING_RECEIPT="$PWD/.private/glm-tp4-dcp1-sparkcache-receipt.json"
+```
+
+The receipt selects the deployment profile. For DCP4, set `SPARKRING_RECEIPT`
+to the output path from its separate verification command. Pass that selected
+receipt to the deployment plan below.
 
 ## Use the managed deployment suite
 
@@ -113,7 +130,7 @@ STATE="$PWD/.private/glm-tp4-deployment"
 
 sr plan --inventory "$STATE/inventory.json" --name glm-tp4 \
   --workspace /srv/sparkring/glm-tp4 --fabric-range 198.18.0.0/21 \
-  --image-receipt "$PWD/.private/glm-tp4-dcp1-image-receipt.json" \
+  --image-receipt "$SPARKRING_RECEIPT" \
   --output "$STATE/preparation.json"
 ```
 

--- a/docs/GLM53_TP4_PREFILL_QUICKSTART.md
+++ b/docs/GLM53_TP4_PREFILL_QUICKSTART.md
@@ -5,7 +5,7 @@ implemented and CPU-tested. The image built from this recipe still requires
 the serving qualification described below. Measurements from a different image
 do not qualify a rebuild.
 
-This guide builds a source-pinned image and selects it through SparkRing's
+This guide downloads or builds a source-pinned image and selects it through SparkRing's
 existing managed mesh deployment. It uses four NVIDIA Sparks, native MTP depth
 three, continuation-prefill coalescing, token-sharded mHC, and NCCL across both
 host PCIe domains. DCP1 is the selected profile; DCP4 is an explicit alternative.
@@ -57,14 +57,26 @@ python runtime/sparkring/source_image/prepare_image.py \
   --source-cache "$PWD/.private/glm-tp4-sources" \
   --native-files /tmp/native-runtime-files-20260908.tar
 
-docker build --platform linux/arm64 --network none \
-  -t sparkring-glm53-tp4-source \
-  "$PWD/.private/glm-tp4-context"
+SPARKRING_IMAGE=ghcr.io/fujitsupolycom/sparkring@sha256:86516f319b505e94686e0ba59200f91dda4b65599b08b3508c931c1e4e42b2a6
+docker pull "$SPARKRING_IMAGE"
+docker pull ghcr.io/fujitsupolycom/sparkring-glm53-sparkcache@sha256:11a556a54041fd823d152a7f051ac4f7c617dc539030df26e93008392fee0746
 ```
 
 Preparation fetches exact public source commits, applies the packaged patches,
-and verifies complete source trees. The build retains the pinned parent's
-framework dependencies and installs the exact hash-verified native libraries.
+and verifies complete source trees. The downloaded image retains the pinned
+parent's framework dependencies and exact hash-verified native libraries.
+The parent pull supplies the local parent identity required by verification;
+Docker reuses shared layers. The [publication record](../runtime/sparkring/source_image/publication.json)
+binds the image digest and source lock.
+
+To build the image yourself instead of pulling it:
+
+```bash
+docker build --platform linux/arm64 --network none \
+  -t sparkring-glm53-tp4-source "$PWD/.private/glm-tp4-context"
+SPARKRING_IMAGE=sparkring-glm53-tp4-source
+```
+
 The optional compiler-rebuild path is described in the common recipe and
 requires separate native-output qualification.
 
@@ -75,7 +87,7 @@ source lock and manifest before executing the CPU verification program.
 
 ```bash
 python runtime/sparkring/source_image/verify_image.py \
-  --image sparkring-glm53-tp4-source \
+  --image "$SPARKRING_IMAGE" \
   --context "$PWD/.private/glm-tp4-context" \
   --profile tp4-dcp1-mtp3-prefill \
   --output "$PWD/.private/glm-tp4-dcp1-image-receipt.json"

--- a/docs/profiles/README.md
+++ b/docs/profiles/README.md
@@ -30,9 +30,13 @@ published configuration hash.
 
 | Profile | Topology | Serving sources and evidence scope | Documentation |
 |---|---|---|---|
+| GLM-5.3 Flash NVFP4-Spark with native MTP3 | four-Spark mesh, TP4/DCP1 or DCP4 | Shared source image; coalescing, mHC and dual-domain NCCL; full shared-image qualification incomplete | [Quickstart](../GLM53_TP4_PREFILL_QUICKSTART.md), [image source lock](../../runtime/sparkring/source_image/glm53-tp4-lock.json) |
+| GLM-5.3 Flash NVFP4-Spark with MTP3 and SparkCache | four-Spark mesh, TP4/DCP1 | Bounded connector-job capture and restore profile; full shared-image recovery qualification incomplete | [Profile selection](../GLM53_TP4_PREFILL_QUICKSTART.md#verify-the-image-and-select-a-profile) |
+| GLM-5.3 Flash original NVFP4 with native MTP3 | two Sparks, TP2/DCP1, one DAC and both host PCIe domains | Shared source image, managed loader, adaptive RoCEnante; 256K context and 6.75 GiB KV per rank; SparkCache unsupported | [Quickstart](../../runtime/profiles/glm53-flash-nvfp4-tp2/README.md) |
+| GLM-5.3 Flash NVFP4-Spark with native MTP3 | switched four-Spark TP4/DCP1 | Provided as-is; switched hardware not validated | [Quickstart](../GLM53_SWITCHED_TP4_QUICKSTART.md) |
 | DeepSeek-V4-Flash-Vision-Exp with DSpark | four-Spark cycle, TP4 | Anemll image and MiaAI-Lab recipe with SparkRing patched NCCL; contributor-reported observations; independent reproduction is not claimed | [Artifact contract](../../runtime/deepseek-vision-exp/profile.json), [recipe](../../recipes/deepseek-v4-flash-vision-exp-tp4.json), [quickstart](../DEEPSEEK_V4_FLASH_VISION_EXP_TP4_QUICKSTART.md) |
 
-The [GLM-5.3 native-MTP3 cache/checkpoint mesh](../GLM53_MTP3_CACHE_CHECKPOINTS_QUICKSTART.md)
+The retired [GLM-5.3 native-MTP3 cache/checkpoint mesh](../GLM53_MTP3_CACHE_CHECKPOINTS_QUICKSTART.md)
 publishes the integrated compute, recurrent checkpoint, optimized SparkCache,
 and transport composition for TP4/DCP4. Its
 [recipe](../../recipes/glm53-mtp3-cache-checkpoints-tp4.json) pins the image and
@@ -49,7 +53,8 @@ qualify every cache boundary or unattended availability of another image.
 The [GLM-5.3 Flash NVFP4-Spark TP2 profile](../GLM53_FLASH_SPARK_TP2_EXPERIMENTAL_QUICKSTART.md)
 is research-only. Model-neutral image and matching SparkCache source pins are
 public; child-image serving qualification remains pending.
-It does not replace the published TP4 profile.
+This 5 GiB NVFP4-Spark pair is distinct from the original-NVFP4 shared-image
+pair listed above.
 
 ## Unsupported integrations
 

--- a/runtime/profiles/glm53-flash-nvfp4-tp2/README.md
+++ b/runtime/profiles/glm53-flash-nvfp4-tp2/README.md
@@ -1,6 +1,6 @@
 # Original GLM-5.3 Flash NVFP4 on two Sparks
 
-Status: **implemented**. This prospective shared-image profile uses the model
+Status: **implemented**. This shared-image profile uses the model
 settings of a bounded TP2/DCP1 text qualification. It requires an explicit
 image identity and a matching verification receipt before creating or starting
 a container. The measured source deployment does not qualify the shared
@@ -56,6 +56,12 @@ inputs from public source bases and repository files. The
 
 For a local source-built image, first produce a CPU verification receipt from
 the exact prepared context:
+
+The [published shared image](../../sparkring/source_image/README.md#download-the-published-image)
+can also be pulled and verified using this path. Prepare its matching source
+context, pull the declared parent for verification, and set
+`SPARKRING_LOCAL_IMAGE_ID` to the result of
+`docker image inspect --format '{{.Id}}' "$SPARKRING_IMAGE"`.
 
 ```bash
 python3 runtime/sparkring/source_image/verify_image.py \

--- a/runtime/sparkring/source_image/README.md
+++ b/runtime/sparkring/source_image/README.md
@@ -2,9 +2,9 @@
 
 **Status: research-only.** Source preparation, profile selection, and CPU
 verification are implemented. This recipe prepares one ARM64 image for the
-listed GLM TP2 and TP4 profiles, including optional SparkCache. Building and
-testing that shared image remains required; results from the reference
-deployments do not qualify it.
+listed GLM TP2 and TP4 profiles, including optional SparkCache. The image is
+published with five passing CPU profile receipts. Full GPU serving tests
+remain required; results from reference deployments do not qualify it.
 
 The ring profiles use the existing native-MTP3 mesh deployment, including
 site rendering, ASIC forwarding, authenticated marker ownership and the
@@ -115,6 +115,31 @@ inactive unless the selected profile enables it.
 The container path `/opt/sparkcache-jj-runtime` and its manifest schema names
 are retained compatibility interfaces for source installation and verification.
 They do not enable SparkCache serving.
+
+## Download the published image
+
+The [publication record](publication.json) binds the generic `sparkring`
+repository, immutable image digest, source lock and five CPU profile checks.
+Status: **research-only**; these checks do not establish GPU serving results.
+
+```bash
+SPARKRING_IMAGE=ghcr.io/fujitsupolycom/sparkring@sha256:86516f319b505e94686e0ba59200f91dda4b65599b08b3508c931c1e4e42b2a6
+docker pull "$SPARKRING_IMAGE"
+```
+
+Prepare the matching context with the pinned native files below, then run the
+image verifier with `--image "$SPARKRING_IMAGE"`. Preparation fetches source
+inputs and creates verification artifacts; a downloaded image does not require
+`docker build`. The verifier also inspects the declared parent image locally:
+
+```bash
+docker pull ghcr.io/fujitsupolycom/sparkring-glm53-sparkcache@sha256:11a556a54041fd823d152a7f051ac4f7c617dc539030df26e93008392fee0746
+```
+
+Use a checkout whose source lock matches `source_lock_sha256` in the
+publication record. The verifier rejects mismatched source or profile assets.
+The publication record is distribution evidence; use the generated profile
+receipt for launch admission.
 
 ## Use pinned native files
 

--- a/runtime/sparkring/source_image/publication.json
+++ b/runtime/sparkring/source_image/publication.json
@@ -1,0 +1,115 @@
+{
+  "schema": "sparkring-shared-image-publication/v1",
+  "status": "research-only",
+  "published": true,
+  "visibility": "public",
+  "published_at_utc": "2026-09-09T00:54:18.170588+00:00",
+  "repository": "ghcr.io/fujitsupolycom/sparkring",
+  "version_tag": "ghcr.io/fujitsupolycom/sparkring:glm53-shared-a8aeff2",
+  "registry_digest": "ghcr.io/fujitsupolycom/sparkring@sha256:86516f319b505e94686e0ba59200f91dda4b65599b08b3508c931c1e4e42b2a6",
+  "manifest_digest": "sha256:86516f319b505e94686e0ba59200f91dda4b65599b08b3508c931c1e4e42b2a6",
+  "config_image_id": "sha256:fffcfdd445110aaaa60db296553ba39d90cb879061c5268ae358cd311c27e721",
+  "platform": "linux/arm64",
+  "source_revision": "a8aeff21e7f53dd87dcea323143c421414ee863e",
+  "merged_main_revision": "4b9b6a0a213456b96400c5e1a1cf59c20ff892c8",
+  "source_lock_sha256": "dd6a14c1724974599535260a25326abf053d01ac998e126498438b5e227ec600",
+  "context_sha256": "c7b63301ba147191320633f859b8621171a6172bf8fca7ff530c1fe4d5f6cb28",
+  "manifest_sha256": "0800675d88841e52a8153448cc74570a440c69ffb4f9bf678e16a78ab78913d4",
+  "native_mode": "pinned",
+  "native_archive_sha256": "aa8fa11831afaa4539e0b74442fd1ea25dd8cf49ad5edb6fd95e7f05fdf5ce86",
+  "source_revisions": {
+    "vllm": "17bd258075f44dda8b405f384732f3c78d03f308",
+    "b12x": "2883a5df65a7ea3cb6e82abb63d1448dd3154887",
+    "sparkcache": "d0cf7296062ec8b4d17d65cd05a416d509e80bd8"
+  },
+  "native_files": {
+    "nccl": {
+      "path": "/opt/sparkring/nccl-pci/libnccl.so.2.30.7",
+      "sha256": "768a450b5eb84bf3d1191795350e43c96de75aeba4783ec314d47672fe6e1fc6"
+    },
+    "snapshot": {
+      "path": "/opt/sparkcache-native/libspark_cache_snapshot.so",
+      "sha256": "cc44b69c9e01aaeb6b94f46cd649e2ec5972fc6b29d1a41b7b033a82ce788f39"
+    },
+    "placement": {
+      "path": "/opt/sparkcache-src/sparkcache/native/build-cuda/libspark_cache_placement.so",
+      "sha256": "2657cdd2e54a097c9544e4c79ae62c0646db6db123ff24e4f0c384238c3a1e8d"
+    }
+  },
+  "checks": {
+    "build_completed": true,
+    "build_gpu_devices_supplied": false,
+    "external_cpu_verified_profiles": 5,
+    "anonymous_manifest_download": true,
+    "anonymous_config_download": true,
+    "tag_digest_matches_bytes": true,
+    "all_profiles_cuda_initialized": false,
+    "all_profiles_model_loaded": false,
+    "existing_serving_container_unchanged": true
+  },
+  "profiles": {
+    "tp4-dcp1-mtp3-prefill": {
+      "status": "research-only",
+      "cpu_verification": "passed",
+      "cuda_initialized": false,
+      "model_loaded": false,
+      "source_lock_sha256": "dd6a14c1724974599535260a25326abf053d01ac998e126498438b5e227ec600",
+      "receipt_sha256": "99a785eb608ad9e9cab40f2f7e0ac63988407751b4c8a534354311d1e6bad1e1",
+      "tp_size": 4,
+      "dcp_size": 1,
+      "sparkcache": false
+    },
+    "tp4-dcp4-mtp3-prefill": {
+      "status": "research-only",
+      "cpu_verification": "passed",
+      "cuda_initialized": false,
+      "model_loaded": false,
+      "source_lock_sha256": "dd6a14c1724974599535260a25326abf053d01ac998e126498438b5e227ec600",
+      "receipt_sha256": "f0206db6d6169b84f26e182a5cb1e7d787354ba361c5afde0d2714b109a2ea1b",
+      "tp_size": 4,
+      "dcp_size": 4,
+      "sparkcache": false
+    },
+    "tp4-dcp1-mtp3-sparkcache": {
+      "status": "research-only",
+      "cpu_verification": "passed",
+      "cuda_initialized": false,
+      "model_loaded": false,
+      "source_lock_sha256": "dd6a14c1724974599535260a25326abf053d01ac998e126498438b5e227ec600",
+      "receipt_sha256": "251f0c46f6947b7553be022fa78d0b45ebf02d4bbe88b6a8b0e7e88c72ab66dc",
+      "tp_size": 4,
+      "dcp_size": 1,
+      "sparkcache": true
+    },
+    "glm53-flash-nvfp4-tp2-mtp3": {
+      "status": "research-only",
+      "cpu_verification": "passed",
+      "cuda_initialized": false,
+      "model_loaded": false,
+      "source_lock_sha256": "dd6a14c1724974599535260a25326abf053d01ac998e126498438b5e227ec600",
+      "receipt_sha256": "7a20760017c18a1db42894f2517352f1e938736ca321ac6905c0b62e61b9a933",
+      "tp_size": 2,
+      "dcp_size": 1,
+      "sparkcache": false,
+      "profile_sha256": "7ff677949c31a37dc955431702c6d032f5db167e242213b9663ae5830f1cb76a",
+      "transport_profile": "tp2-rocenante-adaptive",
+      "transport_manifest_sha256": "eb03cfde826974811be3bfe5d88f36d9de105b73358f3eaa56b9ed44f19127c4"
+    },
+    "glm53-flash-spark-tp4-switched-mtp3": {
+      "status": "research-only",
+      "cpu_verification": "passed",
+      "cuda_initialized": false,
+      "model_loaded": false,
+      "source_lock_sha256": "dd6a14c1724974599535260a25326abf053d01ac998e126498438b5e227ec600",
+      "receipt_sha256": "862a975d64392208cc08121a3303501c0b57a296766549e724ed5abaa4257a81",
+      "tp_size": 4,
+      "dcp_size": 1,
+      "topology": "switched",
+      "collective_backend": "nccl",
+      "sparkcache": false,
+      "profile_sha256": "a943cb08e7547165fc90ac87fe9ab8dc3a3b7a59626d88996bf37e21fa5c1fb8"
+    }
+  },
+  "qualification": "External CPU file, source, native and profile verification passed for all five profiles. GPU serving qualification of this image is incomplete; reference deployments retain their own evidence.",
+  "switched_note": "Switched deployments are provided as-is. This profile has not been validated on switched hardware."
+}


### PR DESCRIPTION
List the shared-image GLM TP2/TP4 profiles, including optional SparkCache and switched setups, with their correct guides and configuration limits. Move superseded TP4 MTP3/DFlash2 entries into a retired table and retain their measured benchmark identities. Publish the image digest and five-profile CPU verification record, and document pulling the image with the matching verification context and parent identity. Validation: 672 repository-relative links and anchors passed; git diff --check passed. Full shared-image GPU/recovery qualification remains incomplete.