### PR TITLE
docs: announce repository restructuring

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # SparkRing
 
+> **Repository restructuring in progress:** Work on `refactor/repository-layout` is simplifying the layout, profile management, quickstarts, and contributor documentation. Contributions remain welcome—we’ll carry ongoing fixes and profile improvements into the refactor as it’s tested and prepared for review. The branch is currently local; existing published profiles and images remain available.
+
 SparkRing is a vLLM-based inference-serving stack with low-latency collective
 communication for switchless clusters of NVIDIA GB10-based devices. 
 


### PR DESCRIPTION
Add a temporary README notice identifying `refactor/repository-layout` and explaining the repository, profile, quickstart, and contributor-documentation work. Confirm that contributions remain welcome and ongoing fixes and profile improvements will be reconciled into the refactor.

The refactor branch is local; this PR contains only the approved notice. Remove the notice when the restructuring is adopted.

Validation: inspected the exact README diff; existing README content is unchanged. Required repository checks will run through this PR.
