### PR TITLE
Warm concurrent GLM sampler filters before readiness

### DIFF
--- a/performance/records/glm53-flash/sampler-concurrency-20260909.json
+++ b/performance/records/glm53-flash/sampler-concurrency-20260909.json
@@ -877,7 +877,8 @@
       ],
       "elapsed_seconds": 13.375
     },
-    "scope": "External helper against the same already-ready API; not installed startup readiness."
+    "scope": "External helper against the same already-ready API; not installed startup readiness.",
+    "helper_commit": "378abab2bac9fe4ea39afe79ed9ff9f16c52cdd3"
   },
   "input_sha256": {
     "c1_receipt": "f611f3e3f1e694421c8e9fae571fce2df3ebb7bafd09ef309a89d2875dfa3a74",

--- a/performance/records/glm53-flash/sampler-concurrency-20260909.json
+++ b/performance/records/glm53-flash/sampler-concurrency-20260909.json
@@ -1,0 +1,897 @@
+{
+  "schema": "sparkring-sampler-concurrency-observation/v1",
+  "status": "research-only",
+  "date": "2026-09-09",
+  "conditions": {
+    "model_target": {
+      "repository": "local-inference-lab/GLM-5.3-Flash-NVFP4-Spark",
+      "revision": "df116c4fb16b1d37ae43d2cfd624de26ffbc832e"
+    },
+    "image_id": "sha256:db4053abcf1c82ce2da5633abd672abcaa32ca77eef5b03d567b1fa24a04b671",
+    "image_reference_scope": "Local immutable image config digest; no registry availability claim.",
+    "hardware": "Four NVIDIA DGX Spark GB10 systems",
+    "tensor_parallel_size": 4,
+    "decode_context_parallel_size": 1,
+    "speculation": "native MTP3",
+    "model_runner": "V2",
+    "load_format": "instanttensor",
+    "cache_state": "Already-ready process and existing JIT namespace; disk-cache coldness was not controlled.",
+    "source_revisions": {
+      "vllm": "1556c3587ee84cc3c91848893d5079d0a7ff6271",
+      "b12x": "2883a5df65a7ea3cb6e82abb63d1448dd3154887",
+      "sparkcache": "d0cf7296062ec8b4d17d65cd05a416d509e80bd8"
+    },
+    "vllm_base_revision": "2a979314dc97b03173a0a76fc15664ec924db32b",
+    "vllm_patch_sha256": "611c10b3eae3ef1a082e83e24eeada1fc95a989e08dcfdf3f790de77dabc8d32"
+  },
+  "source_capture": {
+    "scope": "Rank-zero installed source; common image identified above.",
+    "source_lock_sha256": "bec7cbcf11a2f1e293fc2be6f263e314fab5198f2c7d8c160d85415c36ea2d5d",
+    "files": {
+      "vllm/v1/worker/gpu/sample/sampler.py": {
+        "sha256": "408b08c4ac66de271f476460490f360ef2a9b73528a346d132a22326e1674369",
+        "bytes": 13049
+      },
+      "vllm/v1/worker/gpu/sample/states.py": {
+        "sha256": "4e3671f93695ba5a48fad7d2d13beb231ac8741034904ed5a15d9f7b9b86662e",
+        "bytes": 4826
+      },
+      "vllm/v1/worker/gpu/spec_decode/rejection_sampler.py": {
+        "sha256": "e20adc9b6c8a62a5be232bae15a1e361e898142966a68ea3ef244b39ffc5ce44",
+        "bytes": 11346
+      },
+      "vllm/v1/sample/ops/topk_topp_sampler.py": {
+        "sha256": "12ae8e19add5a6ed89ba19c2e306db5d9836bc3aa704352252519eb048825458",
+        "bytes": 22701
+      },
+      "vllm/v1/sample/ops/topk_topp_triton.py": {
+        "sha256": "255619f699898ddaaac959d9bef4494294c76d730abb8e90549afac83a9bcbe9",
+        "bytes": 46311
+      },
+      "vllm/utils/jit_monitor.py": {
+        "sha256": "8ba1c1e02472382e986aba2ab583e33c071038d5d24d9ee811f2cfac4555dc98",
+        "bytes": 17851
+      }
+    }
+  },
+  "measurement": {
+    "sampler_validator_commit": "9a3d7e416a5502eac1462aa3c2cf30dca53094ba",
+    "sampler_validator_sha256": "83782b4f9a68eae80aea595e7a996179de6a3379f7240a7f359d6acdc352093c",
+    "concurrent_orchestrator_sha256": "623dbb996d4a575f6448bd190e9b25a949130d23e16bde35465e84893b19a7e2",
+    "clock": "Client time.monotonic seconds for original paired sweeps; paired HTTP overlap = minimum end minus maximum start.",
+    "jit_monitor_verbose": false,
+    "warning_deduplication": true,
+    "warning_scope": "Count observed _topk_topp_kernel warning lines on each rank, not compile events or kernel launches.",
+    "c1_precondition": {
+      "schema": "sparkring-sampler-warmup/v1",
+      "coverage": "request-recipe-complete",
+      "jit_coverage_verified": false,
+      "enable_thinking": true,
+      "stream": true,
+      "cases": [
+        {
+          "name": "unfiltered",
+          "temperature": 1.0,
+          "top_k": -1,
+          "top_p": 1.0,
+          "seed": null,
+          "prompt_tokens": 29,
+          "completion_tokens": 32,
+          "total_tokens": 61,
+          "finish_reason": "length",
+          "elapsed_seconds": 0.61
+        },
+        {
+          "name": "temperature",
+          "temperature": 0.7,
+          "top_k": -1,
+          "top_p": 1.0,
+          "seed": null,
+          "prompt_tokens": 28,
+          "completion_tokens": 32,
+          "total_tokens": 60,
+          "finish_reason": "length",
+          "elapsed_seconds": 0.578
+        },
+        {
+          "name": "top-k",
+          "temperature": 1.0,
+          "top_k": 40,
+          "top_p": 1.0,
+          "seed": null,
+          "prompt_tokens": 28,
+          "completion_tokens": 32,
+          "total_tokens": 60,
+          "finish_reason": "length",
+          "elapsed_seconds": 0.703
+        },
+        {
+          "name": "top-p",
+          "temperature": 1.0,
+          "top_k": -1,
+          "top_p": 0.9,
+          "seed": null,
+          "prompt_tokens": 29,
+          "completion_tokens": 32,
+          "total_tokens": 61,
+          "finish_reason": "length",
+          "elapsed_seconds": 0.672
+        },
+        {
+          "name": "top-k-top-p",
+          "temperature": 1.0,
+          "top_k": 40,
+          "top_p": 0.9,
+          "seed": null,
+          "prompt_tokens": 31,
+          "completion_tokens": 32,
+          "total_tokens": 63,
+          "finish_reason": "length",
+          "elapsed_seconds": 0.609
+        },
+        {
+          "name": "seeded-top-k-top-p",
+          "temperature": 0.7,
+          "top_k": 40,
+          "top_p": 0.9,
+          "seed": 0,
+          "prompt_tokens": 32,
+          "completion_tokens": 32,
+          "total_tokens": 64,
+          "finish_reason": "length",
+          "elapsed_seconds": 0.657
+        }
+      ],
+      "elapsed_seconds": 3.829
+    },
+    "paired_sweeps": [
+      {
+        "sweep": 0,
+        "cases": [
+          {
+            "name": "top-k",
+            "http_overlap_seconds": 4.155999999988126,
+            "requests": [
+              {
+                "index": 0,
+                "body": {
+                  "model": "glm-5.3-flash-spark",
+                  "messages": [
+                    {
+                      "role": "user",
+                      "content": "1788982458011363700 top-k 0: Describe a garden in detail."
+                    }
+                  ],
+                  "temperature": 1.0,
+                  "top_k": 40,
+                  "top_p": 1.0,
+                  "min_p": 0.0,
+                  "max_tokens": 128,
+                  "ignore_eos": true,
+                  "stream": true,
+                  "stream_options": {
+                    "include_usage": true,
+                    "continuous_usage_stats": false
+                  },
+                  "n": 1,
+                  "chat_template_kwargs": {
+                    "enable_thinking": true
+                  }
+                },
+                "result": {
+                  "prompt_tokens": 32,
+                  "completion_tokens": 128,
+                  "total_tokens": 160,
+                  "finish_reason": "length"
+                },
+                "start_monotonic": 189103.64,
+                "end_monotonic": 189107.796
+              },
+              {
+                "index": 1,
+                "body": {
+                  "model": "glm-5.3-flash-spark",
+                  "messages": [
+                    {
+                      "role": "user",
+                      "content": "1788982458011363700 top-k 1: Describe a garden in detail."
+                    }
+                  ],
+                  "temperature": 1.0,
+                  "top_k": 40,
+                  "top_p": 1.0,
+                  "min_p": 0.0,
+                  "max_tokens": 128,
+                  "ignore_eos": true,
+                  "stream": true,
+                  "stream_options": {
+                    "include_usage": true,
+                    "continuous_usage_stats": false
+                  },
+                  "n": 1,
+                  "chat_template_kwargs": {
+                    "enable_thinking": true
+                  }
+                },
+                "result": {
+                  "prompt_tokens": 32,
+                  "completion_tokens": 128,
+                  "total_tokens": 160,
+                  "finish_reason": "length"
+                },
+                "start_monotonic": 189103.64,
+                "end_monotonic": 189108.031
+              }
+            ]
+          },
+          {
+            "name": "top-p",
+            "http_overlap_seconds": 4.1560000000172295,
+            "requests": [
+              {
+                "index": 0,
+                "body": {
+                  "model": "glm-5.3-flash-spark",
+                  "messages": [
+                    {
+                      "role": "user",
+                      "content": "1788982462406047400 top-p 0: Describe a garden in detail."
+                    }
+                  ],
+                  "temperature": 1.0,
+                  "top_k": -1,
+                  "top_p": 0.9,
+                  "min_p": 0.0,
+                  "max_tokens": 128,
+                  "ignore_eos": true,
+                  "stream": true,
+                  "stream_options": {
+                    "include_usage": true,
+                    "continuous_usage_stats": false
+                  },
+                  "n": 1,
+                  "chat_template_kwargs": {
+                    "enable_thinking": true
+                  }
+                },
+                "result": {
+                  "prompt_tokens": 34,
+                  "completion_tokens": 128,
+                  "total_tokens": 162,
+                  "finish_reason": "length"
+                },
+                "start_monotonic": 189108.031,
+                "end_monotonic": 189112.187
+              },
+              {
+                "index": 1,
+                "body": {
+                  "model": "glm-5.3-flash-spark",
+                  "messages": [
+                    {
+                      "role": "user",
+                      "content": "1788982462407046800 top-p 1: Describe a garden in detail."
+                    }
+                  ],
+                  "temperature": 1.0,
+                  "top_k": -1,
+                  "top_p": 0.9,
+                  "min_p": 0.0,
+                  "max_tokens": 128,
+                  "ignore_eos": true,
+                  "stream": true,
+                  "stream_options": {
+                    "include_usage": true,
+                    "continuous_usage_stats": false
+                  },
+                  "n": 1,
+                  "chat_template_kwargs": {
+                    "enable_thinking": true
+                  }
+                },
+                "result": {
+                  "prompt_tokens": 34,
+                  "completion_tokens": 128,
+                  "total_tokens": 162,
+                  "finish_reason": "length"
+                },
+                "start_monotonic": 189108.031,
+                "end_monotonic": 189112.359
+              }
+            ]
+          },
+          {
+            "name": "both",
+            "http_overlap_seconds": 6.828000000008615,
+            "requests": [
+              {
+                "index": 0,
+                "body": {
+                  "model": "glm-5.3-flash-spark",
+                  "messages": [
+                    {
+                      "role": "user",
+                      "content": "1788982466734849800 both 0: Describe a garden in detail."
+                    }
+                  ],
+                  "temperature": 1.0,
+                  "top_k": 40,
+                  "top_p": 0.9,
+                  "min_p": 0.0,
+                  "max_tokens": 128,
+                  "ignore_eos": true,
+                  "stream": true,
+                  "stream_options": {
+                    "include_usage": true,
+                    "continuous_usage_stats": false
+                  },
+                  "n": 1,
+                  "chat_template_kwargs": {
+                    "enable_thinking": true
+                  }
+                },
+                "result": {
+                  "prompt_tokens": 34,
+                  "completion_tokens": 128,
+                  "total_tokens": 162,
+                  "finish_reason": "length"
+                },
+                "start_monotonic": 189112.359,
+                "end_monotonic": 189119.187
+              },
+              {
+                "index": 1,
+                "body": {
+                  "model": "glm-5.3-flash-spark",
+                  "messages": [
+                    {
+                      "role": "user",
+                      "content": "1788982466734849800 both 1: Describe a garden in detail."
+                    }
+                  ],
+                  "temperature": 1.0,
+                  "top_k": 40,
+                  "top_p": 0.9,
+                  "min_p": 0.0,
+                  "max_tokens": 128,
+                  "ignore_eos": true,
+                  "stream": true,
+                  "stream_options": {
+                    "include_usage": true,
+                    "continuous_usage_stats": false
+                  },
+                  "n": 1,
+                  "chat_template_kwargs": {
+                    "enable_thinking": true
+                  }
+                },
+                "result": {
+                  "prompt_tokens": 34,
+                  "completion_tokens": 128,
+                  "total_tokens": 162,
+                  "finish_reason": "length"
+                },
+                "start_monotonic": 189112.359,
+                "end_monotonic": 189119.39
+              }
+            ]
+          }
+        ],
+        "worker_warnings": [
+          {
+            "rank": 0,
+            "warning_count": 1,
+            "kernel_names": [
+              "_topk_topp_kernel"
+            ],
+            "timestamps_utc": [
+              "2026-09-09T19:34:18.837198312Z"
+            ],
+            "original_log_sha256": "d2f7050999c9a65b8a550867d40078275fa4e384401ede921d227e1fd61fa684"
+          },
+          {
+            "rank": 1,
+            "warning_count": 1,
+            "kernel_names": [
+              "_topk_topp_kernel"
+            ],
+            "timestamps_utc": [
+              "2026-09-09T19:34:18.844235980Z"
+            ],
+            "original_log_sha256": "ef1b7cb9c026a14d8573df1f0635c3651c4aee67857fa1feeecb90d38b69362c"
+          },
+          {
+            "rank": 2,
+            "warning_count": 1,
+            "kernel_names": [
+              "_topk_topp_kernel"
+            ],
+            "timestamps_utc": [
+              "2026-09-09T19:34:18.860246006Z"
+            ],
+            "original_log_sha256": "a6815dabe1cce7ca747ba82e1d23ce01eae025d0fbcaca36c880819a7c312895"
+          },
+          {
+            "rank": 3,
+            "warning_count": 1,
+            "kernel_names": [
+              "_topk_topp_kernel"
+            ],
+            "timestamps_utc": [
+              "2026-09-09T19:34:18.872000730Z"
+            ],
+            "original_log_sha256": "11351dabae651aed28f0127a80272f3ad58cf2c68f6cfe27c983ec68f2aab039"
+          }
+        ]
+      },
+      {
+        "sweep": 1,
+        "cases": [
+          {
+            "name": "top-k",
+            "http_overlap_seconds": 2.8589999999967404,
+            "requests": [
+              {
+                "index": 0,
+                "body": {
+                  "model": "glm-5.3-flash-spark",
+                  "messages": [
+                    {
+                      "role": "user",
+                      "content": "1788982475478636200 top-k 0: Describe a garden in detail."
+                    }
+                  ],
+                  "temperature": 1.0,
+                  "top_k": 40,
+                  "top_p": 1.0,
+                  "min_p": 0.0,
+                  "max_tokens": 128,
+                  "ignore_eos": true,
+                  "stream": true,
+                  "stream_options": {
+                    "include_usage": true,
+                    "continuous_usage_stats": false
+                  },
+                  "n": 1,
+                  "chat_template_kwargs": {
+                    "enable_thinking": true
+                  }
+                },
+                "result": {
+                  "prompt_tokens": 35,
+                  "completion_tokens": 128,
+                  "total_tokens": 163,
+                  "finish_reason": "length"
+                },
+                "start_monotonic": 189121.109,
+                "end_monotonic": 189124.234
+              },
+              {
+                "index": 1,
+                "body": {
+                  "model": "glm-5.3-flash-spark",
+                  "messages": [
+                    {
+                      "role": "user",
+                      "content": "1788982475479150300 top-k 1: Describe a garden in detail."
+                    }
+                  ],
+                  "temperature": 1.0,
+                  "top_k": 40,
+                  "top_p": 1.0,
+                  "min_p": 0.0,
+                  "max_tokens": 128,
+                  "ignore_eos": true,
+                  "stream": true,
+                  "stream_options": {
+                    "include_usage": true,
+                    "continuous_usage_stats": false
+                  },
+                  "n": 1,
+                  "chat_template_kwargs": {
+                    "enable_thinking": true
+                  }
+                },
+                "result": {
+                  "prompt_tokens": 35,
+                  "completion_tokens": 128,
+                  "total_tokens": 163,
+                  "finish_reason": "length"
+                },
+                "start_monotonic": 189121.109,
+                "end_monotonic": 189123.968
+              }
+            ]
+          },
+          {
+            "name": "top-p",
+            "http_overlap_seconds": 3.187000000005355,
+            "requests": [
+              {
+                "index": 0,
+                "body": {
+                  "model": "glm-5.3-flash-spark",
+                  "messages": [
+                    {
+                      "role": "user",
+                      "content": "1788982478605940300 top-p 0: Describe a garden in detail."
+                    }
+                  ],
+                  "temperature": 1.0,
+                  "top_k": -1,
+                  "top_p": 0.9,
+                  "min_p": 0.0,
+                  "max_tokens": 128,
+                  "ignore_eos": true,
+                  "stream": true,
+                  "stream_options": {
+                    "include_usage": true,
+                    "continuous_usage_stats": false
+                  },
+                  "n": 1,
+                  "chat_template_kwargs": {
+                    "enable_thinking": true
+                  }
+                },
+                "result": {
+                  "prompt_tokens": 35,
+                  "completion_tokens": 128,
+                  "total_tokens": 163,
+                  "finish_reason": "length"
+                },
+                "start_monotonic": 189124.234,
+                "end_monotonic": 189127.765
+              },
+              {
+                "index": 1,
+                "body": {
+                  "model": "glm-5.3-flash-spark",
+                  "messages": [
+                    {
+                      "role": "user",
+                      "content": "1788982478605940300 top-p 1: Describe a garden in detail."
+                    }
+                  ],
+                  "temperature": 1.0,
+                  "top_k": -1,
+                  "top_p": 0.9,
+                  "min_p": 0.0,
+                  "max_tokens": 128,
+                  "ignore_eos": true,
+                  "stream": true,
+                  "stream_options": {
+                    "include_usage": true,
+                    "continuous_usage_stats": false
+                  },
+                  "n": 1,
+                  "chat_template_kwargs": {
+                    "enable_thinking": true
+                  }
+                },
+                "result": {
+                  "prompt_tokens": 35,
+                  "completion_tokens": 128,
+                  "total_tokens": 163,
+                  "finish_reason": "length"
+                },
+                "start_monotonic": 189124.234,
+                "end_monotonic": 189127.421
+              }
+            ]
+          },
+          {
+            "name": "both",
+            "http_overlap_seconds": 2.640999999974156,
+            "requests": [
+              {
+                "index": 0,
+                "body": {
+                  "model": "glm-5.3-flash-spark",
+                  "messages": [
+                    {
+                      "role": "user",
+                      "content": "1788982482141669400 both 0: Describe a garden in detail."
+                    }
+                  ],
+                  "temperature": 1.0,
+                  "top_k": 40,
+                  "top_p": 0.9,
+                  "min_p": 0.0,
+                  "max_tokens": 128,
+                  "ignore_eos": true,
+                  "stream": true,
+                  "stream_options": {
+                    "include_usage": true,
+                    "continuous_usage_stats": false
+                  },
+                  "n": 1,
+                  "chat_template_kwargs": {
+                    "enable_thinking": true
+                  }
+                },
+                "result": {
+                  "prompt_tokens": 32,
+                  "completion_tokens": 128,
+                  "total_tokens": 160,
+                  "finish_reason": "length"
+                },
+                "start_monotonic": 189127.765,
+                "end_monotonic": 189130.406
+              },
+              {
+                "index": 1,
+                "body": {
+                  "model": "glm-5.3-flash-spark",
+                  "messages": [
+                    {
+                      "role": "user",
+                      "content": "1788982482141669400 both 1: Describe a garden in detail."
+                    }
+                  ],
+                  "temperature": 1.0,
+                  "top_k": 40,
+                  "top_p": 0.9,
+                  "min_p": 0.0,
+                  "max_tokens": 128,
+                  "ignore_eos": true,
+                  "stream": true,
+                  "stream_options": {
+                    "include_usage": true,
+                    "continuous_usage_stats": false
+                  },
+                  "n": 1,
+                  "chat_template_kwargs": {
+                    "enable_thinking": true
+                  }
+                },
+                "result": {
+                  "prompt_tokens": 32,
+                  "completion_tokens": 128,
+                  "total_tokens": 160,
+                  "finish_reason": "length"
+                },
+                "start_monotonic": 189127.765,
+                "end_monotonic": 189130.5
+              }
+            ]
+          }
+        ],
+        "worker_warnings": [
+          {
+            "rank": 0,
+            "warning_count": 0,
+            "kernel_names": [],
+            "timestamps_utc": [],
+            "original_log_sha256": "e89e5159c0ba8c2d3242cd1316b399c06fcd923de6b68dd08530a2622d05bbcd"
+          },
+          {
+            "rank": 1,
+            "warning_count": 0,
+            "kernel_names": [],
+            "timestamps_utc": [],
+            "original_log_sha256": "3a7880194da26fbd0d90915513ebf5ff84538ad2a9ad83d907ae3c64e06b5001"
+          },
+          {
+            "rank": 2,
+            "warning_count": 0,
+            "kernel_names": [],
+            "timestamps_utc": [],
+            "original_log_sha256": "410d3bad9eef44acd2105112c6fec3effc9f85119aa6ae7ba067be60c4026b20"
+          },
+          {
+            "rank": 3,
+            "warning_count": 0,
+            "kernel_names": [],
+            "timestamps_utc": [],
+            "original_log_sha256": "2f3755d60bc1ceaf5d42f50250c9f42cfe9cabafe9612c90bcdf458e69ae1f70"
+          }
+        ]
+      }
+    ]
+  },
+  "complete_recipe_replay": {
+    "helper_sha256": "2104e7d83e84d7e2ccbb19e331b487cafea4515ac75eda2dc0082cfc7187a841",
+    "result": {
+      "schema": "sparkring-sampler-warmup/v1",
+      "coverage": "request-recipe-complete",
+      "jit_coverage_verified": false,
+      "enable_thinking": true,
+      "stream": true,
+      "cases": [
+        {
+          "name": "unfiltered",
+          "temperature": 1.0,
+          "top_k": -1,
+          "top_p": 1.0,
+          "seed": null,
+          "prompt_tokens": 28,
+          "completion_tokens": 32,
+          "total_tokens": 60,
+          "finish_reason": "length",
+          "elapsed_seconds": 0.794
+        },
+        {
+          "name": "temperature",
+          "temperature": 0.7,
+          "top_k": -1,
+          "top_p": 1.0,
+          "seed": null,
+          "prompt_tokens": 28,
+          "completion_tokens": 32,
+          "total_tokens": 60,
+          "finish_reason": "length",
+          "elapsed_seconds": 0.586
+        },
+        {
+          "name": "top-k",
+          "temperature": 1.0,
+          "top_k": 40,
+          "top_p": 1.0,
+          "seed": null,
+          "prompt_tokens": 29,
+          "completion_tokens": 32,
+          "total_tokens": 61,
+          "finish_reason": "length",
+          "elapsed_seconds": 0.709
+        },
+        {
+          "name": "top-p",
+          "temperature": 1.0,
+          "top_k": -1,
+          "top_p": 0.9,
+          "seed": null,
+          "prompt_tokens": 29,
+          "completion_tokens": 32,
+          "total_tokens": 61,
+          "finish_reason": "length",
+          "elapsed_seconds": 0.764
+        },
+        {
+          "name": "top-k-top-p",
+          "temperature": 1.0,
+          "top_k": 40,
+          "top_p": 0.9,
+          "seed": null,
+          "prompt_tokens": 31,
+          "completion_tokens": 32,
+          "total_tokens": 63,
+          "finish_reason": "length",
+          "elapsed_seconds": 0.711
+        },
+        {
+          "name": "seeded-top-k-top-p",
+          "temperature": 0.7,
+          "top_k": 40,
+          "top_p": 0.9,
+          "seed": 0,
+          "prompt_tokens": 32,
+          "completion_tokens": 32,
+          "total_tokens": 64,
+          "finish_reason": "length",
+          "elapsed_seconds": 0.616
+        }
+      ],
+      "concurrent_cases": [
+        {
+          "name": "top-k",
+          "concurrency": 2,
+          "max_tokens": 128,
+          "min_tokens": 128,
+          "ignore_eos": true,
+          "http_overlap_seconds": 2.827955,
+          "requests": [
+            {
+              "name": "top-k",
+              "temperature": 1.0,
+              "top_k": 40,
+              "top_p": 1.0,
+              "seed": null,
+              "prompt_tokens": 32,
+              "completion_tokens": 128,
+              "total_tokens": 160,
+              "finish_reason": "length",
+              "elapsed_seconds": 2.828
+            },
+            {
+              "name": "top-k",
+              "temperature": 1.0,
+              "top_k": 40,
+              "top_p": 1.0,
+              "seed": null,
+              "prompt_tokens": 32,
+              "completion_tokens": 128,
+              "total_tokens": 160,
+              "finish_reason": "length",
+              "elapsed_seconds": 2.887
+            }
+          ]
+        },
+        {
+          "name": "top-p",
+          "concurrency": 2,
+          "max_tokens": 128,
+          "min_tokens": 128,
+          "ignore_eos": true,
+          "http_overlap_seconds": 3.208937,
+          "requests": [
+            {
+              "name": "top-p",
+              "temperature": 1.0,
+              "top_k": -1,
+              "top_p": 0.9,
+              "seed": null,
+              "prompt_tokens": 32,
+              "completion_tokens": 128,
+              "total_tokens": 160,
+              "finish_reason": "length",
+              "elapsed_seconds": 3.258
+            },
+            {
+              "name": "top-p",
+              "temperature": 1.0,
+              "top_k": -1,
+              "top_p": 0.9,
+              "seed": null,
+              "prompt_tokens": 32,
+              "completion_tokens": 128,
+              "total_tokens": 160,
+              "finish_reason": "length",
+              "elapsed_seconds": 3.209
+            }
+          ]
+        },
+        {
+          "name": "top-k-top-p",
+          "concurrency": 2,
+          "max_tokens": 128,
+          "min_tokens": 128,
+          "ignore_eos": true,
+          "http_overlap_seconds": 2.701694,
+          "requests": [
+            {
+              "name": "top-k-top-p",
+              "temperature": 1.0,
+              "top_k": 40,
+              "top_p": 0.9,
+              "seed": null,
+              "prompt_tokens": 34,
+              "completion_tokens": 128,
+              "total_tokens": 162,
+              "finish_reason": "length",
+              "elapsed_seconds": 2.702
+            },
+            {
+              "name": "top-k-top-p",
+              "temperature": 1.0,
+              "top_k": 40,
+              "top_p": 0.9,
+              "seed": null,
+              "prompt_tokens": 34,
+              "completion_tokens": 128,
+              "total_tokens": 162,
+              "finish_reason": "length",
+              "elapsed_seconds": 3.041
+            }
+          ]
+        }
+      ],
+      "elapsed_seconds": 13.375
+    },
+    "scope": "External helper against the same already-ready API; not installed startup readiness."
+  },
+  "input_sha256": {
+    "c1_receipt": "f611f3e3f1e694421c8e9fae571fce2df3ebb7bafd09ef309a89d2875dfa3a74",
+    "paired_sweeps_receipt": "9aa86b0dc0031d1144c3cc8dacea7bf7a2ee227e1f6831be2276791694ed873e",
+    "complete_recipe_receipt": "00ca0cee6a08703cb407717c316920383f45da2ac43b0ec19d7b947fb902315a",
+    "installed_source_manifest": "59867b65b8b02988d0da996c79a8684dc0d0f8fdd4fc19edcc601900c81addb7"
+  },
+  "limitations": [
+    "The original issue reports DFlash2; this observation uses native MTP3.",
+    "Warnings may represent disk-cache loading or compilation and warning_once can suppress repeats.",
+    "Zero warnings on the repeat is not proof of zero JIT events or complete variant coverage.",
+    "HTTP overlap does not prove a shared GPU batch or every worker sampler path.",
+    "The paired observation omitted min_tokens; the complete recipe replay sets min_tokens=max_tokens=128 for C2.",
+    "No controlled cold-cache, mixed-prefill, arbitrary concurrency, installed-readiness, or rebuilt-image qualification.",
+    "Private orchestration and host metadata are omitted; request bodies, client intervals, usage, and normalized warning observations are retained."
+  ]
+}

--- a/performance/records/glm53-flash/sampler-concurrency-20260909.md
+++ b/performance/records/glm53-flash/sampler-concurrency-20260909.md
@@ -1,0 +1,83 @@
+# Concurrent sampler warmup observation
+
+Status: **research-only**. Six sequential sampler requests completed, but the
+first subsequent filtered C2 sweep produced a `_topk_topp_kernel` warning on
+each worker. This supports adding concurrent filtered requests to the readiness
+recipe; it does not close all of issue #214.
+
+## Conditions
+
+Four DGX Spark GB10 systems served GLM-5.3-Flash-NVFP4-Spark with TP4/DCP1,
+native MTP3, the V2 runner and InstantTensor loading. The model target in the
+source lock is `local-inference-lab/GLM-5.3-Flash-NVFP4-Spark` at
+`df116c4fb16b1d37ae43d2cfd624de26ffbc832e`. The API was already ready and its
+JIT namespace already existed; this was not a controlled cold-cache test.
+
+| Identity | Value |
+|---|---|
+| Local image config digest | `sha256:db4053abcf1c82ce2da5633abd672abcaa32ca77eef5b03d567b1fa24a04b671` |
+| vLLM composition | `1556c3587ee84cc3c91848893d5079d0a7ff6271` |
+| B12X | `2883a5df65a7ea3cb6e82abb63d1448dd3154887` |
+| SparkCache | `d0cf7296062ec8b4d17d65cd05a416d509e80bd8` |
+| Initial stream validator | SparkRing `9a3d7e416a5502eac1462aa3c2cf30dca53094ba` |
+| Complete recipe helper SHA-256 | `2104e7d83e84d7e2ccbb19e331b487cafea4515ac75eda2dc0082cfc7187a841` |
+
+The image digest identifies local bytes, not a registry release. The
+[JSON record](sampler-concurrency-20260909.json) includes installed rank-zero
+sampler, state, rejection-sampler, Triton-kernel and monitor file hashes. The
+vLLM composition comes from the source lock and image label; inherited package
+version text is not used as that identity.
+
+## Measurement
+
+Six C1 streamed requests first exercised unfiltered, temperature-scaled,
+top-k, top-p, combined-filter and seeded combined-filter settings. Each completed
+32 generated tokens with validated SSE termination and usage.
+
+Two subsequent sweeps each sent three homogeneous C2 pairs: top-k only, top-p
+only, and both filters, at temperature one with no explicit seed. Each request
+used `max_tokens=128` and `ignore_eos=true`; those sweeps omitted `min_tokens`.
+The public record retains each request body, reported usage and client monotonic
+start/end interval. HTTP overlap is the smaller end time minus the larger start
+time. Warning lines were collected from all four ranks for each sweep.
+
+The complete helper recipe was then exercised externally against the same ready
+API, including `min_tokens=128` on its C2 requests. No installed startup helper
+or readiness marker was changed by these API probes.
+
+## Result
+
+| Observation | Result |
+|---|---|
+| Initial six C1 requests | All completed with 32 generated tokens each |
+| First three C2 pairs | All six requests completed with 128 generated tokens each |
+| `_topk_topp_kernel` warnings in first C2 sweep | One observed warning on each of four ranks |
+| Repeated three C2 pairs | All six requests completed with 128 generated tokens each |
+| Observed warnings in repeated sweep | Zero on each rank |
+| Complete six-C1/three-C2 helper replay | All twelve requests passed strict SSE and usage checks |
+
+Each pair had positive measured HTTP overlap. These intervals are evidence of
+concurrent client requests, not a model-throughput comparison.
+
+## Conclusion
+
+The first filtered C2 sweep reached a kernel initialization/load that the six
+C1 requests had not covered in this process. A readiness recipe restricted to
+those C1 requests was insufficient for this observed workload. The extended
+helper completed its bounded request recipe on this already-ready API.
+
+## Limitations
+
+The monitor used `warning_once`, so zero repeat warnings does not prove zero
+JIT events or complete filter-variant coverage. A warning also does not separate
+disk-cache loading from compilation. No compile-time or speedup claim follows
+from these observations.
+
+HTTP overlap does not prove that requests shared a GPU batch or identify every
+worker's execution path. Other valid configurations can route probability
+filtering through FlashInfer, so three particular Triton cache entries are not
+a general readiness contract. The helper retains `jit_coverage_verified=false`.
+
+This native-MTP3 result does not qualify the original DFlash2 report, a rebuilt
+image's startup readiness, controlled cold-JIT behavior, mixed long/short
+prefill, or arbitrary concurrency. Issue #214 remains open for those gaps.

--- a/runtime/glm53-flash-jj-r8-gb10/README.md
+++ b/runtime/glm53-flash-jj-r8-gb10/README.md
@@ -369,6 +369,14 @@ sampler requests through `serve_with_warmup.py`, each with thinking enabled and
 | Top-k and top-p | 1.0 | 40 | 0.9 | absent |
 | Seeded top-k and top-p | 0.7 | 40 | 0.9 | 0 |
 
+If `DFLASH_WARMUP_CONCURRENCIES` includes a value of at least two, the sampler
+recipe then runs three homogeneous pairs: top-k only, top-p only, and both
+filters. Each paired request uses temperature one, no explicit seed,
+`max_tokens=min_tokens=128`, and `ignore_eos=true`. Both requests must complete
+all 128 tokens with finish reason `length`, and their HTTP intervals must
+overlap. The pairs run one stage at a time under the same startup deadline.
+A C1-only configuration skips these pairs and records `coverage=limited-c1-only`.
+
 Explicit neutral filters prevent a checkpoint's generation defaults from choosing
 an unintended arm. In the pinned vLLM source, [sampling state](https://github.com/FujitsuPolycom/vllm/blob/e02b174693e13859de61811b5e8cd13d5308e259/vllm/v1/worker/gpu/sample/states.py#L40-L100)
 normalizes disabled top-k, omits neutral top-k/top-p tensors, and skips temperature
@@ -385,7 +393,7 @@ chunk after the finish is accepted, as are SSE comments and blank lines. Token
 counts come from usage, not the number of chunks. Malformed, failed, truncated,
 oversized or unfinished streams withhold readiness. The `sampling_warmup` log
 records `stream=true`, each arm's usage, finish reason and elapsed time with
-`coverage=request-recipe-complete` and
+`coverage=request-recipe-complete` when all concurrent stages run, and
 `jit_coverage_verified=false`. API readiness, shape batches and sampler requests
 share `DFLASH_WARMUP_TIMEOUT_SECONDS`; each operation receives the remaining
 budget, stream consumption checks the deadline, and an expired budget prevents
@@ -398,10 +406,13 @@ temperature-one/thinking request, not this six-arm recipe. Its
 tests; those results do not qualify a rebuilt image. The operator image in
 `pins.json` also remains unchanged.
 
-Cold-cache full-model sampler coverage, filtered concurrent sampler
-specializations, mixed long/short prefill coverage, and all recurrent KDA
-specializations remain unqualified. The six sequential C1 sampler requests do
-not establish filtered concurrent execution. In particular, the
+Cold-cache full-model sampler coverage, filtered concurrent GPU specializations,
+mixed long/short prefill coverage, and all recurrent KDA specializations remain
+unqualified. The concurrent stages record HTTP overlap, which does not establish
+that both requests shared a GPU batch or identify each worker's sampler path.
+The [bounded sampler observation](../../performance/records/glm53-flash/sampler-concurrency-20260909.md)
+records why C1-only warmup was insufficient on one native-MTP3 runtime.
+In particular, the
 reported several-4K-prefills-behind-long-decode case requires an identified image,
 tokenized request lengths, actual overlapping execution and per-rank JIT evidence.
 The short shape sweep below does not establish that case. Do not gate readiness

--- a/runtime/glm53-flash-jj-r8-gb10/README.md
+++ b/runtime/glm53-flash-jj-r8-gb10/README.md
@@ -356,8 +356,9 @@ The report lists KV separately. A passing offline plan does not qualify a CUDA
 allocation or a serving performance result.
 
 When `DFLASH_WARMUP=1`, the readiness entrypoint runs `warmup_dflash.py` before
-Docker reports rank 0 as healthy. Source builds then run six explicit sampler
-requests through `serve_with_warmup.py`, each with thinking enabled and `min_p=0`:
+Docker reports rank 0 as healthy. Source builds then run six explicit streaming
+sampler requests through `serve_with_warmup.py`, each with thinking enabled and
+`min_p=0`:
 
 | Request | Temperature | top_k | top_p | Explicit seed |
 |---|---:|---:|---:|---:|
@@ -376,14 +377,19 @@ uses its Gumbel fallback for unfiltered or explicitly seeded requests. These
 branches justify the recipe; they do not prove every speculative execution path
 or compiled kernel was reached by an HTTP request.
 
-Status: **implemented**, with CPU request and readiness tests. Each arm must
-return exactly one message-bearing choice with finish reason `stop` or `length`
-and positive integer `usage.completion_tokens`; one failed arm
-withholds readiness. The `sampling_warmup` log records each arm, completed-token
-count and elapsed time with `coverage=request-recipe-complete` and
+Status: **implemented**, with CPU request and readiness tests. Each arm requests
+`stream=true` and final usage. Its SSE stream must contain one choice at index
+zero, finish with `stop` or `length`, report positive integer prompt/completion
+usage with a consistent total, and terminate with `[DONE]`. A final usage-only
+chunk after the finish is accepted, as are SSE comments and blank lines. Token
+counts come from usage, not the number of chunks. Malformed, failed, truncated,
+oversized or unfinished streams withhold readiness. The `sampling_warmup` log
+records `stream=true`, each arm's usage, finish reason and elapsed time with
+`coverage=request-recipe-complete` and
 `jit_coverage_verified=false`. API readiness, shape batches and sampler requests
 share `DFLASH_WARMUP_TIMEOUT_SECONDS`; each operation receives the remaining
-budget, and an expired budget prevents the readiness marker. Shape-request
+budget, stream consumption checks the deadline, and an expired budget prevents
+the readiness marker. Shape-request
 nonces precede repeated prompt text and vary between runs to avoid prefix reuse.
 
 The [published child image](hotfix/README.md) contains the earlier single
@@ -392,13 +398,19 @@ temperature-one/thinking request, not this six-arm recipe. Its
 tests; those results do not qualify a rebuilt image. The operator image in
 `pins.json` also remains unchanged.
 
-Cold-cache full-model sampler coverage, mixed long/short prefill coverage, and
-all recurrent KDA specializations remain unqualified. In particular, the
+Cold-cache full-model sampler coverage, filtered concurrent sampler
+specializations, mixed long/short prefill coverage, and all recurrent KDA
+specializations remain unqualified. The six sequential C1 sampler requests do
+not establish filtered concurrent execution. In particular, the
 reported several-4K-prefills-behind-long-decode case requires an identified image,
 tokenized request lengths, actual overlapping execution and per-rank JIT evidence.
 The short shape sweep below does not establish that case. Do not gate readiness
 on guessed Triton cache filenames: cache presence alone does not prove that the
 serving process initialized every required compiled variant.
+The pinned sampler can select FlashInfer, Gumbel or a speculative path. JIT
+monitor events are not per-worker execution receipts for all of those paths.
+A backend coverage gate needs source-bound reports from every worker after its
+required sampler paths complete; this HTTP warmup does not provide them.
 The default environment template warms every concurrency from C1 through C16
 and prompt spans covering the DFlash Triton `BLOCK_SIZE` specializations
 through 256. DFlash depth seven verifies eight target rows per active request,

--- a/runtime/glm53-flash-jj-r8-gb10/serve_with_warmup.py
+++ b/runtime/glm53-flash-jj-r8-gb10/serve_with_warmup.py
@@ -4,12 +4,14 @@
 from __future__ import annotations
 
 import json
+import concurrent.futures
 import os
 import signal
 import secrets
 import subprocess
 import sys
 import time
+import threading
 import urllib.request
 from pathlib import Path
 
@@ -137,6 +139,7 @@ def warmup_sampling(
     max_tokens: int,
     timeout_seconds: float,
     credential: str | None,
+    concurrencies: tuple[int, ...] = (1,),
 ) -> dict[str, object]:
     """Complete the explicit sampler request recipe before declaring readiness."""
     deadline = warmup_dflash.make_deadline(timeout_seconds)
@@ -147,13 +150,14 @@ def warmup_sampling(
     if credential:
         headers["Authorization"] = f"Bearer {credential}"
     started = time.monotonic()
-    cases = []
-    for name, temperature, top_k, top_p, seed in SAMPLING_CASES:
+    def send_case(case, token_limit, *, peer=None, barrier=None):
+        name, temperature, top_k, top_p, seed = case
+        label = name if peer is None else f"{name} peer={peer}"
         body = {
             "model": model,
             "messages": [{
                 "role": "user",
-                "content": f"Sampling warmup {time.monotonic_ns()} {name}. Reply briefly.",
+                "content": f"Sampling warmup {time.monotonic_ns()} {label}. Reply briefly.",
             }],
             "temperature": temperature,
             "top_k": top_k,
@@ -162,35 +166,70 @@ def warmup_sampling(
             "n": 1,
             "stream": True,
             "stream_options": {"include_usage": True, "continuous_usage_stats": False},
-            "max_tokens": max_tokens,
+            "max_tokens": token_limit,
             "chat_template_kwargs": {"enable_thinking": True},
         }
         if seed is not None:
             body["seed"] = seed
+        if peer is not None:
+            # A fixed decode span prevents EOS from ending a paired request
+            # before the other request can enter the serving scheduler.
+            body.update(ignore_eos=True, min_tokens=token_limit)
         request = urllib.request.Request(
             endpoint.rstrip("/") + "/v1/chat/completions",
             data=json.dumps(body).encode(), headers=headers,
         )
-        case_started = time.monotonic()
+        if barrier is not None:
+            barrier.wait(timeout=warmup_dflash.remaining_seconds(deadline))
+        case_started = time.perf_counter()
         with urllib.request.urlopen(
             request, timeout=warmup_dflash.remaining_seconds(deadline)
         ) as response:
             if response.status != 200 or response.headers.get_content_type() != "text/event-stream":
                 raise RuntimeError(f"Sampling warmup did not return an SSE response: {name}")
-            result = _sampling_stream_result(response, deadline, max_tokens)
+            result = _sampling_stream_result(response, deadline, token_limit)
+        case_finished = time.perf_counter()
+        if peer is not None and (
+            result["completion_tokens"] != token_limit or result["finish_reason"] != "length"
+        ):
+            raise RuntimeError("Concurrent sampling warmup did not complete its fixed token span")
         warmup_dflash.remaining_seconds(deadline)
-        cases.append({
+        return {
             "name": name, "temperature": temperature, "top_k": top_k,
             "top_p": top_p, "seed": seed, **result,
-            "elapsed_seconds": round(time.monotonic() - case_started, 3),
-        })
+            "elapsed_seconds": round(case_finished - case_started, 3),
+        }, case_started, case_finished
+
+    cases = [send_case(case, max_tokens)[0] for case in SAMPLING_CASES]
+    concurrent_cases = []
+    if any(concurrency >= 2 for concurrency in concurrencies):
+        for case in SAMPLING_CASES:
+            if case[0] not in ("top-k", "top-p", "top-k-top-p"):
+                continue
+            barrier = threading.Barrier(2)
+            with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
+                futures = [executor.submit(send_case, case, 128, peer=index, barrier=barrier)
+                           for index in range(2)]
+                results = [future.result(timeout=warmup_dflash.remaining_seconds(deadline))
+                           for future in futures]
+            overlap = min(result[2] for result in results) - max(result[1] for result in results)
+            if overlap <= 0:
+                raise RuntimeError("Concurrent sampling warmup HTTP requests did not overlap")
+            concurrent_cases.append({
+                "name": case[0], "concurrency": 2, "max_tokens": 128,
+                "min_tokens": 128, "ignore_eos": True,
+                "http_overlap_seconds": round(overlap, 6),
+                "requests": [result[0] for result in results],
+            })
+    warmup_dflash.remaining_seconds(deadline)
     return {
         "schema": "sparkring-sampler-warmup/v1",
-        "coverage": "request-recipe-complete",
+        "coverage": "request-recipe-complete" if concurrent_cases else "limited-c1-only",
         "jit_coverage_verified": False,
         "enable_thinking": True,
         "stream": True,
         "cases": cases,
+        "concurrent_cases": concurrent_cases,
         "elapsed_seconds": round(time.monotonic() - started, 3),
     }
 
@@ -239,7 +278,7 @@ def complete_readiness(
             )
             sampling = warmup_sampling(
                 endpoint, model, max_tokens,
-                warmup_dflash.remaining_seconds(deadline), credential
+                warmup_dflash.remaining_seconds(deadline), credential, concurrencies
             )
             print(json.dumps({"sampling_warmup": sampling}, separators=(",", ":")))
         print(json.dumps({"dflash_warmup": result}, separators=(",", ":")))

--- a/runtime/glm53-flash-jj-r8-gb10/serve_with_warmup.py
+++ b/runtime/glm53-flash-jj-r8-gb10/serve_with_warmup.py
@@ -31,6 +31,106 @@ SAMPLING_CASES = (
 )
 
 
+def _sampling_stream_result(response, deadline: float, max_tokens: int) -> dict:
+    """Require one finished choice, final usage and a complete SSE terminator."""
+    finish_reason = None
+    usage = None
+    request_id = None
+    done = False
+    data_lines = []
+    event_type = ""
+    byte_count = 0
+    while True:
+        warmup_dflash.remaining_seconds(deadline)
+        raw = response.readline(65537)
+        warmup_dflash.remaining_seconds(deadline)
+        byte_count += len(raw)
+        if len(raw) > 65536 or byte_count > 4 * 1024 * 1024:
+            raise RuntimeError("Sampling warmup stream exceeds its response bound")
+        if not raw:
+            if data_lines or not done:
+                raise RuntimeError("Sampling warmup stream ended before [DONE]")
+            return {**usage, "finish_reason": finish_reason}
+        try:
+            line = raw.decode("utf-8").rstrip("\r\n")
+        except UnicodeDecodeError as error:
+            raise RuntimeError("Sampling warmup stream is not UTF-8") from error
+        if line.startswith(":"):
+            continue
+        if line:
+            field, _, value = line.partition(":")
+            value = value.removeprefix(" ")
+            if field == "data":
+                data_lines.append(value)
+            elif field == "event":
+                event_type = value
+            continue
+        if event_type == "error":
+            raise RuntimeError("Sampling warmup stream reported an error event")
+        event_type = ""
+        if not data_lines:
+            continue
+        payload = "\n".join(data_lines)
+        data_lines = []
+        if done:
+            raise RuntimeError("Sampling warmup stream contains data after [DONE]")
+        if payload == "[DONE]":
+            if finish_reason is None or usage is None:
+                raise RuntimeError("Sampling warmup stream has no completed choice and usage")
+            done = True
+            continue
+        try:
+            chunk = json.loads(payload)
+        except json.JSONDecodeError as error:
+            raise RuntimeError("Sampling warmup stream contains invalid JSON") from error
+        if not isinstance(chunk, dict) or "error" in chunk:
+            raise RuntimeError("Sampling warmup stream reported an error or invalid chunk")
+        if (
+            chunk.get("object") != "chat.completion.chunk"
+            or not isinstance(chunk.get("id"), str) or not chunk["id"]
+        ):
+            raise RuntimeError("Sampling warmup stream has invalid completion identity")
+        if request_id is None:
+            request_id = chunk["id"]
+        elif request_id != chunk["id"]:
+            raise RuntimeError("Sampling warmup stream changed completion identity")
+        choices = chunk.get("choices")
+        if choices == []:
+            if finish_reason is None or usage is not None:
+                raise RuntimeError("Sampling warmup stream has misplaced or duplicate usage")
+            usage = chunk.get("usage")
+            if not isinstance(usage, dict):
+                raise RuntimeError("Sampling warmup stream has no final usage")
+            completion_tokens = usage.get("completion_tokens")
+            if type(completion_tokens) is not int or completion_tokens <= 0:
+                raise RuntimeError("Sampling warmup generated no tokens")
+            prompt_tokens, total_tokens = usage.get("prompt_tokens"), usage.get("total_tokens")
+            if (
+                type(prompt_tokens) is not int or prompt_tokens <= 0
+                or type(total_tokens) is not int
+                or total_tokens != prompt_tokens + completion_tokens
+                or completion_tokens > max_tokens
+            ):
+                raise RuntimeError("Sampling warmup stream has inconsistent token usage")
+            usage = {key: usage[key] for key in (
+                "prompt_tokens", "completion_tokens", "total_tokens")}
+            continue
+        if (
+            finish_reason is not None or usage is not None
+            or not isinstance(choices, list) or len(choices) != 1
+            or not isinstance(choices[0], dict)
+            or type(choices[0].get("index")) is not int or choices[0]["index"] != 0
+            or not isinstance(choices[0].get("delta"), dict)
+            or chunk.get("usage") is not None
+        ):
+            raise RuntimeError("Sampling warmup stream does not contain one ordered choice")
+        reason = choices[0].get("finish_reason")
+        if reason is not None:
+            if reason not in ("stop", "length"):
+                raise RuntimeError("Sampling warmup stream has an unsuccessful finish reason")
+            finish_reason = reason
+
+
 def warmup_sampling(
     endpoint: str,
     model: str,
@@ -59,6 +159,9 @@ def warmup_sampling(
             "top_k": top_k,
             "top_p": top_p,
             "min_p": 0.0,
+            "n": 1,
+            "stream": True,
+            "stream_options": {"include_usage": True, "continuous_usage_stats": False},
             "max_tokens": max_tokens,
             "chat_template_kwargs": {"enable_thinking": True},
         }
@@ -72,26 +175,13 @@ def warmup_sampling(
         with urllib.request.urlopen(
             request, timeout=warmup_dflash.remaining_seconds(deadline)
         ) as response:
-            result = json.load(response)
-        choices = result.get("choices") if isinstance(result, dict) else None
-        if not isinstance(choices, list) or not choices:
-            raise RuntimeError(f"Sampling warmup response has no completion: {name}")
-        if (
-            len(choices) != 1
-            or not isinstance(choices[0], dict)
-            or not isinstance(choices[0].get("message"), dict)
-            or choices[0].get("finish_reason") not in ("stop", "length")
-        ):
-            raise RuntimeError(f"Sampling warmup response is not one completed choice: {name}")
-        usage = result.get("usage")
-        completion_tokens = usage.get("completion_tokens") if isinstance(usage, dict) else None
-        if type(completion_tokens) is not int or completion_tokens <= 0:
-            raise RuntimeError(f"Sampling warmup generated no tokens: {name}")
+            if response.status != 200 or response.headers.get_content_type() != "text/event-stream":
+                raise RuntimeError(f"Sampling warmup did not return an SSE response: {name}")
+            result = _sampling_stream_result(response, deadline, max_tokens)
         warmup_dflash.remaining_seconds(deadline)
         cases.append({
             "name": name, "temperature": temperature, "top_k": top_k,
-            "top_p": top_p, "seed": seed, "completion_tokens": completion_tokens,
-            "finish_reason": choices[0]["finish_reason"],
+            "top_p": top_p, "seed": seed, **result,
             "elapsed_seconds": round(time.monotonic() - case_started, 3),
         })
     return {
@@ -99,6 +189,7 @@ def warmup_sampling(
         "coverage": "request-recipe-complete",
         "jit_coverage_verified": False,
         "enable_thinking": True,
+        "stream": True,
         "cases": cases,
         "elapsed_seconds": round(time.monotonic() - started, 3),
     }

--- a/runtime/glm53-flash-jj-r8-gb10/test_serve_with_warmup.py
+++ b/runtime/glm53-flash-jj-r8-gb10/test_serve_with_warmup.py
@@ -5,6 +5,7 @@ import copy
 import io
 import json
 import sys
+import threading
 from email.message import Message
 from pathlib import Path
 
@@ -72,7 +73,8 @@ def test_sampling_sweep_covers_filter_and_seed_paths_with_completed_outputs(monk
     assert all(body["stream"] is True and body["n"] == 1 and body["stream_options"] == {
         "include_usage": True, "continuous_usage_stats": False} for body in observed)
     assert len({body["messages"][0]["content"] for body in observed}) == len(observed) == 6
-    assert result["coverage"] == "request-recipe-complete"
+    assert result["coverage"] == "limited-c1-only"
+    assert result["concurrent_cases"] == []
     assert result["jit_coverage_verified"] is False
     assert result["stream"] is True
     assert all(case["completion_tokens"] == 2 for case in result["cases"])
@@ -136,7 +138,7 @@ def test_sampling_accepts_completed_stop_or_token_limit(monkeypatch, finish_reas
     monkeypatch.setattr(wrapper.urllib.request, "urlopen",
                         lambda *_args, **_kwargs: _stream(finish_reason=finish_reason))
     result = wrapper.warmup_sampling("http://localhost", "model", 16, 30, None)
-    assert result["coverage"] == "request-recipe-complete"
+    assert result["coverage"] == "limited-c1-only"
     assert all(case["finish_reason"] == finish_reason for case in result["cases"])
 
 
@@ -154,6 +156,96 @@ def test_sampling_accepts_comments_blank_lines_and_multiline_data(monkeypatch):
     # A chunk can contain several tokens or only metadata; usage supplies totals.
     assert all(case["completion_tokens"] == 2 and case["total_tokens"] == 14
                for case in result["cases"])
+
+
+def test_concurrent_filters_follow_c1_cases_with_fixed_decode_and_http_overlap(monkeypatch):
+    wrapper, _ = _load_module(monkeypatch)
+    observed = []
+    both_started = threading.Barrier(2)
+
+    def urlopen(request, **kwargs):
+        body = json.loads(request.data)
+        observed.append(body)
+        if body.get("min_tokens") == 128:
+            both_started.wait(timeout=5)
+            return _stream(completion_tokens=128, finish_reason="length")
+        return _stream()
+
+    monkeypatch.setattr(wrapper.urllib.request, "urlopen", urlopen)
+    result = wrapper.warmup_sampling("http://localhost", "model", 16, 30, None, (1, 3))
+    assert len(observed) == 12
+    assert all("min_tokens" not in body and "ignore_eos" not in body for body in observed[:6])
+    for start, filters in ((6, (40, 1.0)), (8, (-1, 0.9)), (10, (40, 0.9))):
+        for body in observed[start:start + 2]:
+            assert (body["top_k"], body["top_p"]) == filters
+            assert body["temperature"] == 1.0 and body["min_p"] == 0.0
+            assert "seed" not in body
+            assert body["max_tokens"] == body["min_tokens"] == 128
+            assert body["ignore_eos"] is True and body["stream"] is True
+    assert result["coverage"] == "request-recipe-complete"
+    assert result["jit_coverage_verified"] is False
+    assert len(result["concurrent_cases"]) == 3
+    for case in result["concurrent_cases"]:
+        assert case["concurrency"] == 2 and case["http_overlap_seconds"] > 0
+        assert [request["completion_tokens"] for request in case["requests"]] == [128, 128]
+
+
+@pytest.mark.parametrize("filters", [(40, 1.0), (-1, 0.9), (40, 0.9)])
+@pytest.mark.parametrize("peer", [0, 1])
+def test_each_concurrent_peer_must_complete_before_readiness(tmp_path, monkeypatch, filters, peer):
+    wrapper, warmup = _load_module(monkeypatch)
+    monkeypatch.setattr(warmup, "wait_for_api", lambda *_args: None)
+    monkeypatch.setattr(warmup, "run_warmup", lambda *_args: ())
+    both_started = threading.Barrier(2)
+
+    def urlopen(request, **kwargs):
+        body = json.loads(request.data)
+        if body.get("min_tokens") != 128:
+            return _stream()
+        both_started.wait(timeout=5)
+        fail = ((body["top_k"], body["top_p"]) == filters
+                and f"peer={peer}" in body["messages"][0]["content"])
+        return _stream(completion_tokens=127 if fail else 128, finish_reason="length")
+
+    monkeypatch.setattr(wrapper.urllib.request, "urlopen", urlopen)
+    ready = tmp_path / "ready"
+    ready.touch()
+    with pytest.raises(RuntimeError, match="fixed token span"):
+        wrapper.complete_readiness(
+            rank=0, endpoint="http://localhost", model="model", warmup_enabled=True,
+            concurrencies=(1, 2), shape_words=(8,), max_tokens=16,
+            timeout_seconds=30, credential=None, ready_path=ready,
+        )
+    assert not ready.exists()
+
+
+def test_concurrent_stages_do_not_reset_the_startup_deadline(tmp_path, monkeypatch):
+    wrapper, warmup = _load_module(monkeypatch)
+    clock = [0.0]
+    lock = threading.Lock()
+    both_started = threading.Barrier(2)
+    monkeypatch.setattr(wrapper.time, "monotonic", lambda: clock[0])
+    monkeypatch.setattr(warmup, "wait_for_api", lambda *_args: None)
+    monkeypatch.setattr(warmup, "run_warmup", lambda *_args: ())
+
+    def urlopen(request, **kwargs):
+        paired = json.loads(request.data).get("min_tokens") == 128
+        with lock:
+            clock[0] += 3 if paired else 1
+        if paired:
+            both_started.wait(timeout=5)
+        return _stream(completion_tokens=128 if paired else 2, finish_reason="length")
+
+    monkeypatch.setattr(wrapper.urllib.request, "urlopen", urlopen)
+    ready = tmp_path / "ready"
+    with pytest.raises(RuntimeError, match="deadline"):
+        wrapper.complete_readiness(
+            rank=0, endpoint="http://localhost", model="model", warmup_enabled=True,
+            concurrencies=(1, 2), shape_words=(8,), max_tokens=16,
+            timeout_seconds=10, credential=None, ready_path=ready,
+        )
+    assert clock[0] == 12
+    assert not ready.exists()
 
 
 def _invalid_streams():

--- a/runtime/glm53-flash-jj-r8-gb10/test_serve_with_warmup.py
+++ b/runtime/glm53-flash-jj-r8-gb10/test_serve_with_warmup.py
@@ -1,15 +1,49 @@
 from __future__ import annotations
 
 import importlib.util
+import copy
 import io
 import json
 import sys
+from email.message import Message
 from pathlib import Path
 
 import pytest
 
 
 HERE = Path(__file__).resolve().parent
+
+
+class _Stream(io.BytesIO):
+    status = 200
+
+    def __init__(self, raw):
+        super().__init__(raw)
+        self.headers = Message()
+        self.headers["Content-Type"] = "text/event-stream; charset=utf-8"
+
+
+def _chunk(choices, **kwargs):
+    return {"id": "warmup-response", "object": "chat.completion.chunk",
+            "choices": choices, **kwargs}
+
+
+def _events(*, finish_reason="stop", completion_tokens=2):
+    return [
+        _chunk([{"index": 0, "delta": {"role": "assistant"}, "finish_reason": None}]),
+        _chunk([{"index": 0, "delta": {"reasoning": "Several tokens in one chunk"},
+                 "finish_reason": None}]),
+        _chunk([{"index": 0, "delta": {}, "finish_reason": finish_reason}]),
+        _chunk([], usage={"prompt_tokens": 12, "completion_tokens": completion_tokens,
+                          "total_tokens": 12 + completion_tokens}),
+        "[DONE]",
+    ]
+
+
+def _stream(events=None, **kwargs):
+    events = _events(**kwargs) if events is None else events
+    return _Stream("".join("data: " + (event if isinstance(event, str) else json.dumps(event))
+                          + "\n\n" for event in events).encode())
 
 
 def test_sampling_sweep_covers_filter_and_seed_paths_with_completed_outputs(monkeypatch):
@@ -25,7 +59,7 @@ def test_sampling_sweep_covers_filter_and_seed_paths_with_completed_outputs(monk
         assert request.get_header("X-sparkring-startup-token") == "internal-secret"
         observed.append(json.loads(request.data))
         clock[0] += 1
-        return io.BytesIO(b'{"choices":[{"finish_reason":"stop","message":{"reasoning":"ok"}}],"usage":{"completion_tokens":2}}')
+        return _stream()
 
     monkeypatch.setattr(wrapper.urllib.request, "urlopen", urlopen)
     result = wrapper.warmup_sampling("http://localhost", "model", 16, 10, "secret")
@@ -35,9 +69,12 @@ def test_sampling_sweep_covers_filter_and_seed_paths_with_completed_outputs(monk
     assert any(body["temperature"] == 0.7 and body["top_k"] == -1 and body["top_p"] == 1.0 for body in observed)
     assert any(body.get("seed") == 0 and body["top_k"] == 40 and body["top_p"] == 0.9 for body in observed)
     assert all(body["min_p"] == 0.0 and body["chat_template_kwargs"] == {"enable_thinking": True} for body in observed)
+    assert all(body["stream"] is True and body["n"] == 1 and body["stream_options"] == {
+        "include_usage": True, "continuous_usage_stats": False} for body in observed)
     assert len({body["messages"][0]["content"] for body in observed}) == len(observed) == 6
     assert result["coverage"] == "request-recipe-complete"
     assert result["jit_coverage_verified"] is False
+    assert result["stream"] is True
     assert all(case["completion_tokens"] == 2 for case in result["cases"])
 
 
@@ -51,7 +88,7 @@ def test_every_sampling_arm_must_complete_before_readiness(tmp_path, monkeypatch
     def urlopen(request, timeout):
         calls.append(request)
         count = 0 if len(calls) == failed_index + 1 else 1
-        return io.BytesIO(json.dumps({"choices": [{"finish_reason": "stop", "message": {"reasoning": "ok"}}], "usage": {"completion_tokens": count}}).encode())
+        return _stream(completion_tokens=count)
 
     monkeypatch.setattr(wrapper.urllib.request, "urlopen", urlopen)
     ready = tmp_path / "ready"
@@ -68,10 +105,10 @@ def test_every_sampling_arm_must_complete_before_readiness(tmp_path, monkeypatch
 
 @pytest.mark.parametrize("choices", [
     [None], ["invalid"], [{}],
-    [{"finish_reason": "error", "message": {"content": "partial"}}],
-    [{"finish_reason": None, "message": {"content": "partial"}}],
-    [{"message": {"content": "partial"}}],
-    [{"finish_reason": "tool_calls", "message": {"tool_calls": []}}],
+    [{"index": 0, "finish_reason": "error", "delta": {"content": "partial"}}],
+    [{"index": 0, "finish_reason": None, "delta": {"content": "partial"}}],
+    [{"delta": {"content": "partial"}}],
+    [{"index": 0, "finish_reason": "tool_calls", "delta": {"tool_calls": []}}],
     [{"finish_reason": "stop"}],
     [{"finish_reason": "stop", "message": None}],
     [{"finish_reason": "stop", "message": {}}] * 2,
@@ -80,11 +117,11 @@ def test_invalid_or_unfinished_sampling_choice_withholds_readiness(tmp_path, mon
     wrapper, warmup = _load_module(monkeypatch)
     monkeypatch.setattr(warmup, "wait_for_api", lambda *_args: None)
     monkeypatch.setattr(warmup, "run_warmup", lambda *_args: ())
-    response = json.dumps({"choices": choices, "usage": {"completion_tokens": 1}}).encode()
-    monkeypatch.setattr(wrapper.urllib.request, "urlopen", lambda *_args, **_kwargs: io.BytesIO(response))
+    monkeypatch.setattr(wrapper.urllib.request, "urlopen",
+                        lambda *_args, **_kwargs: _stream([_chunk(choices), "[DONE]"]))
     ready = tmp_path / "ready"
     ready.touch()
-    with pytest.raises(RuntimeError, match="Sampling warmup response"):
+    with pytest.raises(RuntimeError, match="Sampling warmup stream"):
         wrapper.complete_readiness(
             rank=0, endpoint="http://localhost", model="model", warmup_enabled=True,
             concurrencies=(1,), shape_words=(8,), max_tokens=16,
@@ -96,11 +133,110 @@ def test_invalid_or_unfinished_sampling_choice_withholds_readiness(tmp_path, mon
 @pytest.mark.parametrize("finish_reason", ["stop", "length"])
 def test_sampling_accepts_completed_stop_or_token_limit(monkeypatch, finish_reason):
     wrapper, _ = _load_module(monkeypatch)
-    response = json.dumps({"choices": [{"finish_reason": finish_reason, "message": {"reasoning": "ok"}}], "usage": {"completion_tokens": 1}}).encode()
-    monkeypatch.setattr(wrapper.urllib.request, "urlopen", lambda *_args, **_kwargs: io.BytesIO(response))
+    monkeypatch.setattr(wrapper.urllib.request, "urlopen",
+                        lambda *_args, **_kwargs: _stream(finish_reason=finish_reason))
     result = wrapper.warmup_sampling("http://localhost", "model", 16, 30, None)
     assert result["coverage"] == "request-recipe-complete"
     assert all(case["finish_reason"] == finish_reason for case in result["cases"])
+
+
+def test_sampling_accepts_comments_blank_lines_and_multiline_data(monkeypatch):
+    wrapper, _ = _load_module(monkeypatch)
+    frames = []
+    for event in _events():
+        payload = event if isinstance(event, str) else json.dumps(event, indent=2)
+        frames.append(": keepalive\r\n\r\n" + "".join(
+            "data: " + line + "\r\n" for line in payload.splitlines()) + "\r\n")
+    raw = "\r\n".join(frames).encode()
+    monkeypatch.setattr(wrapper.urllib.request, "urlopen",
+                        lambda *_args, **_kwargs: _Stream(raw))
+    result = wrapper.warmup_sampling("http://localhost", "model", 16, 30, None)
+    # A chunk can contain several tokens or only metadata; usage supplies totals.
+    assert all(case["completion_tokens"] == 2 and case["total_tokens"] == 14
+               for case in result["cases"])
+
+
+def _invalid_streams():
+    events = _events()
+    return [
+        b"data: not-json\n\n",
+        b"data: \xff\n\n",
+        _stream(events[:-1]).getvalue(),
+        _stream(events[:2] + [{"error": {"message": "generation failed"}}, "[DONE]"]).getvalue(),
+        b"event: error\ndata: {}\n\n",
+        _stream(events[:2] + events[3:]).getvalue(),
+        _stream(events[:3] + ["[DONE]"]).getvalue(),
+        _stream(events[:3] + events[2:]).getvalue(),
+        _stream(events[:4] + events[3:]).getvalue(),
+        _stream(events + ["[DONE]"]).getvalue(),
+        _stream(events + [events[1]]).getvalue(),
+        _stream(events[:2] + [_chunk([{"index": 1, "delta": {}, "finish_reason": "stop"}])]).getvalue(),
+        _stream(events[:2] + [{**events[2], "id": "other-response"}]).getvalue(),
+        b"data: " + b"x" * 65536 + b"\n\n",
+    ]
+
+
+@pytest.mark.parametrize("raw", _invalid_streams(), ids=[
+    "json", "utf8", "truncated", "engine-error", "error-event", "missing-finish",
+    "missing-usage", "duplicate-finish", "duplicate-usage", "duplicate-done",
+    "after-done", "choice-index", "response-id", "oversized-line",
+])
+def test_malformed_or_incomplete_stream_withholds_readiness(tmp_path, monkeypatch, raw):
+    wrapper, warmup = _load_module(monkeypatch)
+    monkeypatch.setattr(warmup, "wait_for_api", lambda *_args: None)
+    monkeypatch.setattr(warmup, "run_warmup", lambda *_args: ())
+    monkeypatch.setattr(wrapper.urllib.request, "urlopen",
+                        lambda *_args, **_kwargs: _Stream(raw))
+    ready = tmp_path / "ready"
+    ready.touch()
+    with pytest.raises(RuntimeError, match="Sampling warmup stream"):
+        wrapper.complete_readiness(
+            rank=0, endpoint="http://localhost", model="model", warmup_enabled=True,
+            concurrencies=(1,), shape_words=(8,), max_tokens=16,
+            timeout_seconds=30, credential=None, ready_path=ready,
+        )
+    assert not ready.exists()
+
+
+@pytest.mark.parametrize("field,value", [
+    ("completion_tokens", True), ("completion_tokens", "2"),
+    ("completion_tokens", 0), ("completion_tokens", 17),
+    ("prompt_tokens", True), ("prompt_tokens", -1),
+    ("total_tokens", True), ("total_tokens", 15),
+])
+def test_sampling_rejects_invalid_or_inconsistent_usage(monkeypatch, field, value):
+    wrapper, _ = _load_module(monkeypatch)
+    events = copy.deepcopy(_events())
+    events[-2]["usage"][field] = value
+    monkeypatch.setattr(wrapper.urllib.request, "urlopen",
+                        lambda *_args, **_kwargs: _stream(events))
+    with pytest.raises(RuntimeError, match="Sampling warmup"):
+        wrapper.warmup_sampling("http://localhost", "model", 16, 30, None)
+
+
+def test_stream_consumption_uses_the_remaining_startup_deadline(tmp_path, monkeypatch):
+    wrapper, warmup = _load_module(monkeypatch)
+    clock = [0.0]
+    monkeypatch.setattr(wrapper.time, "monotonic", lambda: clock[0])
+    monkeypatch.setattr(warmup, "wait_for_api", lambda *_args: None)
+    monkeypatch.setattr(warmup, "run_warmup", lambda *_args: ())
+
+    class SlowStream(_Stream):
+        def readline(self, limit):
+            clock[0] += 1
+            return super().readline(limit)
+
+    monkeypatch.setattr(wrapper.urllib.request, "urlopen",
+                        lambda *_args, **_kwargs: SlowStream(_stream().getvalue()))
+    ready = tmp_path / "ready"
+    with pytest.raises(RuntimeError, match="deadline"):
+        wrapper.complete_readiness(
+            rank=0, endpoint="http://localhost", model="model", warmup_enabled=True,
+            concurrencies=(1,), shape_words=(8,), max_tokens=16,
+            timeout_seconds=3, credential=None, ready_path=ready,
+        )
+    assert clock[0] == 3
+    assert not ready.exists()
 
 
 def test_api_shapes_and_sampling_share_one_readiness_budget(tmp_path, monkeypatch):
@@ -206,7 +342,7 @@ def test_sampling_request_uses_auth_temperature_and_reasoning(monkeypatch):
     def urlopen(request, timeout):
         observed.append(request)
         assert 0 < timeout <= 10
-        return io.BytesIO(b'{"choices":[{"finish_reason":"stop","message":{"reasoning":"ok"}}],"usage":{"completion_tokens":1}}')
+        return _stream(completion_tokens=1)
 
     monkeypatch.setattr(wrapper.urllib.request, "urlopen", urlopen)
     result = wrapper.warmup_sampling("http://localhost/", "model", 16, 10, "secret")
@@ -228,8 +364,8 @@ def test_sampling_failure_withholds_readiness_marker(tmp_path, monkeypatch):
     monkeypatch.setattr(warmup, "wait_for_api", lambda *_args: None)
     monkeypatch.setattr(warmup, "run_warmup", lambda *_args: ())
     monkeypatch.setattr(wrapper.urllib.request, "urlopen",
-                        lambda *_args, **_kwargs: io.BytesIO(b'{"choices":[]}'))
-    with pytest.raises(RuntimeError, match="Sampling warmup response has no completion"):
+                        lambda *_args, **_kwargs: _stream([_chunk([])]))
+    with pytest.raises(RuntimeError, match="Sampling warmup stream"):
         wrapper.complete_readiness(
             rank=0, endpoint="http://localhost", model="model",
             warmup_enabled=True, concurrencies=(1,), shape_words=(8,),
@@ -393,6 +529,8 @@ def test_both_warmup_requests_carry_internal_token_and_api_auth(monkeypatch):
 
     def urlopen(request, **kwargs):
         observed.append(request)
+        if json.loads(request.data).get("stream"):
+            return _stream(completion_tokens=1)
         return io.BytesIO(b'{"choices":[{"finish_reason":"stop","message":{"content":"ok"}}],"usage":{"completion_tokens":1}}')
 
     monkeypatch.setattr(wrapper.urllib.request, "urlopen", urlopen)

--- a/runtime/sparkring/source_image/README.md
+++ b/runtime/sparkring/source_image/README.md
@@ -24,7 +24,7 @@ startup helper, and runtime profile. Full hashes in that file are authoritative.
 | B12X | Public base `85a08f47750db333a33ab3eae245a0a08452d04c` plus `patches/b12x.patch`; reproduces `2883a5df65a7ea3cb6e82abb63d1448dd3154887`, including four-checkpoint kernels and profile-selected managed loading |
 | NCCL | Public NVIDIA source base `73cf112295c33aee2b895f329f592f2a9b4b0f97` plus the cumulative `patches/nccl.patch`; preserves switchless routing and independent PCIe-domain discovery |
 | SparkCache | `d0cf7296062ec8b4d17d65cd05a416d509e80bd8`, reproduced from its public base and packaged patch; includes capture-job read leases, request cleanup, private restore admission, and the exact common-vLLM source contract |
-| Startup | Four source-pinned helpers under `startup/`; six sampler cases, completed-output admission, and allocation-aware scheduler liveness for the TP4 wrapper |
+| Startup | Four source-pinned helpers under `startup/`; six streamed sampler requests with validated completion and usage, plus allocation-aware scheduler liveness for the TP4 wrapper |
 | TP2 transport | Exact adaptive-grid RoCEnante source under `runtime/transport_profiles/`; selected before B12X import, with independent proxy/kernel and file verification |
 
 | Profile | Checkpoint and parallelism | Communication and cache |

--- a/runtime/sparkring/source_image/README.md
+++ b/runtime/sparkring/source_image/README.md
@@ -24,7 +24,7 @@ startup helper, and runtime profile. Full hashes in that file are authoritative.
 | B12X | Public base `85a08f47750db333a33ab3eae245a0a08452d04c` plus `patches/b12x.patch`; reproduces `2883a5df65a7ea3cb6e82abb63d1448dd3154887`, including four-checkpoint kernels and profile-selected managed loading |
 | NCCL | Public NVIDIA source base `73cf112295c33aee2b895f329f592f2a9b4b0f97` plus the cumulative `patches/nccl.patch`; preserves switchless routing and independent PCIe-domain discovery |
 | SparkCache | `d0cf7296062ec8b4d17d65cd05a416d509e80bd8`, reproduced from its public base and packaged patch; includes capture-job read leases, request cleanup, private restore admission, and the exact common-vLLM source contract |
-| Startup | Four source-pinned helpers under `startup/`; six streamed sampler requests with validated completion and usage, plus allocation-aware scheduler liveness for the TP4 wrapper |
+| Startup | Four source-pinned helpers under `startup/`; six C1 sampler requests and three C2 filtered pairs when concurrency permits, with validated SSE completion/usage and allocation-aware scheduler liveness |
 | TP2 transport | Exact adaptive-grid RoCEnante source under `runtime/transport_profiles/`; selected before B12X import, with independent proxy/kernel and file verification |
 
 | Profile | Checkpoint and parallelism | Communication and cache |

--- a/runtime/sparkring/source_image/glm53-tp4-lock.json
+++ b/runtime/sparkring/source_image/glm53-tp4-lock.json
@@ -391,10 +391,10 @@
   },
   "source_date_epoch": 1788880173,
   "startup": {
-    "revision": "767522e399ad61d3b3cf02259414b1007becc030",
+    "revision": "9a3d7e416a5502eac1462aa3c2cf30dca53094ba",
     "warmup_transform": "glm53-thinking-low/v1",
     "files": {
-      "serve_with_warmup.py": "018f85037d0ed21f92df889fb294a2de50060edf479c8c79afd07e446e33982f",
+      "serve_with_warmup.py": "83782b4f9a68eae80aea595e7a996179de6a3379f7240a7f359d6acdc352093c",
       "warmup_dflash.py": "4d98618a5f58d2991eeb67b9b03ecdd720ac6974f644fa8b5030408a3af0792e",
       "startup_admission.py": "1afdc6b2e421465498bde349dff3edb8428ca995a949b2a2f3c6e358a3af7ef4",
       "scheduler_liveness.py": "9078d796aeb8ad59e7a78e9739168596abecfb20c043925a0d4e728f3673a53c"

--- a/runtime/sparkring/source_image/glm53-tp4-lock.json
+++ b/runtime/sparkring/source_image/glm53-tp4-lock.json
@@ -391,10 +391,10 @@
   },
   "source_date_epoch": 1788880173,
   "startup": {
-    "revision": "9a3d7e416a5502eac1462aa3c2cf30dca53094ba",
+    "revision": "378abab2bac9fe4ea39afe79ed9ff9f16c52cdd3",
     "warmup_transform": "glm53-thinking-low/v1",
     "files": {
-      "serve_with_warmup.py": "83782b4f9a68eae80aea595e7a996179de6a3379f7240a7f359d6acdc352093c",
+      "serve_with_warmup.py": "2104e7d83e84d7e2ccbb19e331b487cafea4515ac75eda2dc0082cfc7187a841",
       "warmup_dflash.py": "4d98618a5f58d2991eeb67b9b03ecdd720ac6974f644fa8b5030408a3af0792e",
       "startup_admission.py": "1afdc6b2e421465498bde349dff3edb8428ca995a949b2a2f3c6e358a3af7ef4",
       "scheduler_liveness.py": "9078d796aeb8ad59e7a78e9739168596abecfb20c043925a0d4e728f3673a53c"

--- a/runtime/sparkring/source_image/startup/serve_with_warmup.py
+++ b/runtime/sparkring/source_image/startup/serve_with_warmup.py
@@ -4,12 +4,14 @@
 from __future__ import annotations
 
 import json
+import concurrent.futures
 import os
 import signal
 import secrets
 import subprocess
 import sys
 import time
+import threading
 import urllib.request
 from pathlib import Path
 
@@ -137,6 +139,7 @@ def warmup_sampling(
     max_tokens: int,
     timeout_seconds: float,
     credential: str | None,
+    concurrencies: tuple[int, ...] = (1,),
 ) -> dict[str, object]:
     """Complete the explicit sampler request recipe before declaring readiness."""
     deadline = warmup_dflash.make_deadline(timeout_seconds)
@@ -147,13 +150,14 @@ def warmup_sampling(
     if credential:
         headers["Authorization"] = f"Bearer {credential}"
     started = time.monotonic()
-    cases = []
-    for name, temperature, top_k, top_p, seed in SAMPLING_CASES:
+    def send_case(case, token_limit, *, peer=None, barrier=None):
+        name, temperature, top_k, top_p, seed = case
+        label = name if peer is None else f"{name} peer={peer}"
         body = {
             "model": model,
             "messages": [{
                 "role": "user",
-                "content": f"Sampling warmup {time.monotonic_ns()} {name}. Reply briefly.",
+                "content": f"Sampling warmup {time.monotonic_ns()} {label}. Reply briefly.",
             }],
             "temperature": temperature,
             "top_k": top_k,
@@ -162,35 +166,70 @@ def warmup_sampling(
             "n": 1,
             "stream": True,
             "stream_options": {"include_usage": True, "continuous_usage_stats": False},
-            "max_tokens": max_tokens,
+            "max_tokens": token_limit,
             "chat_template_kwargs": {"enable_thinking": True},
         }
         if seed is not None:
             body["seed"] = seed
+        if peer is not None:
+            # A fixed decode span prevents EOS from ending a paired request
+            # before the other request can enter the serving scheduler.
+            body.update(ignore_eos=True, min_tokens=token_limit)
         request = urllib.request.Request(
             endpoint.rstrip("/") + "/v1/chat/completions",
             data=json.dumps(body).encode(), headers=headers,
         )
-        case_started = time.monotonic()
+        if barrier is not None:
+            barrier.wait(timeout=warmup_dflash.remaining_seconds(deadline))
+        case_started = time.perf_counter()
         with urllib.request.urlopen(
             request, timeout=warmup_dflash.remaining_seconds(deadline)
         ) as response:
             if response.status != 200 or response.headers.get_content_type() != "text/event-stream":
                 raise RuntimeError(f"Sampling warmup did not return an SSE response: {name}")
-            result = _sampling_stream_result(response, deadline, max_tokens)
+            result = _sampling_stream_result(response, deadline, token_limit)
+        case_finished = time.perf_counter()
+        if peer is not None and (
+            result["completion_tokens"] != token_limit or result["finish_reason"] != "length"
+        ):
+            raise RuntimeError("Concurrent sampling warmup did not complete its fixed token span")
         warmup_dflash.remaining_seconds(deadline)
-        cases.append({
+        return {
             "name": name, "temperature": temperature, "top_k": top_k,
             "top_p": top_p, "seed": seed, **result,
-            "elapsed_seconds": round(time.monotonic() - case_started, 3),
-        })
+            "elapsed_seconds": round(case_finished - case_started, 3),
+        }, case_started, case_finished
+
+    cases = [send_case(case, max_tokens)[0] for case in SAMPLING_CASES]
+    concurrent_cases = []
+    if any(concurrency >= 2 for concurrency in concurrencies):
+        for case in SAMPLING_CASES:
+            if case[0] not in ("top-k", "top-p", "top-k-top-p"):
+                continue
+            barrier = threading.Barrier(2)
+            with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
+                futures = [executor.submit(send_case, case, 128, peer=index, barrier=barrier)
+                           for index in range(2)]
+                results = [future.result(timeout=warmup_dflash.remaining_seconds(deadline))
+                           for future in futures]
+            overlap = min(result[2] for result in results) - max(result[1] for result in results)
+            if overlap <= 0:
+                raise RuntimeError("Concurrent sampling warmup HTTP requests did not overlap")
+            concurrent_cases.append({
+                "name": case[0], "concurrency": 2, "max_tokens": 128,
+                "min_tokens": 128, "ignore_eos": True,
+                "http_overlap_seconds": round(overlap, 6),
+                "requests": [result[0] for result in results],
+            })
+    warmup_dflash.remaining_seconds(deadline)
     return {
         "schema": "sparkring-sampler-warmup/v1",
-        "coverage": "request-recipe-complete",
+        "coverage": "request-recipe-complete" if concurrent_cases else "limited-c1-only",
         "jit_coverage_verified": False,
         "enable_thinking": True,
         "stream": True,
         "cases": cases,
+        "concurrent_cases": concurrent_cases,
         "elapsed_seconds": round(time.monotonic() - started, 3),
     }
 
@@ -239,7 +278,7 @@ def complete_readiness(
             )
             sampling = warmup_sampling(
                 endpoint, model, max_tokens,
-                warmup_dflash.remaining_seconds(deadline), credential
+                warmup_dflash.remaining_seconds(deadline), credential, concurrencies
             )
             print(json.dumps({"sampling_warmup": sampling}, separators=(",", ":")))
         print(json.dumps({"dflash_warmup": result}, separators=(",", ":")))

--- a/runtime/sparkring/source_image/startup/serve_with_warmup.py
+++ b/runtime/sparkring/source_image/startup/serve_with_warmup.py
@@ -31,6 +31,106 @@ SAMPLING_CASES = (
 )
 
 
+def _sampling_stream_result(response, deadline: float, max_tokens: int) -> dict:
+    """Require one finished choice, final usage and a complete SSE terminator."""
+    finish_reason = None
+    usage = None
+    request_id = None
+    done = False
+    data_lines = []
+    event_type = ""
+    byte_count = 0
+    while True:
+        warmup_dflash.remaining_seconds(deadline)
+        raw = response.readline(65537)
+        warmup_dflash.remaining_seconds(deadline)
+        byte_count += len(raw)
+        if len(raw) > 65536 or byte_count > 4 * 1024 * 1024:
+            raise RuntimeError("Sampling warmup stream exceeds its response bound")
+        if not raw:
+            if data_lines or not done:
+                raise RuntimeError("Sampling warmup stream ended before [DONE]")
+            return {**usage, "finish_reason": finish_reason}
+        try:
+            line = raw.decode("utf-8").rstrip("\r\n")
+        except UnicodeDecodeError as error:
+            raise RuntimeError("Sampling warmup stream is not UTF-8") from error
+        if line.startswith(":"):
+            continue
+        if line:
+            field, _, value = line.partition(":")
+            value = value.removeprefix(" ")
+            if field == "data":
+                data_lines.append(value)
+            elif field == "event":
+                event_type = value
+            continue
+        if event_type == "error":
+            raise RuntimeError("Sampling warmup stream reported an error event")
+        event_type = ""
+        if not data_lines:
+            continue
+        payload = "\n".join(data_lines)
+        data_lines = []
+        if done:
+            raise RuntimeError("Sampling warmup stream contains data after [DONE]")
+        if payload == "[DONE]":
+            if finish_reason is None or usage is None:
+                raise RuntimeError("Sampling warmup stream has no completed choice and usage")
+            done = True
+            continue
+        try:
+            chunk = json.loads(payload)
+        except json.JSONDecodeError as error:
+            raise RuntimeError("Sampling warmup stream contains invalid JSON") from error
+        if not isinstance(chunk, dict) or "error" in chunk:
+            raise RuntimeError("Sampling warmup stream reported an error or invalid chunk")
+        if (
+            chunk.get("object") != "chat.completion.chunk"
+            or not isinstance(chunk.get("id"), str) or not chunk["id"]
+        ):
+            raise RuntimeError("Sampling warmup stream has invalid completion identity")
+        if request_id is None:
+            request_id = chunk["id"]
+        elif request_id != chunk["id"]:
+            raise RuntimeError("Sampling warmup stream changed completion identity")
+        choices = chunk.get("choices")
+        if choices == []:
+            if finish_reason is None or usage is not None:
+                raise RuntimeError("Sampling warmup stream has misplaced or duplicate usage")
+            usage = chunk.get("usage")
+            if not isinstance(usage, dict):
+                raise RuntimeError("Sampling warmup stream has no final usage")
+            completion_tokens = usage.get("completion_tokens")
+            if type(completion_tokens) is not int or completion_tokens <= 0:
+                raise RuntimeError("Sampling warmup generated no tokens")
+            prompt_tokens, total_tokens = usage.get("prompt_tokens"), usage.get("total_tokens")
+            if (
+                type(prompt_tokens) is not int or prompt_tokens <= 0
+                or type(total_tokens) is not int
+                or total_tokens != prompt_tokens + completion_tokens
+                or completion_tokens > max_tokens
+            ):
+                raise RuntimeError("Sampling warmup stream has inconsistent token usage")
+            usage = {key: usage[key] for key in (
+                "prompt_tokens", "completion_tokens", "total_tokens")}
+            continue
+        if (
+            finish_reason is not None or usage is not None
+            or not isinstance(choices, list) or len(choices) != 1
+            or not isinstance(choices[0], dict)
+            or type(choices[0].get("index")) is not int or choices[0]["index"] != 0
+            or not isinstance(choices[0].get("delta"), dict)
+            or chunk.get("usage") is not None
+        ):
+            raise RuntimeError("Sampling warmup stream does not contain one ordered choice")
+        reason = choices[0].get("finish_reason")
+        if reason is not None:
+            if reason not in ("stop", "length"):
+                raise RuntimeError("Sampling warmup stream has an unsuccessful finish reason")
+            finish_reason = reason
+
+
 def warmup_sampling(
     endpoint: str,
     model: str,
@@ -59,6 +159,9 @@ def warmup_sampling(
             "top_k": top_k,
             "top_p": top_p,
             "min_p": 0.0,
+            "n": 1,
+            "stream": True,
+            "stream_options": {"include_usage": True, "continuous_usage_stats": False},
             "max_tokens": max_tokens,
             "chat_template_kwargs": {"enable_thinking": True},
         }
@@ -72,26 +175,13 @@ def warmup_sampling(
         with urllib.request.urlopen(
             request, timeout=warmup_dflash.remaining_seconds(deadline)
         ) as response:
-            result = json.load(response)
-        choices = result.get("choices") if isinstance(result, dict) else None
-        if not isinstance(choices, list) or not choices:
-            raise RuntimeError(f"Sampling warmup response has no completion: {name}")
-        if (
-            len(choices) != 1
-            or not isinstance(choices[0], dict)
-            or not isinstance(choices[0].get("message"), dict)
-            or choices[0].get("finish_reason") not in ("stop", "length")
-        ):
-            raise RuntimeError(f"Sampling warmup response is not one completed choice: {name}")
-        usage = result.get("usage")
-        completion_tokens = usage.get("completion_tokens") if isinstance(usage, dict) else None
-        if type(completion_tokens) is not int or completion_tokens <= 0:
-            raise RuntimeError(f"Sampling warmup generated no tokens: {name}")
+            if response.status != 200 or response.headers.get_content_type() != "text/event-stream":
+                raise RuntimeError(f"Sampling warmup did not return an SSE response: {name}")
+            result = _sampling_stream_result(response, deadline, max_tokens)
         warmup_dflash.remaining_seconds(deadline)
         cases.append({
             "name": name, "temperature": temperature, "top_k": top_k,
-            "top_p": top_p, "seed": seed, "completion_tokens": completion_tokens,
-            "finish_reason": choices[0]["finish_reason"],
+            "top_p": top_p, "seed": seed, **result,
             "elapsed_seconds": round(time.monotonic() - case_started, 3),
         })
     return {
@@ -99,6 +189,7 @@ def warmup_sampling(
         "coverage": "request-recipe-complete",
         "jit_coverage_verified": False,
         "enable_thinking": True,
+        "stream": True,
         "cases": cases,
         "elapsed_seconds": round(time.monotonic() - started, 3),
     }


### PR DESCRIPTION
## What and why

A filtered C2 request sweep reached `_topk_topp_kernel` initialization after the six C1 sampler warmups had completed on a TP4 native-MTP3 runtime. Stream the six existing cases and add three homogeneous C2 filtered pairs when the configured warmup concurrency permits at least two requests. Each pair generates exactly 128 tokens; both responses must finish successfully with valid SSE termination and usage. C1-only configurations explicitly report limited coverage.

The shared startup deadline, authentication, neutral filters and thinking behavior are preserved. Malformed, truncated, failed, oversized or incomplete streams prevent readiness. HTTP overlap is recorded without claiming a shared GPU batch. The shared-image startup copy is byte-identical and pinned to canonical commit `378abab2bac9fe4ea39afe79ed9ff9f16c52cdd3`.

Related to #214; keep it open. `jit_coverage_verified` remains false. Backend-dependent kernel coverage, controlled cold-JIT behavior and mixed-prefill remain separate qualification gaps.

## Validation

- 91 focused warmup/startup-admission tests pass, covering all filter arms, both concurrent peers, strict SSE/usage failures, configured C1-only behavior and the shared deadline.
- Operator-runtime and source-image CPU suites: 244 passed, 2 Windows/POSIX permission-mode skips.
- All four startup source files match their pinned commit and hashes. Ruff, documentation links, release-safety and diff checks pass.
- The complete six-C1/three-C2 helper recipe passed against an already-ready TP4/DCP1 native-MTP3 API using local image `sha256:db4053abcf1c82ce2da5633abd672abcaa32ca77eef5b03d567b1fa24a04b671`. This is external request/parser validation, not installed startup or cold-cache qualification.

The [bounded observation and source bindings](https://github.com/FujitsuPolycom/sparkring/blob/3d1f306b5ddfff8b6dc3de4ed6cb975c3e7b8b48/performance/records/glm53-flash/sampler-concurrency-20260909.md) preserve the first C2 warning on all four ranks and zero observed warnings on a repeat. The monitor uses `warning_once`, so zero repeat warnings do not establish zero JIT events or complete variant coverage. This native-MTP3 observation does not qualify the original DFlash2 report.

- [x] I removed credentials and private site identifiers from the change.
- [x] I identified copied or adapted work and updated third-party notices when required.
