### PR TITLE
Publish the NVFP4-Spark TP2 profile and clarify serving guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,17 +26,22 @@ reproducible benchmarks, and [test results](performance/).
 
 ## Profiles
 
+KV is approximate total token capacity. The shared TP4 figure is for DCP1;
+the original-NVFP4 TP2 figure is a reference estimate. `—` means no capacity
+is recorded. Startup reports the actual capacity, which is separate from the
+per-request Context limit.
+
 ### Four Sparks
 
-| Model / predictor | Serving stack | Transport | Layout | Context | Sequences | Batch | Guide |
+| Model / predictor | Serving stack | Transport | Layout | Context | Sequences | KV (tokens) | Guide |
 |---|---|---|---|---:|---:|---:|---|
-| **GLM-5.3 Flash NVFP4-Spark · native MTP3** | [Shared SparkRing image](runtime/sparkring/source_image/README.md) | [Mesh + dual-domain NCCL](runtime/glm53-spark-mtp3-mesh/README.md) | TP4/DCP1; DCP4 option | 1M | 16 | 8,192 | [Quickstart](docs/GLM53_TP4_PREFILL_QUICKSTART.md) |
-| GLM-5.3 Flash NVFP4-Spark · MTP3 + SparkCache | [Shared SparkRing image](runtime/sparkring/source_image/README.md) | [Mesh + dual-domain NCCL](runtime/glm53-spark-mtp3-mesh/README.md) | TP4/DCP1 | 1M | 16 | 8,192 | [Cache profile selection](docs/GLM53_TP4_PREFILL_QUICKSTART.md#verify-the-image-and-select-a-profile) |
-| GLM-5.3 Flash NVFP4-Spark · MTP3, switched | [Shared SparkRing image](runtime/sparkring/source_image/README.md) | Operator-selected NCCL links | TP4/DCP1 | 1M | 16 | 8,192 | [Switched quickstart](docs/GLM53_SWITCHED_TP4_QUICKSTART.md) |
-| GLM-5.2 EXL3 3.5-bpw | [SparkRing vLLM/ExLlamaV3 build](runtime/exl3-r7/README.md) | [SIRCL + NCCL](docs/SIRCL.md) | TP4/DCP4 | 1M | 16 | 4,096 | [Quickstart](docs/GLM52_35BPW_QUICKSTART.md) |
-| DeepSeek-V4-Flash-0731 | [SparkRing vLLM/B12X image](runtime/deepseek0731-gb10/README.md) | [Patched NCCL](spark_transport/nccl/README.md) | TP4/DCP1 | 1M | 32 | 4,096 | [Quickstart](docs/DEEPSEEK_V4_FLASH_QUICKSTART.md) |
-| Qwen3.8-27B EXL3 K5/K6 | [SparkRing vLLM/ExLlamaV3 build](runtime/qwen38/README.md) | [Patched NCCL](spark_transport/nccl/README.md) | TP4/DCP1 | 1M | 64 | 8,192 | [Quickstart](docs/QWEN38_27B_EXL3_K5K6_QUICKSTART.md) |
-| DeepSeek-V4-Flash-Vision-Exp with DSpark (research-only) | [Anemll image / MiaAI-Lab recipe](runtime/deepseek-vision-exp/profile.json) | [SparkRing patched NCCL](spark_transport/nccl/README.md) | TP4 | 1M | 48 | 12,288 | [Quickstart](docs/DEEPSEEK_V4_FLASH_VISION_EXP_TP4_QUICKSTART.md) |
+| **GLM-5.3 Flash NVFP4-Spark · native MTP3** | [Shared SparkRing image](runtime/sparkring/source_image/README.md) | [Mesh + dual-domain NCCL](runtime/glm53-spark-mtp3-mesh/README.md) | TP4/DCP1; DCP4 option | 1M | 16 | ~2.3M | [Quickstart](docs/GLM53_TP4_PREFILL_QUICKSTART.md) |
+| GLM-5.3 Flash NVFP4-Spark · MTP3 + SparkCache | [Shared SparkRing image](runtime/sparkring/source_image/README.md) | [Mesh + dual-domain NCCL](runtime/glm53-spark-mtp3-mesh/README.md) | TP4/DCP1 | 1M | 16 | ~2.3M | [Cache profile selection](docs/GLM53_TP4_PREFILL_QUICKSTART.md#verify-the-image-and-select-a-profile) |
+| GLM-5.3 Flash NVFP4-Spark · MTP3, switched | [Shared SparkRing image](runtime/sparkring/source_image/README.md) | Operator-selected NCCL links | TP4/DCP1 | 1M | 16 | — | [Switched quickstart](docs/GLM53_SWITCHED_TP4_QUICKSTART.md) |
+| GLM-5.2 EXL3 3.5-bpw | [SparkRing vLLM/ExLlamaV3 build](runtime/exl3-r7/README.md) | [SIRCL + NCCL](docs/SIRCL.md) | TP4/DCP4 | 1M | 16 | ~1.2M | [Quickstart](docs/GLM52_35BPW_QUICKSTART.md) |
+| DeepSeek-V4-Flash-0731 | [SparkRing vLLM/B12X image](runtime/deepseek0731-gb10/README.md) | [Patched NCCL](spark_transport/nccl/README.md) | TP4/DCP1 | 1M | 32 | — | [Quickstart](docs/DEEPSEEK_V4_FLASH_QUICKSTART.md) |
+| Qwen3.8-27B EXL3 K5/K6 | [SparkRing vLLM/ExLlamaV3 build](runtime/qwen38/README.md) | [Patched NCCL](spark_transport/nccl/README.md) | TP4/DCP1 | 1M | 64 | — | [Quickstart](docs/QWEN38_27B_EXL3_K5K6_QUICKSTART.md) |
+| DeepSeek-V4-Flash-Vision-Exp with DSpark (research-only) | [Anemll image / MiaAI-Lab recipe](runtime/deepseek-vision-exp/profile.json) | [SparkRing patched NCCL](spark_transport/nccl/README.md) | TP4 | 1M | 48 | — | [Quickstart](docs/DEEPSEEK_V4_FLASH_VISION_EXP_TP4_QUICKSTART.md) |
 
 The Vision-Exp [artifact contract](runtime/deepseek-vision-exp/profile.json)
 identifies the Anemll image, MiaAI-Lab recipe, and SparkRing transport separately.
@@ -52,12 +57,12 @@ Shared-image GLM ring deployment requires the [managed-mesh setup](runtime/glm53
 
 ### Two Sparks
 
-| Model / predictor | Serving stack | Transport | Layout | Context | Sequences | Batch | Guide |
+| Model / predictor | Serving stack | Transport | Layout | Context | Sequences | KV (tokens) | Guide |
 |---|---|---|---|---:|---:|---:|---|
-| **GLM-5.3 Flash original NVFP4 · native MTP3** | [Shared SparkRing image](runtime/sparkring/source_image/README.md) | [Adaptive RoCEnante + dual-domain NCCL](runtime/profiles/glm53-flash-nvfp4-tp2/README.md) | TP2/DCP1 | 256K | 8 | 8,192 | [Quickstart](runtime/profiles/glm53-flash-nvfp4-tp2/README.md) |
-| GLM-5.3 Flash NVFP4-Spark · MTP3, 5 GiB KV | [Three-asset SparkRing package](runtime/sparkring/README.md) | [Patched NCCL](runtime/profiles/glm53-flash-spark-tp2/runtime.env.example) | TP2/DCP1 | 512K | 8 | 8,192 | [Alternative profile](docs/GLM53_FLASH_SPARK_TP2_EXPERIMENTAL_QUICKSTART.md) |
-| DeepSeek-V4-Flash-0731 | [SparkRing vLLM/B12X image](runtime/deepseek0731-gb10/README.md) | [Patched NCCL](spark_transport/nccl/README.md) | TP2/DCP1 | 1M | 32 | 4,096 | [Quickstart](docs/DEEPSEEK_V4_FLASH_QUICKSTART.md) |
-| Qwen3.8-27B EXL3 K5/K6 | [SparkRing vLLM/ExLlamaV3 build](runtime/qwen38/README.md) | [Patched NCCL](spark_transport/nccl/README.md) | TP2/DCP1 | 1M | 32 | 8,192 | [Quickstart](docs/QWEN38_27B_EXL3_K5K6_PAIR_QUICKSTART.md) |
+| **GLM-5.3 Flash original NVFP4 · native MTP3** | [Shared SparkRing image](runtime/sparkring/source_image/README.md) | [Adaptive RoCEnante + dual-domain NCCL](runtime/profiles/glm53-flash-nvfp4-tp2/README.md) | TP2/DCP1 | 256K | 8 | ~0.81M | [Quickstart](runtime/profiles/glm53-flash-nvfp4-tp2/README.md) |
+| GLM-5.3 Flash NVFP4-Spark · MTP3, 5 GiB KV | [Three-asset SparkRing package](runtime/sparkring/README.md) | [Patched NCCL](runtime/profiles/glm53-flash-spark-tp2/runtime.env.example) | TP2/DCP1 | 512K | 8 | — | [Alternative profile](docs/GLM53_FLASH_SPARK_TP2_EXPERIMENTAL_QUICKSTART.md) |
+| DeepSeek-V4-Flash-0731 | [SparkRing vLLM/B12X image](runtime/deepseek0731-gb10/README.md) | [Patched NCCL](spark_transport/nccl/README.md) | TP2/DCP1 | 1M | 32 | — | [Quickstart](docs/DEEPSEEK_V4_FLASH_QUICKSTART.md) |
+| Qwen3.8-27B EXL3 K5/K6 | [SparkRing vLLM/ExLlamaV3 build](runtime/qwen38/README.md) | [Patched NCCL](spark_transport/nccl/README.md) | TP2/DCP1 | 1M | 32 | — | [Quickstart](docs/QWEN38_27B_EXL3_K5K6_PAIR_QUICKSTART.md) |
 
 The original-NVFP4 shared-image pair uses 6.75 GiB KV per rank, one DAC and
 both host PCIe domains. Coalescing and mHC are enabled; SparkCache is

--- a/docs/GLM53_MTP3_CACHE_CHECKPOINTS_QUICKSTART.md
+++ b/docs/GLM53_MTP3_CACHE_CHECKPOINTS_QUICKSTART.md
@@ -1,7 +1,7 @@
 # GLM-5.3 native MTP3 with verified caching and recurrent checkpoints
 
 For a source-built TP4/DCP1 prefill profile with coalescing and mHC sharding,
-use the [TP4 prefill image guide](GLM53_TP4_PREFILL_QUICKSTART.md). That profile
+use the [GLM-5.3 Flash TP4 Ring guide](GLM53_TP4_PREFILL_QUICKSTART.md). That profile
 disables the SparkCache connector. This guide describes the separately pinned
 published image with persistent caching enabled.
 

--- a/docs/GLM53_TP4_PREFILL_QUICKSTART.md
+++ b/docs/GLM53_TP4_PREFILL_QUICKSTART.md
@@ -1,4 +1,4 @@
-# GLM-5.3 Flash on four Sparks
+# GLM-5.3 Flash TP4 Ring
 
 Status: **research-only**. The source recipe and managed setup integration are
 implemented and CPU-tested. The image built from this recipe still requires

--- a/docs/GLM53_TP4_PREFILL_QUICKSTART.md
+++ b/docs/GLM53_TP4_PREFILL_QUICKSTART.md
@@ -1,4 +1,4 @@
-# GLM-5.3 Flash TP4 prefill image
+# GLM-5.3 Flash on four Sparks
 
 Status: **research-only**. The source recipe and managed setup integration are
 implemented and CPU-tested. The image built from this recipe still requires

--- a/runtime/sparkring/source_image/README.md
+++ b/runtime/sparkring/source_image/README.md
@@ -203,7 +203,7 @@ profile. Keep the canonical public image receipt unchanged. Follow
 `runtime/glm53-spark-mtp3-mesh/MANAGED_MESH.md` for host lifecycle and startup
 ownership; replacing a running model remains a separate deployment action.
 
-Use the [TP4 prefill quickstart](../../../docs/GLM53_TP4_PREFILL_QUICKSTART.md)
+Use the [four-Spark GLM quickstart](../../../docs/GLM53_TP4_PREFILL_QUICKSTART.md)
 for DCP1 or DCP4. To enable the bounded cache configuration, verify and select
 `tp4-dcp1-mtp3-sparkcache` in both the receipt and private mesh site.
 The [original-NVFP4 TP2 guide](../../profiles/glm53-flash-nvfp4-tp2/README.md)

--- a/runtime/sparkring/source_image/README.md
+++ b/runtime/sparkring/source_image/README.md
@@ -203,7 +203,7 @@ profile. Keep the canonical public image receipt unchanged. Follow
 `runtime/glm53-spark-mtp3-mesh/MANAGED_MESH.md` for host lifecycle and startup
 ownership; replacing a running model remains a separate deployment action.
 
-Use the [four-Spark GLM quickstart](../../../docs/GLM53_TP4_PREFILL_QUICKSTART.md)
+Use the [GLM-5.3 Flash TP4 Ring quickstart](../../../docs/GLM53_TP4_PREFILL_QUICKSTART.md)
 for DCP1 or DCP4. To enable the bounded cache configuration, verify and select
 `tp4-dcp1-mtp3-sparkcache` in both the receipt and private mesh site.
 The [original-NVFP4 TP2 guide](../../profiles/glm53-flash-nvfp4-tp2/README.md)


### PR DESCRIPTION
Make runtime/profiles/glm53-flash-spark-tp2 the canonical TP2 shared-image profile: NVFP4-Spark, managed B12X, single-DAC dual-domain transport, static MTP3, 8.75 GiB KV per node and a 262144-token request limit. The reference allocator reports about one million KV tokens. Preserve the required public 2 GiB memory guard; the separate reference trial ran with guards off and does not qualify this shared image. Redirect the original-NVFP4 guide and preserve historical configurations through immutable links. Name the TP4 guide GLM-5.3 Flash TP4 Ring and replace README Batch columns with rounded KV token capacities. Validation: 93 focused tests passed with one platform skip, Ruff passed, 694 repository-relative links checked, and all 22 profile asset hashes verified. A matching rebuilt image/publication record is required before merge; model/kernel/native source revisions are unchanged.