### PR TITLE
tp2: render only the selected HCA functions into B12X_ROCE_HCA

### DIFF
--- a/runtime/profiles/glm53-flash-spark-tp2/README.md
+++ b/runtime/profiles/glm53-flash-spark-tp2/README.md
@@ -76,7 +76,7 @@ records the common-source requirements and reference-trial limits.
 | Scheduler | Eight sequences, 8,192 batched tokens, prefill interval 8 |
 | Prefill | Token-sharded mHC and recurrent-checkpoint coalescing; sequential KDA projection |
 | Graphs | `FULL_AND_PIECEWISE`, mode 0; `[1,2,4,8,12,16,20,24,28,32]` |
-| Transport | HCA indices 0/2; two RoCEnante paths; 16 MiB all-reduce and all-gather input-shard limits |
+| Transport | HCA indices 0/2 (`rocep1s0f0`, `roceP2p1s0f0`); only these two functions are rendered into `B12X_ROCE_HCA`, so the other cage may be uncabled; two RoCEnante paths; 16 MiB all-reduce and all-gather input-shard limits |
 | NCCL | Verified 2.30.7; eight channels; `=rocep1s0f0,roceP2p1s0f0` |
 | Multimodal / SparkCache | Four images, zero videos; SparkCache disabled |
 | Lifecycle | Active 2 GiB host-memory guard; manual create/start; Docker restart `no` |

--- a/runtime/profiles/glm53-flash-spark-tp2/launch.py
+++ b/runtime/profiles/glm53-flash-spark-tp2/launch.py
@@ -35,10 +35,15 @@ def transport_environment(rank: int) -> dict[str, str]:
         raise ValueError("The profile's transport manifest has changed")
     indices = transport["local_hca_indices"]
     inventory = transport["hca_inventory"]
+    # Expose only the selected functions. The RoCE proxy opens every device in
+    # B12X_ROCE_HCA and requires each to be ACTIVE, so listing the full inventory
+    # aborts RoCEnante on a host with one physical DAC (the f1 functions have no
+    # carrier). Peer-map indices are positions in the rendered list.
+    selected = [inventory[index] for index in indices]
     return {
-        "B12X_ROCE_HCA": ",".join(inventory),
+        "B12X_ROCE_HCA": ",".join(selected),
         "B12X_ROCE_PAIR_PATHS": str(transport["path_count"]),
-        "B12X_ROCE_PEER_HCA_MAP": f"{1 - rank}=" + "/".join(map(str, indices)),
+        "B12X_ROCE_PEER_HCA_MAP": f"{1 - rank}=" + "/".join(str(i) for i in range(len(selected))),
         "NCCL_IB_HCA": "=" + ",".join(inventory[index] for index in indices),
         "NCCL_IB_MERGE_NICS": "0",
         "NCCL_CROSS_NIC": "1",

--- a/runtime/profiles/glm53-flash-spark-tp2/test_glm53_spark_tp2_profile.py
+++ b/runtime/profiles/glm53-flash-spark-tp2/test_glm53_spark_tp2_profile.py
@@ -168,8 +168,11 @@ def test_profile_selects_spark_kv875_settings_and_no_cache():
 def test_rank_plan_maps_both_pci_functions_of_one_cage(inputs, rank):
     value = plan(inputs, rank)
     env = value["environment"]
-    assert env["B12X_ROCE_HCA"] == "rocep1s0f0,rocep1s0f1,roceP2p1s0f0,roceP2p1s0f1"
-    assert env["B12X_ROCE_PEER_HCA_MAP"] == f"{1 - rank}=0/2"
+    # Only the selected functions are exposed to the RoCE proxy: it requires every
+    # listed device to be ACTIVE, and the f1 functions carry no cable on a
+    # single-DAC install. Peer-map indices address the rendered list.
+    assert env["B12X_ROCE_HCA"] == "rocep1s0f0,roceP2p1s0f0"
+    assert env["B12X_ROCE_PEER_HCA_MAP"] == f"{1 - rank}=0/1"
     assert env["NCCL_IB_HCA"] == "=rocep1s0f0,roceP2p1s0f0"
     assert env["B12X_ROCE_PAIR_PATHS"] == "2"
     assert env["NCCL_MIN_NCHANNELS"] == env["NCCL_MAX_NCHANNELS"] == "8"
@@ -243,7 +246,7 @@ def test_tp2_clears_inherited_mesh_sitecustomize(inputs, tmp_path):
 @pytest.mark.parametrize(
     "assignment",
     [
-        "B12X_ROCE_PEER_HCA_MAP=1=2/1",
+        "B12X_ROCE_PEER_HCA_MAP=1=1/0",
         "VLLM_PLUGINS=sparkcache",
         "SPARK_CACHE_ENABLED=1",
         "VLLM_HOST_IP=duplicate",


### PR DESCRIPTION
## Behavior and reason

The TP2 launcher supplies only the two RDMA functions selected for physical
cage p0: `rocep1s0f0` and `roceP2p1s0f0`. The RoCEnante peer map uses positions
`0/1` in that two-device list. The topology inventory still identifies those
physical functions as `0/2`; NCCL selects the same physical devices.

The proxy requires every listed device to be ACTIVE. Listing uncabled cage-p1
functions therefore prevents RoCEnante initialization and causes fallback to
PyNCCL. Selecting only the required functions permits the unused cage to be
uncabled without changing the intended data path.

Fixes #268. Implementation contributed by @SecureBot in commit
`27d6b0dbd2b5a2113fb8c14923d70fb354d5a0ee`.

## Compatibility

Path count, NCCL device selection, model settings, image contents and packaged
profile/transport manifest hashes are unchanged. The rendered environment
changes, so containers must be recreated to use it. Existing running containers
are not modified by merging this PR.

## Validation and limits

- Maintainer check against main at `a48c862`: 99 TP2 launcher and R33 profile
  tests passed; 773 repository-relative Markdown links and focused Ruff checks
  passed.
- Contributor-reported live check: two GB10 nodes, one QSFP112 DAC on port0,
  both port1 interfaces NO-CARRIER, R33 image config ID beginning `3c7779ad71dd`,
  and `--r33-sparkcache`. The four-device list produced inactive-port warnings
  and PyNCCL-only selection. The two-device list selected B12X_ROCENANTE first
  for TP and EP groups on both ranks without that warning.
- Status: implemented with contributor-reported activation evidence. No
  throughput comparison or complete profile requalification is claimed here.
  The maintainer did not unplug cables or change DGX2 during this check.
- The earlier single-DAC traffic measurements kept both physical cables
  connected; they did not establish operation with the other cage uncabled.

No copied third-party implementation or credentials are added.
